### PR TITLE
Add tasks to support conversion of topic tags into topic links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,13 @@ gem 'pg', '0.17.1'
 gem 'faraday', '0.9.0'
 gem 'nokogiri', '1.6.3.1'
 gem 'sidekiq', '3.2.6'
-
 gem 'plek', '1.9.0'
 gem 'airbrake', '4.1.0'
-
 gem 'unicorn', '4.8.3'
 gem 'logstasher', '0.4.8'
 gem 'sidekiq-logging-json', '0.0.14'
 gem 'statsd-ruby', '1.2.1'
+gem 'gds-api-adapters'
 
 group :test do
   gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    PriorityQueue (0.1.2)
     actionmailer (4.1.11)
       actionpack (= 4.1.11)
       actionview (= 4.1.11)
@@ -46,6 +47,8 @@ GEM
       safe_yaml (~> 1.0.0)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
@@ -62,12 +65,24 @@ GEM
     foreman (0.75.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
+    gds-api-adapters (23.2.2)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek
+      rack-cache
+      rest-client (~> 1.8.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
     kgio (2.9.2)
+    link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)
       logstash-event (~> 1.1.0)
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
@@ -76,8 +91,10 @@ GEM
     minitest (5.7.0)
     multi_json (1.11.1)
     multipart-post (2.0.0)
+    netrc (0.10.3)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
+    null_logger (0.0.1)
     pg (0.17.1)
     plek (1.9.0)
     pry (0.10.1)
@@ -88,6 +105,8 @@ GEM
       byebug (~> 3.4)
       pry (~> 0.10)
     rack (1.5.4)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.11)
@@ -110,6 +129,10 @@ GEM
     redis (3.1.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
@@ -148,6 +171,9 @@ GEM
     timers (1.1.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -165,6 +191,7 @@ DEPENDENCIES
   factory_girl_rails
   faraday (= 0.9.0)
   foreman (= 0.75.0)
+  gds-api-adapters
   logstasher (= 0.4.8)
   nokogiri (= 1.6.3.1)
   pg (= 0.17.1)

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -33,6 +33,12 @@ class SubscriberListQuery
     end
   end
 
+  def subscriber_lists_with_key(key)
+    # This uses the `?` hstore operator, which returns true only if the hstore
+    # contains the specified key.
+    SubscriberList.where("tags ? :key", key: key)
+  end
+
 private
   # Return all SubscriberLists which are marked with any of the same link types
   # as those requested.  For example, if `links` is:
@@ -60,11 +66,5 @@ private
     # This uses the `?&` hstore operator, which returns true only if the hstore
     # contains all the specified keys.
     SubscriberList.where("#{@query_field} ?& Array[:keys]", keys: query_hash.keys)
-  end
-
-  def subscriber_lists_with_key(key)
-    # This uses the `?` hstore operator, which returns true only if the hstore
-    # contains the specified key.
-    SubscriberList.where("tags ? :key", key: key)
   end
 end

--- a/db/migrate/20151019131359_remove_dead_subscriber_lists.rb
+++ b/db/migrate/20151019131359_remove_dead_subscriber_lists.rb
@@ -1,0 +1,23 @@
+class RemoveDeadSubscriberLists < ActiveRecord::Migration
+  def up
+    [
+      # redirected to 'prisons-probation'
+      'prisons-probation/researching-prisons',
+      # redirected to 'climate-change-energy'
+      'environmental-management/climate-change-energy',
+      # redirected to 'government/collections/eea-swiss-nationals-and-ec-association-agreements-modernised-guidance',
+      'immigration-operational-guidance/european-casework-instructions',
+      # not present in content store
+      'pharmaceutical-industry/advertising-medicines',
+    ].each do |topic_path|
+      list = SubscriberListQuery.new.find_exact_match_with(topics: [topic_path]).first
+      if list.present?
+        list.destroy!
+      end
+    end
+  end
+
+  def down
+    #noop
+  end
+end

--- a/db/migrate/20151019131428_update_outdated_topic_tags_on_subscriber_lists.rb
+++ b/db/migrate/20151019131428_update_outdated_topic_tags_on_subscriber_lists.rb
@@ -1,0 +1,42 @@
+class UpdateOutdatedTopicTagsOnSubscriberLists < ActiveRecord::Migration
+  def up
+    tag_mappings = [
+      {
+        from: 'schools-colleges/behaviour-attendance',
+        to: 'schools-colleges-childrens-services/school-behaviour-attendance'
+      },
+      {
+        from: 'schools-colleges/administration-finance',
+        to: 'schools-colleges-childrens-services/school-college-funding-finance'
+      },
+      {
+        from: 'schools-colleges/curriculum-qualifications',
+        to: 'schools-colleges-childrens-services/curriculum-qualifications'
+      },
+      {
+        from: 'schools-colleges/governance',
+        to: 'schools-colleges-childrens-services/running-school-college'
+      },
+      {
+        from: 'farming-food-grants-payments/export-refunds',
+        to: 'business-tax/import-export'
+      },
+      {
+        from: 'farming-food-grants-payments/environmental-land-management',
+        to: 'environmental-management/land-management'
+      },
+      {
+        from: 'farming-food-grants-payments/promotion-schemes',
+        to: 'government/government-funding-programmes'
+      },
+    ]
+
+    tag_mappings.each do |mapping|
+      list = SubscriberListQuery.new.find_exact_match_with(topics: [ mapping[:from] ]).first
+      if list.present?
+        list.tags = {topics: [ mapping[:to] ] }
+        list.save!
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151001154627) do
+ActiveRecord::Schema.define(version: 20151019131428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,12 @@
 require "gov_delivery/client"
+require 'gds_api/content_store'
 
 module Services
   def self.gov_delivery
     @gov_delivery ||= GovDelivery::Client.new(EmailAlertAPI.config.gov_delivery)
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.new.find('content-store'))
   end
 end

--- a/lib/tasks/links_migration/destroy_old_lists.rake
+++ b/lib/tasks/links_migration/destroy_old_lists.rake
@@ -3,6 +3,6 @@ require "tasks/links_migration/link_migrator"
 namespace :links_migration do
   desc "Remove Subscriber Lists with no matching content ID in Content Store"
   task destroy_outdated_subscriber_lists: [:environment] do
-    LinkMigrator.new.destroy_non_matching_subscriber_lists
+    Tasks::LinksMigration::LinkMigrator.new.destroy_non_matching_subscriber_lists
   end
 end

--- a/lib/tasks/links_migration/destroy_old_lists.rake
+++ b/lib/tasks/links_migration/destroy_old_lists.rake
@@ -1,0 +1,8 @@
+require "tasks/links_migration/link_migrator"
+
+namespace :links_migration do
+  desc "Remove Subscriber Lists with no matching content ID in Content Store"
+  task destroy_outdated_subscriber_lists: [:environment] do
+    LinkMigrator.new.destroy_non_matching_subscriber_lists
+  end
+end

--- a/lib/tasks/links_migration/destroy_old_lists.rake
+++ b/lib/tasks/links_migration/destroy_old_lists.rake
@@ -1,8 +1,0 @@
-require "tasks/links_migration/link_migrator"
-
-namespace :links_migration do
-  desc "Remove Subscriber Lists with no matching content ID in Content Store"
-  task destroy_outdated_subscriber_lists: [:environment] do
-    Tasks::LinksMigration::LinkMigrator.new.destroy_non_matching_subscriber_lists
-  end
-end

--- a/lib/tasks/links_migration/link_migrator.rb
+++ b/lib/tasks/links_migration/link_migrator.rb
@@ -1,41 +1,45 @@
-class LinkMigrator
-  def populate_topic_links
-    relevant_subscriber_lists.each do |sl|
-      base_path = base_path_from(sl)
-      content_item = Services.content_store.content_item(namespaced(base_path))
-      if content_item && content_item.content_id.present?
-        puts "Updating links in SubscriberList #{sl.id}"
-        sl.update(links: {topics: [content_item.content_id]})
+module Tasks
+  module LinksMigration
+    class LinkMigrator
+      def populate_topic_links
+        relevant_subscriber_lists.each do |sl|
+          base_path = base_path_from(sl)
+          content_item = Services.content_store.content_item(namespaced(base_path))
+          if content_item && content_item.content_id.present?
+            puts "Updating links in SubscriberList #{sl.id}"
+            sl.update(links: {topics: [content_item.content_id]})
+          end
+        end
+      end
+
+      def destroy_non_matching_subscriber_lists
+        relevant_subscriber_lists.each do |sl|
+          base_path = base_path_from(sl)
+          content_item = Services.content_store.content_item(namespaced(base_path))
+
+          if content_item.blank? || content_item.content_id.blank?
+            puts "Destroying Subscriber List id: #{sl.id}"
+            sl.destroy!
+          end
+        end
+      end
+
+    private
+
+      def base_path_from(subscriber_list)
+        # Only one base path is ever specified in topic tags
+        subscriber_list.tags[:topics].first
+      end
+
+      def relevant_subscriber_lists
+        @relevant_subscriber_lists ||= SubscriberListQuery.new(query_field: :tags)
+          .subscriber_lists_with_key(:topics)
+      end
+
+      def namespaced(base_path)
+        # Because the base paths in email-alert-api don't include '/topic'
+        "/topic/#{base_path}"
       end
     end
-  end
-
-  def destroy_non_matching_subscriber_lists
-    relevant_subscriber_lists.each do |sl|
-      base_path = base_path_from(sl)
-      content_item = Services.content_store.content_item(namespaced(base_path))
-
-      if content_item.blank? || content_item.content_id.blank?
-        puts "Destroying Subscriber List id: #{sl.id}"
-        sl.destroy!
-      end
-    end
-  end
-
-private
-
-  def base_path_from(subscriber_list)
-    # Only one base path is ever specified in topic tags
-    subscriber_list.tags[:topics].first
-  end
-
-  def relevant_subscriber_lists
-    @relevant_subscriber_lists ||= SubscriberListQuery.new(query_field: :tags)
-      .subscriber_lists_with_key(:topics)
-  end
-
-  def namespaced(base_path)
-    # Because the base paths in email-alert-api don't include '/topic'
-    "/topic/#{base_path}"
   end
 end

--- a/lib/tasks/links_migration/link_migrator.rb
+++ b/lib/tasks/links_migration/link_migrator.rb
@@ -1,0 +1,41 @@
+class LinkMigrator
+  def populate_topic_links
+    relevant_subscriber_lists.each do |sl|
+      base_path = base_path_from(sl)
+      content_item = Services.content_store.content_item(namespaced(base_path))
+      if content_item && content_item.content_id.present?
+        puts "Updating links in SubscriberList #{sl.id}"
+        sl.update(links: {topics: [content_item.content_id]})
+      end
+    end
+  end
+
+  def destroy_non_matching_subscriber_lists
+    relevant_subscriber_lists.each do |sl|
+      base_path = base_path_from(sl)
+      content_item = Services.content_store.content_item(namespaced(base_path))
+
+      if content_item.blank? || content_item.content_id.blank?
+        puts "Destroying Subscriber List id: #{sl.id}"
+        sl.destroy!
+      end
+    end
+  end
+
+private
+
+  def base_path_from(subscriber_list)
+    # Only one base path is ever specified in topic tags
+    subscriber_list.tags[:topics].first
+  end
+
+  def relevant_subscriber_lists
+    @relevant_subscriber_lists ||= SubscriberListQuery.new(query_field: :tags)
+      .subscriber_lists_with_key(:topics)
+  end
+
+  def namespaced(base_path)
+    # Because the base paths in email-alert-api don't include '/topic'
+    "/topic/#{base_path}"
+  end
+end

--- a/lib/tasks/links_migration/link_migrator.rb
+++ b/lib/tasks/links_migration/link_migrator.rb
@@ -1,44 +1,82 @@
 module Tasks
   module LinksMigration
     class LinkMigrator
+      class DodgyBasePathError < StandardError; end
+
       def populate_topic_links
-        relevant_subscriber_lists.each do |sl|
-          base_path = base_path_from(sl)
-          content_item = Services.content_store.content_item(namespaced(base_path))
-          if content_item && content_item.content_id.present?
-            puts "Updating links in SubscriberList #{sl.id}"
-            sl.update(links: {topics: [content_item.content_id]})
+        relevant_subscriber_lists.each do |list|
+          content_item = Services.content_store.content_item(base_path_from(list))
+
+          if content_item.blank?
+            raise DodgyBasePathError, <<-ERROR.strip_heredoc
+              No content item found for #{base_path_from(list)},
+              run `bundle exec rake links_migration:report_non_matching`
+              and fix these cases before continuing migration.
+            ERROR
           end
+
+          if content_item.content_id.blank?
+            raise DodgyBasePathError, <<-ERROR.strip_heredoc
+              No content ID found for #{base_path_from(list)},
+              run `bundle exec rake links_migration:report_non_matching`
+              and fix these cases before continuing migration.
+            ERROR
+          end
+
+          puts "Updating links in SubscriberList #{list.id}"
+          list.update(links: {topics: [content_item.content_id]})
         end
       end
 
-      def destroy_non_matching_subscriber_lists
-        relevant_subscriber_lists.each do |sl|
-          base_path = base_path_from(sl)
-          content_item = Services.content_store.content_item(namespaced(base_path))
+      def report_non_matching_subscriber_lists
+        no_content_item = []
+        no_content_id   = []
 
-          if content_item.blank? || content_item.content_id.blank?
-            puts "Destroying Subscriber List id: #{sl.id}"
-            sl.destroy!
+        relevant_subscriber_lists.each do |list|
+          print "."
+          content_item = Services.content_store.content_item(base_path_from(list))
+
+          if content_item.blank?
+            no_content_item << list
+            next
+          end
+
+          if content_item.content_id.blank?
+            no_content_id << list
           end
         end
+
+        puts
+        puts "***No content item found***"
+        no_content_item.each do |list|
+          puts "#{list.id}, #{topic_tag(list)}"
+        end
+        puts "Total: #{no_content_item.count}"
+
+        puts
+        puts "***No content id found***"
+        no_content_id.each do |list|
+          puts "#{list.id}, #{topic_tag(list)}"
+        end
+        puts "Total: #{no_content_id.count}"
+
+        puts
+        puts "GRAND TOTAL: #{no_content_item.count + no_content_id.count}"
       end
 
-    private
+private
+      def topic_tag(list)
+        # Only one slug is ever specified in topic tags
+        list.tags[:topics].first
+      end
 
       def base_path_from(subscriber_list)
-        # Only one base path is ever specified in topic tags
-        subscriber_list.tags[:topics].first
+        "/topic/#{topic_tag(subscriber_list)}"
       end
 
       def relevant_subscriber_lists
         @relevant_subscriber_lists ||= SubscriberListQuery.new(query_field: :tags)
           .subscriber_lists_with_key(:topics)
-      end
-
-      def namespaced(base_path)
-        # Because the base paths in email-alert-api don't include '/topic'
-        "/topic/#{base_path}"
       end
     end
   end

--- a/lib/tasks/links_migration/populate_topic_links.rake
+++ b/lib/tasks/links_migration/populate_topic_links.rake
@@ -3,6 +3,6 @@ require "tasks/links_migration/link_migrator"
 namespace :links_migration do
   desc "Populate topics in empty links on SubscriberList using the tags field"
   task populate_topic_links: [:environment] do
-    LinkMigrator.new.populate_topic_links
+    Tasks::LinksMigration::LinkMigrator.new.populate_topic_links
   end
 end

--- a/lib/tasks/links_migration/populate_topic_links.rake
+++ b/lib/tasks/links_migration/populate_topic_links.rake
@@ -1,0 +1,8 @@
+require "tasks/links_migration/link_migrator"
+
+namespace :links_migration do
+  desc "Populate topics in empty links on SubscriberList using the tags field"
+  task populate_topic_links: [:environment] do
+    LinkMigrator.new.populate_topic_links
+  end
+end

--- a/lib/tasks/links_migration/report_non_matching.rake
+++ b/lib/tasks/links_migration/report_non_matching.rake
@@ -1,0 +1,8 @@
+require "tasks/links_migration/link_migrator"
+
+namespace :links_migration do
+  desc "Populate topics in empty links on SubscriberList using the tags field"
+  task report_non_matching: [:environment] do
+    Tasks::LinksMigration::LinkMigrator.new.report_non_matching_subscriber_lists
+  end
+end

--- a/spec/lib/tasks/links_migration/link_migrator_spec.rb
+++ b/spec/lib/tasks/links_migration/link_migrator_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+require "tasks/links_migration/link_migrator"
+
+RSpec.describe LinkMigrator do
+  class FakeContentStore
+    require "rspec/mocks/standalone"
+
+    def mock_content_item
+      double("content_item", content_id: "uuid-888")
+    end
+
+    def content_item(path)
+      path == "/topic/oil-and-gas/something" ? mock_content_item : nil
+    end
+  end
+
+  before do
+    allow(Services).to receive(:content_store).and_return(FakeContentStore.new)
+  end
+
+  describe "#populate_topic_links" do
+    it "copies content IDs for appropriate topic tag matches" do
+      subscriber_list1 = create(:subscriber_list, tags: {topics: ["oil-and-gas/something"]})
+      subscriber_list2 = create(:subscriber_list, tags: {topics: ["benefits/some-other-thing"]})
+      subscriber_list3 = create(:subscriber_list, tags: {policies: ["foobars"]})
+
+      LinkMigrator.new.populate_topic_links
+      [subscriber_list1, subscriber_list2, subscriber_list3].each { |s| s.reload }
+
+      expect(subscriber_list1.links).to eq(topics: ["uuid-888"])
+      expect(subscriber_list2.links).to eq({})
+      expect(subscriber_list3.links).to eq({})
+    end
+  end
+
+  describe "#destroy_non_matching_subscriber_lists" do
+    it "destroys subscriber lists with no match in the content store" do
+      subscriber_list = create(:subscriber_list, tags: {topics: ["oil-and-gas/something"]})
+      create(:subscriber_list, tags: {topics: ["benefits/some-other-thing"]})
+
+      LinkMigrator.new.destroy_non_matching_subscriber_lists
+
+      expect(SubscriberList.count).to eq 1
+      expect(SubscriberList.first).to eq subscriber_list
+    end
+  end
+end

--- a/spec/lib/tasks/links_migration/link_migrator_spec.rb
+++ b/spec/lib/tasks/links_migration/link_migrator_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe LinkMigrator do
     allow(Services).to receive(:content_store).and_return(FakeContentStore.new)
   end
 
+  around do |example|
+    the_real_stdout = $stdout
+    $stdout = StringIO.new
+    example.run
+    $stdout = the_real_stdout
+  end
+
   describe "#populate_topic_links" do
     it "copies content IDs for appropriate topic tag matches" do
       subscriber_list1 = create(:subscriber_list, tags: {topics: ["oil-and-gas/something"]})

--- a/spec/lib/tasks/links_migration/link_migrator_spec.rb
+++ b/spec/lib/tasks/links_migration/link_migrator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "tasks/links_migration/link_migrator"
 
-RSpec.describe LinkMigrator do
+RSpec.describe Tasks::LinksMigration::LinkMigrator do
   class FakeContentStore
     require "rspec/mocks/standalone"
 
@@ -31,7 +31,7 @@ RSpec.describe LinkMigrator do
       subscriber_list2 = create(:subscriber_list, tags: {topics: ["benefits/some-other-thing"]})
       subscriber_list3 = create(:subscriber_list, tags: {policies: ["foobars"]})
 
-      LinkMigrator.new.populate_topic_links
+      Tasks::LinksMigration::LinkMigrator.new.populate_topic_links
       [subscriber_list1, subscriber_list2, subscriber_list3].each { |s| s.reload }
 
       expect(subscriber_list1.links).to eq(topics: ["uuid-888"])
@@ -45,7 +45,7 @@ RSpec.describe LinkMigrator do
       subscriber_list = create(:subscriber_list, tags: {topics: ["oil-and-gas/something"]})
       create(:subscriber_list, tags: {topics: ["benefits/some-other-thing"]})
 
-      LinkMigrator.new.destroy_non_matching_subscriber_lists
+      Tasks::LinksMigration::LinkMigrator.new.destroy_non_matching_subscriber_lists
 
       expect(SubscriberList.count).to eq 1
       expect(SubscriberList.first).to eq subscriber_list


### PR DESCRIPTION
As part of the move towards using content IDs to uniquely identify
content across gov.uk, SubscriberLists need to have their existing tags
converted from slugs to content IDs.

This commit adds rake tasks to:
- Query the Content Store with a slug and write the returned content ID
  to the corresponding SubscriberList links hash.
- Delete SubscriberLists that don't return a content ID from the Content
  Store.

Trello: https://trello.com/c/ZD65QUBN/326-email-alerts-based-on-links-hash