### PR TITLE
Remove superfluous use of 'FactoryGirl' throughout specs

### DIFF
--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe SubscriberList, type: :model do
   describe "scopes" do
 
     before do
-      @list1 = FactoryGirl.create(:subscriber_list, tags: {
+      @list1 = create(:subscriber_list, tags: {
         format: ["raib_report"],
       })
-      @list2 = FactoryGirl.create(:subscriber_list, tags: {
+      @list2 = create(:subscriber_list, tags: {
         topics: ["environmental-management/boating"],
       })
-      @list3 = FactoryGirl.create(:subscriber_list, tags: {
+      @list3 = create(:subscriber_list, tags: {
         topics: ["environmental-management/boating", "environmental-management/sailing" , "environmental-management/swimming"],
       })
     end
@@ -25,16 +25,16 @@ RSpec.describe SubscriberList, type: :model do
 
   describe ".find_with_at_least_one_tag_of_each_type" do
     before do
-      @list1 = FactoryGirl.create(:subscriber_list, tags: {
+      @list1 = create(:subscriber_list, tags: {
         topics: ["oil-and-gas/licensing"],
         organisations: ["environment-agency", "hm-revenue-customs"]
       })
 
-      @list2 = FactoryGirl.create(:subscriber_list, tags: {
+      @list2 = create(:subscriber_list, tags: {
         topics: ["business-tax/vat", "oil-and-gas/licensing"]
       })
 
-      FactoryGirl.create(:subscriber_list, tags: {
+      create(:subscriber_list, tags: {
         topics: ["environmental-management/boating"],
       })
     end
@@ -82,7 +82,7 @@ RSpec.describe SubscriberList, type: :model do
 
   describe ".where_tags_equal(tag_hash)" do
     before do
-      @list = FactoryGirl.create(:subscriber_list, tags: {
+      @list = create(:subscriber_list, tags: {
         topics: ["oil-and-gas/licensing"],
         organisations: ["environment-agency", "hm-revenue-customs"]
       })
@@ -108,7 +108,7 @@ RSpec.describe SubscriberList, type: :model do
 
   describe "#tags" do
     it "deserializes the tag arrays" do
-      list = FactoryGirl.create(:subscriber_list, tags: {
+      list = create(:subscriber_list, tags: {
         topics: ["environmental-management/boating"],
       })
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require 'rspec/rails'
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/requests/get_subscriber_list_spec.rb
+++ b/spec/requests/get_subscriber_list_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Getting a subscriber list", type: :request do
 
   context "when present" do
     before do
-      FactoryGirl.create(:subscriber_list, tags: {topics: ["oil-and-gas/licensing", "drug-device-alert"]})
+      create(:subscriber_list, tags: {topics: ["oil-and-gas/licensing", "drug-device-alert"]})
     end
 
     it "returns a 200" do

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Sending a notification", type: :request do
   def create_many_lists
     duplicate_topic_id = "UKGOVUK_DUPLICATE"
 
-    all_match = FactoryGirl.create(:subscriber_list,
+    all_match = create(:subscriber_list,
       gov_delivery_id: duplicate_topic_id,
       tags: {
         topics: ["oil-and-gas/licensing"],
@@ -95,12 +95,12 @@ RSpec.describe "Sending a notification", type: :request do
       }
     )
 
-    partial_type_match = FactoryGirl.create(:subscriber_list, tags: {
+    partial_type_match = create(:subscriber_list, tags: {
       topics: ["oil-and-gas/licensing"],
       browse_pages: ["tax/vat"]
     })
 
-    full_type_partial_tag_match = FactoryGirl.create(:subscriber_list,
+    full_type_partial_tag_match = create(:subscriber_list,
       gov_delivery_id: duplicate_topic_id,
       tags: {
         topics: ["oil-and-gas/licensing"],
@@ -108,12 +108,12 @@ RSpec.describe "Sending a notification", type: :request do
       }
     )
 
-    full_type_no_tag_match = FactoryGirl.create(:subscriber_list, tags: {
+    full_type_no_tag_match = create(:subscriber_list, tags: {
       topics: ["schools-colleges/administration-finance"],
       organisations: ["department-for-education"]
     })
 
-    full_type_but_empty = FactoryGirl.create(:subscriber_list, tags: {
+    full_type_but_empty = create(:subscriber_list, tags: {
       topics: [],
       organisations: ["environment-agency", "hm-revenue-customs"]
     })

--- a/spec/unit/data_hygiene/tag_changer_spec.rb
+++ b/spec/unit/data_hygiene/tag_changer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe DataHygiene::TagChanger, "#update_records_tags" do
 
   it "creates a new record with an updated topic tag" do
-    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list = create(:subscriber_list, tags: {
       topics: ["environmental-management/boating"],
     })
     tag_changer = DataHygiene::TagChanger.new(
@@ -29,7 +29,7 @@ RSpec.describe DataHygiene::TagChanger, "#update_records_tags" do
   end
 
   it "preserves additional tags" do
-    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list = create(:subscriber_list, tags: {
       topics: ["environmental-management/agency"],
       organisations: ["Environment Agency"]
     })
@@ -49,11 +49,11 @@ RSpec.describe DataHygiene::TagChanger, "#update_records_tags" do
   end
 
   it "preserves additional topics" do
-    subscriber_list = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list = create(:subscriber_list, tags: {
       topics: ["environmental-management/agency", "environmental-management/littering"],
       organisations: ["Environment Agency"]
     })
-    subscriber_list2 = FactoryGirl.create(:subscriber_list, tags: {
+    subscriber_list2 = create(:subscriber_list, tags: {
       topics: ["environmental-management/123agency"],
       organisations: ["Environment Agency"]
     })


### PR DESCRIPTION
Makes them a little less verbose and thus easier to read.