### PR TITLE
Implement Nagios-compatible healtcheck

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -4,8 +4,12 @@ class HealthcheckController < ActionController::Base
   def check
     render json: {
       checks: {
-        queue_size: queue_size,
-        queue_age:  queue_age
+        queue_size: {
+          status: queue_size_status
+        },
+        queue_age:  {
+          status: queue_age_status
+        }
       },
       status: 'ok' #FIXME: probably need to pin this on DB connectivity and
                    #Redis connectivity
@@ -13,6 +17,30 @@ class HealthcheckController < ActionController::Base
   end
 
 private
+
+  def queue_size_status
+    queue_size_count = queue_size
+    case
+    when queue_size_count < 2
+      'ok'
+    when queue_size_count < 5
+      'warning'
+    else
+      'critical'
+    end
+  end
+
+  def queue_age_status
+    queue_age_seconds = queue_age
+    case
+    when queue_age_seconds <= 30
+      'ok'
+    when queue_age_seconds <= 60
+      'warning'
+    else
+      'critical'
+    end
+  end
 
   def queue_size
     Sidekiq::Queue.new('default').size

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -18,20 +18,47 @@ RSpec.describe HealthcheckController, type: :controller do
       expect(data['status']).to eq('ok')
     end
 
-    it "includes queue length in the response" do
+    it "includes queue length check in the response" do
       allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(13)
       get :check
 
       data = JSON.parse(response.body)
-      expect(data['checks']['queue_size']).to eq(13)
+      expect(data['checks']).to include('queue_size')
     end
 
-    it "includes queue age in the response" do
+    it "returns ok for small queue sizes" do
+      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(1)
+
+      get :check
+
+      data = JSON.parse(response.body)
+      expect(data['checks']['queue_size']['status']).to eq('ok')
+    end
+
+    it "returns warning for medium queue sizes" do
+      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(4)
+
+      get :check
+
+      data = JSON.parse(response.body)
+      expect(data['checks']['queue_size']['status']).to eq('warning')
+    end
+
+    it "returns critical for large queue sizes" do
+      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(10)
+
+      get :check
+
+      data = JSON.parse(response.body)
+      expect(data['checks']['queue_size']['status']).to eq('critical')
+    end
+
+    it "includes queue age check in the response" do
       allow_any_instance_of(HealthcheckController).to receive(:queue_age).and_return(3600.5)
       get :check
 
       data = JSON.parse(response.body)
-      expect(data['checks']['queue_age']).to eq(3600.5)
+      expect(data['checks']).to include('queue_age')
     end
   end
 end


### PR DESCRIPTION
The healthcheck this replaces didn't return a suitable format for Nagios - the correct format is:

```
{
    "status": "ok",
    "checks": {
        "sufficient_devops": {
            "status": "ok"
        },
        "whizzbangs_recently_frobnicated": {
            "status": "ok"
        }
    }
}
```

which means we need to determine what is `ok`, `warning` etc. within the code.

**Note**: the numbers here are guesses - we should tweak them based on real data from production.
