### PR TITLE
Use sidekiq-statsd gem to monitor Sidekiq stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'logstasher', '0.4.8'
 gem 'sidekiq-logging-json', '0.0.14'
 gem 'statsd-ruby', '1.2.1'
 gem 'gds-api-adapters'
+gem 'sidekiq-statsd', '0.1.5'
 
 group :test do
   gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,10 @@ GEM
       redis-namespace (>= 1.3.1)
     sidekiq-logging-json (0.0.14)
       sidekiq (~> 3)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     slop (3.6.0)
     sprockets (3.4.0)
       rack (> 1, < 3)
@@ -220,6 +224,7 @@ DEPENDENCIES
   rspec-rails (= 3.1.0)
   sidekiq (= 3.2.6)
   sidekiq-logging-json (= 0.0.14)
+  sidekiq-statsd (= 0.1.5)
   statsd-ruby (= 1.2.1)
   unicorn (= 4.8.3)
   webmock

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,10 @@
 Sidekiq.configure_server do |config|
   config.redis = EmailAlertAPI.config.redis_config
   config.error_handlers << Proc.new {|ex, context_hash| Airbrake.notify(ex, context_hash) }
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.email-alert-api', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
Story: https://trello.com/c/hoeciDWu/53-add-icinga-checks-for-sidekiq-retry-counts

Similar to https://github.com/alphagov/whitehall/pull/2370, add the
`sidekiq-statsd` gem to log Sidekiq statistics to statsd.