### PR TITLE
[DO NOT MERGE] Change handling of email alert titles

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -29,7 +29,11 @@ class SubscriberListsController < ApplicationController
 
 private
   def build_subscriber_list
-    gov_delivery_response = Services.gov_delivery.create_topic(params[:title])
+    gov_delivery_response = Services.gov_delivery.create_topic(
+      params[:title],
+      params[:short_name],
+      params[:description]
+    )
     SubscriberList.build_from(
       params: subscriber_list_params,
       gov_delivery_id: gov_delivery_response.to_param
@@ -47,7 +51,7 @@ private
   end
 
   def subscriber_list_params
-    params.slice(:title)
+    params.slice(:title, :short_name, :description)
       .merge(tags: params.fetch(:tags, {}))
       .merge(links: params.fetch(:links, {}))
       .merge(document_type: params.fetch(:document_type, ""))

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -13,6 +13,8 @@ class SubscriberList < ActiveRecord::Base
   def self.build_from(params:, gov_delivery_id:)
     new(
       title: params[:title],
+      short_name: params[:short_name],
+      description: params[:description],
       tags:  params[:tags],
       links: params[:links],
       document_type: params[:document_type],

--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -9,14 +9,14 @@ module GovDelivery
       @options = options
     end
 
-    def create_topic(name, topic_id = nil)
+    def create_topic(name, short_name, description, topic_id = nil)
       # GovDelivery documentation for this endpoint:
       # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Topics_CreateTopic.htm
       parse_topic_response(
         EmailAlertAPI.statsd.time('topics.create') do
           post_xml(
             "topics.xml",
-            RequestBuilder.create_topic_xml(name, topic_id),
+            RequestBuilder.create_topic_xml(name, short_name, description, topic_id),
           )
         end
       )

--- a/app/services/gov_delivery/request_builder.rb
+++ b/app/services/gov_delivery/request_builder.rb
@@ -1,11 +1,12 @@
 module GovDelivery
   module RequestBuilder
-    def self.create_topic_xml(name, topic_id = nil)
+    def self.create_topic_xml(name, short_name, description, topic_id = nil)
       Nokogiri::XML::Builder.new { |xml|
         xml.topic {
           xml.code(topic_id) if topic_id
           xml.name name
-          xml.send(:'short-name', name)
+          xml.send(:'short-name', short_name)
+          xml.description description
           xml.visibility 'Unlisted'
           xml.send(:'pagewatch-enabled', "false", type: :boolean)
           xml.send(:'rss-feed-url', nil: :true)

--- a/db/migrate/20170118161735_add_short_name_and_description_to_subscriber_list.rb
+++ b/db/migrate/20170118161735_add_short_name_and_description_to_subscriber_list.rb
@@ -1,0 +1,6 @@
+class AddShortNameAndDescriptionToSubscriberList < ActiveRecord::Migration
+  def change
+    add_column :subscriber_lists, :short_name, :string, after: :title
+    add_column :subscriber_lists, :description, :string, after: :title
+  end
+end

--- a/db/migrate/20170118162215_remove_title_length_limit_in_subscriber_list.rb
+++ b/db/migrate/20170118162215_remove_title_length_limit_in_subscriber_list.rb
@@ -1,0 +1,9 @@
+class RemoveTitleLengthLimitInSubscriberList < ActiveRecord::Migration
+  def up
+    change_column :subscriber_lists, :title, :string, limit: nil
+  end
+
+  def down
+    change_column :subscriber_lists, :title, :string, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160905121642) do
+ActiveRecord::Schema.define(version: 20170118162215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "subscriber_lists", force: :cascade do |t|
-    t.string   "title",           limit: 255
+    t.string   "title"
     t.string   "gov_delivery_id", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 20160905121642) do
     t.json     "links_json",                  default: {}, null: false
     t.json     "tags",                        default: {}, null: false
     t.json     "links",                       default: {}, null: false
+    t.string   "short_name"
+    t.string   "description"
   end
 
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe SubscriberList, type: :model do
     let(:params) {
       {
         title: "Ronnie Pickering",
+        short_name: "Ronnie",
+        description: "Don't you know who I am?",
         tags: { topics: ["motoring/road_rage"] },
         links: { topics: ["uuid-888"] },
       }
@@ -17,6 +19,8 @@ RSpec.describe SubscriberList, type: :model do
 
     it "builds a new SubscriberList without a format" do
       expect(list.title).to eq "Ronnie Pickering"
+      expect(list.short_name).to eq "Ronnie"
+      expect(list.description).to eq "Don't you know who I am?"
       expect(list.tags).to eq({:topics=>["motoring/road_rage"]})
       expect(list.links).to eq({:topics=>["uuid-888"]})
       expect(list.gov_delivery_id).to eq "GOVUK_888"

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe "Creating a subscriber list", type: :request do
       %w{
         id
         title
+        short_name
+        description
         document_type
         subscription_url
         gov_delivery_id
@@ -102,6 +104,8 @@ RSpec.describe "Creating a subscriber list", type: :request do
   def create_subscriber_list(tags: {}, links: {}, document_type: nil)
     payload = {
       title: "This is a sample title",
+      short_name: "This is a short name",
+      description: "This is a description.",
       gov_delivery_id: "UKGOVUK_1234",
       tags: tags,
       links: links,

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe GovDelivery::Client do
     before do
       @base_url = "http://#{config.fetch(:username)}:#{config.fetch(:password)}@#{config.fetch(:hostname)}/api/account/#{config.fetch(:account_code)}/topics.xml"
       @topic_name = "Test topic"
+      @topic_short_name = "Test"
+      @topic_description = "This is a test."
       @govdelivery_response = %{<?xml version="1.0" encoding="UTF-8"?>
         <topic>
           <to-param>UKGOVUK_1234</to-param>
@@ -28,13 +30,14 @@ RSpec.describe GovDelivery::Client do
     end
 
     it "POSTs the topic creation request XML to the topics endpoint" do
-      client.create_topic(@topic_name)
+      client.create_topic(@topic_name, @topic_short_name, @topic_description)
 
       assert_requested(:post, @base_url) do |req|
         expect(req.body).to be_equivalent_to(%{
           <topic>
             <name>#{@topic_name}</name>
-            <short-name>#{@topic_name}</short-name>
+            <short-name>#{@topic_short_name}</short-name>
+            <description>#{@topic_description}</description>
             <visibility>Unlisted</visibility>
             <pagewatch-enabled type="boolean">false</pagewatch-enabled>
             <rss-feed-url nil="true"/>
@@ -46,7 +49,7 @@ RSpec.describe GovDelivery::Client do
     end
 
     it "returns an object that encapsulates the parsed response" do
-      response = client.create_topic(@topic_name)
+      response = client.create_topic(@topic_name, @topic_short_name, @topic_description)
 
       expect(response).to be_equivalent_to(Struct.new(
         :to_param, :topic_uri, :link
@@ -66,7 +69,7 @@ RSpec.describe GovDelivery::Client do
       end
 
       it "raises a TopicAlreadyExistsError" do
-        expect { client.create_topic(@topic_name) }.to raise_error(GovDelivery::Client::TopicAlreadyExistsError)
+        expect { client.create_topic(@topic_name, @topic_short_name, @topic_description) }.to raise_error(GovDelivery::Client::TopicAlreadyExistsError)
       end
     end
 
@@ -74,14 +77,15 @@ RSpec.describe GovDelivery::Client do
       let(:topic_id) { "UKGOVUK_PROVIDED_CODE" }
 
       it "sends the ID as the 'code'" do
-        client.create_topic(@topic_name, topic_id)
+        client.create_topic(@topic_name, @topic_short_name, @topic_description, topic_id)
 
         assert_requested(:post, @base_url) do |req|
           expect(req.body).to be_equivalent_to(%{
             <topic>
               <code>#{topic_id}</code>
               <name>#{@topic_name}</name>
-              <short-name>#{@topic_name}</short-name>
+              <short-name>#{@topic_short_name}</short-name>
+              <description>#{@topic_description}</description>
               <visibility>Unlisted</visibility>
               <pagewatch-enabled type="boolean">false</pagewatch-enabled>
               <rss-feed-url nil="true"/>


### PR DESCRIPTION
This commit splits the `title`, `short_name` and `description` attributes so that they can be sent separately to GovDelivery.

Since `title` and `short_name` have a 255 character limit enforced by GovDelivery, this commit adds the ability to pass a different, shorter string for these fields whilst keeping all the data in the `description` field.

https://github.com/alphagov/finder-frontend/pull/284 makes changes to `finder-frontend` so that a separate `short_name` is sent to `email-alert-api`.

Trello: https://trello.com/c/KTHRa4a0/422-fix-email-alert-api-errors-when-the-email-alert-short-name-is-longer-than-255-characters