### PR TITLE
Do not use the actual email address in development

### DIFF
--- a/config/gov_delivery.yml
+++ b/config/gov_delivery.yml
@@ -1,5 +1,5 @@
 gov_delivery:
-  username: gov-delivery+staging@digital.cabinet-office.gov.uk
+  username: govdelivery@example.com
   password: nottherealpassword
   account_code: UKGOVUK
   protocol: https


### PR DESCRIPTION
Using the actual e-mail address used to login to govdelivery staging combined with a bad password can cause developers booting the e-mail alert API up on VM's/their local machines to lock the staging account on govdeliveries side.
