### PR TITLE
Patch out hstore

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20160224152054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "hstore"
 
   create_table "subscriber_lists", force: :cascade do |t|
     t.string   "title",           limit: 255

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -5,5 +5,5 @@ export RAILS_ENV=test
 
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-bundle exec rake db:drop db:create db:schema:load
+bundle exec rake db:schema:load
 bundle exec rspec


### PR DESCRIPTION
This is temporary until we can remove HSTORE, the
setup of the extension will now be done in CI itself.