### PR TITLE
Switch to checking govdelivery hostname.

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -28,10 +28,10 @@ task sync_govdelivery_topic_mappings: :environment do
     exit
   end
 
-  unless EmailAlertAPI.config.gov_delivery[:account_code] == "UKGOVUKDUP"
+  unless EmailAlertAPI.config.gov_delivery[:hostname] == "stage-api.govdelivery.com"
     puts "It looks like you're running this sync with a non-staging GovDelivery configuration."
     puts "Running this against production GovDelivery would be a really bad idea."
-    puts "If the GovDelivery staging account code has changed, please update this applciation and try again."
+    puts "If the GovDelivery staging hostname has changed, please update this applciation and try again."
 
     exit
   end


### PR DESCRIPTION
We can't check the account name here because we
actually have three accounts:

GovDelivery production:
- GOV.UK production (UKGOVUK)

GovDelivery staging:
- GOV.UK staging (UKGOVUK)
- GOV.UK integration (UKGOVUKDUP)

We need to only allow the last two accounts to sync,
so we now check the API hostname.