### PR TITLE
Add health check for GovDelivery

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -17,6 +17,9 @@ class HealthcheckController < ActionController::Base
             queue_retry_size: {
               status: queue_retry_size_status
             },
+            govdelivery: {
+              status: govdelivery_status
+            },
           },
           status: status
         }
@@ -29,6 +32,14 @@ private
   def status
     ActiveRecord::Base.connected? &&
       Sidekiq.redis { |conn| conn.info } ? 'ok' : 'critical'
+  end
+
+  def govdelivery_status
+    if Services.gov_delivery.ping.status == 200
+      'ok'
+    else
+      'critical'
+    end
   end
 
   def queue_retry_size_status

--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -22,6 +22,10 @@ module GovDelivery
       )
     end
 
+    def ping
+      http_client.get("categories.xml")
+    end
+
     def read_topic_by_name(name)
       # GovDelivery documentation for this endpoint:
       # http://developer.govdelivery.com/api_docs/comm_cloud_v1/#API/Comm Cloud V1/API_CommCloudV1_Topics_ListTopics.htm


### PR DESCRIPTION
During maintenance this afternoon we realised that if our GovDelivery API credentials would stop working, we would perhaps not notice instantly. This PR proposes a canary for this situation.

It adds a check to the `/healthcheck` endpoint that will fail if GovDelivery returns anything other than `200` for a routine request. This will be picked up by [Icinga](https://github.com/alphagov/govuk-puppet/blob/359752e58e26f6dfc799e7915b0fb23924a52f19/modules/icinga/files/usr/lib/nagios/plugins/check_json_healthcheck).

Notes:

- I've used the `categories.xml` because it's unlikely to change, doesn't rely on state and is reasonably performant, since we don't use categories. But it's not ideal probably.
- This will raise an Nagios alert that _something_ is wrong with GovDelivery, but not really what.

Thoughts, @elliotcm @danielroseman @alphagov/team-finding-things ?