### PR TITLE
Log count of subscriber lists emails are sent to

### DIFF
--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -8,10 +8,14 @@ class NotificationWorker
 
     lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: notification[:tags])
 
+    Rails.logger.info "Passing email '#{notification[:subject]}' to #{lists.count} lists in GovDelivery"
+
     EmailAlertAPI.services(:gov_delivery).send_bulletin(
       lists.map(&:gov_delivery_id),
       notification[:subject],
       notification[:body]
     )
+
+    Rails.logger.info "Email '#{notification[:subject]}' sent"
   end
 end


### PR DESCRIPTION
Without this logging, it's hard to tell whether the service has been
sending anything to GovDelivery.
