### PR TITLE
Remove hstore

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -60,19 +60,13 @@ class SubscriberList < ActiveRecord::Base
 
 private
   def tag_values_are_valid
-    json_tags_valid = self[:tags_json].all? { |_, v| v.is_a?(Array) }
-    hstore_tags_valid = self[:tags].all? { |_, v| v.match(/^\[(.)*\]$/) }
-
-    unless json_tags_valid && hstore_tags_valid
+    unless self[:tags_json].all? { |_, v| v.is_a?(Array) }
       self.errors.add(:tags, "All tag values must be sent as Arrays")
     end
   end
 
   def link_values_are_valid
-    json_links_valid = self[:links_json].all? { |_, v| v.is_a?(Array) }
-    hstore_links_valid = self[:links].all? { |_, v| v.match(/^\[(.)*\]$/) }
-
-    unless json_links_valid && hstore_links_valid
+    unless self[:links_json].all? { |_, v| v.is_a?(Array) }
       self.errors.add(:links, "All link values must be sent as Arrays")
     end
   end

--- a/db/migrate/20160905121642_remove_hstore.rb
+++ b/db/migrate/20160905121642_remove_hstore.rb
@@ -1,0 +1,24 @@
+class RemoveHstore < ActiveRecord::Migration
+  def up
+    remove_column :subscriber_lists, :tags
+    remove_column :subscriber_lists, :links
+    add_column :subscriber_lists, :tags, :json, default: {}, null: false
+    add_column :subscriber_lists, :links, :json, default: {}, null: false
+
+    SubscriberList.connection.update("UPDATE subscriber_lists SET tags = tags_json, links = links_json")
+  end
+
+  def down
+    remove_column :subscriber_lists, :tags
+    remove_column :subscriber_lists, :links
+    add_column :subscriber_lists, :tags, :hstore, default: {}, null: false
+    add_column :subscriber_lists, :links, :hstore, default: {}, null: false
+
+    SubscriberList.all.each do |subscriber_list|
+      subscriber_list.update_columns(
+        tags: subscriber_list.tags_json,
+        links: subscriber_list.links_json,
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160718090427) do
+ActiveRecord::Schema.define(version: 20160905121642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,16 +19,13 @@ ActiveRecord::Schema.define(version: 20160718090427) do
   create_table "subscriber_lists", force: :cascade do |t|
     t.string   "title",           limit: 255
     t.string   "gov_delivery_id", limit: 255
-    t.hstore   "tags",                        default: {}, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.hstore   "links",                       default: {}, null: false
     t.string   "document_type",               default: "", null: false
     t.json     "tags_json",                   default: {}, null: false
     t.json     "links_json",                  default: {}, null: false
+    t.json     "tags",                        default: {}, null: false
+    t.json     "links",                       default: {}, null: false
   end
-
-  add_index "subscriber_lists", ["links"], name: "index_subscriber_lists_on_links", using: :gin
-  add_index "subscriber_lists", ["tags"], name: "index_subscriber_lists_on_tags", using: :gin
 
 end

--- a/lib/data_hygiene/tag_changer.rb
+++ b/lib/data_hygiene/tag_changer.rb
@@ -23,7 +23,7 @@ private
       new_record = record.dup
       [:tags, :tags_json].each do |field|
         topics = record[field]["topics"]
-        topics = JSON.parse(topics) if field == :tags
+        topics = JSON.parse(topics) if topics.is_a?(String)
 
         topics.map! do |topic|
           topic == from_topic_tag ? to_topic_tag : topic


### PR DESCRIPTION
This swaps the `links` and `tags` fields from hstore to json.

Next step would be to start reading from them again, and then deleting the duplicate columns.

First two commits need to be deployed first, final commit (with migration) can then be deployed immediately after.

https://trello.com/c/ilzk5Wt4/4-switch-email-alert-api-to-use-json-columns