### PR TITLE
Delete SubscriberList's without subscribers on GovDelivery

### DIFF
--- a/app/services/gov_delivery/client.rb
+++ b/app/services/gov_delivery/client.rb
@@ -22,6 +22,13 @@ module GovDelivery
       )
     end
 
+    def fetch_topic(code)
+      # GovDelivery documentation for this endpoint:
+      # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Topics_ReadTopic.htm
+      response = http_client.get("topics/#{code}.xml")
+      Hash.from_xml(response.body)['topic']
+    end
+
     def delete_topic(topic_id)
       # GovDelivery documentation for this endpoint:
       # http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm Cloud V1/API_CommCloudV1_Topics_DeleteTopic.htm

--- a/lib/data_hygiene/delete_topics_without_subscribers.rb
+++ b/lib/data_hygiene/delete_topics_without_subscribers.rb
@@ -1,0 +1,124 @@
+require 'thread'
+
+module DataHygiene
+  class DeleteTopicsWithoutSubscribers
+    attr_reader :client
+    delegate :puts, to: :@output
+    delegate :gets, to: :@input
+
+    def initialize(client: Services.gov_delivery, input: STDIN, output: STDOUT)
+      @client = client
+      @input = input
+      @output = output
+    end
+
+    def call
+      puts "#{with_zero_subscribers.count} subscriber lists without subscribers"
+      with_zero_subscribers.each { |sl| puts "#{sl.gov_delivery_id} - #{sl.title}"}
+      if with_gov_delivery_error.count > 0
+        puts ''
+        puts "#{with_gov_delivery_error.count} subscriber lists with errors - THESE ARE NOT BEING DELETED"
+        with_gov_delivery_error.each { |sl| puts "#{sl.gov_delivery_id} - #{sl.title}"}
+      end
+
+      puts ''
+      puts "#{with_zero_subscribers.count} subscriber lists without subscribers, enter `delete` to delete from database and GovDelivery: "
+      command = gets
+
+      if command.chomp == 'delete'
+        with_zero_subscribers.each do |subscriber_list|
+          delete_topic(subscriber_list)
+        end
+      end
+    end
+
+    def subscriber_lists
+      @subscriber_lists ||= ThreadedSubscriberCountRetriever.new(client: client, output: @output).call
+    end
+
+    def with_zero_subscribers
+      @with_zero_subscribers ||= subscriber_lists
+        .select { |c, s| c&.zero? }
+        .map(&:last)
+    end
+
+    def with_gov_delivery_error
+      @with_gov_delivery_error ||= subscriber_lists
+        .select { |c, s| c.nil? }
+        .map(&:last)
+    end
+
+  private
+
+    def subscriber_count(gov_delivery_id)
+      topic = client.fetch_topic(gov_delivery_id)
+      topic && topic['subscribers_count']
+    rescue GovDelivery::Client::UnknownError
+      nil
+    end
+
+    def delete_topic(subscriber_list)
+      subscribers = subscriber_count(subscriber_list.gov_delivery_id)
+
+      if subscribers.nil?
+        puts "Skipping #{subscriber_list.gov_delivery_id} as it does not appear on GovDelivery"
+      elsif subscribers.zero?
+        puts "Deleting: #{subscriber_list.gov_delivery_id}"
+        delete_topic_with_error_catching(subscriber_list.gov_delivery_id)
+        SubscriberList.where(gov_delivery_id: subscriber_list.gov_delivery_id).delete_all
+      else
+        puts "Skipping #{subscriber_list.gov_delivery_id} as it now has #{subscribers} subscribers"
+      end
+    end
+
+    def delete_topic_with_error_catching(gov_delivery_id)
+      client.delete_topic(gov_delivery_id)
+    rescue GovDelivery::Client::UnknownError
+      puts "---- Error deleting: #{gov_delivery_id}"
+    end
+
+    class ThreadedSubscriberCountRetriever
+      MAX_THREAD_COUNT = 40
+      MIN_BATCH_SIZE = 10
+
+      attr_reader :client
+      delegate :puts, :print, to: :@output
+
+      def initialize(client: nil, output: STDOUT)
+        @client = client
+        @output = output
+      end
+
+      def call
+        group_size = [(SubscriberList.count.to_f / MAX_THREAD_COUNT).ceil, MIN_BATCH_SIZE].max
+        subscriber_list_sets = SubscriberList.all.each_slice(group_size)
+
+        results = []
+        semaphore = Mutex.new
+        threads = subscriber_list_sets.map do |subscriber_list_set|
+          Thread.new do
+            results_for_thread = add_count_of_subscribers(subscriber_list_set)
+            semaphore.synchronize { results += results_for_thread }
+          end
+        end
+        threads.each(&:join)
+        puts ''
+        results
+      end
+
+      def add_count_of_subscribers(subscriber_lists)
+        subscriber_lists.map do |subscriber_list|
+          print '.'
+          [subscriber_count(subscriber_list.gov_delivery_id), subscriber_list]
+        end
+      end
+
+      def subscriber_count(gov_delivery_id)
+        topic = client.fetch_topic(gov_delivery_id)
+        topic && topic['subscribers_count']
+      rescue GovDelivery::Client::UnknownError
+        nil
+      end
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,3 +1,11 @@
+desc "Delete subscriber lists without subscribers"
+task delete_topics_without_subscribers: :environment do
+  require "data_hygiene/delete_topics_without_subscribers"
+
+  DataHygiene::DeleteTopicsWithoutSubscribers.new.call
+  puts 'FINISHED'
+end
+
 desc "Create duplicate record for new tags"
 task duplicate_record_for_tag: :environment do
   require "data_hygiene/tag_changer"

--- a/spec/lib/data_hygiene/delete_topics_without_subscribers_spec.rb
+++ b/spec/lib/data_hygiene/delete_topics_without_subscribers_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+require 'data_hygiene/delete_topics_without_subscribers'
+
+RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
+  let!(:subscriber_list) { create(:subscriber_list, title: 'Test') }
+  let(:client) { double('GovDelivery::Client') }
+  let(:input) { StringIO.new }
+  let(:output) { StringIO.new }
+  subject { described_class.new(client: client, input: input, output: output) }
+
+  describe '#with_zero_subscribers' do
+    before do
+      allow(client).to receive(:fetch_topic).and_return(fetch_topics_response)
+    end
+
+    context 'when the topic has no subscribers' do
+      let(:fetch_topics_response) { { 'subscribers_count' => 0 } }
+
+      it 'is included in the list' do
+        expect(subject.with_zero_subscribers).to include(subscriber_list)
+      end
+    end
+
+    context 'when the topic has subscribers' do
+      let(:fetch_topics_response) { { 'subscribers_count' => 2 } }
+
+      it 'is not included in the list' do
+        expect(subject.with_zero_subscribers).not_to include(subscriber_list)
+      end
+    end
+
+    context 'when the topic does not exist' do
+      let(:fetch_topics_response) { nil }
+
+      it 'is not included in the list' do
+        expect(subject.with_zero_subscribers).not_to include(subscriber_list)
+      end
+    end
+
+    context '#when the GovDelivery `fetch_topic` endpoint has an error' do
+      let(:fetch_topics_response) { { 'subscribers_count' => 0 } }
+      before do
+        allow(client).to receive(:fetch_topic)
+          .with(subscriber_list.gov_delivery_id)
+          .and_raise(GovDelivery::Client::UnknownError)
+      end
+
+      it 'marks the subscriber list as having an error' do
+        expect(subject.with_gov_delivery_error).to include(subscriber_list)
+      end
+
+      it 'continues to process the remaining items in the list' do
+        second_subscriber_list = create(:subscriber_list, title: 'Other', gov_delivery_id: 'beta')
+        expect(subject.with_zero_subscribers).to include(second_subscriber_list)
+      end
+    end
+  end
+
+  describe '#with_gov_delivery_error' do
+    before do
+      allow(client).to receive(:fetch_topic).and_return(fetch_topics_response)
+    end
+
+    subject { described_class.new(client: client, input: input, output: output) }
+
+    context 'when the topic has no subscribers' do
+      let(:fetch_topics_response) { { 'subscribers_count' => 0 } }
+
+      it 'is not included in the list' do
+        expect(subject.with_gov_delivery_error).not_to include(subscriber_list)
+      end
+    end
+
+    context 'when the topic has subscribers' do
+      let(:fetch_topics_response) { { 'subscribers_count' => 2 } }
+
+      it 'is not included in the list' do
+        expect(subject.with_gov_delivery_error).not_to include(subscriber_list)
+      end
+    end
+
+    context 'when the topic does not exist' do
+      let(:fetch_topics_response) { nil }
+
+      it 'is included in the list' do
+        expect(subject.with_gov_delivery_error).to include(subscriber_list)
+      end
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(client).to receive(:fetch_topic).and_return('subscribers_count' => 0)
+      allow(client).to receive(:delete_topic)
+    end
+
+    context 'when the user enters the delete command' do
+      let(:expected_log_output) do
+        [
+          ".",
+          '1 subscriber lists without subscribers',
+          "#{subscriber_list.gov_delivery_id} - Test",
+          '',
+          '1 subscriber lists without subscribers, enter `delete` to delete from database and GovDelivery: ',
+          "Deleting: #{subscriber_list.gov_delivery_id}",
+          ''
+        ].join("\n")
+      end
+
+      before do
+        input.puts('delete')
+        input.rewind
+        allow(client).to receive(:delete_topic)
+      end
+
+      it 'deletes a subscriber list with 0 subscribers' do
+        expect(client).to receive(:delete_topic).with(subscriber_list.gov_delivery_id)
+
+        subject.call
+      end
+
+      it 'deletes the record from the database' do
+        expect { subject.call }.to change { SubscriberList.count }.by(-1)
+      end
+
+      it 'correctly logs the process' do
+        subject.call
+        output.rewind
+
+        expect(output.read).to eq(expected_log_output)
+      end
+
+      context '#when the GovDelivery `delete_topic` endpoint has an error' do
+        let!(:second_subscriber_list) { create(:subscriber_list, title: 'Other', gov_delivery_id: 'beta') }
+        let(:expected_log_output) do
+          [
+            "..",
+            '2 subscriber lists without subscribers',
+            "#{subscriber_list.gov_delivery_id} - #{subscriber_list.title}",
+            "#{second_subscriber_list.gov_delivery_id} - #{second_subscriber_list.title}",
+            '',
+            '2 subscriber lists without subscribers, enter `delete` to delete from database and GovDelivery: ',
+            "Deleting: #{subscriber_list.gov_delivery_id}",
+            "---- Error deleting: #{subscriber_list.gov_delivery_id}",
+            "Deleting: #{second_subscriber_list.gov_delivery_id}",
+            ''
+          ].join("\n")
+        end
+        before do
+          allow(client).to receive(:delete_topic)
+            .with(subscriber_list.gov_delivery_id)
+            .and_raise(GovDelivery::Client::UnknownError)
+        end
+
+        it 'reports the error and continues deleting' do
+          subject.call
+          output.rewind
+
+          expect(output.read).to eq(expected_log_output)
+        end
+      end
+    end
+
+    context 'when the user does not enter the delete command' do
+      before do
+        input.puts('skip')
+        input.rewind
+      end
+
+      it 'does not delete any subscriber lists' do
+        expect(client).not_to receive(:delete_topic)
+
+        subject.call
+      end
+
+      it 'does not delete the record from the database' do
+        expect { subject.call }.not_to change { SubscriberList.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
For each SubscriberList query GovDelivery for the 
count of subscribers and filter out those that have 
a count of 0 so they can be deleted. Any subscriber 
lists that fail to successfully get data from GovDelivery
are logged for future investigation.
