### PR TITLE
Add created_at timestamp

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -7,6 +7,7 @@ APP = Application.new(
   gov_delivery_client: GovDeliveryClient.create_client(CONFIG.fetch(:gov_delivery)),
   storage_adapter: PostgresAdapter.new(config: CONFIG.fetch(:postgres)),
   uuid_generator: ->() { SecureRandom.uuid },
+  clock: ->() { Time.now },
 )
 
 run HTTPAPI

--- a/entities/subscriber_list.rb
+++ b/entities/subscriber_list.rb
@@ -1,0 +1,16 @@
+SubscriberList = Struct.new(
+  :id,
+  :title,
+  :subscription_url,
+  :gov_delivery_id,
+  :created_at,
+  :tags,
+) do
+  def to_json(*args, &block)
+    to_h
+      .merge(
+        :created_at => created_at.iso8601,
+      )
+      .to_json(*args, &block)
+  end
+end

--- a/features/create_subscriber_list.feature
+++ b/features/create_subscriber_list.feature
@@ -23,6 +23,7 @@ Feature: Create a subscriber list
           "title": "CMA cases of type Markets and Mergers and about Energy",
           "subscription_url": "https://stage-public.govdelivery.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_1234",
           "gov_delivery_id": "UKGOVUK_1234",
+          "created_at": "2014-10-06T14:00:00Z",
           "tags": {
             "document_type": [ "cma_case" ],
             "case_type": [ "markets", "mergers" ],

--- a/features/get_subscriber_list.feature
+++ b/features/get_subscriber_list.feature
@@ -26,6 +26,7 @@ Feature: Get a subscriber list
           "title": "CMA cases about markets and mergers",
           "subscription_url": "https://stage-public.govdelivery.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_1234",
           "gov_delivery_id": "UKGOVUK_1234",
+          "created_at": "2014-10-06T14:00:00Z",
           "tags": {
             "document_type": [ "cma_case" ],
             "case_type": [ "markets", "mergers" ]

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,11 +20,14 @@ STORAGE_ADAPTER = PostgresAdapter.new(
   config: CONFIG.fetch(:postgres),
 )
 
+CURRENT_TIME = Time.parse("2014-10-06T14:00:00 UTC")
+
 APP = Application.new(
   config: CONFIG,
   uuid_generator: UUID_GENERATOR,
   storage_adapter: STORAGE_ADAPTER,
   gov_delivery_client: GOV_DELIVERY_API_CLIENT,
+  clock: ->() { CURRENT_TIME.dup },
 )
 
 # Sinatra stuff

--- a/persistence/postgres_adapter.rb
+++ b/persistence/postgres_adapter.rb
@@ -1,5 +1,6 @@
 require "sequel"
 Sequel.extension :pg_hstore, :pg_hstore_ops
+Sequel.default_timezone = :utc
 
 class PostgresAdapter
   def initialize(config:)

--- a/services/create_subscriber_list.rb
+++ b/services/create_subscriber_list.rb
@@ -27,8 +27,8 @@ private
 
   def subscriber_list_data
     {
-      gov_delivery_id: gov_delivery_id,
-      subscription_url: subscription_url,
+      "gov_delivery_id" => gov_delivery_id,
+      "subscription_url" => subscription_url,
     }.merge(subscriber_list_attributes)
   end
 

--- a/spec/entities/subscriber_list_spec.rb
+++ b/spec/entities/subscriber_list_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+require "subscriber_list"
+require "json"
+
+RSpec.describe SubscriberList do
+  subject(:subscriber_list) {
+    SubscriberList.new(
+      id,
+      title,
+      subscription_url,
+      gov_delivery_id,
+      created_at,
+      tags,
+    )
+  }
+
+  let(:id) { double(:id) }
+  let(:title) { double(:title) }
+  let(:subscription_url) { double(:subscription_url) }
+  let(:gov_delivery_id) { double(:gov_delivery_id) }
+  let(:tags) { double(:tags) }
+  let(:created_at) { double(:created_at, iso8601: formatted_time) }
+  let(:formatted_time) { "2014-10-06T14:00:00 UTC" }
+
+  describe "#to_json" do
+    it "formats the Time object to iso8601" do
+      expect(subscriber_list.to_json).to include(
+        %{"created_at":"#{formatted_time}"}
+      )
+    end
+  end
+end


### PR DESCRIPTION
- Normalised hash keys throughout to strings.
- Timestamp generated by the application from an injected clock object.
- Subscriber list becomes a Struct with some knowledge of serialisation.
