### PR TITLE
Update migration to reflect new policy names

### DIFF
--- a/db/migrate/20150428072646_seed_policy_subscriptions_mapping.csv
+++ b/db/migrate/20150428072646_seed_policy_subscriptions_mapping.csv
@@ -16,7 +16,7 @@ reducing-the-impact-of-climate-change-in-developing-countries,climate-change-imp
 reducing-hunger-and-malnutrition-in-developing-countries,hunger-and-malnutrition-in-developing-countries
 increasing-the-effectiveness-of-uk-aid,overseas-aid-effectiveness
 making-sure-children-in-developing-countries-get-a-good-education,education-in-developing-countries
-giving-more-power-back-to-cities-through-city-deals,city-deal
+giving-more-power-back-to-cities-through-city-deals,city-deals-and-growth-deals
 reducing-drugs-misuse-and-dependence,drug-misuse-and-dependency
 treating-patients-and-service-users-with-respect-dignity-and-compassion,compassionate-care-in-the-nhs
 reducing-the-deficit-and-rebalancing-the-economy,deficit-reduction
@@ -220,6 +220,6 @@ promoting-human-rights-internationally,human-rights-internationally
 preventing-and-reducing-anti-competitive-activities,competition-law
 sustaining-a-thriving-maritime-sector,maritime-sector
 transforming-government-services-to-make-them-more-efficient-and-effective-for-users,central-government-efficiency
-making-companies-more-accountable-to-shareholders-and-the-public,corporate-accountability
+making-companies-more-accountable-to-shareholders-and-the-public,corporate-governance
 strengthening-uk-relationships-in-asia-latin-america-and-africa-to-support-uk-prosperity-and-security,uk-prosperity-and-security-asia-latin-america-and-africa
 providing-better-information-and-protection-for-consumers,consumer-protection


### PR DESCRIPTION
The policies "Corporate accountability" and "City deal" are being renamed. This updates the migration to seed the subscription mappings to reflect their new names. The migration has not been run yet so is safe to be edited.