### PR TITLE
Use `gov_delivery_id` when finding exact match

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -2,7 +2,7 @@ require "gov_delivery/client"
 
 class SubscriberListsController < ApplicationController
   def show
-    subscriber_list = find_subscriber_list
+    subscriber_list = FindExactQuery.new(find_exact_query_params).exact_match
     if subscriber_list
       respond_to do |format|
         format.json { render json: subscriber_list.to_json }
@@ -15,7 +15,7 @@ class SubscriberListsController < ApplicationController
   end
 
   def create
-    subscriber_list = build_subscriber_list
+    subscriber_list = SubscriberList.new(subscriber_list_params)
     if subscriber_list.save
       respond_to do |format|
         format.json { render json: subscriber_list.to_json, status: 201 }
@@ -29,33 +29,31 @@ class SubscriberListsController < ApplicationController
 
 private
 
-  def build_subscriber_list
-    gov_delivery_id = if params[:gov_delivery_id].present?
+  def subscriber_list_params
+    find_exact_query_params.merge(
+      title: params[:title],
+      enabled: params[:gov_delivery_id].blank?,
+      gov_delivery_id: gov_delivery_id,
+    )
+  end
+
+  def find_exact_query_params
+    {
+      tags: params.fetch(:tags, {}),
+      links: params.fetch(:links, {}),
+      document_type: params.fetch(:document_type, ""),
+      email_document_supertype: params.fetch(:email_document_supertype, ""),
+      government_document_supertype: params.fetch(:government_document_supertype, ""),
+      gov_delivery_id: params[:gov_delivery_id],
+    }
+  end
+
+  def gov_delivery_id
+    if params[:gov_delivery_id].present?
       params[:gov_delivery_id]
     else
       gov_delivery_response = Services.gov_delivery.create_topic(params[:title])
       gov_delivery_response.to_param
     end
-
-    SubscriberList.build_from(
-      params: subscriber_list_params,
-      gov_delivery_id: gov_delivery_id
-    )
-  end
-
-  def find_subscriber_list
-    FindExactQuery.new(subscriber_list_params.except(:title, :enabled)).exact_match
-  end
-
-  def subscriber_list_params
-    {
-      title: params[:title],
-      tags: params.fetch(:tags, {}),
-      links: params.fetch(:links, {}),
-      document_type: params.fetch(:document_type, ""),
-      enabled: params[:gov_delivery_id].blank?,
-      email_document_supertype: params.fetch(:email_document_supertype, ""),
-      government_document_supertype: params.fetch(:government_document_supertype, "")
-    }
   end
 end

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -1,12 +1,13 @@
 class FindExactQuery
   class InvalidFindCriteria < StandardError; end
 
-  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:)
+  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:, gov_delivery_id: nil)
     @tags = tags.symbolize_keys
     @links = links.symbolize_keys
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
+    @gov_delivery_id = gov_delivery_id
   end
 
   def exact_match
@@ -18,10 +19,14 @@ class FindExactQuery
 private
 
   def base_scope
-    SubscriberList
-      .where(document_type: @document_type)
-      .where(email_document_supertype: @email_document_supertype)
-      .where(government_document_supertype: @government_document_supertype)
+    @base_scope ||= begin
+      scope = SubscriberList
+        .where(document_type: @document_type)
+        .where(email_document_supertype: @email_document_supertype)
+        .where(government_document_supertype: @government_document_supertype)
+      scope = scope.where(gov_delivery_id: @gov_delivery_id) if @gov_delivery_id.present?
+      scope
+    end
   end
 
   def find_exact(query_field, query)

--- a/spec/requests/get_subscriber_list_spec.rb
+++ b/spec/requests/get_subscriber_list_spec.rb
@@ -157,6 +157,32 @@ RSpec.describe "Getting a subscriber list", type: :request do
     expect(response.status).to eq(404)
   end
 
+  context "when passing in gov_delivery_id" do
+    it "does not find a subscriber list of the gov_delivery_id does not match" do
+      get_subscriber_list(
+        tags: { topics: ["vat-rates"] },
+        document_type: "tax",
+        gov_delivery_id: "NEW-TOPIC"
+      )
+      expect(response.status).to eq(404)
+    end
+
+    it "finds the subscriber list if the gov_delivery_id matches" do
+      alpha = FactoryGirl.create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "alpha")
+      beta = FactoryGirl.create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "beta")
+      gamma = FactoryGirl.create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "gamma")
+
+      get_subscriber_list(
+        tags: { topics: ["vat-rates"] },
+        gov_delivery_id: "beta"
+      )
+      expect(response.status).to eq(200)
+
+      subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+      expect(subscriber_list.fetch("id")).to eq(beta.id)
+    end
+  end
+
   def get_subscriber_list(query_payload)
     get "/subscriber-lists", query_payload, json_headers
   end


### PR DESCRIPTION
When we create a subscriber list via the api it first 
does a lookup to see if a subscriber list with the
same criteria already exists.

With the migration of whitehall data it is possible 
that multiple subscriber lists with different 
gov_delivery_id will exists. As this is the case
it is important that when we are filtering we get 
the correct record. 

This is more important during the create process as 
otherwise you would find a subscriber list with same
criteria, and would skip the creation of a record with
the desired gov_delivery_id resulting in users not
being notified.

example:

```
'https://www.gov.uk/government/feed?topics%5B%5D=uk-economy' has topic_id UKGOVUK_6888
'https://www.gov.uk/government/topics/uk-economy.atom' has topic_id UKGOVUK_8609
```

https://trello.com/c/5yVMib2f/124-2-add-support-for-whitehall-topics-in-new-email-stack