### PR TITLE
If the request is invalid respond with unprocessable

### DIFF
--- a/features/create_topic.feature
+++ b/features/create_topic.feature
@@ -41,3 +41,65 @@ Feature: Create a topic
         }
       """
     And a topic has not been created
+
+  Scenario: Unprocessable request
+    Given there are no topics
+    When I POST to "/topics" with
+      """
+      {
+        "title": "Anything",
+        "tags": {}
+      }
+      """
+    Then I get a "422" response with the following body
+      """
+        {
+          "error": "A topic was not created due to invalid attributes"
+        }
+      """
+    When I POST to "/topics" with
+      """
+      {
+        "title": "Anything",
+        "tags": {
+          "tag_key": "anything"
+        }
+      }
+      """
+    Then I get a "422" response with the following body
+      """
+        {
+          "error": "A topic was not created due to invalid attributes"
+        }
+      """
+    When I POST to "/topics" with
+      """
+      {
+        "title": "Anything",
+        "tags": ""
+      }
+      """
+    Then I get a "422" response with the following body
+      """
+        {
+          "error": "A topic was not created due to invalid attributes"
+        }
+      """
+    When I POST to "/topics" with
+      """
+      {
+        "title": "",
+        "tags": {
+          "document_type": [ "cma_case" ],
+          "case_type": [ "markets", "mergers" ],
+          "market_sector": [ "energy" ]
+        }
+      }
+      """
+    Then I get a "422" response with the following body
+      """
+        {
+          "error": "A topic was not created due to invalid attributes"
+        }
+      """
+

--- a/services/processable_input_filter.rb
+++ b/services/processable_input_filter.rb
@@ -1,0 +1,49 @@
+class ProcessableInputFilter
+  def initialize(service:, context:, title:, tags:)
+    @service = service
+    @context = context
+    @title = title
+    @tags = tags
+  end
+
+  def call
+    if processable_request?
+      service.call(context)
+    else
+      context.unprocessible(error: error_message)
+    end
+  end
+
+private
+
+  attr_reader(
+    :service,
+    :context,
+    :title,
+    :tags,
+  )
+
+  def processable_request?
+    valid_title? && valid_tag_structure?
+  end
+
+  def valid_title?
+    !title.nil? && !title.empty?
+  end
+
+  def valid_tag_structure?
+    if tags.empty? || !tags.is_a?(Hash) || !all_tags_are_arrays?
+      false
+    else
+      true
+    end
+  end
+
+  def all_tags_are_arrays?
+    tags.values.all? { |v| v.is_a?(Array) }
+  end
+
+  def error_message
+    "A topic was not created due to invalid attributes"
+  end
+end


### PR DESCRIPTION
This pull request is to handle responding with a 422 error in the case of invalid parameters being sent to the server. It should stop invalid parameters ever reaching the gov_delivery service.

Trello ticket:
https://trello.com/c/fvSPtNrm/345-emailalertapi-post-topics-to-respond-422-when-the-input-isn-t-processable
