### PR TITLE
Add govuk request id to email body...

### DIFF
--- a/lib/govuk_request_id.rb
+++ b/lib/govuk_request_id.rb
@@ -4,7 +4,7 @@ class GovukRequestId
       return body unless body.present?
 
       if body =~ /^</
-        body += govuk_request_id_html_comment
+        body += govuk_request_id_html
       end
 
       body
@@ -12,8 +12,8 @@ class GovukRequestId
 
   private
 
-    def govuk_request_id_html_comment
-      "\n<!-- govuk_request_id: #{govuk_request_id} -->\n"
+    def govuk_request_id_html
+      %Q(<span data-govuk-request-id="#{govuk_request_id}"></span>)
     end
 
     def govuk_request_id

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe NotificationsController, type: :controller do
         <div>
           <div>Travel advice</div>
         </div>
-
-        <!-- govuk_request_id: 12345-67890 -->
+        <span data-govuk-request-id="12345-67890"></span>
       BODY
     }
     let(:notification_params) {
@@ -28,7 +27,7 @@ RSpec.describe NotificationsController, type: :controller do
       }
     }
     let(:expected_notification_params) {
-      notification_params.merge(links: {}).merge(body: expected_body)
+      notification_params.merge(links: {}).merge(body: expected_body.strip)
     }
 
     before do

--- a/spec/lib/govuk_request_id_spec.rb
+++ b/spec/lib/govuk_request_id_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe GovukRequestId, :insert do
   context "when the body is html" do
     let(:body) { "<p><span>Some body content</span></p>" }
     let(:expected_body) do
-      %Q(<p><span>Some body content</span></p>\n<!-- govuk_request_id: 12345-67890 -->\n)
+      %Q(<p><span>Some body content</span></p><span data-govuk-request-id="12345-67890"></span>)
     end
 
     it "adds a data attribute to the first child element" do


### PR DESCRIPTION
https://trello.com/c/tFRwaUPB/26-ensure-request-id-is-set-in-message-body-by-email-alert-api

Adds the govuk request id from GdsApi::Headers populated in the adapter
middleware into the email body as an html div with the request id as a data attribute.
No-op for non html email body content.

This is an amendment to https://github.com/alphagov/email-alert-api/pull/110/commits/b2ecfeb23f5471303c44c3519a56a06c49459ffb as html comments no not appear in the received emails.