### PR TITLE
Allow optional defaults when sending email alerts

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -8,6 +8,6 @@ class NotificationsController < ApplicationController
 private
 
   def notification_params
-    params.slice(:subject, :body, :tags)
+    params.slice(:subject, :body, :tags, :from_address_id, :urgent, :header, :footer)
   end
 end

--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -29,14 +29,14 @@ module GovDelivery
       )
     end
 
-    def send_bulletin(topic_ids, subject, body)
+    def send_bulletin(topic_ids, subject, body, options = {})
       # GovDelivery documentation for this endpoint:
       # http://knowledge.govdelivery.com/display/API/Create+and+Send+Bulletin
       parse_topic_response(
         EmailAlertAPI.statsd.time('bulletin.send') do
           post_xml(
             "bulletins/send_now.xml",
-            RequestBuilder.send_bulletin_xml(topic_ids, subject, body),
+            RequestBuilder.send_bulletin_xml(topic_ids, subject, body, options),
           )
         end
       )

--- a/app/services/gov_delivery/request_builder.rb
+++ b/app/services/gov_delivery/request_builder.rb
@@ -14,7 +14,7 @@ module GovDelivery
       }.to_xml
     end
 
-    def self.send_bulletin_xml(topic_ids, subject, body)
+    def self.send_bulletin_xml(topic_ids, subject, body, options = {})
       Nokogiri::XML::Builder.new { |xml|
         xml.bulletin {
           xml.subject subject
@@ -28,6 +28,14 @@ module GovDelivery
               }
             }
           }
+          xml.from_address_id(options[:from_address_id]) if options[:from_address_id]
+          xml.urgent(options[:urgent]) if options[:urgent]
+          xml.header {
+            xml.cdata options[:header]
+          } if options[:header]
+          xml.footer {
+            xml.cdata options[:footer]
+          } if options[:footer]
         }
       }.to_xml
     end

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -15,10 +15,13 @@ class NotificationWorker
       Rails.logger.info "notification_json: #{notification_json}"
       Rails.logger.info "--- End email to GovDelivery ---"
 
+      options = notification.slice(:from_address_id, :urgent, :header, :footer)
+
       EmailAlertAPI.services(:gov_delivery).send_bulletin(
         lists.map(&:gov_delivery_id),
         notification[:subject],
-        notification[:body]
+        notification[:body],
+        options
       )
       Rails.logger.info "Email '#{notification[:subject]}' sent"
     else

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -171,6 +171,43 @@ RSpec.describe GovDelivery::Client do
       end
     end
 
+    it "POSTs the bulletin with extra parameters if present to the send_now endpoint" do
+      stub_request(:post, @base_url).to_return(body: @govdelivery_response)
+
+      client.send_bulletin(topic_ids, subject, body, {
+        from_address_id: 12345,
+        urgent: true,
+        header: "<h1>Foo</h1>",
+        footer: "<p>bar</p>"
+      })
+
+      assert_requested(:post, @base_url) do |req|
+        expect(req.body).to be_equivalent_to(
+          %{
+            <bulletin>
+              <subject>a subject line</subject>
+              <body><![CDATA[a body]]></body>
+              <topics type="array">
+                <topic>
+                  <code>UKGOVUK_123</code>
+                </topic>
+                <topic>
+                  <code>UKGOVUK_124</code>
+                </topic>
+                <topic>
+                  <code>UKGOVUK_125</code>
+                </topic>
+              </topics>
+              <from_address_id>12345</from_address_id>
+              <urgent>true</urgent>
+              <header><![CDATA[<h1>Foo</h1>]]></header>
+              <footer><![CDATA[<p>bar</p>]]></footer>
+            </bulletin>
+          }
+        )
+      end
+    end
+
     it "returns an object that encapsulates the parsed response" do
       stub_request(:post, @base_url).to_return(body: @govdelivery_response)
 


### PR DESCRIPTION
gov delivery now allows us to send header, footer, from_address_id and
urgent flags when sending email notifications in order to override defaults
set in their admin interface.

Trello Ticket: https://trello.com/c/M6XBkDUF/499-govdelivery-api-features-for-email-settings-3
