### PR TITLE
Rake task to update subscriber list tags

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -14,6 +14,14 @@ class SubscriberList < ActiveRecord::Base
     end
   end
 
+  def self.with_at_least_one_topic_value(value)
+    lists_with_key(:topics).each_with_object([]) do |subscription_list, results|
+      if subscription_list.tags[:topics].include?(value)
+        results << subscription_list
+      end
+    end
+  end
+
   def self.where_tags_equal(tags)
     lists_with_all_matching_keys(tags).select do |list|
       list.tags.all? do |tag_type, tag_array|
@@ -73,5 +81,11 @@ private
     # This uses the `?&` hstore operator, which returns true only if the hstore
     # contains all the specified keys.
     where("tags ?& Array[:tag_keys]", tag_keys: tags.keys)
+  end
+
+  def self.lists_with_key(key)
+    # This uses the `?` hstore operator, which returns true only if the hstore
+    # contains the specified key.
+    where("tags ? :key", key: key)
   end
 end

--- a/lib/data_hygiene/tag_changer.rb
+++ b/lib/data_hygiene/tag_changer.rb
@@ -1,0 +1,38 @@
+class DataHygiene::TagChanger
+  def initialize(from_topic_tag:, to_topic_tag:)
+    @from_topic_tag = from_topic_tag
+    @to_topic_tag = to_topic_tag
+  end
+
+  def update_records_tags
+    commit_update unless to_topic_tag.blank?
+  end
+
+private
+
+  attr_reader :from_topic_tag, :to_topic_tag
+
+  def subscriber_records_with_tags
+    SubscriberList.with_at_least_one_topic_value(from_topic_tag)
+  end
+
+  def commit_update
+    subscriber_records_with_tags.each do |record|
+      log "Duplicating SubscriberList id: #{record.id} replacing #{from_topic_tag} with #{to_topic_tag}"
+
+      new_record = record.dup
+      topics = JSON.parse(record[:tags]["topics"])
+
+      topics.map! do |topic|
+        topic == from_topic_tag ? to_topic_tag : topic
+      end
+
+      new_record[:tags]["topics"] = topics.to_json
+      new_record.save
+    end
+  end
+
+  def log(message)
+    puts message
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,0 +1,19 @@
+desc "Create duplicate record for new tags"
+task duplicate_record_for_tag: :environment do
+  require "data_hygiene/tag_changer"
+
+  from_topic_tag = ENV['FROM_TOPIC_TAG']
+  to_topic_tag = ENV['TO_TOPIC_TAG']
+
+  if from_topic_tag.blank?
+    $stderr.puts "A from_topic_tag must be supplied"
+    exit 1
+  elsif to_topic_tag.blank?
+    $stderr.puts "A to_topic_tag must be supplied"
+    exit 1
+  end
+
+  puts 'STARTING'
+  DataHygiene::TagChanger.new(from_topic_tag: from_topic_tag, to_topic_tag: to_topic_tag).update_records_tags
+  puts 'FINISHED'
+end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -1,6 +1,28 @@
 require "rails_helper"
 
 RSpec.describe SubscriberList, type: :model do
+
+  describe "scopes" do
+
+    before do
+      @list1 = FactoryGirl.create(:subscriber_list, tags: {
+        format: ["raib_report"],
+      })
+      @list2 = FactoryGirl.create(:subscriber_list, tags: {
+        topics: ["environmental-management/boating"],
+      })
+      @list3 = FactoryGirl.create(:subscriber_list, tags: {
+        topics: ["environmental-management/boating", "environmental-management/sailing" , "environmental-management/swimming"],
+      })
+    end
+
+    describe ".with_at_least_one_topic_value" do
+      it "finds lists where at least one value is in the topic tags" do
+        expect(SubscriberList.with_at_least_one_topic_value('environmental-management/boating')).to eq [@list2, @list3]
+      end
+    end
+  end
+
   describe ".find_with_at_least_one_tag_of_each_type" do
     before do
       @list1 = FactoryGirl.create(:subscriber_list, tags: {

--- a/spec/unit/data_hygiene/tag_changer_spec.rb
+++ b/spec/unit/data_hygiene/tag_changer_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe DataHygiene::TagChanger, "#update_records_tags" do
+
+  it "creates a new record with an updated topic tag" do
+    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+      topics: ["environmental-management/boating"],
+    })
+    tag_changer = DataHygiene::TagChanger.new(
+      from_topic_tag: "environmental-management/boating",
+      to_topic_tag: "environmental-management/speed-boating"
+    )
+    stub_logging(tag_changer)
+    expect { tag_changer.update_records_tags }.to change(SubscriberList, :count).by(1)
+    expect(tag_changer.logs).to eq [
+      "Duplicating SubscriberList id: #{SubscriberList.first.id} replacing environmental-management/boating with environmental-management/speed-boating"
+    ]
+    expect(SubscriberList.last.gov_delivery_id).to eq subscriber_list.gov_delivery_id
+    expect(SubscriberList.last.tags[:topics]).to eq ["environmental-management/speed-boating"]
+  end
+
+  it "does not create a new record for an empty to_topic_tag" do
+    tag_changer = DataHygiene::TagChanger.new(
+      from_topic_tag: "environmental-management/boating",
+      to_topic_tag: ""
+    )
+
+    expect { tag_changer.update_records_tags }.not_to change(SubscriberList, :count)
+  end
+
+  it "preserves additional tags" do
+    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+      topics: ["environmental-management/agency"],
+      organisations: ["Environment Agency"]
+    })
+    tag_changer = DataHygiene::TagChanger.new(
+      from_topic_tag: "environmental-management/agency",
+      to_topic_tag: "environmental-management/speed-boating"
+    )
+    stub_logging(tag_changer)
+
+    expect { tag_changer.update_records_tags }.to change(SubscriberList, :count).by(1)
+    expect(tag_changer.logs).to eq [
+      "Duplicating SubscriberList id: #{SubscriberList.first.id} replacing environmental-management/agency with environmental-management/speed-boating"
+    ]
+    expect(SubscriberList.last.gov_delivery_id).to eq subscriber_list.gov_delivery_id
+    expect(SubscriberList.last.tags[:topics]).to eq ["environmental-management/speed-boating"]
+    expect(SubscriberList.last.tags[:organisations]).to eq subscriber_list.tags[:organisations]
+  end
+
+  it "preserves additional topics" do
+    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+      topics: ["environmental-management/agency", "environmental-management/littering"],
+      organisations: ["Environment Agency"]
+    })
+    subscriber_list2 = FactoryGirl.create(:subscriber_list, tags: {
+      topics: ["environmental-management/123agency"],
+      organisations: ["Environment Agency"]
+    })
+    tag_changer = DataHygiene::TagChanger.new(
+      from_topic_tag: "environmental-management/agency",
+      to_topic_tag: "environmental-management/sewage"
+    )
+    stub_logging(tag_changer)
+
+    expect { tag_changer.update_records_tags }.to change(SubscriberList, :count).by(1)
+    expect(tag_changer.logs).to eq [
+      "Duplicating SubscriberList id: #{SubscriberList.first.id} replacing environmental-management/agency with environmental-management/sewage"
+    ]
+    expect(SubscriberList.last.gov_delivery_id).to eq subscriber_list.gov_delivery_id
+    expect(SubscriberList.last.tags[:topics]).to eq ["environmental-management/sewage", "environmental-management/littering"]
+    expect(SubscriberList.last.tags[:organisations]).to eq subscriber_list.tags[:organisations]
+  end
+
+  # Replace the `log` method on a TopicTagger with one that appends the logged
+  # messages to an array.  Return the array.
+  def stub_logging(tag_changer)
+    def tag_changer.log(message)
+      @logs ||= []
+      @logs << message
+    end
+    def tag_changer.logs
+      @logs
+    end
+  end
+end


### PR DESCRIPTION
When a topic changes, we should update the Subscribers List in Email
Alert API to keep subscribers updated.
This should be done by creating a new entry for the updated topic with
the same govdelivery identifier.

https://www.pivotaltracker.com/story/show/83840958
