### PR TITLE
Rescue Zero Subscriber Errors on bulletin send

### DIFF
--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -171,6 +171,32 @@ RSpec.describe GovDelivery::Client do
       end
     end
 
+    it "fails silently on zero subscriber error from govdelivery" do
+      @govdelivery_response = %{
+        <?xml version="1.0" encoding="UTF-8"?>
+        <errors>
+          <code>GD-12004</code>
+          <error>To send a bulletin you must select at least one topic or category that has subscribers</error>
+        </errors>
+      }
+      stub_request(:post, @base_url).to_return(body: @govdelivery_response)
+
+      expect { client.send_bulletin(topic_ids, subject, body) }.not_to raise_error
+    end
+
+    it "raises error on any other error from govdelivery" do
+      @govdelivery_response = %{
+        <?xml version="1.0" encoding="UTF-8"?>
+        <errors>
+          <code>GD-12004</code>
+          <error>Invalid bulletin</error>
+        </errors>
+      }
+      stub_request(:post, @base_url).to_return(body: @govdelivery_response)
+
+      expect { client.send_bulletin(topic_ids, subject, body) }.to raise_error
+    end
+
     it "POSTs the bulletin with extra parameters if present to the send_now endpoint" do
       stub_request(:post, @base_url).to_return(body: @govdelivery_response)
 


### PR DESCRIPTION
Bug: If a single user creates a topic, and then either fails to
complete the subscription process, or later unsubscribes, we will
continue to send emails to that topic. While that topic has zero
subscriptions, govdelivery will return an error message, which will
cause sidekiq to continually retry the bulletin send until success.
This means that the first user to then subscribe to that topic, will
soon receive all emails that we were trying to send during the time the
topic had zero subscribers.

This commit captures that specific error. It has to check both error
code and message, as that error code is used for other errors by
govdelivery.