### PR TITLE
Symmetrize persistence mapper

### DIFF
--- a/repositories/subscriber_list_repository.rb
+++ b/repositories/subscriber_list_repository.rb
@@ -22,7 +22,7 @@ class SubscriberListRepository
   # TODO: find_by_exact_tags?
   def find_by_tags(tags)
     adapter
-      .find_by(namespace, :tags, tags)
+      .find_by(namespace, :tags, mapper.dump_hash_values(tags))
       .map(&method(:load))
   end
 
@@ -50,34 +50,43 @@ private
     end
 
     def dump(subscriber_list)
+      serialized_tags = dump_hash_values(subscriber_list.tags)
+
       subscriber_list
         .to_h
         .merge(
+          tags: serialized_tags,
           created_at: subscriber_list.created_at.utc,
         )
     end
 
     def load(persisted_data)
-      deserialized_tags = json_load_hash_values(persisted_data.fetch(:tags))
+      deserialized_tags = load_hash_values(persisted_data.fetch(:tags))
       created_at = persisted_data.fetch(:created_at).utc
 
       loaded_data = persisted_data
         .merge(
-          created_at: created_at,
           tags: deserialized_tags,
+          created_at: created_at,
         )
 
       factory.call(loaded_data)
     end
 
-  private
+    def dump_hash_values(hash)
+      hash.reduce({}) { |result, (k, v)|
+        result.merge(k => JSON.dump(v))
+      }
+    end
 
-    attr_reader :factory
-
-    def json_load_hash_values(hash)
+    def load_hash_values(hash)
       hash.reduce({}) { |result, (k, v)|
         result.merge(k => JSON.load(v))
       }
     end
+
+  private
+
+    attr_reader :factory
   end
 end


### PR DESCRIPTION
This has actually added some redundant code but eliminates a potential time
bomb by removing dependency on the implicit magic of Sequel HStore serializing
non string hash values.
