### PR TITLE
Add airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "faraday", "0.9.0"
 gem "rake", "~> 10.3"
 gem "unicorn", "4.8.3"
 gem "nokogiri", "1.6.3.1"
+gem "airbrake", "4.0.0"
 
 group :development do
   gem "mr-sparkle"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.6)
+    airbrake (4.0.0)
+      builder
+      multi_json
     awesome_print (1.2.0)
     builder (3.2.2)
     coderay (1.1.0)
@@ -86,6 +89,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (= 4.0.0)
   awesome_print
   cucumber (~> 1.3)
   equivalent-xml (= 0.5.1)

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,21 @@
 require_relative "configuration"
 
-require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new(:spec)
+Dir[File.join(File.dirname(__FILE__), 'lib/tasks/*.rake')].each { |file| load file }
 
-require 'cucumber'
-require 'cucumber/rake/task'
-Cucumber::Rake::Task.new(:cucumber) do |t|
-  t.cucumber_opts = "features --format pretty"
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+
+  require 'cucumber'
+  require 'cucumber/rake/task'
+  Cucumber::Rake::Task.new(:cucumber) do |t|
+    t.cucumber_opts = "features --format pretty"
+  end
+
+  task default: [
+    "spec",
+    "cucumber",
+  ]
+rescue LoadError
+  # nope
 end
-
-task default: [
-  "spec",
-  "cucumber",
-]

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,1 @@
+# This is overwritten on deploy

--- a/http/http_api.rb
+++ b/http/http_api.rb
@@ -1,4 +1,6 @@
 require "sinatra"
+require "airbrake"
+require "config/initializers/airbrake"
 
 # TODO: Disable ShowExceptions in a less gross way, do we care about development mode?
 Sinatra::ShowExceptions.class_eval do
@@ -12,6 +14,11 @@ Sinatra::ShowExceptions.class_eval do
 end
 
 class HTTPAPI < Sinatra::Application
+  configure do
+    Airbrake.configuration.ignore << "Sinatra::NotFound"
+    use Airbrake::Sinatra
+  end
+
   post "/topics" do
     app.create_topic(adapter)
   end

--- a/lib/tasks/airbrake.rake
+++ b/lib/tasks/airbrake.rake
@@ -1,0 +1,3 @@
+require 'airbrake/tasks'
+
+require_relative '../../config/initializers/airbrake'


### PR DESCRIPTION
Airbrake is being used to track our errors through errbit. The initializer is overridden on deployment.
