### PR TITLE
Work around inconsistent data.

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -66,8 +66,14 @@ task sync_govdelivery_topic_mappings: :environment do
   end
 
   puts "Creating remote topics to match the #{SubscriberList.count} local topics.."
+  created = {}
   SubscriberList.find_each do |list|
+    next if created.has_key?(list.gov_delivery_id)
+
     puts "-- Creating #{list.title} (#{list.gov_delivery_id}) in GovDelivery"
-    Services.gov_delivery.create_topic(list.title, list.gov_delivery_id)
+    title = list.title || "MISSING TITLE #{list.gov_delivery_id}"
+    Services.gov_delivery.create_topic(title, list.gov_delivery_id)
+
+    created[list.gov_delivery_id] = true
   end
 end


### PR DESCRIPTION
We have some topics without titles and some duplicates.

Discussions are ongoing about how to deal with these.

Until then, only create one of each gov_delivery_id
and use filler titles where not present.