### PR TITLE
Start reading from JSON fields.

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -21,11 +21,11 @@ class SubscriberList < ActiveRecord::Base
   end
 
   def tags
-    @_tags ||= parsed_hstore(super)
+    @_tags ||= tags_json
   end
 
   def links
-    @_links ||= parsed_hstore(super)
+    @_links ||= links_json
   end
 
   def reload

--- a/lib/data_hygiene/tag_changer.rb
+++ b/lib/data_hygiene/tag_changer.rb
@@ -21,13 +21,17 @@ private
       log "Duplicating SubscriberList id: #{record.id} replacing #{from_topic_tag} with #{to_topic_tag}"
 
       new_record = record.dup
-      topics = JSON.parse(record[:tags]["topics"])
+      [:tags, :tags_json].each do |field|
+        topics = record[field]["topics"]
+        topics = JSON.parse(topics) if field == :tags
 
-      topics.map! do |topic|
-        topic == from_topic_tag ? to_topic_tag : topic
+        topics.map! do |topic|
+          topic == from_topic_tag ? to_topic_tag : topic
+        end
+
+        new_record[field]["topics"] = topics
+        new_record[field]["topics"] = new_record[field]["topics"].to_json if field == :tags
       end
-
-      new_record[:tags]["topics"] = topics.to_json
       new_record.save
     end
   end


### PR DESCRIPTION
Currently both hstore and json fields match, this
step switches the app over to reading from the
JSON fields.

Once this is shipped and happy, we'll switch the
hstore fields over to JSON fields with a full copy
of the data, switch to reading/writing those fields,
and then delete the *_json fields.

This should complete the migration with no downtime.

https://trello.com/c/ilzk5Wt4/4-switch-email-alert-api-to-use-json-columns