### PR TITLE
Add document_type only query to email-alert-api

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -5,6 +5,7 @@ class SubscriberList < ActiveRecord::Base
 
   validate :tag_values_are_valid
   validate :link_values_are_valid
+  validate :either_document_type_tags_or_links_present
 
   def self.build_from(params:, gov_delivery_id:)
     new(
@@ -59,6 +60,14 @@ private
         self.errors.add(:links, "All link values must be sent as Arrays")
       end
     end
+  end
+
+  def either_document_type_tags_or_links_present
+    return if self[:document_type].present?
+    return if self[:tags].present?
+    return if self[:links].present?
+
+    self.errors.add(:base, "Must have either a document_type, tags or links")
   end
 
   def parsed_hstore(field)

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -15,6 +15,10 @@ class SubscriberListQuery
     end
   end
 
+  def where_only_document_type_matches(document_type)
+    subscriber_lists_without_tags_or_links.where(document_type: document_type)
+  end
+
   def at_least_one_topic_value_matches(value)
     subscriber_lists_with_key(:topics).each_with_object([]) do |subscriber_list, results|
       if subscriber_list.send(@query_field)[:topics].include?(value)
@@ -66,5 +70,9 @@ private
     # This uses the `?&` hstore operator, which returns true only if the hstore
     # contains all the specified keys.
     SubscriberList.where("#{@query_field} ?& Array[:keys]", keys: query_hash.keys)
+  end
+
+  def subscriber_lists_without_tags_or_links
+    SubscriberList.where(tags: "", links: "")
   end
 end

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -47,12 +47,21 @@ private
       .where_all_links_match_at_least_one_value_in(@links_hash)
   end
 
+  def lists_matched_on_document_type_only
+    @lists_matched_on_document_type_only ||= SubscriberListQuery.new(query_field: :neither)
+      .where_only_document_type_matches(@document_type)
+  end
+
   def filter_by_document_type(matching_lists)
     matching_lists.select { |l| l.document_type.blank? || l.document_type == @document_type }
   end
 
   def matching_lists
-    (lists_matched_on_links + lists_matched_on_tags).uniq { |l| l.id }
+    (
+      lists_matched_on_links +
+      lists_matched_on_tags +
+      lists_matched_on_document_type_only
+    ).uniq { |l| l.id }
   end
 
   def lists

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :subscriber_list do
     sequence(:gov_delivery_id) {|n| "UKGOVUK_#{n}" }
+    tags({ topics: ["motoring/road_rage"] })
   end
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -29,6 +29,46 @@ RSpec.describe SubscriberList, type: :model do
     end
   end
 
+  describe "validations" do
+    subject { FactoryGirl.build(:subscriber_list) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+
+    it "is invalid without either a document_type, tags or links" do
+      subject.document_type = ""
+      subject.tags = {}
+      subject.links = {}
+
+      expect(subject).to be_invalid
+    end
+
+    it "is valid with a document type but no tags or links" do
+      subject.document_type = "document-type"
+      subject.tags = {}
+      subject.links = {}
+
+      expect(subject).to be_valid
+    end
+
+    it "is valid with tags but no document_type or links" do
+      subject.document_type = ""
+      subject.tags = { foo: ["bar"] }
+      subject.links = {}
+
+      expect(subject).to be_valid
+    end
+
+    it "is valid with links but no document_type or tags" do
+      subject.document_type = ""
+      subject.tags = {}
+      subject.links = { foo: ["bar"] }
+
+      expect(subject).to be_valid
+    end
+  end
+
   describe "#tags" do
     it "deserializes the tag arrays" do
       list = create(:subscriber_list, tags: { topics: ["environmental-management/boating"] })

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -60,13 +60,53 @@ RSpec.describe "Creating a subscriber list", type: :request do
     expect(response.status).to eq(422)
   end
 
-  def create_subscriber_list(tags: {}, links: {})
-    request_body = JSON.dump({
+  describe "creating a subscriber list with a document_type" do
+    it "returns a 201" do
+      create_subscriber_list(document_type: "travel_advice")
+
+      expect(response.status).to eq(201)
+    end
+
+    it "sets the document_type on the subscriber list" do
+      create_subscriber_list(
+        tags: { countries: ["andorra"] },
+        document_type: "travel_advice"
+      )
+
+      subscriber_list = SubscriberList.last
+      expect(subscriber_list.document_type).to eq("travel_advice")
+    end
+  end
+
+  context "when creating a subscriber list with no tags or links" do
+    context "and a document_type is provided" do
+      it "returns a 201" do
+        create_subscriber_list(document_type: "travel_advice")
+
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "and no document_type is provided" do
+      it "returns a 422" do
+        create_subscriber_list
+
+        expect(response.status).to eq(422);
+        expect(response.body).to match(/Must have either a document_type, tags or links/)
+      end
+    end
+  end
+
+  def create_subscriber_list(tags: {}, links: {}, document_type: nil)
+    payload = {
       title: "This is a sample title",
       gov_delivery_id: "UKGOVUK_1234",
       tags: tags,
-      links: links
-    })
+      links: links,
+    }
+
+    payload.merge!(document_type: document_type) if document_type
+    request_body = JSON.dump(payload)
 
     post "/subscriber-lists", request_body, json_headers
   end

--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe NotificationWorker do
       end
     end
 
+    context "when the subscriber list has no tags or links" do
+      before do
+        create(:subscriber_list, document_type: 'travel-advice', tags: {}, links: {})
+      end
+
+      it "sends a bulletin when document_type matches" do
+        notification_params[:document_type] = 'travel-advice'
+        make_it_perform
+        expect(@gov_delivery).to have_received(:send_bulletin)
+      end
+
+      it "does not send a bulletin when document_type does not match" do
+        notification_params[:document_type] = 'not-travel-advice'
+        make_it_perform
+        expect(@gov_delivery).not_to have_received(:send_bulletin)
+      end
+    end
+
     context "given a non-matching subscriber list" do
       before do
         create(


### PR DESCRIPTION
https://trello.com/c/gPjk5P2A/611-add-document-type-only-query-to-email-alert-api