### PR TITLE
Govdelivery logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'airbrake', '4.1.0'
 gem 'unicorn', '4.8.3'
 gem 'capistrano-rails', group: :development
 gem 'logstasher', '0.4.8'
+gem 'sidekiq-logging-json', '0.0.14'
 gem 'statsd-ruby', '1.2.1'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    sidekiq-logging-json (0.0.14)
+      sidekiq (~> 3)
     slop (3.6.0)
     sprockets (2.12.3)
       hike (~> 1.2)
@@ -195,6 +197,7 @@ DEPENDENCIES
   rails (= 4.1.7.1)
   rspec-rails (= 3.1.0)
   sidekiq (= 3.2.6)
+  sidekiq-logging-json (= 0.0.14)
   statsd-ruby (= 1.2.1)
   unicorn (= 4.8.3)
   webmock

--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -49,6 +49,21 @@ module GovDelivery
   private
     attr_reader :options
 
+    def logger
+      unless @logger
+        @logger = Logger.new(File.join(Rails.root, "log/govdelivery.log"))
+        @logger.formatter = proc do |severity, datetime, progname, msg|
+          {
+            "@fields.application" => "email-alert-api",
+            "@timestamp" => datetime.iso8601,
+            "@tags" => "govdelivery",
+            "@message" => msg
+          }.to_json + "\n"
+        end
+      end
+      @logger
+    end
+
     def base_url
       "#{options.fetch(:protocol)}://#{options.fetch(:hostname)}/api/account/#{options.fetch(:account_code)}"
     end
@@ -65,6 +80,7 @@ module GovDelivery
     end
 
     def post_xml(path, body)
+      logger.info("XML sent to GovDelivery: #{body}")
       http_client.post(
         path,
         body,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,3 +6,6 @@ end
 Sidekiq.configure_client do |config|
   config.redis = EmailAlertAPI.config.redis_config
 end
+
+require 'sidekiq/logging/json'
+Sidekiq.logger.formatter = Sidekiq::Logging::Json::Logger.new

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: true
 :concurrency:  2
-:logfile: ./log/sidekiq.log
+:logfile: ./log/sidekiq.json.log
 :queues:
   - default


### PR DESCRIPTION
Adds sidekiq logging, and seperate logfile for what we send to govdelivery.