### PR TITLE
Validate tags are all arrays

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -1,6 +1,8 @@
 require "gov_delivery/client"
 
 class SubscriberListsController < ApplicationController
+  before_filter :validate_request, only: :create
+
   def show
     subscriber_list = SubscriberList.where_tags_equal(params[:tags]).first
 
@@ -36,5 +38,13 @@ private
       gov_delivery_id: response.to_param,
       tags: params[:tags]
     )
+  end
+
+  def validate_request
+    params[:tags].each do |key, value|
+      unless value.is_a?(Array)
+        render json: {message: "All tag values must be sent as Arrays"}, status: 422
+      end
+    end
   end
 end

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe "Creating a subscriber list", type: :request do
     )
   end
 
+  it "returns an error if tag isn't an array" do
+    create_subscriber_list(topic: "oil-and-gas/licensing")
+
+    expect(response.status).to eq(422)
+  end
+
   def create_subscriber_list(tags)
     post "/subscriber-lists", {
       title: "This is a sample title",


### PR DESCRIPTION
Previously, if you sent a tag that had a value that was not an array
(e.g. a string), then you’d get a hard to debug error caused by
JSON.parse failing.

This adds a simple validation of the params on the controller.
