### PR TITLE
Optional gov_delivery_id when creating a subscriber_list

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -28,11 +28,18 @@ class SubscriberListsController < ApplicationController
   end
 
 private
+
   def build_subscriber_list
-    gov_delivery_response = Services.gov_delivery.create_topic(params[:title])
+    gov_delivery_id = if params[:gov_delivery_id].present?
+      params[:gov_delivery_id]
+    else
+      gov_delivery_response = Services.gov_delivery.create_topic(params[:title])
+      gov_delivery_response.to_param
+    end
+
     SubscriberList.build_from(
       params: subscriber_list_params,
-      gov_delivery_id: gov_delivery_response.to_param
+      gov_delivery_id: gov_delivery_id
     )
   end
 
@@ -47,6 +54,7 @@ private
       .merge(tags: params.fetch(:tags, {}))
       .merge(links: params.fetch(:links, {}))
       .merge(document_type: params.fetch(:document_type, ""))
+      .merge(enabled: params[:gov_delivery_id].blank?)
   end
 
   def links

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -15,6 +15,7 @@ class SubscriberList < ActiveRecord::Base
       title: params[:title],
       tags:  params[:tags],
       links: params[:links],
+      enabled: params[:enabled],
       document_type: params[:document_type],
       gov_delivery_id: gov_delivery_id,
     )

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe "Creating a subscriber list", type: :request do
     )
   end
 
+   it "creates an enabled subscriber_list" do
+    create_subscriber_list(tags: {topics: ["oil-and-gas/licensing"]})
+
+    subscriber_list = SubscriberList.last
+    expect(subscriber_list).to have_attributes(
+      gov_delivery_id: 'UKGOVUK_1234',
+      enabled: true,
+    )
+  end
+
   it "returns a 201" do
     create_subscriber_list(tags: {topics: ["oil-and-gas/licensing"]})
 
@@ -132,6 +142,30 @@ RSpec.describe "Creating a subscriber list", type: :request do
         expect(response.status).to eq(422);
         expect(response.body).to match(/Must have either a document_type, tags or links/)
       end
+    end
+  end
+
+  context "when gov_delivery_id is passed in" do
+    it "does not attempt to create a new topic on gov delivery" do
+      create_subscriber_list(
+        gov_delivery_id: 'TOPIC_AAAA',
+        tags: {topics: ["oil-and-gas/licensing"]},
+      )
+
+      assert_not_requested(:post, base_url + '/topics.xml')
+    end
+
+    it "creates a disabled subscriber_list with the specified gov_delivery_id" do
+      create_subscriber_list(
+        gov_delivery_id: 'TOPIC_AAAA',
+        tags: {topics: ["oil-and-gas/licensing"]},
+      )
+
+      subscriber_list = SubscriberList.last
+      expect(subscriber_list).to have_attributes(
+        gov_delivery_id: 'TOPIC_AAAA',
+        enabled: false,
+      )
     end
   end
 


### PR DESCRIPTION
If a gov_delivery_id is passed in when creating a 
subscriber list, then then subscriber list is marked
as being disabled by default.

https://trello.com/c/PKxw58Hu/126-1-backfill-existing-topics-into-email-alert-api-db-disabled