### PR TITLE
[WIP] Add option to specify a different GovDelivery account

### DIFF
--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -24,7 +24,12 @@ module EmailAlertAPI
 
       all_configs.fetch(@environment).tap do |env_config|
         env_config.merge!(environment_credentials) if ENV["GOVDELIVERY_USERNAME"]
+        env_config.merge!(govdelivery_account_code) if ENV["GOVDELIVERY_ACCOUNT_CODE"]
       end
+    end
+
+    def govdelivery_account_code
+      { account_code: ENV['GOVDELIVERY_ACCOUNT_CODE'] }
     end
 
     def environment_credentials

--- a/spec/lib/email_alert_api/config_spec.rb
+++ b/spec/lib/email_alert_api/config_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe EmailAlertAPI::Config do
+
+  describe 'Gov Delivery account code' do
+    subject { EmailAlertAPI::Config.new(Rails.env) }
+
+    it 'returns the value specified in gov_delivery.yml' do
+      expected_code = 'UKGOVUK'
+
+      expect(subject.gov_delivery.fetch(:account_code)).to eq(expected_code)
+    end
+
+    context 'when an ACCOUNT_CODE is provided in the environment' do
+      before do
+        ENV['GOVDELIVERY_ACCOUNT_CODE'] = 'UKGOVUK-2'
+      end
+
+      it 'returns the code from the environment variable' do
+        expected_code = 'UKGOVUK-2'
+
+        expect(subject.gov_delivery.fetch(:account_code)).to eq(expected_code)
+      end
+
+      after do
+        ENV.delete 'GOVDELIVERY_ACCOUNT_CODE'
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Adds an option to override the account code for Gov Delivery. It uses an environment variable, in the same way it is currently done for Gov Delivery credentials.

The GovDelivery account code is used to [build the URL for subscriptions](https://github.com/alphagov/email-alert-api/blob/a9c0001755483681d9305ccbcbe3bf9f5e16f90c/app/models/subscriber_list.rb#L34-42) 

This is [an example for code UKGOVUK](https://public.govdelivery.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_398). 

In `integration`, we want to specify a different account code. This PR allows the user to configure it using an environment variable: `GOVDELIVERY_ACCOUNT_CODE`

For example, by exporting the environment variable as described bellow, we would create subscription links with the following format: 
> https://public.govdelivery.com/accounts/UKGOVUK-2/subscriber/new?topic_id=UKGOVUK_398

```terminal
$ export $GOVDELIVERY_ACCOUNT_CODE=UKGOVUK-2
```

### Next steps
