### PR TITLE
Remove temporary *_json fields

### DIFF
--- a/db/migrate/20170208150700_remove_temp_json_fields.rb
+++ b/db/migrate/20170208150700_remove_temp_json_fields.rb
@@ -1,0 +1,6 @@
+class RemoveTempJsonFields < ActiveRecord::Migration
+  def change
+    remove_column :subscriber_lists, :links_json
+    remove_column :subscriber_lists, :tags_json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160905121642) do
+ActiveRecord::Schema.define(version: 20170208150700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,8 +22,6 @@ ActiveRecord::Schema.define(version: 20160905121642) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "document_type",               default: "", null: false
-    t.json     "tags_json",                   default: {}, null: false
-    t.json     "links_json",                  default: {}, null: false
     t.json     "tags",                        default: {}, null: false
     t.json     "links",                       default: {}, null: false
   end

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
         updated_at
         tags
         links
-        tags_json
-        links_json
       }.to_set
     )
     expect(subscriber_list).to include(


### PR DESCRIPTION
These `links_json` and tags_json` fields where added 
for the `hstore` to `json` data type migration which 
has now been completed, so we can now remove this fields.

As an additional task we need to manually remove the 
`hstore` extension from the postgres database instances.