### PR TITLE
Don't attempt to fetch topic by name

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -27,11 +27,7 @@ private
   def create_or_fetch_subscriber_list
     gov_delivery = EmailAlertAPI.services(:gov_delivery)
 
-    begin
-      response = gov_delivery.create_topic(params[:title])
-    rescue GovDelivery::Client::TopicAlreadyExistsError
-      response = gov_delivery.read_topic_by_name(params[:title])
-    end
+    response = gov_delivery.create_topic(params[:title])
 
     SubscriberList.new(
       title: params[:title],


### PR DESCRIPTION
Currently on staging, gov_delivery.read_topic_by_name takes 40 seconds
to return. This means that if a topic exists on govdelivery, but isn’t
in the email-alert-api database, then we attempt to fetch it, but that
will always result in an ambiguous timeout.

Until we can fix this, I think it is better to return an explicit
TopicAlreadyExistsError.
