### PR TITLE
Rename 'parent' links to 'policies'

### DIFF
--- a/db/migrate/20151111124933_remove_policy_subscriber_lists_with_erroneous_links.rb
+++ b/db/migrate/20151111124933_remove_policy_subscriber_lists_with_erroneous_links.rb
@@ -1,0 +1,11 @@
+class RemovePolicySubscriberListsWithErroneousLinks < ActiveRecord::Migration
+  def up
+    SubscriberListQuery.new(query_field: :tags).subscriber_lists_with_key(:policies).each do |sl|
+      sl.destroy!
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/migrate/20151111150405_rename_parent_links_to_policies.rb
+++ b/db/migrate/20151111150405_rename_parent_links_to_policies.rb
@@ -1,0 +1,15 @@
+class RenameParentLinksToPolicies < ActiveRecord::Migration
+  def up
+    SubscriberListQuery.new(query_field: :links).subscriber_lists_with_key(:parent).each do |sl|
+      sl.links = { policies: sl.links[:parent] }
+      sl.save!
+    end
+  end
+
+  def down
+    SubscriberListQuery.new(query_field: :links).subscriber_lists_with_key(:policies).each do |sl|
+      sl.links = { parent: sl.links[:policies] }
+      sl.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027155930) do
+ActiveRecord::Schema.define(version: 20151111150405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/links_migration/for_topics/runner.rake
+++ b/lib/tasks/links_migration/for_topics/runner.rake
@@ -5,12 +5,12 @@ namespace :links_migration do
 
     desc "Print out a report of topic subscriber lists with no obvious content ID match in the content store"
     task report_non_matching: [:environment] do
-      Tasks::LinksMigration::LinkMigrator.new.report_non_matching_subscriber_lists
+      Tasks::LinksMigration::TopicLinkMigrator.new.report_non_matching_subscriber_lists
     end
 
     desc "Populate topics in empty links on SubscriberList using the tags field"
     task populate_topic_links: [:environment] do
-      Tasks::LinksMigration::LinkMigrator.new.populate_topic_links
+      Tasks::LinksMigration::TopicLinkMigrator.new.populate_links
     end
 
   end

--- a/lib/tasks/links_migration/policy_link_migrator.rb
+++ b/lib/tasks/links_migration/policy_link_migrator.rb
@@ -24,7 +24,7 @@ module Tasks
           end
 
           puts "Updating links in SubscriberList #{list.id}"
-          list.update(links: {parent: [content_item.content_id]})
+          list.update(links: {policies: [content_item.content_id]})
         end
       end
 

--- a/lib/tasks/links_migration/topic_link_migrator.rb
+++ b/lib/tasks/links_migration/topic_link_migrator.rb
@@ -3,7 +3,7 @@ module Tasks
     class TopicLinkMigrator
       class DodgyBasePathError < StandardError; end
 
-      def populate_topic_links
+      def populate_links
         relevant_subscriber_lists.each do |list|
           content_item = Services.content_store.content_item(base_path_from(list))
 

--- a/spec/lib/tasks/links_migration/link_migrator_spec.rb
+++ b/spec/lib/tasks/links_migration/link_migrator_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe "Links Migration" do
   end
 
   describe Tasks::LinksMigration::TopicLinkMigrator do
-    describe "#populate_topic_links" do
+    describe "#populate_links" do
       let(:subject) { Tasks::LinksMigration::TopicLinkMigrator.new }
 
       it "copies content IDs for appropriate topic tag matches" do
         subscriber_list = create(:subscriber_list, tags: {topics: ["oil-and-gas/something"]})
 
-        subject.populate_topic_links
+        subject.populate_links
         subscriber_list.reload
 
         expect(subscriber_list.links).to eq(topics: ["uuid-888"])
@@ -61,7 +61,7 @@ RSpec.describe "Links Migration" do
       it "raises an exception if the content item has no ID" do
         create(:subscriber_list, tags: {topics: ["benefits/some-other-thing"]})
 
-        expect {subject.populate_topic_links}.to raise_error(
+        expect {subject.populate_links}.to raise_error(
           Tasks::LinksMigration::TopicLinkMigrator::DodgyBasePathError
         )
       end
@@ -69,7 +69,7 @@ RSpec.describe "Links Migration" do
       it "raises an exception if no content item is returned" do
         create(:subscriber_list, tags: {topics: ["no-match"]})
 
-        expect {subject.populate_topic_links}.to raise_error(
+        expect {subject.populate_links}.to raise_error(
           Tasks::LinksMigration::TopicLinkMigrator::DodgyBasePathError
         )
       end
@@ -86,7 +86,7 @@ RSpec.describe "Links Migration" do
         subject.populate_policy_links
         subscriber_list.reload
 
-        expect(subscriber_list.links).to eq(parent: ["uuid-999"])
+        expect(subscriber_list.links).to eq(policies: ["uuid-999"])
       end
 
       it "raises an exception if the content item has no ID" do


### PR DESCRIPTION
This further modifies a recent change to naming conventions for policy
SubscriberLists. Currently, these refer to their corresponding policy
content item with a links hash containing the key 'parent'. This commit
renames 'parent' to 'policies'. This is better for discoverability, makes
it clearer what type of content a given SubscriberList relates to, and is
consistent with links hash naming conventions used elsewhere in gov.uk.