### PR TITLE
Remove a bandaid that no longer applies...

### DIFF
--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -2,25 +2,7 @@ class NotificationWorker
   include Sidekiq::Worker
 
   def perform(notification_params)
-    # FIXME:
-    # tl;dr - remove the check on String below after 15th Nov 2015.
-    #
-    # The parameter to this worker was previously being encoded as JSON at the
-    # point of being enqueued (in NotificationsController). Sidekiq was calling
-    # JSON.dump on this, resulting in worker args that were JSON encoded twice.
-    # When this worker was changed to expect notification_params to be a simple
-    # Ruby hash (after being deserialized by Sidekiq), it began breaking in
-    # production due to old, previously-failing jobs re-trying one of their 25,
-    # exponentially backed off retries. The check below ensures that
-    # notification_params are correctly handled, irrespective of whether they
-    # were passed in already-encoded or not. This is a bandaid which should be
-    # removed after an appropriate length of time - 15th Nov 2015 should be
-    # sufficient.
-    notification_params = if notification_params.is_a?(String)
-                            JSON.parse(notification_params).with_indifferent_access
-                          else
-                            notification_params.with_indifferent_access
-                          end
+    notification_params = notification_params.with_indifferent_access
 
     @tags_hash  = Hash(notification_params[:tags])
     @links_hash = Hash(notification_params[:links])

--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -32,19 +32,6 @@ RSpec.describe NotificationWorker do
             {}
           )
       end
-
-      # FIXME: temporary test, see comment in NotificationWorker.perform
-      it "handles params correctly if they are passed in already-encoded" do
-        NotificationWorker.new.perform(notification_params.to_json)
-
-        expect(@gov_delivery).to have_received(:send_bulletin)
-          .with(
-            ['gov123'],
-            "Test subject",
-            "Test body copy",
-            {}
-          )
-      end
     end
 
     context "given a subscriber list matched on both links and tags" do


### PR DESCRIPTION
There was a bandaid added which meant that items
on the queue would work irrespective of whether
they were hashes or hashes encoded as strings. All
of these items should have now been processed by
the queue.