### PR TITLE
Also delete topics which 404 as well as ones with 0 subscribers

### DIFF
--- a/app/services/gov_delivery/response_parser.rb
+++ b/app/services/gov_delivery/response_parser.rb
@@ -28,6 +28,8 @@ module GovDelivery
     end
 
     def values
+      # This returns all values as strings rather than observing the `type`s
+      # in the XML, so beware of comparisons like 0 == '0'
       first_level_element_nodes.map(&:text)
     end
 

--- a/lib/data_hygiene/delete_unneeded_topics.rb
+++ b/lib/data_hygiene/delete_unneeded_topics.rb
@@ -1,7 +1,7 @@
 require 'thread'
 
 module DataHygiene
-  class DeleteTopicsWithoutSubscribers
+  class DeleteUnneededTopics
     attr_reader :client
     delegate :puts, to: :@output
     delegate :gets, to: :@input

--- a/lib/data_hygiene/delete_unneeded_topics.rb
+++ b/lib/data_hygiene/delete_unneeded_topics.rb
@@ -26,15 +26,19 @@ module DataHygiene
         with_gov_delivery_error.each { |sl| puts "#{sl.gov_delivery_id} - #{sl.title}"}
       end
 
-      puts ''
-      puts "#{with_zero_subscribers.count} subscriber lists without subscribers and #{with_missing_topic.count} subscriber lists don't exist in GovDelivery, enter `delete` to delete from database and GovDelivery: "
-      command = gets
+      to_delete = with_zero_subscribers + with_missing_topic
+      if to_delete.count > 0
+        puts ''
+        puts "#{with_zero_subscribers.count} subscriber lists without subscribers and #{with_missing_topic.count} subscriber lists don't exist in GovDelivery, enter `delete` to delete from database and GovDelivery: "
+        command = gets
 
-      if command.chomp == 'delete'
-        to_delete = with_zero_subscribers + with_missing_topic
-        to_delete.each do |subscriber_list|
-          delete_topic(subscriber_list)
+        if command.chomp == 'delete'
+          to_delete.each do |subscriber_list|
+            delete_topic(subscriber_list)
+          end
         end
+      else
+        puts 'Nothing to delete'
       end
     end
 

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,8 +1,8 @@
-desc "Delete subscriber lists without subscribers"
-task delete_topics_without_subscribers: :environment do
-  require "data_hygiene/delete_topics_without_subscribers"
+desc "Delete subscriber lists without subscribers and ones which don't exist in GovDelivery"
+task delete_unneeded_topics: :environment do
+  require "data_hygiene/delete_unneeded_topics"
 
-  DataHygiene::DeleteTopicsWithoutSubscribers.new.call
+  DataHygiene::DeleteUnneededTopics.new.call
   puts 'FINISHED'
 end
 

--- a/spec/lib/data_hygiene/delete_topics_without_subscribers_spec.rb
+++ b/spec/lib/data_hygiene/delete_topics_without_subscribers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
     end
 
     context 'when the topic has no subscribers' do
-      let(:fetch_topics_response) { { 'subscribers_count' => 0 } }
+      let(:fetch_topics_response) { double('subscribers_count' => '0') }
 
       it 'is included in the list' do
         expect(subject.with_zero_subscribers).to include(subscriber_list)
@@ -22,7 +22,7 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
     end
 
     context 'when the topic has subscribers' do
-      let(:fetch_topics_response) { { 'subscribers_count' => 2 } }
+      let(:fetch_topics_response) { double('subscribers_count' => '2') }
 
       it 'is not included in the list' do
         expect(subject.with_zero_subscribers).not_to include(subscriber_list)
@@ -31,6 +31,9 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
 
     context 'when the topic does not exist' do
       let(:fetch_topics_response) { nil }
+      before do
+        allow(client).to receive(:fetch_topic).and_raise(GovDelivery::Client::TopicNotFound)
+      end
 
       it 'is not included in the list' do
         expect(subject.with_zero_subscribers).not_to include(subscriber_list)
@@ -38,7 +41,7 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
     end
 
     context '#when the GovDelivery `fetch_topic` endpoint has an error' do
-      let(:fetch_topics_response) { { 'subscribers_count' => 0 } }
+      let(:fetch_topics_response) { double('subscribers_count' => '0') }
       before do
         allow(client).to receive(:fetch_topic)
           .with(subscriber_list.gov_delivery_id)
@@ -56,6 +59,52 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
     end
   end
 
+  describe '#with_missing_topic' do
+    before do
+      allow(client).to receive(:fetch_topic).and_return(fetch_topics_response)
+    end
+
+    subject { described_class.new(client: client, input: input, output: output) }
+
+    context 'when the topic has no subscribers' do
+      let(:fetch_topics_response) { double('subscribers_count' => '0') }
+
+      it 'is not included in the list' do
+        expect(subject.with_missing_topic).not_to include(subscriber_list)
+      end
+    end
+
+    context 'when the topic has subscribers' do
+      let(:fetch_topics_response) { double('subscribers_count' => '2') }
+
+      it 'is not included in the list' do
+        expect(subject.with_missing_topic).not_to include(subscriber_list)
+      end
+    end
+
+    context 'when the topic does not exist' do
+      let(:fetch_topics_response) { nil }
+      before do
+        allow(client).to receive(:fetch_topic).and_raise(GovDelivery::Client::TopicNotFound)
+      end
+
+      it 'is included in the list' do
+        expect(subject.with_missing_topic).to include(subscriber_list)
+      end
+    end
+
+    context 'when fetching the topic raises another error' do
+      let(:fetch_topics_response) { nil }
+      before do
+        allow(client).to receive(:fetch_topic).and_raise(GovDelivery::Client::UnknownError)
+      end
+
+      it 'is not included in the list' do
+        expect(subject.with_missing_topic).not_to include(subscriber_list)
+      end
+    end
+  end
+
   describe '#with_gov_delivery_error' do
     before do
       allow(client).to receive(:fetch_topic).and_return(fetch_topics_response)
@@ -64,7 +113,7 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
     subject { described_class.new(client: client, input: input, output: output) }
 
     context 'when the topic has no subscribers' do
-      let(:fetch_topics_response) { { 'subscribers_count' => 0 } }
+      let(:fetch_topics_response) { double('subscribers_count' => '0') }
 
       it 'is not included in the list' do
         expect(subject.with_gov_delivery_error).not_to include(subscriber_list)
@@ -72,7 +121,7 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
     end
 
     context 'when the topic has subscribers' do
-      let(:fetch_topics_response) { { 'subscribers_count' => 2 } }
+      let(:fetch_topics_response) { double('subscribers_count' => '2') }
 
       it 'is not included in the list' do
         expect(subject.with_gov_delivery_error).not_to include(subscriber_list)
@@ -81,6 +130,20 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
 
     context 'when the topic does not exist' do
       let(:fetch_topics_response) { nil }
+      before do
+        allow(client).to receive(:fetch_topic).and_raise(GovDelivery::Client::TopicNotFound)
+      end
+
+      it 'is not included in the list' do
+        expect(subject.with_gov_delivery_error).not_to include(subscriber_list)
+      end
+    end
+
+    context 'when fetching the topic raises another error' do
+      let(:fetch_topics_response) { nil }
+      before do
+        allow(client).to receive(:fetch_topic).and_raise(GovDelivery::Client::UnknownError)
+      end
 
       it 'is included in the list' do
         expect(subject.with_gov_delivery_error).to include(subscriber_list)
@@ -89,60 +152,76 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
   end
 
   describe '#call' do
+    let!(:missing_subscriber_list) { create(:subscriber_list, title: 'Missing list', gov_delivery_id: 'missing') }
+    let!(:erroring_subscriber_list) { create(:subscriber_list, title: 'Erroring list', gov_delivery_id: 'erroring') }
+    let(:expected_log_output) do
+      [
+        '...',
+        '1 subscriber lists without subscribers',
+        "#{subscriber_list.gov_delivery_id} - Test",
+        '',
+        "1 subscriber lists don't exist in GovDelivery",
+        "#{missing_subscriber_list.gov_delivery_id} - Missing list",
+        '',
+        '1 subscriber lists with errors - THESE ARE NOT BEING DELETED',
+        "#{erroring_subscriber_list.gov_delivery_id} - Erroring list",
+        '',
+        "1 subscriber lists without subscribers and 1 subscriber lists don't exist in GovDelivery, enter `delete` to delete from database and GovDelivery: ",
+        ''
+      ].join("\n")
+    end
+
     before do
-      allow(client).to receive(:fetch_topic).and_return('subscribers_count' => 0)
+      allow(client).to receive(:fetch_topic).and_return(double('subscribers_count' => '0'))
+
+      allow(client).to receive(:fetch_topic)
+        .with(missing_subscriber_list.gov_delivery_id)
+        .and_raise(GovDelivery::Client::TopicNotFound)
+
+      allow(client).to receive(:fetch_topic)
+        .with(erroring_subscriber_list.gov_delivery_id)
+        .and_raise(GovDelivery::Client::UnknownError)
+
       allow(client).to receive(:delete_topic)
+
     end
 
     context 'when the user enters the delete command' do
-      let(:expected_log_output) do
+      let(:extra_log_output_when_deleting_succeeds) do
         [
-          ".",
-          '1 subscriber lists without subscribers',
-          "#{subscriber_list.gov_delivery_id} - Test",
-          '',
-          '1 subscriber lists without subscribers, enter `delete` to delete from database and GovDelivery: ',
           "Deleting: #{subscriber_list.gov_delivery_id}",
+          "Deleting: #{missing_subscriber_list.gov_delivery_id}",
           ''
         ].join("\n")
       end
-
       before do
         input.puts('delete')
         input.rewind
-        allow(client).to receive(:delete_topic)
       end
 
-      it 'deletes a subscriber list with 0 subscribers' do
+      it 'deletes a subscriber list with 0 subscribers from GovDelivery' do
         expect(client).to receive(:delete_topic).with(subscriber_list.gov_delivery_id)
 
         subject.call
       end
 
-      it 'deletes the record from the database' do
-        expect { subject.call }.to change { SubscriberList.count }.by(-1)
+      it 'deletes the subscriber list with 0 subscribers and the one missing from GovDelivery from the database' do
+        expect { subject.call }.to change { SubscriberList.count }.by(-2)
       end
 
       it 'correctly logs the process' do
         subject.call
         output.rewind
 
-        expect(output.read).to eq(expected_log_output)
+        expect(output.read).to eq(expected_log_output + extra_log_output_when_deleting_succeeds)
       end
 
       context '#when the GovDelivery `delete_topic` endpoint has an error' do
-        let!(:second_subscriber_list) { create(:subscriber_list, title: 'Other', gov_delivery_id: 'beta') }
-        let(:expected_log_output) do
+        let(:extra_log_output_when_deleting_fails) do
           [
-            "..",
-            '2 subscriber lists without subscribers',
-            "#{subscriber_list.gov_delivery_id} - #{subscriber_list.title}",
-            "#{second_subscriber_list.gov_delivery_id} - #{second_subscriber_list.title}",
-            '',
-            '2 subscriber lists without subscribers, enter `delete` to delete from database and GovDelivery: ',
             "Deleting: #{subscriber_list.gov_delivery_id}",
             "---- Error deleting: #{subscriber_list.gov_delivery_id}",
-            "Deleting: #{second_subscriber_list.gov_delivery_id}",
+            "Deleting: #{missing_subscriber_list.gov_delivery_id}",
             ''
           ].join("\n")
         end
@@ -152,11 +231,15 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
             .and_raise(GovDelivery::Client::UnknownError)
         end
 
-        it 'reports the error and continues deleting' do
+        it 'reports the error and continues deleting the next subscriber_lists' do
           subject.call
           output.rewind
 
-          expect(output.read).to eq(expected_log_output)
+          expect(output.read).to eq(expected_log_output + extra_log_output_when_deleting_fails)
+        end
+
+        it 'does not delete that subscriber_list from the database' do
+          expect { subject.call }.to change { SubscriberList.count }.by(-1)
         end
       end
     end
@@ -175,6 +258,13 @@ RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
 
       it 'does not delete the record from the database' do
         expect { subject.call }.not_to change { SubscriberList.count }
+      end
+
+      it 'correctly logs the process' do
+        subject.call
+        output.rewind
+
+        expect(output.read).to eq(expected_log_output)
       end
     end
   end

--- a/spec/lib/data_hygiene/delete_unneeded_topics_spec.rb
+++ b/spec/lib/data_hygiene/delete_unneeded_topics_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
-require 'data_hygiene/delete_topics_without_subscribers'
+require 'data_hygiene/delete_unneeded_topics'
 
-RSpec.describe DataHygiene::DeleteTopicsWithoutSubscribers do
+RSpec.describe DataHygiene::DeleteUnneededTopics do
   let!(:subscriber_list) { create(:subscriber_list, title: 'Test') }
   let(:client) { double('GovDelivery::Client') }
   let(:input) { StringIO.new }

--- a/spec/services/gov_delivery/client_spec.rb
+++ b/spec/services/gov_delivery/client_spec.rb
@@ -129,24 +129,24 @@ RSpec.describe GovDelivery::Client do
       end
 
       it 'returns a hash representation of the topic' do
-        expect(client.fetch_topic(topic_code)).to eq(
+        expect(client.fetch_topic(topic_code)).to have_attributes(
           'name' => 'Topic name',
           'short_name' => 'Topic short name',
           'code' => 'UKGOV_1234',
-          'pagewatch_enabled' => false,
-          'lock_version' => 0,
-          'description' => nil,
-          'watch_tagged_content' => false,
-          'pagewatch_autosend' => false,
-          'default_pagewatch_results' => nil,
-          'pagewatch_suspended' => true,
-          'rss_feed_title' => nil,
+          'pagewatch_enabled' => 'false',
+          'lock_version' => '0',
+          'description' => '',
+          'watch_tagged_content' => 'false',
+          'pagewatch_autosend' => 'false',
+          'default_pagewatch_results' => '',
+          'pagewatch_suspended' => 'true',
+          'rss_feed_title' => '',
           'rss_feed_url' => 'https://www.gov.uk/government',
-          'rss_feed_description' => nil,
-          'subscribers_count' => 0,
-          'wireless_enabled' => false,
-          'pagewatch_type' => nil,
-          'pages' => [],
+          'rss_feed_description' => '',
+          'subscribers_count' => '0',
+          'wireless_enabled' => 'false',
+          'pagewatch_type' => '',
+          'pages' => '',
           'visibility' => 'Unlisted'
         )
       end
@@ -163,8 +163,8 @@ RSpec.describe GovDelivery::Client do
         XML
       end
 
-      it 'returns nil' do
-        expect(client.fetch_topic(topic_code)).to be_nil
+      it 'raises a TopicNotFound error' do
+        expect { client.fetch_topic(topic_code) }.to raise_error(GovDelivery::Client::TopicNotFound)
       end
     end
   end


### PR DESCRIPTION
Deleting these cleans up our data and also may fix some errors for users. If we have a subscriber list in our database which doesn't exist in GovDelivery, we'll redirect users to GovDelivery to sign up but that will fail because they don't recognise the topic id. We don't have any of these right now in this app, but since GovDelivery data can be modified in their UI it seems useful to support this here as well as in govuk-delivery (where we have about 2000 topics in this state).

This changes the error-raising behaviour of the client but this shouldn't cause any problems elsewhere in the application because `TopicNotFound` is a subclass of `UnknownError` which should already be handled.

It's not very nice to have to check for a string zero, but now that we're using `parse_topic_response` for the extra error handling we'd need to change the [behaviour of `ResponseParser`](https://github.com/alphagov/email-alert-api/blob/f5558d1a09cd74528740883c9374ec2075fe611d/app/services/gov_delivery/response_parser.rb#L30-L32) to fix this, and that's outside the scope of this PR (but worth looking at separately).

https://trello.com/c/Ruf2l6R9/120-also-delete-topics-from-our-databases-if-they-don-t-exist-in-govdelivery