### PR TITLE
Support content items where the tags hash values are not arrays

### DIFF
--- a/app/queries/matched_for_notification.rb
+++ b/app/queries/matched_for_notification.rb
@@ -20,7 +20,7 @@ class MatchedForNotification
 
       subscriber_list_tags_or_links.keys.all? do |key|
         (
-          content_item_tags_or_links[key] & subscriber_list_tags_or_links[key]
+          Array(content_item_tags_or_links[key]) & subscriber_list_tags_or_links[key]
         ).any?
       end
     end

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -69,6 +69,26 @@ RSpec.describe MatchedForNotification do
       end
     end
 
+    context "Specialist publisher edge case" do
+      let!(:subscriber_list) { create(:subscriber_list, tags: { format: ["employment_tribunal_decision"] }) }
+
+      it "finds the list when the criteria values is a string that is present in the subscriber list values for the field" do
+        lists = execute_query(field: :tags, query_hash: {
+          format: "employment_tribunal_decision",
+        })
+
+        expect(lists).to eq([subscriber_list])
+      end
+
+      it "does not find the list when the criteria values is a string that is not present in the subscriber list values for the field" do
+        lists = execute_query(field: :tags, query_hash: {
+          format: "drug_safety_update",
+        })
+
+        expect(lists).to eq([])
+      end
+    end
+
     it "doesn't return lists which have no tag types present in the document" do
       lists = execute_query(field: :tags, query_hash: {
         another_tag_thats_not_part_of_any_subscription: ["elephants"],


### PR DESCRIPTION
This is required to support `specialist publisher` which send through
the `format` criteria in the `tags` hash as a string value insteade of
an array of strings.

We have revert this to the previous format rathger than fixing the
bug at source as we are not able to get 100% confidence that this
is the only source of data in this format.