### PR TITLE
Wrap notification logging in rescue block

### DIFF
--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe NotificationWorker do
             {}
           )
       end
+
+      context "Logging of the notification creates an unexpected exception" do
+        before do
+          expect(NotificationLog).to receive(:create).and_raise(Exception)
+        end
+
+        it "the process ends without an exception" do
+          expect { make_it_perform }.not_to raise_error
+        end
+
+        it "the bulletin is still sent" do
+          make_it_perform
+
+          expect(@gov_delivery).to have_received(:send_bulletin)
+        end
+      end
     end
 
     context "filtering on document_type" do


### PR DESCRIPTION
The previous implementation could potentially have 
resulted in subscribers receiving an email multiple 
times if the NotificationLog create call failed. In
addition no NotificationLog would have been written
is send_bulletin raised an error.

By being a little more paranoid and wrapping the
logging code in a result block we can move it to
earlier in the processing stream thus ensuring that
we always log notification requests and that we never
send multiple notifications for a single change.

https://trello.com/c/b9ZonGXn/121-logging