### PR TITLE
Search for subscriber lists by document_type as well as links/tags

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -37,9 +37,13 @@ private
   end
 
   def find_subscriber_list
-    match = SubscriberListQuery.new(query_field: :links).find_exact_match_with(subscriber_list_params[:links]).first
-    return match if match.present?
-    return SubscriberListQuery.new(query_field: :tags).find_exact_match_with(subscriber_list_params[:tags]).first
+    links_query = SubscriberListQuery.new(query_field: :links)
+    tags_query = SubscriberListQuery.new(query_field: :tags)
+    document_type_query = SubscriberListQuery.new(query_field: :neither)
+
+    links_query.find_exact_match_with(links, document_type).first ||
+      tags_query.find_exact_match_with(tags, document_type).first ||
+      document_type_query.where_only_document_type_matches(document_type).first
   end
 
   def subscriber_list_params
@@ -47,5 +51,17 @@ private
       .merge(tags: params.fetch(:tags, {}))
       .merge(links: params.fetch(:links, {}))
       .merge(document_type: params.fetch(:document_type, ""))
+  end
+
+  def links
+    subscriber_list_params[:links]
+  end
+
+  def tags
+    subscriber_list_params[:tags]
+  end
+
+  def document_type
+    subscriber_list_params[:document_type]
   end
 end

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -27,9 +27,13 @@ class SubscriberListQuery
     end
   end
 
-  def find_exact_match_with(query_hash)
+  def find_exact_match_with(query_hash, document_type)
     return [] unless query_hash.present?
-    subscriber_lists_with_all_matching_keys(query_hash).select do |list|
+
+    subscriber_lists = subscriber_lists_with_all_matching_keys(query_hash)
+    subscriber_lists = subscriber_lists.where(document_type: document_type)
+
+    subscriber_lists.select do |list|
       list.send(@query_field).all? do |descriptor, array_of_values|
         next if query_hash[descriptor].nil?
         query_hash[descriptor].sort == array_of_values.sort

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -99,15 +99,19 @@ RSpec.describe SubscriberListQuery do
 
   describe "#find_exact_match_with(links:, tags:)" do
     before do
-      @list_with_tags = create(:subscriber_list, tags: {
-        topics: ["oil-and-gas/licensing"],
-        organisations: ["environment-agency", "hm-revenue-customs"]
-      })
+      @list_with_tags = create(
+        :subscriber_list,
+        tags: {
+          topics: ["oil-and-gas/licensing"],
+          organisations: ["environment-agency", "hm-revenue-customs"]
+        },
+        document_type: "policy",
+      )
     end
 
     it "requires all tag types in the document to be present in the list" do
       found_lists = SubscriberListQuery.new(query_field: :tags)
-        .find_exact_match_with({ topics: ["oil-and-gas/licensing"] })
+        .find_exact_match_with({ topics: ["oil-and-gas/licensing"] }, "policy")
       expect(found_lists).to eq([])
     end
 
@@ -117,25 +121,38 @@ RSpec.describe SubscriberListQuery do
           topics: ["oil-and-gas/licensing"],
           organisations: ["environment-agency", "hm-revenue-customs"],
           foo: ["bar"]
-        })
+        }, "policy")
+      expect(found_lists).to eq([])
+    end
+
+    it "requires the a match on the document type" do
+      found_lists = SubscriberListQuery.new(query_field: :tags)
+        .find_exact_match_with({
+          topics: ["oil-and-gas/licensing"],
+          organisations: ["environment-agency", "hm-revenue-customs"]
+        }, "something_else")
       expect(found_lists).to eq([])
     end
 
     it "requires all tag types in the list to be present in the document" do
-      list_with_links = create(:subscriber_list, links: { topics: ["uuid-888"] })
+      list_with_links = create(
+        :subscriber_list,
+        links: { topics: ["uuid-888"] },
+        document_type: "policy",
+      )
 
       found_by_tags = SubscriberListQuery.new(query_field: :tags)
         .find_exact_match_with({
           topics: ["oil-and-gas/licensing"],
           organisations: ["environment-agency", "hm-revenue-customs"]
-        })
+        }, "policy")
 
       expect(found_by_tags).to eq([@list_with_tags])
 
       found_by_links = SubscriberListQuery.new(query_field: :links)
         .find_exact_match_with({
           topics: ["uuid-888"]
-        })
+        }, "policy")
 
       expect(found_by_links).to eq([list_with_links])
     end


### PR DESCRIPTION
As part of the work to migrate users onto the email-alert-frontend workflow for Travel Advice (rather than Pagewatch), we need to make sure that the subscriber list can be found in email-alert-api in order to retrieve the subscription url to point users to.

This pull request makes it so that you can now search for a subscriber list by document type as well as links and tags. There will need to be some equivalent work in gds-api-adapters to pass this through and in email-alert-frontend to call gds-api-adapters with this field.