### PR TITLE
Add middleware to handle JSON requests

### DIFF
--- a/http/http_api.rb
+++ b/http/http_api.rb
@@ -2,6 +2,7 @@ require "sinatra"
 require "airbrake"
 require "config/initializers/airbrake"
 require "sinatra_adapter"
+require "middleware/post_body_content_type_parser"
 
 # TODO: Disable ShowExceptions in a less gross way, do we care about development mode?
 Sinatra::ShowExceptions.class_eval do
@@ -18,6 +19,8 @@ class HTTPAPI < Sinatra::Application
   configure do
     Airbrake.configuration.ignore << "Sinatra::NotFound"
     use Airbrake::Sinatra
+
+    use Rack::PostBodyContentTypeParser
   end
 
   post "/subscriber_lists" do

--- a/middleware/post_body_content_type_parser.rb
+++ b/middleware/post_body_content_type_parser.rb
@@ -1,0 +1,33 @@
+# Taken from rack-contrib here:
+# https://github.com/rack/rack-contrib/blob/281be2899d3d9bdb159e6bf6b9179d2d89354aaa/lib/rack/contrib/post_body_content_type_parser.rb
+#
+# TODO: Delete this code once above commit is released for rack-contrib
+# Current released version of rack-contrib (v1.1.0) does not take into account
+# an empty String as content body.
+
+require 'json'
+
+module Rack
+  class PostBodyContentTypeParser
+
+    CONTENT_TYPE = 'CONTENT_TYPE'.freeze
+    POST_BODY = 'rack.input'.freeze
+    FORM_INPUT = 'rack.request.form_input'.freeze
+    FORM_HASH = 'rack.request.form_hash'.freeze
+
+    APPLICATION_JSON = 'application/json'.freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      if Rack::Request.new(env).media_type == APPLICATION_JSON && (body = env[POST_BODY].read).length != 0
+        env[POST_BODY].rewind
+        env.update(FORM_HASH => JSON.parse(body), FORM_INPUT => env[POST_BODY])
+      end
+      @app.call(env)
+    end
+
+  end
+end


### PR DESCRIPTION
In order for sinatra to handle JSON requests properly by adding the body to the params, we must use some middleware to parse JSON type requests. This middleware is taken from the rack-contrib gem and should be replaced by the gem in the future. Currently the latest stable release does not contain this code and this is taken directly from master.
