### PR TITLE
Add links field to SubscriberList

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -1,8 +1,6 @@
 require "gov_delivery/client"
 
 class SubscriberListsController < ApplicationController
-  before_filter :validate_request, only: :create
-
   def show
     subscriber_list = SubscriberList.where_tags_equal(params[:tags]).first
 
@@ -18,37 +16,28 @@ class SubscriberListsController < ApplicationController
   end
 
   def create
-    list = create_or_fetch_subscriber_list
-
+    list = build_subscriber_list
     if list.save
       respond_to do |format|
         format.json { render json: list.to_json, status: 201 }
       end
     else
       respond_to do |format|
-        format.json { render json: {message: "Couldn't create the subscriber list"}, status: 422 }
+        format.json { render json: {message: list.errors.full_messages.to_sentence}, status: 422 }
       end
     end
   end
 
 private
-  def create_or_fetch_subscriber_list
-    gov_delivery = Services.gov_delivery
-
-    response = gov_delivery.create_topic(params[:title])
-
-    SubscriberList.new(
-      title: params[:title],
-      gov_delivery_id: response.to_param,
-      tags: params[:tags]
+  def build_subscriber_list
+    gov_delivery_response = Services.gov_delivery.create_topic(params[:title])
+    SubscriberList.build_from(
+      params: subscriber_list_params,
+      gov_delivery_id: gov_delivery_response.to_param
     )
   end
 
-  def validate_request
-    params[:tags].each do |key, value|
-      unless value.is_a?(Array)
-        render json: {message: "All tag values must be sent as Arrays"}, status: 422
-      end
-    end
+  def subscriber_list_params
+    params.slice(:title, :tags, :links)
   end
 end

--- a/db/migrate/20151001102405_add_links_to_subscriber_list.rb
+++ b/db/migrate/20151001102405_add_links_to_subscriber_list.rb
@@ -1,0 +1,7 @@
+class AddLinksToSubscriberList < ActiveRecord::Migration
+  def change
+    add_column :subscriber_lists, :links, :hstore, null: false, default: {}
+
+    add_index :subscriber_lists, :links, using: :gin
+  end
+end

--- a/db/migrate/20151001154627_add_null_false_to_tags_field.rb
+++ b/db/migrate/20151001154627_add_null_false_to_tags_field.rb
@@ -1,0 +1,5 @@
+class AddNullFalseToTagsField < ActiveRecord::Migration
+  def change
+    change_column :subscriber_lists, :tags, :hstore, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150508081921) do
+ActiveRecord::Schema.define(version: 20151001154627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,11 +20,13 @@ ActiveRecord::Schema.define(version: 20150508081921) do
   create_table "subscriber_lists", force: true do |t|
     t.string   "title"
     t.string   "gov_delivery_id"
-    t.hstore   "tags"
+    t.hstore   "tags",            default: {}, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.hstore   "links",           default: {}, null: false
   end
 
+  add_index "subscriber_lists", ["links"], name: "index_subscriber_lists_on_links", using: :gin
   add_index "subscriber_lists", ["tags"], name: "index_subscriber_lists_on_tags", using: :gin
 
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -1,6 +1,21 @@
 require "rails_helper"
 
 RSpec.describe SubscriberList, type: :model do
+  describe ".build_from(params:, gov_delivery_id:)" do
+    it "builds a new SubscriberList" do
+      params = {
+        title: "Ronnie Pickering",
+        tags: { topics: ["motoring/road_rage"] },
+        links: { topics: ["uuid-888"] },
+      }
+      gov_delivery_id = "GOVUK_888"
+      list = SubscriberList.build_from(params: params, gov_delivery_id: gov_delivery_id)
+      expect(list.title).to eq "Ronnie Pickering"
+      expect(list.tags).to eq({:topics=>["motoring/road_rage"]})
+      expect(list.links).to eq({:topics=>["uuid-888"]})
+      expect(list.gov_delivery_id).to eq "GOVUK_888"
+    end
+  end
 
   describe "scopes" do
 

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -8,46 +8,63 @@ RSpec.describe "Creating a subscriber list", type: :request do
   end
 
   it "returns a 201" do
-    create_subscriber_list(topics: ["oil-and-gas/licensing"])
+    create_subscriber_list(tags: {topics: ["oil-and-gas/licensing"]})
 
     expect(response.status).to eq(201)
   end
 
   it "returns the created subscriber list" do
-    create_subscriber_list(topics: ["oil-and-gas/licensing"])
-
+    create_subscriber_list(
+      tags: {topics: ["oil-and-gas/licensing"]},
+      links: {topics: ["uuid-888"]}
+    )
     response_hash = JSON.parse(response.body)
-
     subscriber_list = response_hash["subscriber_list"]
 
-    expect(subscriber_list.keys.to_set).to eq([
-      "id",
-      "title",
-      "subscription_url",
-      "gov_delivery_id",
-      "created_at",
-      "updated_at",
-      "tags"
-    ].to_set)
-
+    expect(subscriber_list.keys.to_set).to eq(
+      %w{
+        id
+        title
+        subscription_url
+        gov_delivery_id
+        created_at
+        updated_at
+        tags
+        links
+      }.to_set
+    )
     expect(subscriber_list).to include(
       "tags" => {
         "topics" => ["oil-and-gas/licensing"]
+      },
+      "links" => {
+        "topics" => ["uuid-888"]
       }
     )
   end
 
   it "returns an error if tag isn't an array" do
-    create_subscriber_list(topic: "oil-and-gas/licensing")
+    create_subscriber_list(
+      tags: {topics: "oil-and-gas/licensing"},
+    )
 
     expect(response.status).to eq(422)
   end
 
-  def create_subscriber_list(tags)
+  it "returns an error if link isn't an array" do
+    create_subscriber_list(
+      links: {topics: "uuid-888"},
+    )
+
+    expect(response.status).to eq(422)
+  end
+
+  def create_subscriber_list(tags: {}, links: {})
     request_body = JSON.dump({
       title: "This is a sample title",
       gov_delivery_id: "UKGOVUK_1234",
-      tags: tags
+      tags: tags,
+      links: links
     })
 
     post "/subscriber-lists", request_body, json_headers

--- a/spec/requests/get_subscriber_list_spec.rb
+++ b/spec/requests/get_subscriber_list_spec.rb
@@ -21,15 +21,18 @@ RSpec.describe "Getting a subscriber list", type: :request do
 
       subscriber_list = response_hash["subscriber_list"]
 
-      expect(subscriber_list.keys.to_set).to eq([
-        "id",
-        "title",
-        "subscription_url",
-        "gov_delivery_id",
-        "created_at",
-        "updated_at",
-        "tags"
-      ].to_set)
+      expect(subscriber_list.keys.to_set).to eq(
+        %w{
+          id
+          title
+          subscription_url
+          gov_delivery_id
+          created_at
+          updated_at
+          tags
+          links
+        }.to_set
+      )
 
       expect(subscriber_list).to include(
         "tags" => {


### PR DESCRIPTION
As part of the move towards identifying taggable content via unique content_ids,
and consequently handling email subscriptions and alerts via the same,
this commit does the following:

- Adds a links hstore to the SubscriberList model. This is intended to
  contain tags which are identified by content_id rather than path.
- Adds a factory method to build SubscriberLists, moving this logic out of the controller.

Trello: https://trello.com/c/guDFlWXp