### PR TITLE
Handle non-XML response bodies from govdelivery

### DIFF
--- a/app/services/gov_delivery/response_parser.rb
+++ b/app/services/gov_delivery/response_parser.rb
@@ -9,6 +9,10 @@ module GovDelivery
       Struct.new(*keys).new(*values)
     end
 
+    def xml?
+      xml_tree.root.present?
+    end
+
   private
 
     attr_reader(

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -184,6 +184,12 @@ RSpec.describe GovDelivery::Client do
       expect { client.send_bulletin(topic_ids, subject, body) }.not_to raise_error
     end
 
+    it "raises a helpful error for empty responses from govdelivery" do
+      stub_request(:post, @base_url).to_return(body: "")
+
+      expect { client.send_bulletin(topic_ids, subject, body) }.to raise_error(GovDelivery::Client::UnexpectedResponseBodyError)
+    end
+
     it "raises error on any other error from govdelivery" do
       @govdelivery_response = %{
         <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Currently, in this situation the following error gets raised:

```
NoMethodError: undefined method `element_children' for nil:NilClass
app/services/gov_delivery/response_parser.rb:31→ first_level_element_nodes
app/services/gov_delivery/response_parser.rb:21→ keys
app/services/gov_delivery/response_parser.rb:9→ parse
app/services/gov_delivery/client.rb:94→ parse_topic_response
app/services/gov_delivery/client.rb:38→ send_bulletin
app/workers/notification_worker.rb:20→ perform
sidekiq-3.2.6/lib/sidekiq/processor.rb:75→ execute_job
sidekiq-3.2.6/lib/sidekiq/processor.rb:52→ block (2 levels) in process
sidekiq-3.2.6/lib/sidekiq/middleware/chain.rb:122→ call
sidekiq-3.2.6/lib/sidekiq/middleware/chain.rb:122→ block in invoke
```

Instead, let's raise a semantic error that at least tells you what the response
was.