### PR TITLE
Enabled flag on subscriber lists

### DIFF
--- a/app/controllers/notification_logs_controller.rb
+++ b/app/controllers/notification_logs_controller.rb
@@ -17,7 +17,9 @@ private
       :document_type,
       :emailing_app,
       :publishing_app,
-      gov_delivery_ids: []
+      gov_delivery_ids: [],
+      enabled_gov_delivery_ids: [],
+      disabled_gov_delivery_ids: [],
     )
   end
 end

--- a/app/models/notification_log.rb
+++ b/app/models/notification_log.rb
@@ -11,4 +11,12 @@ class NotificationLog < ActiveRecord::Base
   def gov_delivery_ids=(vals)
     super vals.sort
   end
+
+  def enabled_gov_delivery_ids=(vals)
+    super vals.sort
+  end
+
+  def disabled_gov_delivery_ids=(vals)
+    super vals.sort
+  end
 end

--- a/db/migrate/20170302162543_add_enabled_flag_to_subscriber_lists.rb
+++ b/db/migrate/20170302162543_add_enabled_flag_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddEnabledFlagToSubscriberLists < ActiveRecord::Migration
+  def change
+    add_column :subscriber_lists, :enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20170302162818_add_enabled_disabled_gov_delivery_ids_to_notification_log.rb
+++ b/db/migrate/20170302162818_add_enabled_disabled_gov_delivery_ids_to_notification_log.rb
@@ -1,0 +1,6 @@
+class AddEnabledDisabledGovDeliveryIdsToNotificationLog < ActiveRecord::Migration
+  def change
+    add_column :notification_logs, :enabled_gov_delivery_ids, :json, default: []
+    add_column :notification_logs, :disabled_gov_delivery_ids, :json, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170221141514) do
+ActiveRecord::Schema.define(version: 20170302162543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,9 +38,10 @@ ActiveRecord::Schema.define(version: 20170221141514) do
     t.string   "gov_delivery_id", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "document_type",               default: "", null: false
-    t.json     "tags",                        default: {}, null: false
-    t.json     "links",                       default: {}, null: false
+    t.string   "document_type",               default: "",   null: false
+    t.json     "tags",                        default: {},   null: false
+    t.json     "links",                       default: {},   null: false
+    t.boolean  "enabled",                     default: true, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,23 +11,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302162543) do
+ActiveRecord::Schema.define(version: 20170302162818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "notification_logs", force: :cascade do |t|
-    t.string   "govuk_request_id",  default: ""
-    t.string   "content_id",        default: ""
+    t.string   "govuk_request_id",          default: ""
+    t.string   "content_id",                default: ""
     t.datetime "public_updated_at"
-    t.json     "links",             default: {}
-    t.json     "tags",              default: {}
-    t.string   "document_type",     default: ""
-    t.string   "emailing_app",      default: "", null: false
-    t.json     "gov_delivery_ids",  default: []
-    t.string   "publishing_app",    default: ""
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.json     "links",                     default: {}
+    t.json     "tags",                      default: {}
+    t.string   "document_type",             default: ""
+    t.string   "emailing_app",              default: "", null: false
+    t.json     "gov_delivery_ids",          default: []
+    t.string   "publishing_app",            default: ""
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.json     "enabled_gov_delivery_ids",  default: []
+    t.json     "disabled_gov_delivery_ids", default: []
   end
 
   add_index "notification_logs", ["content_id", "public_updated_at"], name: "index_notification_logs_on_content_id_and_public_updated_at", using: :btree

--- a/spec/controllers/notification_logs_controller_spec.rb
+++ b/spec/controllers/notification_logs_controller_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe NotificationLogsController, type: :controller do
       document_type: 'guidence',
       emailing_app: 'email_alert_api',
       publishing_app: 'Whitehall',
-      gov_delivery_ids: ['Topic 2', 'Topic 1']
+      gov_delivery_ids: ['Topic 4', 'Topic 3', 'Topic 2', 'Topic 1'],
+      enabled_gov_delivery_ids: ['Topic 4', 'Topic 2'],
+      disabled_gov_delivery_ids: ['Topic 3', 'Topic 1'],
     }
   end
 
@@ -23,7 +25,9 @@ RSpec.describe NotificationLogsController, type: :controller do
       document_type: 'guidence',
       emailing_app: 'email_alert_api',
       publishing_app: 'Whitehall',
-      gov_delivery_ids: ['Topic 1', 'Topic 2']
+      gov_delivery_ids: ['Topic 1', 'Topic 2', 'Topic 3', 'Topic 4'],
+      enabled_gov_delivery_ids: ['Topic 2', 'Topic 4'],
+      disabled_gov_delivery_ids: ['Topic 1', 'Topic 3'],
     )
   end
 

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
         updated_at
         tags
         links
+        enabled
       }.to_set
     )
     expect(subscriber_list).to include(


### PR DESCRIPTION
Allow subscriber lists to be marked as disabled, this will assist with migrating data form GovUkDelivery. 

Logging has been setup to log both enabled and disabled matches from GovUkDelivery and EmailAlertApi so that we can monitor and differences between the system before, during and after the migration.