### PR TITLE
Add document_type to subscriber lists and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ tags via the external services.
   GovDelivery's servers)
  * Associated tags indicate what the subscribers for that list are interested in
   and what updates they should receive
+ * An optional document_type indicates the types of notifications that will be
+  matched for subscribers. If the list has a document_type set, only
+  notifications with a matching document_type will be sent; if the list has
+  no document_type, messages will be sent whether or not the notification has
+  a document_type.
 
 - **Topic**:
  * GovDelivery terminology for a subscriber list
@@ -77,6 +82,7 @@ or export them using dotenv or similar.
     "title": "Title of topic",
     "subscription_url": "https://public-url/subscribe-here?topic_id=123",
     "gov_delivery_id": "123",
+    "document_type": "",
     "created_at": "20141010T12:00:00",
     "updated_at": "20141010T12:00:00",
     "tags": {

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -10,7 +10,7 @@ class NotificationsController < ApplicationController
 private
 
   def notification_params
-    params.slice(:subject, :body, :from_address_id, :urgent, :header, :footer)
+    params.slice(:subject, :body, :from_address_id, :urgent, :header, :footer, :document_type)
       .merge(tags: params.fetch(:tags, {}))
       .merge(links: params.fetch(:links, {}))
   end

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -46,5 +46,6 @@ private
     params.slice(:title)
       .merge(tags: params.fetch(:tags, {}))
       .merge(links: params.fetch(:links, {}))
+      .merge(document_type: params.fetch(:document_type, ""))
   end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -11,6 +11,7 @@ class SubscriberList < ActiveRecord::Base
       title: params[:title],
       tags:  params[:tags],
       links: params[:links],
+      document_type: params[:document_type],
       gov_delivery_id: gov_delivery_id,
     )
   end

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -24,7 +24,7 @@ class NotificationWorker
 
     @tags_hash  = Hash(notification_params[:tags])
     @links_hash = Hash(notification_params[:links])
-    lists = (lists_matched_on_links + lists_matched_on_tags).uniq { |l| l.id }
+    @document_type = notification_params[:document_type]
     delivery_ids = lists.map(&:gov_delivery_id)
 
     if lists.any?
@@ -63,5 +63,17 @@ private
   def lists_matched_on_links
     @lists_matched_on_links ||= SubscriberListQuery.new(query_field: :links)
       .where_all_links_match_at_least_one_value_in(@links_hash)
+  end
+
+  def filter_by_document_type(matching_lists)
+    matching_lists.select { |l| l.document_type.blank? || l.document_type == @document_type }
+  end
+
+  def matching_lists
+    (lists_matched_on_links + lists_matched_on_tags).uniq { |l| l.id }
+  end
+
+  def lists
+    @lists ||= filter_by_document_type(matching_lists)
   end
 end

--- a/db/migrate/20160205102023_add_document_type_to_subscriber_list.rb
+++ b/db/migrate/20160205102023_add_document_type_to_subscriber_list.rb
@@ -1,0 +1,5 @@
+class AddDocumentTypeToSubscriberList < ActiveRecord::Migration
+  def change
+    add_column :subscriber_lists, :document_type, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151112144850) do
+ActiveRecord::Schema.define(version: 20160205102023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20151112144850) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.hstore   "links",                       default: {}, null: false
+    t.string   "document_type",               default: "", null: false
   end
 
   add_index "subscriber_lists", ["links"], name: "index_subscriber_lists_on_links", using: :gin

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -19,5 +19,14 @@ RSpec.describe NotificationsController, type: :controller do
 
       post :create, notification_params.merge(format: :json)
     end
+
+    it "allows an optional document_type parameter" do
+      notification_params[:document_type] = "travel_advice"
+      expect(NotificationWorker).to receive(:perform_async).with(
+        notification_params.merge(links: {})
+      )
+
+      post :create, notification_params.merge(format: :json)
+    end
   end
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -2,18 +2,30 @@ require "rails_helper"
 
 RSpec.describe SubscriberList, type: :model do
   describe ".build_from(params:, gov_delivery_id:)" do
-    it "builds a new SubscriberList" do
-      params = {
+    let(:params) {
+      {
         title: "Ronnie Pickering",
         tags: { topics: ["motoring/road_rage"] },
         links: { topics: ["uuid-888"] },
       }
-      gov_delivery_id = "GOVUK_888"
-      list = SubscriberList.build_from(params: params, gov_delivery_id: gov_delivery_id)
+    }
+    let(:gov_delivery_id) { "GOVUK_888" }
+
+    let(:list) {
+      SubscriberList.build_from(params: params, gov_delivery_id: gov_delivery_id)
+    }
+
+    it "builds a new SubscriberList without a format" do
       expect(list.title).to eq "Ronnie Pickering"
       expect(list.tags).to eq({:topics=>["motoring/road_rage"]})
       expect(list.links).to eq({:topics=>["uuid-888"]})
       expect(list.gov_delivery_id).to eq "GOVUK_888"
+      expect(list.document_type).to be_nil
+    end
+
+    it "builds a new SubscriberList with a format" do
+      params[:document_type] = "travel_advice"
+      expect(list.document_type).to eq "travel_advice"
     end
   end
 

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
       %w{
         id
         title
+        document_type
         subscription_url
         gov_delivery_id
         created_at

--- a/spec/requests/get_subscriber_list_spec.rb
+++ b/spec/requests/get_subscriber_list_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Getting a subscriber list", type: :request do
         %w{
           id
           title
+          document_type
           subscription_url
           gov_delivery_id
           created_at
@@ -54,6 +55,7 @@ RSpec.describe "Getting a subscriber list", type: :request do
           id
           title
           subscription_url
+          document_type
           gov_delivery_id
           created_at
           updated_at


### PR DESCRIPTION
Allow an optional document_type field to be set on subscriber lists, and supplied in notifications.

If present on subscriber lists that are already matched on links or tags, only notifications with a matching document_type will be sent. Notifications will always be sent on matching subscriber lists without a value for document_type, whether or not that value is provided in the notification.

```
subscriber list document_type | content item document_type | send email?
------------------------------+----------------------------+------------
travel-advice                 | travel-advice              | yes
travel-advice                 | publication                | no
travel-advice                 | [missing]                  | no
[missing]                     | publication                | yes
[missing]                     | [missing]                  | yes
```
