### PR TITLE
Preserve the log directory in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp
-log
+/log/*
+!/log/.gitkeep


### PR DESCRIPTION
The sidekiq worker won't boot without the log directory existing:

    worker.1 | No such file or directory @ rb_sysopen - ./log/sidekiq.json.log

...so keep the directory in the repo.

This gitignore syntax means that it will ignore everything in the log
directory except the .gitkeep file, so the directory itself will be
kept.