### PR TITLE
Add content IDs to Subscriber Lists

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -18,8 +18,7 @@ class SubscriberListsController < ApplicationController
   end
 
   def create
-    list = create_or_fetch_subscriber_list
-
+    list = build_subscriber_list
     if list.save
       respond_to do |format|
         format.json { render json: list.to_json, status: 201 }
@@ -32,16 +31,9 @@ class SubscriberListsController < ApplicationController
   end
 
 private
-  def create_or_fetch_subscriber_list
-    gov_delivery = Services.gov_delivery
-
-    response = gov_delivery.create_topic(params[:title])
-
-    SubscriberList.new(
-      title: params[:title],
-      gov_delivery_id: response.to_param,
-      tags: params[:tags]
-    )
+  def build_subscriber_list
+    gov_delivery_response = Services.gov_delivery.create_topic(params[:title])
+    SubscriberList.build_from(params: params, gov_delivery_id: gov_delivery_response.to_param)
   end
 
   def validate_request

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -3,6 +3,15 @@ require 'json'
 class SubscriberList < ActiveRecord::Base
   self.include_root_in_json = true
 
+  def self.build_from(params:, gov_delivery_id:)
+    new(
+      title: params[:title],
+      gov_delivery_id: gov_delivery_id,
+      tags: params[:tags],
+      content_id: params[:content_id]
+    )
+  end
+
   # Find all lists in which all the tags present have at least one match in the
   # supplied list of tags.  Note - does not require that all the tags supplied
   # have any matches.

--- a/db/migrate/20150930130825_add_content_id_to_subscriber_list.rb
+++ b/db/migrate/20150930130825_add_content_id_to_subscriber_list.rb
@@ -1,0 +1,5 @@
+class AddContentIdToSubscriberList < ActiveRecord::Migration
+  def change
+    add_column :subscriber_lists, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150508081921) do
+ActiveRecord::Schema.define(version: 20150930130825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20150508081921) do
     t.hstore   "tags"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "content_id"
   end
 
   add_index "subscriber_lists", ["tags"], name: "index_subscriber_lists_on_tags", using: :gin

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe SubscriberList, type: :model do
   describe "scopes" do
 
     before do
-      @list1 = FactoryGirl.create(:subscriber_list, tags: {
+      @list1 = create(:subscriber_list, tags: {
         format: ["raib_report"],
       })
-      @list2 = FactoryGirl.create(:subscriber_list, tags: {
+      @list2 = create(:subscriber_list, tags: {
         topics: ["environmental-management/boating"],
       })
-      @list3 = FactoryGirl.create(:subscriber_list, tags: {
+      @list3 = create(:subscriber_list, tags: {
         topics: ["environmental-management/boating", "environmental-management/sailing" , "environmental-management/swimming"],
       })
     end
@@ -38,16 +38,16 @@ RSpec.describe SubscriberList, type: :model do
 
   describe ".find_with_at_least_one_tag_of_each_type" do
     before do
-      @list1 = FactoryGirl.create(:subscriber_list, tags: {
+      @list1 = create(:subscriber_list, tags: {
         topics: ["oil-and-gas/licensing"],
         organisations: ["environment-agency", "hm-revenue-customs"]
       })
 
-      @list2 = FactoryGirl.create(:subscriber_list, tags: {
+      @list2 = create(:subscriber_list, tags: {
         topics: ["business-tax/vat", "oil-and-gas/licensing"]
       })
 
-      FactoryGirl.create(:subscriber_list, tags: {
+      create(:subscriber_list, tags: {
         topics: ["environmental-management/boating"],
       })
     end
@@ -95,7 +95,7 @@ RSpec.describe SubscriberList, type: :model do
 
   describe ".where_tags_equal(tag_hash)" do
     before do
-      @list = FactoryGirl.create(:subscriber_list, tags: {
+      @list = create(:subscriber_list, tags: {
         topics: ["oil-and-gas/licensing"],
         organisations: ["environment-agency", "hm-revenue-customs"]
       })
@@ -121,7 +121,7 @@ RSpec.describe SubscriberList, type: :model do
 
   describe "#tags" do
     it "deserializes the tag arrays" do
-      list = FactoryGirl.create(:subscriber_list, tags: {
+      list = create(:subscriber_list, tags: {
         topics: ["environmental-management/boating"],
       })
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -1,6 +1,19 @@
 require "rails_helper"
 
 RSpec.describe SubscriberList, type: :model do
+  let(:klass) { SubscriberList }
+
+  describe ".build_from(params:, gov_delivery_id:)" do
+    it "builds a new klass" do
+      params = { title: "Ronnie Pickering", tags: { topics: ["motoring/road_rage"] }.as_json, content_id: "888" }
+      gov_delivery_id = "GOVUK_888"
+      list = klass.build_from(params: params, gov_delivery_id: gov_delivery_id)
+      expect(list.title).to eq "Ronnie Pickering"
+      expect(list.tags).to eq({:topics=>["motoring/road_rage"]})
+      expect(list.content_id).to eq "888"
+      expect(list.gov_delivery_id).to eq "GOVUK_888"
+    end
+  end
 
   describe "scopes" do
 
@@ -18,7 +31,7 @@ RSpec.describe SubscriberList, type: :model do
 
     describe ".with_at_least_one_topic_value" do
       it "finds lists where at least one value is in the topic tags" do
-        expect(SubscriberList.with_at_least_one_topic_value('environmental-management/boating')).to eq [@list2, @list3]
+        expect(klass.with_at_least_one_topic_value('environmental-management/boating')).to eq [@list2, @list3]
       end
     end
   end
@@ -40,17 +53,17 @@ RSpec.describe SubscriberList, type: :model do
     end
 
     it "finds lists where at least one value of each tag in the subscription is present in the document" do
-      lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: {
+      lists = klass.with_at_least_one_tag_of_each_type(tags: {
         topics: ["oil-and-gas/licensing"]
       })
       expect(lists).to eq([@list2])
 
-      lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: {
+      lists = klass.with_at_least_one_tag_of_each_type(tags: {
         topics: ["business-tax/vat"],
       })
       expect(lists).to eq([@list2])
 
-      lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: {
+      lists = klass.with_at_least_one_tag_of_each_type(tags: {
         topics: ["oil-and-gas/licensing"],
         organisations: ["environment-agency"]
       })
@@ -58,7 +71,7 @@ RSpec.describe SubscriberList, type: :model do
     end
 
     it "finds lists where all the tag types in the subscription have a value present, even those there are other tag types in the document" do
-      lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: {
+      lists = klass.with_at_least_one_tag_of_each_type(tags: {
         topics: ["oil-and-gas/licensing"],
         another_tag_thats_not_part_of_the_subscription: ["elephants"],
       })
@@ -66,14 +79,14 @@ RSpec.describe SubscriberList, type: :model do
     end
 
     it "finds lists where all the tag types in the subscription have a value present, even when they have other values which aren't present " do
-      lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: {
+      lists = klass.with_at_least_one_tag_of_each_type(tags: {
         topics: ["oil-and-gas/licensing", "elephants"],
       })
       expect(lists).to eq([@list2])
     end
 
     it "doesn't return lists which have no tag types present in the document" do
-      lists = SubscriberList.with_at_least_one_tag_of_each_type(tags: {
+      lists = klass.with_at_least_one_tag_of_each_type(tags: {
         another_tag_thats_not_part_of_any_subscription: ["elephants"],
       })
       expect(lists).to eq([])
@@ -89,14 +102,14 @@ RSpec.describe SubscriberList, type: :model do
     end
 
     it "requires all tag types in the document to be present in the list" do
-      found_lists = SubscriberList.where_tags_equal({
+      found_lists = klass.where_tags_equal({
         topics: ["oil-and-gas/licensing"],
       })
       expect(found_lists).to eq([])
     end
 
     it "requires all tag types in the list to be present in the document" do
-      found_lists = SubscriberList.where_tags_equal({
+      found_lists = klass.where_tags_equal({
         topics: ["oil-and-gas/licensing"],
         organisations: ["environment-agency", "hm-revenue-customs"],
         other_tag_type: ["foo"],
@@ -120,7 +133,7 @@ RSpec.describe SubscriberList, type: :model do
 
   describe "#subscription_url" do
     it "provides the subscription URL based on the gov_delivery_id" do
-      list = SubscriberList.new(gov_delivery_id: "UKGOVUK_4567")
+      list = klass.new(gov_delivery_id: "UKGOVUK_4567")
 
       expect(list.subscription_url).to eq(
         "http://govdelivery-public.example.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_4567"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require 'rspec/rails'
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -15,21 +15,22 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
   it "returns the created subscriber list" do
     create_subscriber_list(topics: ["oil-and-gas/licensing"])
-
     response_hash = JSON.parse(response.body)
-
     subscriber_list = response_hash["subscriber_list"]
 
-    expect(subscriber_list.keys.to_set).to eq([
-      "id",
-      "title",
-      "subscription_url",
-      "gov_delivery_id",
-      "created_at",
-      "updated_at",
-      "tags"
-    ].to_set)
-
+    expect(subscriber_list.keys.to_set).to eq(
+      %w{
+        id
+        title
+        subscription_url
+        gov_delivery_id
+        created_at
+        updated_at
+        tags
+        content_id
+      }.to_set
+    )
+    expect(subscriber_list["content_id"]).to eq "8383db"
     expect(subscriber_list).to include(
       "tags" => {
         "topics" => ["oil-and-gas/licensing"]
@@ -47,7 +48,8 @@ RSpec.describe "Creating a subscriber list", type: :request do
     request_body = JSON.dump({
       title: "This is a sample title",
       gov_delivery_id: "UKGOVUK_1234",
-      tags: tags
+      tags: tags,
+      content_id: "8383db"
     })
 
     post "/subscriber-lists", request_body, json_headers

--- a/spec/requests/get_subscriber_list_spec.rb
+++ b/spec/requests/get_subscriber_list_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Getting a subscriber list", type: :request do
 
   context "when present" do
     before do
-      FactoryGirl.create(:subscriber_list, tags: {topics: ["oil-and-gas/licensing", "drug-device-alert"]})
+      create(:subscriber_list, tags: {topics: ["oil-and-gas/licensing", "drug-device-alert"]})
     end
 
     it "returns a 200" do

--- a/spec/requests/get_subscriber_list_spec.rb
+++ b/spec/requests/get_subscriber_list_spec.rb
@@ -21,15 +21,18 @@ RSpec.describe "Getting a subscriber list", type: :request do
 
       subscriber_list = response_hash["subscriber_list"]
 
-      expect(subscriber_list.keys.to_set).to eq([
-        "id",
-        "title",
-        "subscription_url",
-        "gov_delivery_id",
-        "created_at",
-        "updated_at",
-        "tags"
-      ].to_set)
+      expect(subscriber_list.keys.to_set).to eq(
+        %w{
+          id
+          title
+          subscription_url
+          gov_delivery_id
+          created_at
+          updated_at
+          tags
+          content_id
+        }.to_set
+      )
 
       expect(subscriber_list).to include(
         "tags" => {

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Sending a notification", type: :request do
   def create_many_lists
     duplicate_topic_id = "UKGOVUK_DUPLICATE"
 
-    all_match = FactoryGirl.create(:subscriber_list,
+    all_match = create(:subscriber_list,
       gov_delivery_id: duplicate_topic_id,
       tags: {
         topics: ["oil-and-gas/licensing"],
@@ -95,12 +95,12 @@ RSpec.describe "Sending a notification", type: :request do
       }
     )
 
-    partial_type_match = FactoryGirl.create(:subscriber_list, tags: {
+    partial_type_match = create(:subscriber_list, tags: {
       topics: ["oil-and-gas/licensing"],
       browse_pages: ["tax/vat"]
     })
 
-    full_type_partial_tag_match = FactoryGirl.create(:subscriber_list,
+    full_type_partial_tag_match = create(:subscriber_list,
       gov_delivery_id: duplicate_topic_id,
       tags: {
         topics: ["oil-and-gas/licensing"],
@@ -108,12 +108,12 @@ RSpec.describe "Sending a notification", type: :request do
       }
     )
 
-    full_type_no_tag_match = FactoryGirl.create(:subscriber_list, tags: {
+    full_type_no_tag_match = create(:subscriber_list, tags: {
       topics: ["schools-colleges/administration-finance"],
       organisations: ["department-for-education"]
     })
 
-    full_type_but_empty = FactoryGirl.create(:subscriber_list, tags: {
+    full_type_but_empty = create(:subscriber_list, tags: {
       topics: [],
       organisations: ["environment-agency", "hm-revenue-customs"]
     })

--- a/spec/unit/data_hygiene/tag_changer_spec.rb
+++ b/spec/unit/data_hygiene/tag_changer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe DataHygiene::TagChanger, "#update_records_tags" do
 
   it "creates a new record with an updated topic tag" do
-    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list = create(:subscriber_list, tags: {
       topics: ["environmental-management/boating"],
     })
     tag_changer = DataHygiene::TagChanger.new(
@@ -29,7 +29,7 @@ RSpec.describe DataHygiene::TagChanger, "#update_records_tags" do
   end
 
   it "preserves additional tags" do
-    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list = create(:subscriber_list, tags: {
       topics: ["environmental-management/agency"],
       organisations: ["Environment Agency"]
     })
@@ -49,11 +49,11 @@ RSpec.describe DataHygiene::TagChanger, "#update_records_tags" do
   end
 
   it "preserves additional topics" do
-    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list = create(:subscriber_list, tags: {
       topics: ["environmental-management/agency", "environmental-management/littering"],
       organisations: ["Environment Agency"]
     })
-    subscriber_list2 = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list2 = create(:subscriber_list, tags: {
       topics: ["environmental-management/123agency"],
       organisations: ["Environment Agency"]
     })


### PR DESCRIPTION
NOTE: review this by clicking on each commit, the entire diff is a bit noisy.

As part of the move towards identifying taggable content via unique content_ids,
and consequently handling email subscriptions and alerts via the same,
this commit does the following:

- Adds content_id to the SubscriberList model.
- Adds a factory method to build SubscriberLists, moving this logic out
  of the controller.

Trello: https://trello.com/c/ZD65QUBN/326-email-alerts-based-on-links-hash