### PR TITLE
Add airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "faraday", "0.9.0"
 gem "rake", "~> 10.3"
 gem "unicorn", "4.8.3"
 gem "nokogiri", "1.6.3.1"
+gem "airbrake", "4.0.0"
 
 group :development do
   gem "mr-sparkle"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.6)
+    airbrake (4.0.0)
+      builder
+      multi_json
     awesome_print (1.2.0)
     builder (3.2.2)
     coderay (1.1.0)
@@ -86,6 +89,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (= 4.0.0)
   awesome_print
   cucumber (~> 1.3)
   equivalent-xml (= 0.5.1)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,1 @@
+# This is overwritten on deploy

--- a/http/http_api.rb
+++ b/http/http_api.rb
@@ -1,4 +1,11 @@
 require "sinatra"
+require "airbrake"
+require "config/initializers/airbrake"
+
+configure do
+  Airbrake.configuration.ignore << "Sinatra::NotFound"
+  use Airbrake::Sinatra
+end
 
 # TODO: Disable ShowExceptions in a less gross way, do we care about development mode?
 Sinatra::ShowExceptions.class_eval do


### PR DESCRIPTION
Airbrake is being used to track our errors through errbit. The initializer is overridden on deployment.
