### PR TITLE
Log the list of delivery ids an email is sent to

### DIFF
--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -8,7 +8,7 @@ class NotificationWorker
 
     lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: notification[:tags])
 
-    Rails.logger.info "Passing email '#{notification[:subject]}' to #{lists.count} lists in GovDelivery"
+    Rails.logger.info "Passing email '#{notification[:subject]}' to #{lists.count} lists in GovDelivery [#{lists.map(&:gov_delivery_id).join(', ')}]"
 
     EmailAlertAPI.services(:gov_delivery).send_bulletin(
       lists.map(&:gov_delivery_id),


### PR DESCRIPTION
I can't see the emails the api claims to have sent in the govdelivery admin; hopefully if we log the delivery ids I'll have more chance of finding them.
