### PR TITLE
Use the same port as bowl uses to start the app

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec rackup
+bundle exec rackup -p 3088


### PR DESCRIPTION
We should use the same port in our startup script to start the app as bowl uses, for consistency
