### PR TITLE
Add govuk-request-id data atrribute to html email alert body

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -10,8 +10,13 @@ class NotificationsController < ApplicationController
 private
 
   def notification_params
-    params.slice(:subject, :body, :from_address_id, :urgent, :header, :footer, :document_type)
+    params.slice(:subject, :from_address_id, :urgent, :header, :footer, :document_type)
       .merge(tags: params.fetch(:tags, {}))
       .merge(links: params.fetch(:links, {}))
+      .merge(body: notification_body)
+  end
+
+  def notification_body
+    GovukRequestId.insert(params[:body])
   end
 end

--- a/lib/govuk_request_id.rb
+++ b/lib/govuk_request_id.rb
@@ -1,0 +1,23 @@
+class GovukRequestId
+  class << self
+    def insert(body)
+      return body unless body.present?
+
+      if body =~ /^</
+        body += govuk_request_id_html_comment
+      end
+
+      body
+    end
+
+  private
+
+    def govuk_request_id_html_comment
+      "\n<!-- govuk_request_id: #{govuk_request_id} -->\n"
+    end
+
+    def govuk_request_id
+      GdsApi::GovukHeaders.headers[:govuk_request_id]
+    end
+  end
+end

--- a/spec/lib/govuk_request_id_spec.rb
+++ b/spec/lib/govuk_request_id_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe GovukRequestId, :insert do
+  before do
+    allow(GdsApi::GovukHeaders).to receive(:headers)
+      .and_return(govuk_request_id: "12345-67890")
+  end
+
+  context "when the body is nil" do
+    it "doesn't do anything" do
+      expect(described_class.insert(nil)).to eq(nil)
+    end
+  end
+
+  context "when the body is empty" do
+    let(:body) { "" }
+    it "doesn't do anything" do
+      expect(described_class.insert(body)).to eq("")
+    end
+  end
+
+  context "when the body doesn't contain html" do
+    let(:body) { "Some email content" }
+    it "doesn't do anything" do
+      expect(described_class.insert(body)).to eq(body)
+    end
+  end
+
+  context "when the body is html" do
+    let(:body) { "<p><span>Some body content</span></p>" }
+    let(:expected_body) do
+      %Q(<p><span>Some body content</span></p>\n<!-- govuk_request_id: 12345-67890 -->\n)
+    end
+
+    it "adds a data attribute to the first child element" do
+      expect(described_class.insert(body)).to eq(expected_body)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/tFRwaUPB/26-ensure-request-id-is-set-in-message-body-by-email-alert-api

As part of ongoing monitoring for email alerts and other request tracing work we'd like to be able to trace an email alert from origin to delivery using the existing request id header created by the load balancer and used in other parts of the stack.
This change only adds a data attribute to an html body and no-ops with blank or text bodies.

See also work by @elliotcm for how this links to travel advice, publishing-api etc...
https://github.com/alphagov/govuk-puppet/pull/4320
https://github.com/alphagov/travel-advice-publisher/pull/139
https://github.com/alphagov/publishing-api/pull/269

paired with Pablo on this.

/cc @gpeng