### PR TITLE
Rename policy SubscriberList links to 'parent'

### DIFF
--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -36,7 +36,7 @@ class SubscriberListQuery
   def subscriber_lists_with_key(key)
     # This uses the `?` hstore operator, which returns true only if the hstore
     # contains the specified key.
-    SubscriberList.where("tags ? :key", key: key)
+    SubscriberList.where("#{@query_field} ? :key", key: key)
   end
 
 private

--- a/db/migrate/20151102165117_rename_policy_links_to_parent.rb
+++ b/db/migrate/20151102165117_rename_policy_links_to_parent.rb
@@ -1,0 +1,17 @@
+class RenamePolicyLinksToParent < ActiveRecord::Migration
+  def up
+    SubscriberListQuery.new(query_field: :links).subscriber_lists_with_key(:policy).each do |list|
+      content_id = list.links[:policy]
+      list.links = {parent: content_id}
+      list.save!
+    end
+  end
+
+  def down
+    SubscriberListQuery.new(query_field: :links).subscriber_lists_with_key(:parent).each do |list|
+      content_id = list.links[:parent]
+      list.links = {policy: content_id}
+      list.save!
+    end
+  end
+end

--- a/lib/tasks/links_migration/policy_link_migrator.rb
+++ b/lib/tasks/links_migration/policy_link_migrator.rb
@@ -24,7 +24,7 @@ module Tasks
           end
 
           puts "Updating links in SubscriberList #{list.id}"
-          list.update(links: {policy: [content_item.content_id]})
+          list.update(links: {parent: [content_item.content_id]})
         end
       end
 

--- a/spec/lib/tasks/links_migration/link_migrator_spec.rb
+++ b/spec/lib/tasks/links_migration/link_migrator_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Links Migration" do
         subject.populate_policy_links
         subscriber_list.reload
 
-        expect(subscriber_list.links).to eq(policy: ["uuid-999"])
+        expect(subscriber_list.links).to eq(parent: ["uuid-999"])
       end
 
       it "raises an exception if the content item has no ID" do


### PR DESCRIPTION
The policy-publisher and govuk-content-schemas have been updated (https://github.com/alphagov/policy-publisher/pull/111) such that email signup content items now carry a link to their parent content item. The key used in the link is 'parent'. The implication of this is that email-alert-api will start receiving links keyed with 'parent' for policy email subscriptions and notifications. This commit supports that transition.

Trello: https://trello.com/c/EzjSpzQl/402-update-email-alert-frontend-to-start-passing-content-ids-as-well-as-slugs