### PR TITLE
Always append govuk request id element to the email body...

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ and it will respond with the JSON response for the `GET` call above.
 and it will respond with `202 Accepted` (the call is queued to prevent slowness
 in the external notifications API).
 
+### GOVUK request id
+
+Email body text is appended with an html element with a data attribute containing the originating request id.
+This element is an empty span and will not be visible to the recipient.
+Plain text emails will not contain this element as their content is stripped of any html.
+
 ### healthcheck API
 
 A queue health check endpoint is available at /healthcheck

--- a/lib/govuk_request_id.rb
+++ b/lib/govuk_request_id.rb
@@ -3,11 +3,7 @@ class GovukRequestId
     def insert(body)
       return body unless body.present?
 
-      if body =~ /^</
-        body += govuk_request_id_html
-      end
-
-      body
+      body + govuk_request_id_html
     end
 
   private

--- a/spec/lib/govuk_request_id_spec.rb
+++ b/spec/lib/govuk_request_id_spec.rb
@@ -19,14 +19,7 @@ RSpec.describe GovukRequestId, :insert do
     end
   end
 
-  context "when the body doesn't contain html" do
-    let(:body) { "Some email content" }
-    it "doesn't do anything" do
-      expect(described_class.insert(body)).to eq(body)
-    end
-  end
-
-  context "when the body is html" do
+  context "when the body is not empty" do
     let(:body) { "<p><span>Some body content</span></p>" }
     let(:expected_body) do
       %Q(<p><span>Some body content</span></p><span data-govuk-request-id="12345-67890"></span>)

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Sending a notification", type: :request do
       .with(
         relevant_list_ids,
         "This is a sample subject",
-        "Here is some body copy",
+        "Here is some body copy<span data-govuk-request-id=\"\"></span>",
         {},
       )
   end
@@ -63,7 +63,7 @@ RSpec.describe "Sending a notification", type: :request do
       .with(
         relevant_list_ids,
         "This is a sample subject",
-        "Here is some body copy",
+        "Here is some body copy<span data-govuk-request-id=\"\"></span>",
         {
           "from_address_id" => "12345",
           "urgent" => true,


### PR DESCRIPTION
The email alert api often receives payloads with leading whitespace,
since we are attempting to detect html we should allow a match on
strings with leading whitespace.