### PR TITLE
Add syncing of local topics to remote govdelivery.

### DIFF
--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -9,14 +9,14 @@ module GovDelivery
       @options = options
     end
 
-    def create_topic(name)
+    def create_topic(name, topic_id = nil)
       # GovDelivery documentation for this endpoint:
-      # http://developer.govdelivery.com/api_docs/comm_cloud_v1/#API/Comm Cloud V1/API_CommCloudV1_Topics_CreateTopic.htm
+      # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Topics_CreateTopic.htm
       parse_topic_response(
         EmailAlertAPI.statsd.time('topics.create') do
           post_xml(
             "topics.xml",
-            RequestBuilder.create_topic_xml(name),
+            RequestBuilder.create_topic_xml(name, topic_id),
           )
         end
       )

--- a/app/services/gov_delivery/request_builder.rb
+++ b/app/services/gov_delivery/request_builder.rb
@@ -1,8 +1,9 @@
 module GovDelivery
   module RequestBuilder
-    def self.create_topic_xml(name)
+    def self.create_topic_xml(name, topic_id = nil)
       Nokogiri::XML::Builder.new { |xml|
         xml.topic {
+          xml.code(topic_id) if topic_id
           xml.name name
           xml.send(:'short-name', name)
           xml.visibility 'Unlisted'

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe GovDelivery::Client do
           <link rel="self" href="/api/account/UKGOVUK/topics/UKGOVUK_1234"/>
         </topic>
       }
+
+      stub_request(:post, @base_url).to_return(body: @govdelivery_response)
     end
 
     it "POSTs the topic creation request XML to the topics endpoint" do
-      stub_request(:post, @base_url).to_return(body: @govdelivery_response)
-
       client.create_topic(@topic_name)
 
       assert_requested(:post, @base_url) do |req|
@@ -46,8 +46,6 @@ RSpec.describe GovDelivery::Client do
     end
 
     it "returns an object that encapsulates the parsed response" do
-      stub_request(:post, @base_url).to_return(body: @govdelivery_response)
-
       response = client.create_topic(@topic_name)
 
       expect(response).to be_equivalent_to(Struct.new(
@@ -72,6 +70,28 @@ RSpec.describe GovDelivery::Client do
       end
     end
 
+    context "when a topic ID is provided" do
+      let(:topic_id) { "UKGOVUK_PROVIDED_CODE" }
+
+      it "sends the ID as the 'code'" do
+        client.create_topic(@topic_name, topic_id)
+
+        assert_requested(:post, @base_url) do |req|
+          expect(req.body).to be_equivalent_to(%{
+            <topic>
+              <code>#{topic_id}</code>
+              <name>#{@topic_name}</name>
+              <short-name>#{@topic_name}</short-name>
+              <visibility>Unlisted</visibility>
+              <pagewatch-enabled type="boolean">false</pagewatch-enabled>
+              <rss-feed-url nil="true"/>
+              <rss-feed-title nil="true"/>
+              <rss-feed-description nil="true"/>
+            </topic>
+          })
+        end
+      end
+    end
   end
 
   describe "#read_topic_by_name" do


### PR DESCRIPTION
This is ONLY to be used in integration/staging, to
keep our subscription lists in sync.

The code contains a double lock to reduce the risk
of this being run in production.

https://trello.com/c/PTDavZWZ/1-sync-integration-and-staging-topic-ids