### PR TITLE
Rename tag key used for policy SubscriberLists

### DIFF
--- a/db/migrate/20151112144850_rename_policy_tags_to_policies.rb
+++ b/db/migrate/20151112144850_rename_policy_tags_to_policies.rb
@@ -1,0 +1,15 @@
+class RenamePolicyTagsToPolicies < ActiveRecord::Migration
+  def up
+    SubscriberListQuery.new(query_field: :tags).subscriber_lists_with_key(:policy).each do |sl|
+      sl.tags = { policies: sl.tags[:policy] }
+      sl.save!
+    end
+  end
+
+  def down
+    SubscriberListQuery.new(query_field: :tags).subscriber_lists_with_key(:policies).each do |sl|
+      sl.tags = { policy: sl.tags[:policies] }
+      sl.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151111150405) do
+ActiveRecord::Schema.define(version: 20151112144850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Also review and merge: https://github.com/alphagov/content-store/pull/168 and https://github.com/alphagov/policy-publisher/pull/114

Items tagged to policies currently do not trigger email alerts, as the
SubscriberLists in the email-alert-api are tagged with 'policy' (singular).
This change will be deployed alongside a frontend change to ensure policy
subscriptions are created with the correct tags in the first place.