### PR TITLE
Add temporary fix to correctly handle NotificationWorker jobs

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,8 +1,6 @@
 class NotificationsController < ApplicationController
   def create
-    # Ensure the Sidekiq worker receives a simple data type as its argument -
-    # in this case a JSON string (rather than a Ruby hash).
-    NotificationWorker.perform_async(notification_params.to_json)
+    NotificationWorker.perform_async(notification_params)
 
     respond_to do |format|
       format.json { render json: {message: "Notification queued for sending"}, status: 202 }

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -2,8 +2,25 @@ class NotificationWorker
   include Sidekiq::Worker
 
   def perform(notification_params)
-    # The worker params are a serialized hash, hence the call to JSON.parse
-    notification_params = JSON.parse(notification_params).with_indifferent_access
+    # FIXME:
+    # tl;dr - remove the check on String below after 15th Nov 2015.
+    #
+    # The parameter to this worker was previously being encoded as JSON at the
+    # point of being enqueued (in NotificationsController). Sidekiq was calling
+    # JSON.dump on this, resulting in worker args that were JSON encoded twice.
+    # When this worker was changed to expect notification_params to be a simple
+    # Ruby hash (after being deserialized by Sidekiq), it began breaking in
+    # production due to old, previously-failing jobs re-trying one of their 25,
+    # exponentially backed off retries. The check below ensures that
+    # notification_params are correctly handled, irrespective of whether they
+    # were passed in already-encoded or not. This is a bandaid which should be
+    # removed after an appropriate length of time - 15th Nov 2015 should be
+    # sufficient.
+    notification_params = if notification_params.is_a?(String)
+                            JSON.parse(notification_params).with_indifferent_access
+                          else
+                            notification_params.with_indifferent_access
+                          end
 
     @tags_hash  = Hash(notification_params[:tags])
     @links_hash = Hash(notification_params[:links])

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe NotificationsController, type: :controller do
 
     it "serializes the tags and passes them to the NotificationWorker" do
       expect(NotificationWorker).to receive(:perform_async).with(
-        notification_params.merge(links: {}).to_json
+        notification_params.merge(links: {})
       )
 
       post :create, notification_params.merge(format: :json)

--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NotificationWorker do
     end
 
     def make_it_perform
-      NotificationWorker.new.perform(notification_params.to_json)
+      NotificationWorker.new.perform(notification_params)
     end
 
     context "given a subscriber list matched on tags" do
@@ -23,6 +23,19 @@ RSpec.describe NotificationWorker do
 
       it "sends a bulletin with the correct IDs" do
         make_it_perform
+
+        expect(@gov_delivery).to have_received(:send_bulletin)
+          .with(
+            ['gov123'],
+            "Test subject",
+            "Test body copy",
+            {}
+          )
+      end
+
+      # FIXME: temporary test, see comment in NotificationWorker.perform
+      it "handles params correctly if they are passed in already-encoded" do
+        NotificationWorker.new.perform(notification_params.to_json)
 
         expect(@gov_delivery).to have_received(:send_bulletin)
           .with(


### PR DESCRIPTION
This adds a temporary bandaid which correctly handles queued jobs that
may have been enqueued with or without encoding of the params hash at
the point of calling NotificationWorker.perform.

Relevant history can be observed in the October history of these two views:
https://github.com/alphagov/email-alert-api/commits/master/app/controllers/notifications_controller.rb
https://github.com/alphagov/email-alert-api/commits/master/app/workers/notification_worker.rb

Trello: https://trello.com/c/AuskAQ9S/390-fix-nomethoderror-in-email-alert-api-notifications