### PR TITLE
Add a JSON healthcheck to email-alert-api

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,24 @@
+require 'sidekiq/api'
+
+class HealthcheckController < ActionController::Base
+  def check
+    render json: {
+      checks: {
+        queue_size: queue_size,
+        queue_age:  queue_age
+      },
+      status: 'ok' #FIXME: probably need to pin this on DB connectivity and
+                   #Redis connectivity
+    }
+  end
+
+private
+
+  def queue_size
+    Sidekiq::Queue.new('default').size
+  end
+
+  def queue_age
+    Sidekiq::Queue.new('default').latency
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   get "/subscriber-lists", to: "subscriber_lists#show"
 
   resources :notifications, only: [:create]
+
+  get "/healthcheck", to: "healthcheck#check"
 end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe HealthcheckController, type: :controller do
+  describe "#check" do
+    it "responds with JSON" do
+      get :check
+
+      expect(response.status).to eq(200)
+      expect(response.content_type).to eq('application/json')
+
+      data = JSON.parse(response.body)
+    end
+
+    it "responds with 'ok'" do
+      get :check
+
+      data = JSON.parse(response.body)
+      expect(data['status']).to eq('ok')
+    end
+
+    it "includes queue length in the response" do
+      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(13)
+      get :check
+
+      data = JSON.parse(response.body)
+      expect(data['checks']['queue_size']).to eq(13)
+    end
+
+    it "includes queue age in the response" do
+      allow_any_instance_of(HealthcheckController).to receive(:queue_age).and_return(3600.5)
+      get :check
+
+      data = JSON.parse(response.body)
+      expect(data['checks']['queue_age']).to eq(3600.5)
+    end
+  end
+end


### PR DESCRIPTION
This healthcheck includes a few things:
- an `ok` message, which tells us that the app is responding
- a nested hash called `checks`, which contains:
  - `queue_size`: this is the length of the unprocessed Sidekiq queue,
    which can be graphed to indicate that our API is backed up
  - `queue_age`: a delta in seconds of the age of the oldest item in the
    Sidekiq queue, which can be used to indicate that there's a problem
    processing messages

Both of the metrics represented here are intended to be monitored using Nagios.
