### PR TITLE
Policies cleanup

### DIFF
--- a/db/migrate/20151023151545_rename_policies_tag_on_a_subscriber_list.rb
+++ b/db/migrate/20151023151545_rename_policies_tag_on_a_subscriber_list.rb
@@ -1,0 +1,16 @@
+class RenamePoliciesTagOnASubscriberList < ActiveRecord::Migration
+  def up
+    target_list = SubscriberListQuery.new.find_exact_match_with(
+      { policies: ["inspections-of-schools-colleges-and-children-s-services"] }
+    ).first
+
+    if target_list.present?
+      target_list.tags = {policy: ["inspections-of-schools-colleges-and-children-s-services"]}
+      target_list.save!
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151019131428) do
+ActiveRecord::Schema.define(version: 20151023151545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/links_migration/for_policies/runner.rake
+++ b/lib/tasks/links_migration/for_policies/runner.rake
@@ -1,0 +1,38 @@
+namespace :links_migration do
+  namespace :for_policies do
+
+    desc "Print a mapping illustrating which policy lists need to have their users moved by govdelivery"
+    task report_lists_to_be_merged: [:environment] do
+      tagged_with_policies = SubscriberListQuery.new.subscriber_lists_with_key(:policies)
+      tagged_with_policy   = SubscriberListQuery.new.subscriber_lists_with_key(:policy)
+
+      no_equivalent_found = []
+      remap_count = 0
+
+      tagged_with_policies.each do |list|
+        policy_equivalent = tagged_with_policy.find { |l| l.tags[:policy] == list.tags[:policies] }
+        if policy_equivalent.present?
+          puts "#{list.tags} => #{policy_equivalent.tags}"
+          puts "#{list.gov_delivery_id} => #{policy_equivalent.gov_delivery_id}"
+          puts
+          remap_count += 1
+        else
+          no_equivalent_found << list
+        end
+      end
+
+      if no_equivalent_found.present?
+        puts
+        puts "========================================================================="
+        puts "No policy equivalent found, change tags keyed with 'policies' to 'policy'"
+        puts "========================================================================="
+        no_equivalent_found.each { |list| puts "#{list.id}, #{list.tags}" }
+      end
+
+      puts
+      puts "Total remaps: #{remap_count}"
+      puts
+    end
+
+  end
+end

--- a/lib/tasks/links_migration/for_topics/runner.rake
+++ b/lib/tasks/links_migration/for_topics/runner.rake
@@ -1,0 +1,17 @@
+require "tasks/links_migration/link_migrator"
+
+namespace :links_migration do
+  namespace :for_topics do
+
+    desc "Print out a report of topic subscriber lists with no obvious content ID match in the content store"
+    task report_non_matching: [:environment] do
+      Tasks::LinksMigration::LinkMigrator.new.report_non_matching_subscriber_lists
+    end
+
+    desc "Populate topics in empty links on SubscriberList using the tags field"
+    task populate_topic_links: [:environment] do
+      Tasks::LinksMigration::LinkMigrator.new.populate_topic_links
+    end
+
+  end
+end

--- a/lib/tasks/links_migration/populate_topic_links.rake
+++ b/lib/tasks/links_migration/populate_topic_links.rake
@@ -1,8 +1,0 @@
-require "tasks/links_migration/link_migrator"
-
-namespace :links_migration do
-  desc "Populate topics in empty links on SubscriberList using the tags field"
-  task populate_topic_links: [:environment] do
-    Tasks::LinksMigration::LinkMigrator.new.populate_topic_links
-  end
-end

--- a/lib/tasks/links_migration/report_non_matching.rake
+++ b/lib/tasks/links_migration/report_non_matching.rake
@@ -1,8 +1,0 @@
-require "tasks/links_migration/link_migrator"
-
-namespace :links_migration do
-  desc "Populate topics in empty links on SubscriberList using the tags field"
-  task report_non_matching: [:environment] do
-    Tasks::LinksMigration::LinkMigrator.new.report_non_matching_subscriber_lists
-  end
-end


### PR DESCRIPTION
This PR is part of the cleanup of 216 policy Subscriber Lists which are incorrectly tagged. Their `tags` field uses the key `policies` rather than `policy`.

Trello: https://trello.com/c/SbzetTvB/388-fix-policy-email-alerts

Adds a couple of things:

+ a rake task to report which policy-tagged subscriber lists need their users migrated - this will be sent to govdelivery to sort out, figured committing the script might be useful in case needed again in the short term.
+ a data migration to rewrite the tagging on one specific lists - unlike the 215 others caught by the report above this one doesn't have a 'policy' duplicate but still uses the wrong key in its tag.