### PR TITLE
Add JSON columns to SubscriberList.

### DIFF
--- a/app/models/extensions/symbolize_json.rb
+++ b/app/models/extensions/symbolize_json.rb
@@ -1,0 +1,22 @@
+module SymbolizeJSON
+  def self.included(model)
+    model.columns.each do |column|
+      next unless column.sql_type == "json"
+
+      define_method(column.name) do
+        SymbolizeJSON.symbolize(self[column.name])
+      end
+    end
+  end
+
+  def self.symbolize(value)
+    case value
+    when Array
+      value.map { |element| symbolize(element) }
+    when Hash
+      value.deep_symbolize_keys
+    else
+      value
+    end
+  end
+end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -1,6 +1,9 @@
 require 'json'
+require_relative "extensions/symbolize_json"
 
 class SubscriberList < ActiveRecord::Base
+  include SymbolizeJSON
+
   self.include_root_in_json = true
 
   validate :tag_values_are_valid
@@ -28,6 +31,16 @@ class SubscriberList < ActiveRecord::Base
   def reload
     @_tags  = nil
     @_links = nil
+    super
+  end
+
+  def tags=(hash)
+    self.tags_json = hash
+    super
+  end
+
+  def links=(hash)
+    self.links_json = hash
     super
   end
 

--- a/db/migrate/20160718090427_add_json_columns_to_subscriber_list.rb
+++ b/db/migrate/20160718090427_add_json_columns_to_subscriber_list.rb
@@ -1,0 +1,6 @@
+class AddJSONColumnsToSubscriberList < ActiveRecord::Migration
+  def change
+    add_column :subscriber_lists, :tags_json, :json, default: {}, null: false
+    add_column :subscriber_lists, :links_json, :json, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160224152054) do
+ActiveRecord::Schema.define(version: 20160718090427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 20160224152054) do
     t.datetime "updated_at"
     t.hstore   "links",                       default: {}, null: false
     t.string   "document_type",               default: "", null: false
+    t.json     "tags_json",                   default: {}, null: false
+    t.json     "links_json",                  default: {}, null: false
   end
 
   add_index "subscriber_lists", ["links"], name: "index_subscriber_lists_on_links", using: :gin

--- a/lib/tasks/json_migration.rake
+++ b/lib/tasks/json_migration.rake
@@ -1,0 +1,9 @@
+desc "Copy over tags and links into new json field"
+task json_migration: :environment do
+  SubscriberList.all.each do |subscriber_list|
+    subscriber_list.update_columns(
+      tags_json: subscriber_list.tags,
+      links_json: subscriber_list.links,
+    )
+  end
+end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -87,4 +87,18 @@ RSpec.describe SubscriberList, type: :model do
       )
     end
   end
+
+  describe "#tags=" do
+    it "inserts into hstore and json to prepare for transition" do
+      subject.tags = { foo: ["bar"] }
+      expect(subject.tags_json).to eq(subject.tags)
+    end
+  end
+
+  describe "#links=" do
+    it "inserts into hstore and json to prepare for transition" do
+      subject.links = { foo: ["bar"] }
+      expect(subject.links_json).to eq(subject.links)
+    end
+  end
 end

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe "Creating a subscriber list", type: :request do
         updated_at
         tags
         links
+        tags_json
+        links_json
       }.to_set
     )
     expect(subscriber_list).to include(


### PR DESCRIPTION
This preps us for moving away from hstore which is
a postgres extension which makes puppet/CI more
complicated.

We're now on postgres 9.3+ which means we have JSON
columns available by default.