### PR TITLE
Stop writing to `links_json` and `tags_json`

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -20,16 +20,6 @@ class SubscriberList < ActiveRecord::Base
     )
   end
 
-  def tags=(hash)
-    self.tags_json = hash
-    super
-  end
-
-  def links=(hash)
-    self.links_json = hash
-    super
-  end
-
   def subscription_url
     gov_delivery_config.fetch(:protocol) +
     "://" +

--- a/lib/data_hygiene/tag_changer.rb
+++ b/lib/data_hygiene/tag_changer.rb
@@ -21,15 +21,14 @@ private
       log "Duplicating SubscriberList id: #{record.id} replacing #{from_topic_tag} with #{to_topic_tag}"
 
       new_record = record.dup
-      [:tags, :tags_json].each do |field|
-        topics = record[field]["topics"]
 
-        topics.map! do |topic|
-          topic == from_topic_tag ? to_topic_tag : topic
-        end
+      topics = record['tags']['topics']
 
-        new_record[field]["topics"] = topics
+      topics.map! do |topic|
+        topic == from_topic_tag ? to_topic_tag : topic
       end
+
+      new_record['tags']['topics'] = topics
       new_record.save
     end
   end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -87,18 +87,4 @@ RSpec.describe SubscriberList, type: :model do
       )
     end
   end
-
-  describe "#tags=" do
-    it "inserts into both json fields during transition" do
-      subject.tags = { foo: ["bar"] }
-      expect(subject.tags_json).to eq(subject.tags)
-    end
-  end
-
-  describe "#links=" do
-    it "inserts into both json fields during transition" do
-      subject.links = { foo: ["bar"] }
-      expect(subject.links_json).to eq(subject.links)
-    end
-  end
 end


### PR DESCRIPTION
As fields are no longer being read from as such we
can now disable writing.