### PR TITLE
Add statsd monitoring of request time and response code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'airbrake', '4.1.0'
 gem 'unicorn', '4.8.3'
 gem 'capistrano-rails', group: :development
 gem 'logstasher', '0.4.8'
+gem 'statsd-ruby', '1.2.1'
 
 group :test do
   gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
       colorize
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    statsd-ruby (1.2.1)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -192,5 +193,6 @@ DEPENDENCIES
   rails (= 4.1.6)
   rspec-rails (= 3.1.0)
   sidekiq (= 3.2.6)
+  statsd-ruby (= 1.2.1)
   unicorn (= 4.8.3)
   webmock

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module EmailAlertAPI
   end
 
   cattr_accessor :config
+  cattr_accessor :statsd
 end
 
 require_relative "../lib/email_alert_api/config"

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,0 +1,10 @@
+require "statsd"
+
+# Statsd "the process" listens on a port on the provided host for UDP
+# messages. Given that it's UDP, it's fire-and-forget and will not
+# block your application. You do not need to have a statsd process
+# running locally on your development environment.
+statsd_client = Statsd.new("localhost")
+statsd_client.namespace = "govuk.app.email-alert-api"
+
+EmailAlertAPI.statsd = statsd_client


### PR DESCRIPTION
- Use timing to provide metrics of requests to govdelivery
- Increment a counter for each type of response we receive

This should allow us to alert on the values of these things.

[trello ticket](https://trello.com/c/AUjc9REM/405-add-statsd-counts-for-govdelivery-interaction-3)
