### PR TITLE
Drop and recreate the database between jobs

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -5,5 +5,5 @@ export RAILS_ENV=test
 
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-bundle exec rake db:schema:load
+bundle exec rake db:drop db:create db:schema:load
 bundle exec rspec


### PR DESCRIPTION
This matches the behaviour in other apps, and should fix the currently failing tests which complain about the database not existing. We’re not sure how the database was created previously – possibly that it was being manually created on each slave.