### PR TITLE
Slightly more descriptive logging on notification worker

### DIFF
--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -8,7 +8,12 @@ class NotificationWorker
 
     lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: notification[:tags])
 
-    Rails.logger.info "Passing email '#{notification[:subject]}' to #{lists.count} lists in GovDelivery [#{lists.map(&:gov_delivery_id).join(', ')}]"
+    Rails.logger.info "--- Sending email to GovDelivery ---"
+    Rails.logger.info "subject: '#{notification[:subject]}'"
+    Rails.logger.info "tags: '#{notification[:tags]}'"
+    Rails.logger.info "matched #{lists.count} lists in GovDelivery: [#{lists.map(&:gov_delivery_id).join(', ')}]"
+    Rails.logger.info "notification_json: #{notification_json}"
+    Rails.logger.info "--- End email to GovDelivery ---"
 
     EmailAlertAPI.services(:gov_delivery).send_bulletin(
       lists.map(&:gov_delivery_id),


### PR DESCRIPTION
I was struggling to debug why emails weren't working on preview. Ideally, we should be logging this centrally, probably on kibana, but this is a temporary fix.
