### PR TITLE
Fix db:setup rake task

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -18,8 +18,8 @@ namespace :db do
     # Hardcoded for now to test if this works.
     config = CONFIG.fetch(:postgres)
     database_name = config[:database]
-    system("sudo -u postgres psql -d template1 -c 'DROP DATABASE #{database_name}'")
-    system("sudo -u postgres psql -d template1 -c 'CREATE DATABASE #{database_name}'")
-    system("sudo -u postgres psql -d #{database_name} -c 'CREATE EXTENSION IF NOT EXISTS hstore'")
+    system("psql -d postgres -c 'DROP DATABASE #{database_name}'")
+    system("psql -d postgres -c 'CREATE DATABASE #{database_name}'")
+    system("psql -d #{database_name} -c 'CREATE EXTENSION IF NOT EXISTS hstore'")
   end
 end


### PR DESCRIPTION
Connect to the `postgres` database instead of the `template1` database to drop and create other databases. `template1` isn't really safe to connect to, and if another user is connected to that database then the command will fail.

Also stop doing this as the `postgres` user -- the default user on CI is `jenkins`, and there's a Postgres user available for it.
