### PR TITLE
Force application to only respond to JSON

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,18 +2,22 @@ require 'sidekiq/api'
 
 class HealthcheckController < ActionController::Base
   def check
-    render json: {
-      checks: {
-        queue_size: {
-          status: queue_size_status
-        },
-        queue_age:  {
-          status: queue_age_status
+    respond_to do |format|
+      format.json {
+        render json: {
+          checks: {
+            queue_size: {
+              status: queue_size_status
+            },
+            queue_age:  {
+              status: queue_age_status
+            }
+          },
+          status: 'ok' #FIXME: probably need to pin this on DB connectivity and
+                       #Redis connectivity
         }
-      },
-      status: 'ok' #FIXME: probably need to pin this on DB connectivity and
-                   #Redis connectivity
-    }
+      }
+    end
   end
 
 private

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,9 @@ class NotificationsController < ApplicationController
   def create
     NotificationWorker.perform_async(notification_params.to_json)
 
-    render json: {message: "Notification queued for sending"}, status: 202
+    respond_to do |format|
+      format.json { render json: {message: "Notification queued for sending"}, status: 202 }
+    end
   end
 
 private

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -7,9 +7,13 @@ class SubscriberListsController < ApplicationController
     subscriber_list = SubscriberList.where_tags_equal(params[:tags]).first
 
     if subscriber_list
-      render json: subscriber_list.to_json
+      respond_to do |format|
+        format.json { render json: subscriber_list.to_json }
+      end
     else
-      render json: {message: "Could not find the subscriber list"}, status: 404
+      respond_to do |format|
+        format.json { render json: {message: "Could not find the subscriber list"}, status: 404 }
+      end
     end
   end
 
@@ -17,9 +21,13 @@ class SubscriberListsController < ApplicationController
     list = create_or_fetch_subscriber_list
 
     if list.save
-      render json: list.to_json, status: 201
+      respond_to do |format|
+        format.json { render json: list.to_json, status: 201 }
+      end
     else
-      render json: {message: "Couldn't create the subscriber list"}, status: 422
+      respond_to do |format|
+        format.json { render json: {message: "Couldn't create the subscriber list"}, status: 422 }
+      end
     end
   end
 

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe HealthcheckController, type: :controller do
   describe "#check" do
     it "responds with JSON" do
-      get :check
+      get :check, format: :json
 
       expect(response.status).to eq(200)
       expect(response.content_type).to eq('application/json')
@@ -12,7 +12,7 @@ RSpec.describe HealthcheckController, type: :controller do
     end
 
     it "responds with 'ok'" do
-      get :check
+      get :check, format: :json
 
       data = JSON.parse(response.body)
       expect(data['status']).to eq('ok')
@@ -20,7 +20,7 @@ RSpec.describe HealthcheckController, type: :controller do
 
     it "includes queue length check in the response" do
       allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(13)
-      get :check
+      get :check, format: :json
 
       data = JSON.parse(response.body)
       expect(data['checks']).to include('queue_size')
@@ -29,7 +29,7 @@ RSpec.describe HealthcheckController, type: :controller do
     it "returns ok for small queue sizes" do
       allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(1)
 
-      get :check
+      get :check, format: :json
 
       data = JSON.parse(response.body)
       expect(data['checks']['queue_size']['status']).to eq('ok')
@@ -38,7 +38,7 @@ RSpec.describe HealthcheckController, type: :controller do
     it "returns warning for medium queue sizes" do
       allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(4)
 
-      get :check
+      get :check, format: :json
 
       data = JSON.parse(response.body)
       expect(data['checks']['queue_size']['status']).to eq('warning')
@@ -47,7 +47,7 @@ RSpec.describe HealthcheckController, type: :controller do
     it "returns critical for large queue sizes" do
       allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(10)
 
-      get :check
+      get :check, format: :json
 
       data = JSON.parse(response.body)
       expect(data['checks']['queue_size']['status']).to eq('critical')
@@ -55,7 +55,7 @@ RSpec.describe HealthcheckController, type: :controller do
 
     it "includes queue age check in the response" do
       allow_any_instance_of(HealthcheckController).to receive(:queue_age).and_return(3600.5)
-      get :check
+      get :check, format: :json
 
       data = JSON.parse(response.body)
       expect(data['checks']).to include('queue_age')

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NotificationsController, type: :controller do
     it "serializes the tags and passes them to the NotificationWorker" do
       expect(NotificationWorker).to receive(:perform_async).with(notification_params.to_json)
 
-      post :create, notification_params
+      post :create, notification_params.merge(format: :json)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,4 +21,6 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  config.include JSONRequestHelpers, type: :request
 end

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -44,10 +44,12 @@ RSpec.describe "Creating a subscriber list", type: :request do
   end
 
   def create_subscriber_list(tags)
-    post "/subscriber-lists", {
+    request_body = JSON.dump({
       title: "This is a sample title",
       gov_delivery_id: "UKGOVUK_1234",
       tags: tags
-    }
+    })
+
+    post "/subscriber-lists", request_body, json_headers
   end
 end

--- a/spec/requests/get_subscriber_list_spec.rb
+++ b/spec/requests/get_subscriber_list_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe "Getting a subscriber list", type: :request do
   end
 
   def get_subscriber_list(tags)
-    get "/subscriber-lists", tags: tags
+    get "/subscriber-lists", { tags: tags }, json_headers
   end
 end

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -136,6 +136,6 @@ RSpec.describe "Sending a notification", type: :request do
       tags: tags,
     }.merge(options))
 
-    post "/notifications", request_body, "CONTENT_TYPE" => "application/json"
+    post "/notifications", request_body, json_headers
   end
 end

--- a/spec/support/helpers/json_request_helpers.rb
+++ b/spec/support/helpers/json_request_helpers.rb
@@ -1,0 +1,8 @@
+module JSONRequestHelpers
+  def json_headers
+    {
+      'CONTENT_TYPE' => "application/json",
+      'ACCEPT' => 'application/json'
+    }
+  end
+end


### PR DESCRIPTION
As with all other GOV.UK APIs we should only respond to JSON requests.
