### PR TITLE
Default footer

### DIFF
--- a/app/services/gov_delivery/request_builder.rb
+++ b/app/services/gov_delivery/request_builder.rb
@@ -35,10 +35,14 @@ module GovDelivery
             xml.cdata options[:header]
           } if options[:header]
           xml.footer {
-            xml.cdata options[:footer]
-          } if options[:footer]
+            xml.cdata options[:footer] || default_footer
+          }
         }
       }.to_xml
+    end
+
+    def self.default_footer
+      @default_footer ||= File.read(File.expand_path(File.join(__dir__, 'templates', 'default_footer.html')))
     end
   end
 end

--- a/app/services/gov_delivery/request_builder.rb
+++ b/app/services/gov_delivery/request_builder.rb
@@ -35,7 +35,7 @@ module GovDelivery
             xml.cdata options[:header]
           } if options[:header]
           xml.footer {
-            xml.cdata options[:footer] || default_footer
+            xml.cdata default_footer
           }
         }
       }.to_xml

--- a/app/services/gov_delivery/templates/default_footer.html
+++ b/app/services/gov_delivery/templates/default_footer.html
@@ -1,0 +1,24 @@
+<table>
+  <tbody>
+    <tr>
+      <td style="padding-top: 10px; padding-bottom: 10px; width: 740px;">
+        <p style="font-family: arial, helvetica, sans-serif;">
+          <a href="[[SUBSCRIBER_PREFERENCES_URL]]" target="_blank" title="Subscriber preferences" style="font-family: Helvetica, Arial, sans-serif; font-size: 15px; margin-bottom: 1em;">
+            Manage your GOV.UK email preferences including unsubscribing
+          </a>
+        </p>
+        <p style="font-family: Helvetica, Arial, sans-serif; font-size: 15px;">
+          <span style="font-size: 15px;">
+            Sign up for alerts about <a href="https://www.gov.uk/government/publications" target="_blank" title="publications">publications</a> and <a href="https://www.gov.uk/government/announcements" target="_blank" title="announcements">announcements</a>
+            <br>
+          </span>
+          <span style="font-size: 15px;">
+            Sign up for alerts about <a href="https://www.gov.uk/foreign-travel-advice" target="_blank" title="foreign travel">foreign travel</a>
+            <br>
+            Provided by </span><a href="https://www.gov.uk" target="_blank" title="GOV.UK" style="font-size: 15px;">GOV.UK</a><span style="font-size: 15px;">. </span><a href="https://www.gov.uk/feedback/contact" style="font-size: 15px;">Contact us</a><span style="font-size: 15px;"> to ask questions or report problems.
+          </span>
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/services/gov_delivery/templates/default_footer.html
+++ b/app/services/gov_delivery/templates/default_footer.html
@@ -1,24 +1,48 @@
-<table>
-  <tbody>
-    <tr>
-      <td style="padding-top: 10px; padding-bottom: 10px; width: 740px;">
-        <p style="font-family: arial, helvetica, sans-serif;">
-          <a href="[[SUBSCRIBER_PREFERENCES_URL]]" target="_blank" title="Subscriber preferences" style="font-family: Helvetica, Arial, sans-serif; font-size: 15px; margin-bottom: 1em;">
-            Manage your GOV.UK email preferences including unsubscribing
-          </a>
-        </p>
-        <p style="font-family: Helvetica, Arial, sans-serif; font-size: 15px;">
-          <span style="font-size: 15px;">
-            Sign up for alerts about <a href="https://www.gov.uk/government/publications" target="_blank" title="publications">publications</a> and <a href="https://www.gov.uk/government/announcements" target="_blank" title="announcements">announcements</a>
-            <br>
-          </span>
-          <span style="font-size: 15px;">
-            Sign up for alerts about <a href="https://www.gov.uk/foreign-travel-advice" target="_blank" title="foreign travel">foreign travel</a>
-            <br>
-            Provided by </span><a href="https://www.gov.uk" target="_blank" title="GOV.UK" style="font-size: 15px;">GOV.UK</a><span style="font-size: 15px;">. </span><a href="https://www.gov.uk/feedback/contact" style="font-size: 15px;">Contact us</a><span style="font-size: 15px;"> to ask questions or report problems.
-          </span>
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<div style="max-width:700px;">
+<!--[if mso]>
+  <table role="presentation"><tr><td width="700">
+<![endif]-->
+<table role="presentation" style="width: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+  <tr bgcolor="#0B0C0C" style="background: #0B0C0C;">
+    <td style="padding: 16px 20px;">
+      <span style="color:white;font-family:Helvetica,Arial,sans-serif;font-size:17px;font-weight:bold;">
+        We want to improve this email alerts service. <a style="color:white" href="https://www.smartsurvey.co.uk/s/govuk-email/" title="Feedback survey">Tell us how it could be better.</a>
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 16px 0;">
+      <span style="font-family:Helvetica,Arial,sans-serif;font-size:15px;font-weight:bold;">
+        Too many emails? <a href="[[SUBSCRIBER_PREFERENCES_URL]]" title="Subscriber preferences">Change the frequency of your GOV.UK email alerts or unsubscribe</a>
+      </span>
+    </td>
+  </tr>
+
+  <tr>
+    <td style="padding: 0 0 6px;">
+      <span style="font-family:Helvetica,Arial,sans-serif;font-size:15px;">
+        Sign up for alerts about <a href="https://www.gov.uk/government/publications" title="Publications">publications</a> and <a href="https://www.gov.uk/government/announcements" title="Announcements">announcements</a>
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 0 0 6px;">
+      <span style="font-family:Helvetica,Arial,sans-serif;font-size:15px;">
+        Sign up for alerts about <a href="https://www.gov.uk/foreign-travel-advice" title="Foreign travel">foreign travel</a>
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <span style="font-family:Helvetica,Arial,sans-serif;font-size:15px;">
+        Provided by <a href="https://www.gov.uk" title="GOV.UK" style="font-size:15px">GOV.UK</a>.
+        This email was sent to [[EMAIL_ADDRESS]]
+      </span>
+    </td>
+  </tr>
+
 </table>
+<!--[if mso]>
+  </td></tr></table>
+<![endif]-->
+</div>

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe GovDelivery::Client do
 
     context 'when topic exists' do
       let(:govdelivery_response) do
-        <<~XML
+        <<-XML.strip_heredoc
           <?xml version="1.0" encoding="UTF-8"?>
           <topic>
             <name>Topic name</name>
@@ -154,7 +154,7 @@ RSpec.describe GovDelivery::Client do
 
     context 'when topic does not exist' do
       let(:govdelivery_response) do
-        <<~XML
+        <<-XML.strip_heredoc
           <?xml version="1.0" encoding="UTF-8"?>
           <errors>
             <code>GD-14002</code>

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe GovDelivery::Client do
       end.to raise_error(GovDelivery::Client::UnknownError)
     end
 
-    it "POSTs the bulletin with extra parameters if present to the send_now endpoint" do
+    it "POSTs the bulletin with extra parameters (EXCEPT FOOTER) if present to the send_now endpoint" do
       stub_request(:post, @base_url).to_return(body: @govdelivery_response)
 
       client.send_bulletin(topic_ids, subject, body, {
@@ -328,7 +328,7 @@ RSpec.describe GovDelivery::Client do
           <from_address_id>12345</from_address_id>
           <urgent>true</urgent>
           <header><![CDATA[<h1>Foo</h1>]]></header>
-          <footer><![CDATA[<p>bar</p>]]></footer>
+          <footer><![CDATA[#{GovDelivery::RequestBuilder.default_footer}]]></footer>
         </bulletin>
       XML
       assert_requested(:post, @base_url) do |req|

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -243,26 +243,26 @@ RSpec.describe GovDelivery::Client do
 
       client.send_bulletin(topic_ids, subject, body)
 
+      expected_xml = <<-XML.strip_heredoc
+        <bulletin>
+          <subject>a subject line</subject>
+          <body><![CDATA[a body]]></body>
+          <topics type="array">
+            <topic>
+              <code>UKGOVUK_123</code>
+            </topic>
+            <topic>
+              <code>UKGOVUK_124</code>
+            </topic>
+            <topic>
+              <code>UKGOVUK_125</code>
+            </topic>
+          </topics>
+          <footer><![CDATA[#{GovDelivery::RequestBuilder.default_footer}]]></footer>
+        </bulletin>
+      XML
       assert_requested(:post, @base_url) do |req|
-        expect(req.body).to be_equivalent_to(
-          %{
-            <bulletin>
-              <subject>a subject line</subject>
-              <body><![CDATA[a body]]></body>
-              <topics type="array">
-                <topic>
-                  <code>UKGOVUK_123</code>
-                </topic>
-                <topic>
-                  <code>UKGOVUK_124</code>
-                </topic>
-                <topic>
-                  <code>UKGOVUK_125</code>
-                </topic>
-              </topics>
-            </bulletin>
-          }
-        )
+        expect(req.body).to be_equivalent_to(expected_xml)
       end
     end
 
@@ -310,30 +310,29 @@ RSpec.describe GovDelivery::Client do
         footer: "<p>bar</p>"
       })
 
+      expected_xml = <<-XML.strip_heredoc
+        <bulletin>
+          <subject>a subject line</subject>
+          <body><![CDATA[a body]]></body>
+          <topics type="array">
+            <topic>
+              <code>UKGOVUK_123</code>
+            </topic>
+            <topic>
+              <code>UKGOVUK_124</code>
+            </topic>
+            <topic>
+              <code>UKGOVUK_125</code>
+            </topic>
+          </topics>
+          <from_address_id>12345</from_address_id>
+          <urgent>true</urgent>
+          <header><![CDATA[<h1>Foo</h1>]]></header>
+          <footer><![CDATA[<p>bar</p>]]></footer>
+        </bulletin>
+      XML
       assert_requested(:post, @base_url) do |req|
-        expect(req.body).to be_equivalent_to(
-          %{
-            <bulletin>
-              <subject>a subject line</subject>
-              <body><![CDATA[a body]]></body>
-              <topics type="array">
-                <topic>
-                  <code>UKGOVUK_123</code>
-                </topic>
-                <topic>
-                  <code>UKGOVUK_124</code>
-                </topic>
-                <topic>
-                  <code>UKGOVUK_125</code>
-                </topic>
-              </topics>
-              <from_address_id>12345</from_address_id>
-              <urgent>true</urgent>
-              <header><![CDATA[<h1>Foo</h1>]]></header>
-              <footer><![CDATA[<p>bar</p>]]></footer>
-            </bulletin>
-          }
-        )
+        expect(req.body).to be_equivalent_to(expected_xml)
       end
     end
 


### PR DESCRIPTION
This is pending #141 being merged

Send a default footer via the API. This footer can be overwritten if the source app passed in a footer (special publisher)

This PR also fixes a bug related to squiggly heredocs (<<~) and ruby 2.3.0

https://trello.com/c/hRFWQxHc/77-make-footers-consistent
