### PR TITLE
Make it explicit that secrets are overwritten

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,3 +1,5 @@
+## : This file is overwritten on deploy.
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.
@@ -15,8 +17,3 @@ development:
 
 test:
   secret_key_base: 8bcfe54ee0999f12fc3a57eb369fc010788e3e4335ea8a7d85dea34859265260b9bfdce6bc92296c2e8d4af1ca534276759b14de510de9347b67b0b1c8532bee
-
-# Do not keep production secrets in the repository,
-# instead read values from the environment.
-production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
We overwrite this file when it's deployed to production, so we should make it more explicit in the code.
