### PR TITLE
Improve `/healthcheck` endpoint

### DIFF
--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,5 +1,14 @@
 require "rails_helper"
 
+ENV['SIDEKIQ_QUEUE_SIZE_WARNING'] = '2'
+ENV['SIDEKIQ_QUEUE_SIZE_CRITICAL'] = '5'
+
+ENV['SIDEKIQ_QUEUE_LATENCY_WARNING'] = '5'
+ENV['SIDEKIQ_QUEUE_LATENCY_CRITICAL'] = '10'
+
+ENV['SIDEKIQ_RETRY_SIZE_WARNING'] = '5'
+ENV['SIDEKIQ_RETRY_SIZE_CRITICAL'] = '10'
+
 RSpec.describe HealthcheckController, type: :controller do
   describe "#check" do
     it "responds with JSON" do
@@ -19,7 +28,12 @@ RSpec.describe HealthcheckController, type: :controller do
     end
 
     it "includes queue length check in the response" do
-      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(13)
+      queues = {
+        "scheduled_publishing"=>0,
+        "panopticon"=>1
+      }
+
+      allow_any_instance_of(HealthcheckController).to receive(:sidekiq_queues).and_return(queues)
       get :check, format: :json
 
       data = JSON.parse(response.body)
@@ -27,7 +41,12 @@ RSpec.describe HealthcheckController, type: :controller do
     end
 
     it "returns ok for small queue sizes" do
-      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(1)
+      queues = {
+        "scheduled_publishing"=>0,
+        "panopticon"=>1
+      }
+
+      allow_any_instance_of(HealthcheckController).to receive(:sidekiq_queues).and_return(queues)
 
       get :check, format: :json
 
@@ -36,7 +55,13 @@ RSpec.describe HealthcheckController, type: :controller do
     end
 
     it "returns warning for medium queue sizes" do
-      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(4)
+      queues = {
+        "scheduled_publishing"=>0,
+        "panopticon"=>1,
+        "foo"=>3
+      }
+
+      allow_any_instance_of(HealthcheckController).to receive(:sidekiq_queues).and_return(queues)
 
       get :check, format: :json
 
@@ -45,7 +70,13 @@ RSpec.describe HealthcheckController, type: :controller do
     end
 
     it "returns critical for large queue sizes" do
-      allow_any_instance_of(HealthcheckController).to receive(:queue_size).and_return(10)
+      queues = {
+        "scheduled_publishing"=>0,
+        "panopticon"=>1,
+        "foo"=>10
+      }
+
+      allow_any_instance_of(HealthcheckController).to receive(:sidekiq_queues).and_return(queues)
 
       get :check, format: :json
 
@@ -60,5 +91,22 @@ RSpec.describe HealthcheckController, type: :controller do
       data = JSON.parse(response.body)
       expect(data['checks']).to include('queue_age')
     end
+
+    it "returns critical for large latencies" do
+      latencies = {
+        "foo"=>1,
+        "bar"=>5,
+        "baz"=>10
+      }
+
+      allow_any_instance_of(HealthcheckController).to receive(:queue_latencies).and_return(latencies)
+
+      get :check, format: :json
+
+      data = JSON.parse(response.body)
+      expect(data['checks']['queue_age']['status']).to eq('critical')
+
+    end
+
   end
 end


### PR DESCRIPTION
As part of improving our Sidekiq monitoring, we
now graph all stats in Graphite. We are also 
moving to a 12factor style of application. 

Applications should have a notion of what is 
‘normal’ and can therefore set their thresholds 
rather than having these set by Puppet

Depends on: https://github.gds/gds/puppet/pull/3671