### PR TITLE
Hack to make postgres HSTORE store array values

### DIFF
--- a/repositories/topic_repository.rb
+++ b/repositories/topic_repository.rb
@@ -19,9 +19,7 @@ class TopicRepository
   def find_by_tags(tags)
     adapter
       .find_by(namespace, :tags, tags)
-      .map { |_id, topic_data|
-        load(topic_data)
-      }
+      .map(&method(:load))
   end
 
 private
@@ -52,12 +50,12 @@ private
     end
 
     def load(data)
-      fixed_tags = data.fetch(:tags).reduce({}) { |result, (k, v)|
+      deserialized_tags = data.fetch(:tags).reduce({}) { |result, (k, v)|
         result.merge(k => JSON.load(v))
       }
 
       factory.call(data.merge(
-        tags: fixed_tags,
+        tags: deserialized_tags,
       ))
     end
 


### PR DESCRIPTION
Temporary HSTORE hack so we can store arrays as the hash values.

HSTORE only stores simple string keys to string values, no nesting supported.
