### PR TITLE
Missing Application class dependency in production

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -6,6 +6,7 @@ APP = Application.new(
   config: CONFIG,
   gov_delivery_client: GovDeliveryClient.create_client(CONFIG.fetch(:gov_delivery)),
   storage_adapter: PostgresAdapter.new(config: CONFIG.fetch(:postgres)),
+  uuid_generator: ->() { SecureRandom.uuid },
 )
 
 run HTTPAPI


### PR DESCRIPTION
Perhaps we could run the `startup.sh` as part of the test suite?
