### PR TITLE
Expose GET bulletin endpoints in client...

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -7,6 +7,14 @@ class NotificationsController < ApplicationController
     end
   end
 
+  def index
+    render json: Services.gov_delivery.fetch_bulletins(params[:start_at])
+  end
+
+  def show
+    render json: Services.gov_delivery.fetch_bulletin(params[:id])
+  end
+
 private
 
   def notification_params

--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -51,6 +51,22 @@ module GovDelivery
     rescue ZeroSubscriberError
     end
 
+    def fetch_bulletins(start_at=nil)
+      # GovDelivery documentation for this endpoint:
+      # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Bulletins_ListSentBulletins.htm
+      endpoint = "bulletins/sent.xml"
+      endpoint += "?start_at=#{start_at}" if start_at
+      response = http_client.get(endpoint)
+      Hash.from_xml(response.body)
+    end
+
+    def fetch_bulletin(id)
+      # GovDelivery documentation for this endpoint:
+      # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Bulletins_ReadBulletin.htm
+      response = http_client.get("bulletins/#{id}.xml")
+      Hash.from_xml(response.body)
+    end
+
   private
     attr_reader :options
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :subscriber_lists, path: "subscriber-lists", only: [:create]
   get "/subscriber-lists", to: "subscriber_lists#show"
 
-  resources :notifications, only: [:create]
+  resources :notifications, only: [:create, :index, :show]
 
   get "/healthcheck", to: "healthcheck#check"
 end


### PR DESCRIPTION
Part of this: https://trello.com/c/umy3X5Vx/38-add-govdelivery-check

Expose [GovDelivery API GET endpoints](http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Bulletins_ListSentBulletins.htm) for sent bulletins and showing the content of individual bulletins. This potentially gives apps like travel-advice-publisher [visibility of what has been processed by the email-alert-api and GovDelivery](https://github.com/alphagov/travel-advice-publisher/tree/add-govdelivery-bulletin-check).
