### PR TITLE
Use username and password from environment variables if present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Run `./startup.sh`.
 
 GovDelivery client code is stored in `app/services/gov_delivery`.
 
+To connect to the real GovDelivery, provide the credentials as environment
+variables, i.e.:
+
+`GOVDELIVERY_USERNAME=govdelivery@example.com GOVDELIVERY_PASSWORD=nottherealpassword rails s`
+
+or export them using dotenv or similar.
+
 ## Available endpoints
 
 * `GET /subscriber-lists?tags[organisation]=cabinet-office` - gets a stored

--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -11,14 +11,27 @@ module EmailAlertAPI
     end
 
     def gov_delivery
-      all_configs = YAML.load(File.open(app_root+"config/gov_delivery.yml"))
-      environment_config = all_configs.fetch(@environment)
-
       @gov_delivery ||= environment_config.symbolize_keys.freeze
     end
 
     def redis_config
       YAML.load(File.open(app_root+"config/redis.yml")).symbolize_keys
+    end
+
+  private
+    def environment_config
+      all_configs = YAML.load(File.open(app_root+"config/gov_delivery.yml"))
+
+      all_configs.fetch(@environment).tap do |env_config|
+        env_config.merge!(environment_credentials) if ENV["GOVDELIVERY_USERNAME"]
+      end
+    end
+
+    def environment_credentials
+      {
+        "username" => ENV["GOVDELIVERY_USERNAME"],
+        "password" => ENV["GOVDELIVERY_PASSWORD"],
+      }
     end
   end
 end


### PR DESCRIPTION
Otherwise, use those from the yml file. This allows overriding with real govdelivery credentials without the risk of committing them.

Update README to explain the env vars used.
