### PR TITLE
Remove capistrano-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'plek', '1.9.0'
 gem 'airbrake', '4.1.0'
 
 gem 'unicorn', '4.8.3'
-gem 'capistrano-rails', group: :development
 gem 'logstasher', '0.4.8'
 gem 'sidekiq-logging-json', '0.0.14'
 gem 'statsd-ruby', '1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,22 +37,9 @@ GEM
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
       slop (~> 3.6)
-    capistrano (3.3.3)
-      capistrano-stats (~> 1.0.3)
-      i18n
-      rake (>= 10.0.0)
-      sshkit (~> 1.3)
-    capistrano-bundler (1.1.3)
-      capistrano (~> 3.1)
-      sshkit (~> 1.2)
-    capistrano-rails (1.1.2)
-      capistrano (~> 3.1)
-      capistrano-bundler (~> 1.1)
-    capistrano-stats (1.0.3)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     coderay (1.1.0)
-    colorize (0.7.3)
     columnize (0.8.9)
     connection_pool (2.1.0)
     crack (0.4.2)
@@ -90,9 +77,6 @@ GEM
     minitest (5.4.3)
     multi_json (1.10.1)
     multipart-post (2.0.0)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     pg (0.17.1)
@@ -159,10 +143,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sshkit (1.5.1)
-      colorize
-      net-scp (>= 1.1.2)
-      net-ssh (>= 2.8.0)
     statsd-ruby (1.2.1)
     thor (0.19.1)
     thread_safe (0.3.4)
@@ -184,7 +164,6 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.1.0)
   byebug
-  capistrano-rails
   equivalent-xml
   factory_girl_rails
   faraday (= 0.9.0)


### PR DESCRIPTION
I think this was added accidentally as our Ruby apps don't have any deployment
related code in them - we keep it in the alphagov-deployment repo.

It was added in 92d347b042449db8784997574b5fa2963ed3d361