### PR TITLE
Rake runs Cucumber in strict mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ begin
   require 'cucumber'
   require 'cucumber/rake/task'
   Cucumber::Rake::Task.new(:cucumber) do |t|
-    t.cucumber_opts = "features --format pretty"
+    t.cucumber_opts = "features --strict --format pretty"
   end
 
   task default: [


### PR DESCRIPTION
This casuses pending tests to exit non zero and break the build rather than
appear as a pass.

The build failing on this PR means the desired effect has been achieved, the current state of master is actually an undetected fail.

A further pull request will rectify the problematic test.
