### PR TITLE
Allow db acess on the VM without password

### DIFF
--- a/config/postgres.yml
+++ b/config/postgres.yml
@@ -1,6 +1,6 @@
 postgres:
-  host: localhost
-  user: email_alert_api_user
+  host:
+  user:
   database: email_alert_api_test
   password:
   migrations_dir: persistence/postgres/migrations


### PR DESCRIPTION
On the VM when providing a host we cannot hit the database without a password. In order to bypass this, let's not use a host
