### PR TITLE
Don't send bulletins if no topics match

### DIFF
--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -7,20 +7,22 @@ class NotificationWorker
     notification = JSON.parse(notification_json).with_indifferent_access
 
     lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: notification[:tags])
+    if lists.any?
+      Rails.logger.info "--- Sending email to GovDelivery ---"
+      Rails.logger.info "subject: '#{notification[:subject]}'"
+      Rails.logger.info "tags: '#{notification[:tags]}'"
+      Rails.logger.info "matched #{lists.count} lists in GovDelivery: [#{lists.map(&:gov_delivery_id).join(', ')}]"
+      Rails.logger.info "notification_json: #{notification_json}"
+      Rails.logger.info "--- End email to GovDelivery ---"
 
-    Rails.logger.info "--- Sending email to GovDelivery ---"
-    Rails.logger.info "subject: '#{notification[:subject]}'"
-    Rails.logger.info "tags: '#{notification[:tags]}'"
-    Rails.logger.info "matched #{lists.count} lists in GovDelivery: [#{lists.map(&:gov_delivery_id).join(', ')}]"
-    Rails.logger.info "notification_json: #{notification_json}"
-    Rails.logger.info "--- End email to GovDelivery ---"
-
-    EmailAlertAPI.services(:gov_delivery).send_bulletin(
-      lists.map(&:gov_delivery_id),
-      notification[:subject],
-      notification[:body]
-    )
-
-    Rails.logger.info "Email '#{notification[:subject]}' sent"
+      EmailAlertAPI.services(:gov_delivery).send_bulletin(
+        lists.map(&:gov_delivery_id),
+        notification[:subject],
+        notification[:body]
+      )
+      Rails.logger.info "Email '#{notification[:subject]}' sent"
+    else
+      Rails.logger.info "No matching lists in GovDelivery, not sending email. subject: '#{notification[:subject]}', tags: '#{notification[:tags]}'"
+    end
   end
 end

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe "Sending a notification", type: :request do
       )
   end
 
+  it "doesn't send notifications for if there's no lists" do
+    send_notification(
+      topics: ["oil-and-gas/licensing"],
+      organisations: ["environment-agency", "hm-revenue-customs"]
+    )
+
+    NotificationWorker.drain
+
+    expect(@gov_delivery).not_to have_received(:send_bulletin)
+  end
+
   def create_many_lists
     all_match = FactoryGirl.create(:subscriber_list, tags: {
       topics: ["oil-and-gas/licensing"],


### PR DESCRIPTION
If we try and send bulletins via govdelivery with an empty list of
topics, we get an error returned:

```
GD-12004: To send a bulletin you must select at least one topic or category that has subscribers
```

We'd like not to get that, so don't try sending the bulletin if there are
no matching topics.  Instead, add a log entry indicating that we didn't
try to send the bulletin.

Story: https://www.pivotaltracker.com/story/show/83203610
