### PR TITLE
Fix duplicate subscriptions.

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -9,6 +9,7 @@ class SubscriberList < ActiveRecord::Base
   validate :tag_values_are_valid
   validate :link_values_are_valid
   validate :either_document_type_tags_or_links_present
+  validates :gov_delivery_id, uniqueness: true
 
   def self.build_from(params:, gov_delivery_id:)
     new(

--- a/db/migrate/20160816102950_remove_dupes.rb
+++ b/db/migrate/20160816102950_remove_dupes.rb
@@ -1,0 +1,18 @@
+class RemoveDupes < ActiveRecord::Migration
+  def up
+    # These have been checked and are just straight up bad.
+    SubscriberList.where(gov_delivery_id: nil).delete_all
+
+    # For everything else, keep the most recent.  These have also been checked.
+    gov_delivery_ids = SubscriberList.group(:gov_delivery_id).having("count(*) > 1").count.keys.compact
+
+    gov_delivery_ids.each do |gov_delivery_id|
+      dupes = SubscriberList.where(gov_delivery_id: gov_delivery_id).order(:created_at).to_a
+      dupes.pop # Remove the most recent
+      dupes.delete_all
+    end
+
+    # Stop this from happening again, reinforced by a matching Ruby constraint
+    add_index :subscriber_lists, :gov_delivery_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160718090427) do
+ActiveRecord::Schema.define(version: 20160816102950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20160718090427) do
     t.json     "links_json",                  default: {}, null: false
   end
 
+  add_index "subscriber_lists", ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true, using: :btree
   add_index "subscriber_lists", ["links"], name: "index_subscriber_lists_on_links", using: :gin
   add_index "subscriber_lists", ["tags"], name: "index_subscriber_lists_on_tags", using: :gin
 


### PR DESCRIPTION
For *some reason* we have duplicate entries in the
subscriber list table for the same govdelivery
topic.

This removes all where the gov_delivery_id is null
which were specialist document subscriptions and
have been checked with Chris Patuzzo.

For the rest it removes all but the most recent.
The tags, links, and title all match for these, so
there should be no effect on the end user.

Finally, both Ruby and DB uniqueness constraints
are added to the subscriber list model.