### PR TITLE
Add rake tasks for syncing staging/integration topics.

### DIFF
--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -22,6 +22,12 @@ module GovDelivery
       )
     end
 
+    def delete_topic(topic_id)
+      # GovDelivery documentation for this endpoint:
+      # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Topics_DeleteTopic.htm
+      http_client.delete("topics/#{topic_id}.xml")
+    end
+
     def ping
       http_client.get("categories.xml")
     end
@@ -64,6 +70,13 @@ module GovDelivery
       # GovDelivery documentation for this endpoint:
       # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Bulletins_ReadBulletin.htm
       response = http_client.get("bulletins/#{id}.xml")
+      Hash.from_xml(response.body)
+    end
+
+    def fetch_topics
+      # GovDelivery documentation for this endpoint:
+      # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Topics_ListTopics.htm
+      response = http_client.get("topics.xml")
       Hash.from_xml(response.body)
     end
 

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -17,3 +17,60 @@ task duplicate_record_for_tag: :environment do
   DataHygiene::TagChanger.new(from_topic_tag: from_topic_tag, to_topic_tag: to_topic_tag).update_records_tags
   puts 'FINISHED'
 end
+
+desc "Sync topic mappings from govdelivery, DO NOT USE IN PRODUCTION"
+task sync_topic_mappings: :environment do
+  puts "Fetching topics.."
+  topics = Services.gov_delivery.fetch_topics["topics"]
+
+  if topics.blank?
+    puts "No topics found."
+    exit
+  end
+
+  gov_delivery_ids = []
+
+  puts "Updating local topics.."
+  topics.each do |topic|
+    list = SubscriberList.find_by(title: topic["name"])
+
+    if list
+      puts "-- Updating #{topic["name"]} (#{list.gov_delivery_id} -> #{topic["code"]})"
+      list.update_columns(gov_delivery_id: topic["code"])
+    else
+      puts "-- Missing local copy of #{topic["name"]} (#{topic["code"]})"
+    end
+
+    gov_delivery_ids << topic["code"]
+  end
+
+  extra_lists = SubscriberList.where.not(gov_delivery_id: gov_delivery_ids)
+  puts "Deleting #{extra_lists.count} local subscriber lists not found in govdelivery.."
+  extra_lists.delete_all
+end
+
+desc "Delete topics from govdelivery where title starts with string, DO NOT USE IN PRODUCTION"
+task :delete_matching_topics, [:string] => :environment do |_, args|
+  string = args[:string]
+
+  if string.blank?
+    puts "Provide a string to match"
+    puts "rake delete_matching_topics['string to match']"
+    exit
+  end
+
+  puts "Fetching topics.."
+  topics = Services.gov_delivery.fetch_topics["topics"]
+
+  if topics.blank?
+    puts "No topics found."
+    exit
+  end
+
+  topics.each do |topic|
+    if topic["name"].starts_with?(string)
+      puts "Deleting #{topic["name"]} (#{topic["code"]})"
+      Services.gov_delivery.delete_topic(topic["code"])
+    end
+  end
+end


### PR DESCRIPTION
We have issues with testing email alerts in integration
and staging because we sync the email alert API's
data from production to staging/integration but
govdelivery do not.  This leads to IDs not matching.

This adds one task to alter local data to match
the staging version, and another to delete remote
topics which match a string, useful for cleaning
up mass amounts of staging topics.

https://trello.com/c/PTDavZWZ/31-sync-integration-and-staging-topic-ids