### PR TITLE
Document how the staging / integration sync works

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,6 @@ and it will respond with the JSON response for the `GET` call above.
 and it will respond with `202 Accepted` (the call is queued to prevent slowness
 in the external notifications API).
 
-### GOVUK request id
-
-Email body text is appended with an html element with a data attribute containing the originating request id.
-This element is an empty span and will not be visible to the recipient.
-Plain text emails will not contain this element as their content is stripped of any html.
-
 ### healthcheck API
 
 A queue health check endpoint is available at /healthcheck
@@ -140,6 +134,12 @@ A queue health check endpoint is available at /healthcheck
   "status": "ok"
  }
 ```
+
+## GOVUK request id
+
+Email body text is appended with an html element with a data attribute containing the originating request id.
+This element is an empty span and will not be visible to the recipient.
+Plain text emails will not contain this element as their content is stripped of any html.
 
 ### Manually retrying failed notification jobs
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Sidekiq::RetrySet.new.retry_all
 
 See the [Sidekiq docs](https://github.com/mperham/sidekiq/wiki/API) for more information.
 
+## Integration & Staging Environments
+
+- [Overview of the Integration & Staging Synchronisation Process](doc/integration-staging-sync.md)
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/doc/integration-staging-sync.md
+++ b/doc/integration-staging-sync.md
@@ -1,0 +1,43 @@
+# Integration & Staging Sync
+
+## Overview
+
+Every morning the data in our integration and staging databases is synchronised
+with production. We also need to keep GovDelivery in sync so that the
+GovDelivery Topic IDs that we hold in our database continue to link to the
+correct topics in every environment.
+
+This is complicated by the fact that both integration and staging talk to the
+same staging 'instance' of GovDelivery. Despite being separate accounts, the
+GovDelivery topic ids have to be unique across the entire instance.
+
+To achieve the synchronisation we have a rake task
+(`sync_govdelivery_topic_mappings`) which is automatically triggered when the
+'Data Sync Complete' job runs in Jenkins on [integration](https://deploy.integra
+tion.publishing.service.gov.uk/job/Data_Sync_Complete/) and [staging](https://de
+ploy.staging.publishing.service.gov.uk/job/Data_Sync_Complete/).
+
+This rake task does three things:
+
+1) Update the subscriber lists in our database to ensure the prefix for all of
+the topics matches the account id. This only has an effect in integration, where
+it changes all topics from UKGOVUK_XXXXX to UKGOVUKDUP_XXXXX.
+
+2) Get a list of all topics currently in GovDelivery and delete them.
+
+3) Recreate all of the topics in our subscriber lists, specifying both the title
+of the topic and its topic id.
+
+Sometimes the task does not run correctly – for example it may fail to find any
+existing topics and delete them. If this happens, it may then create the new
+topics with completely different topic IDs, ignoring the IDs being specified.
+Surprise!
+
+The rake task is safe to re-run at any time, but it does take a while to
+complete.
+
+New topics that are created within an environment (e.g. when testing with new
+email signups in integration) will use the correct account id prefix for their
+environment and should 'just work'*.
+
+\* Famous last words.


### PR DESCRIPTION
The GovDelivery topic mapping sync is a little confusing. This is an attempt to document it.