### PR TITLE
Fix error in Cucumber step label

### DIFF
--- a/features/step_definitions/subscriber_list_steps.rb
+++ b/features/step_definitions/subscriber_list_steps.rb
@@ -60,7 +60,7 @@ When(/^I POST to "(.*?)" with duplicate but differently ordered tag set$/) do |p
   @response = post(path, params)
 end
 
-When(/^When I POST to "(.*?)" with invalid parameters$/) do |path|
+When(/^I POST to "(.*?)" with invalid parameters$/) do |path|
   params = {
     "not_title" => "Any title",
     "tags" => ["not", "a", "hash"],


### PR DESCRIPTION
Trivial fix of Cucumber step mislabelling.

Please merge this failing PR first so that this mistake can be detected in future.
https://github.com/alphagov/email-alert-api/pull/16
