### PR TITLE
Store GovDelivery credentials as environment variables.

### DIFF
--- a/config/gov_delivery.yml.erb
+++ b/config/gov_delivery.yml.erb
@@ -1,6 +1,6 @@
 development:
-  username: govdelivery@example.com
-  password: nottherealpassword
+  username: <%= ENV['GOV_DELIVERY_USERNAME'] || "email@example.com" %>
+  password: <%= ENV['GOV_DELIVERY_PASSWORD'] || "nottherealpassword" %>
   account_code: UKGOVUK
   protocol: https
   hostname: stage-api.govdelivery.com

--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -11,7 +11,11 @@ module EmailAlertAPI
     end
 
     def gov_delivery
-      all_configs = YAML.load(File.open(app_root+"config/gov_delivery.yml"))
+      all_configs = YAML.load(
+        ERB.new(
+          File.read(app_root+"config/gov_delivery.yml.erb")
+        ).result
+      )
       environment_config = all_configs.fetch(@environment)
 
       @gov_delivery ||= environment_config.symbolize_keys.freeze


### PR DESCRIPTION
When we want to make email alert API work in development, we need to provide a "real" username and password. We don't, however, want to run the risk of committing these details.

If we store them as environment variables, we'll never commit them.
