### PR TITLE
Put the error code from govdelivery in errors

### DIFF
--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -83,7 +83,7 @@ module GovDelivery
                     else UnknownError
                     end
 
-      raise error_class.new, parsed_response.error
+      raise error_class.new, "#{parsed_response.code}: #{parsed_response.error}"
     end
   end
 end


### PR DESCRIPTION
Quite a few of the potential GovDelivery errors are documented as having
the same descriptive string, but different error codes.  Therefore,
let's put the error code into our exception messages, so we'll be able
to distinguish these.
