### PR TITLE
Reinstate JSON parsing of parameters passed into NotificationsWorker

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,8 @@
 class NotificationsController < ApplicationController
   def create
-    NotificationWorker.perform_async(notification_params)
+    # Ensure the Sidekiq worker receives a simple data type as its argument -
+    # in this case a JSON string (rather than a Ruby hash).
+    NotificationWorker.perform_async(notification_params.to_json)
 
     respond_to do |format|
       format.json { render json: {message: "Notification queued for sending"}, status: 202 }

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -2,7 +2,9 @@ class NotificationWorker
   include Sidekiq::Worker
 
   def perform(notification_params)
-    notification_params = notification_params.with_indifferent_access
+    # The worker params are a serialized hash, hence the call to JSON.parse
+    notification_params = JSON.parse(notification_params).with_indifferent_access
+
     @tags_hash  = Hash(notification_params[:tags])
     @links_hash = Hash(notification_params[:links])
     lists = (lists_matched_on_links + lists_matched_on_tags).uniq { |l| l.id }

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe NotificationsController, type: :controller do
 
     it "serializes the tags and passes them to the NotificationWorker" do
       expect(NotificationWorker).to receive(:perform_async).with(
-        notification_params.merge(links: {})
+        notification_params.merge(links: {}).to_json
       )
 
       post :create, notification_params.merge(format: :json)

--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe NotificationWorker do
       { subject: "Test subject", body: "Test body copy" }
     end
 
+    def make_it_perform
+      NotificationWorker.new.perform(notification_params.to_json)
+    end
+
     context "given a subscriber list matched on tags" do
       before do
         create(:subscriber_list, gov_delivery_id: 'gov123', tags: {topics: ['foo/bar']})
@@ -18,7 +22,7 @@ RSpec.describe NotificationWorker do
       end
 
       it "sends a bulletin with the correct IDs" do
-        NotificationWorker.new.perform(notification_params)
+        make_it_perform
 
         expect(@gov_delivery).to have_received(:send_bulletin)
           .with(
@@ -42,7 +46,7 @@ RSpec.describe NotificationWorker do
       end
 
       it "sends a bulletin with the correct IDs" do
-        NotificationWorker.new.perform(notification_params)
+        make_it_perform
 
         expect(@gov_delivery).to have_received(:send_bulletin)
           .with(
@@ -66,7 +70,7 @@ RSpec.describe NotificationWorker do
       end
 
       it "does not send a bulletin" do
-        NotificationWorker.new.perform(notification_params)
+        make_it_perform
 
         expect(@gov_delivery).to_not have_received(:send_bulletin)
       end


### PR DESCRIPTION
This is causing an exception in production as the params are a serialized
hash picked off a Redis queue. This wasn't previously picked up by tests.


Trello: https://trello.com/c/AuskAQ9S/390-fix-nomethoderror-in-email-alert-api-notifications