### PR TITLE
Policy SubscriberLists content ID migration

### DIFF
--- a/db/migrate/20151027155930_remove_dead_policy_subscriber_list.rb
+++ b/db/migrate/20151027155930_remove_dead_policy_subscriber_list.rb
@@ -1,0 +1,17 @@
+class RemoveDeadPolicySubscriberList < ActiveRecord::Migration
+  def up
+    # This list doesn't match anything except similarly named placeholders in
+    # the Content Store.
+    target_list = SubscriberListQuery.new.find_exact_match_with(
+      { policy: ["inspections-of-schools-colleges-and-children-s-services"] }
+    ).first
+
+    if target_list.present?
+      target_list.destroy!
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151023151545) do
+ActiveRecord::Schema.define(version: 20151027155930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/links_migration/for_policies/runner.rake
+++ b/lib/tasks/links_migration/for_policies/runner.rake
@@ -1,3 +1,5 @@
+require "tasks/links_migration/policy_link_migrator"
+
 namespace :links_migration do
   namespace :for_policies do
 
@@ -34,5 +36,15 @@ namespace :links_migration do
       puts
     end
 
+    desc "Print out a report of policy subscriber lists with no obvious content ID match in the content store"
+    task report_non_matching: [:environment] do
+      Tasks::LinksMigration::PolicyLinkMigrator.new.report_non_matching_subscriber_lists
+    end
+
+    desc "Populate empty links fields with policies, based on SubscriberList#tags"
+    task populate_links: [:environment] do
+      Tasks::LinksMigration::PolicyLinkMigrator.new.populate_topic_links
+    end
   end
+
 end

--- a/lib/tasks/links_migration/for_topics/runner.rake
+++ b/lib/tasks/links_migration/for_topics/runner.rake
@@ -1,4 +1,4 @@
-require "tasks/links_migration/link_migrator"
+require "tasks/links_migration/topic_link_migrator"
 
 namespace :links_migration do
   namespace :for_topics do

--- a/lib/tasks/links_migration/policy_link_migrator.rb
+++ b/lib/tasks/links_migration/policy_link_migrator.rb
@@ -1,0 +1,83 @@
+module Tasks
+  module LinksMigration
+    class PolicyLinkMigrator
+      class DodgyBasePathError < StandardError; end
+
+      def populate_policy_links
+        relevant_subscriber_lists.each do |list|
+          content_item = Services.content_store.content_item(base_path_from(list))
+
+          if content_item.blank?
+            raise DodgyBasePathError, <<-ERROR.strip_heredoc
+              No content item found for #{base_path_from(list)},
+              run the report_non_matching rake task and fix these
+              cases before continuing migration.
+            ERROR
+          end
+
+          if content_item.content_id.blank?
+            raise DodgyBasePathError, <<-ERROR.strip_heredoc
+              No content item found for #{base_path_from(list)},
+              run the report_non_matching rake task and fix these
+              cases before continuing migration.
+            ERROR
+          end
+
+          puts "Updating links in SubscriberList #{list.id}"
+          list.update(links: {policy: [content_item.content_id]})
+        end
+      end
+
+      def report_non_matching_subscriber_lists
+        no_content_item = []
+        no_content_id   = []
+
+        relevant_subscriber_lists.each do |list|
+          print "."
+          content_item = Services.content_store.content_item(base_path_from(list))
+
+          if content_item.blank?
+            no_content_item << list
+            next
+          end
+
+          if content_item.content_id.blank?
+            no_content_id << list
+          end
+        end
+
+        puts
+        puts "***No content item found***"
+        no_content_item.each do |list|
+          puts "#{list.id}, #{policy_tag(list)}"
+        end
+        puts "Total: #{no_content_item.count}"
+
+        puts
+        puts "***No content id found***"
+        no_content_id.each do |list|
+          puts "#{list.id}, #{policy_tag(list)}"
+        end
+        puts "Total: #{no_content_id.count}"
+
+        puts
+        puts "GRAND TOTAL: #{no_content_item.count + no_content_id.count}"
+      end
+
+private
+      def policy_tag(list)
+        # Only one slug is ever specified in policy tags
+        list.tags[:policy].first
+      end
+
+      def base_path_from(subscriber_list)
+        "/government/policies/#{policy_tag(subscriber_list)}"
+      end
+
+      def relevant_subscriber_lists
+        @relevant_subscriber_lists ||= SubscriberListQuery.new(query_field: :tags)
+          .subscriber_lists_with_key(:policy)
+      end
+    end
+  end
+end

--- a/lib/tasks/links_migration/topic_link_migrator.rb
+++ b/lib/tasks/links_migration/topic_link_migrator.rb
@@ -1,6 +1,6 @@
 module Tasks
   module LinksMigration
-    class LinkMigrator
+    class TopicLinkMigrator
       class DodgyBasePathError < StandardError; end
 
       def populate_topic_links
@@ -10,16 +10,16 @@ module Tasks
           if content_item.blank?
             raise DodgyBasePathError, <<-ERROR.strip_heredoc
               No content item found for #{base_path_from(list)},
-              run `bundle exec rake links_migration:report_non_matching`
-              and fix these cases before continuing migration.
+              run the report_non_matching rake task and fix these
+              cases before continuing migration.
             ERROR
           end
 
           if content_item.content_id.blank?
             raise DodgyBasePathError, <<-ERROR.strip_heredoc
-              No content ID found for #{base_path_from(list)},
-              run `bundle exec rake links_migration:report_non_matching`
-              and fix these cases before continuing migration.
+              No content item found for #{base_path_from(list)},
+              run the report_non_matching rake task and fix these
+              cases before continuing migration.
             ERROR
           end
 


### PR DESCRIPTION
This is part of the move to using content IDs for all content across
Gov UK. This commit provides a pair of rake tasks that will assist in
populating content IDs on the links hash of each policy SubscriberList.
It follows a very similar design to the preceding topic-specific tasks.

Trello: https://trello.com/c/Dx7lLo4r/383-policy-email-alerts-in-email-alert-api-need-to-support-content-id