### PR TITLE
Add subscriber list ID to the title on gov delivery

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -15,14 +15,14 @@ class SubscriberListsController < ApplicationController
   end
 
   def create
-    subscriber_list = SubscriberList.new(subscriber_list_params)
-    if subscriber_list.save
+    creator = SubscriberListCreator.new(subscriber_list_params)
+    if creator.save
       respond_to do |format|
-        format.json { render json: subscriber_list.to_json, status: 201 }
+        format.json { render json: creator.record.to_json, status: 201 }
       end
     else
       respond_to do |format|
-        format.json { render json: {message: subscriber_list.errors.full_messages.to_sentence}, status: 422 }
+        format.json { render json: {message: creator.record.errors.full_messages.to_sentence}, status: 422 }
       end
     end
   end
@@ -33,7 +33,6 @@ private
     find_exact_query_params.merge(
       title: params[:title],
       enabled: params[:gov_delivery_id].blank?,
-      gov_delivery_id: gov_delivery_id,
       # gov_uk_delivery migration fields. these can be removed once the migration is completed
       migrated_from_gov_uk_delivery: params[:gov_delivery_id].present?,
       created_at: params[:created_at],
@@ -49,14 +48,5 @@ private
       government_document_supertype: params.fetch(:government_document_supertype, ""),
       gov_delivery_id: params[:gov_delivery_id],
     }
-  end
-
-  def gov_delivery_id
-    if params[:gov_delivery_id].present?
-      params[:gov_delivery_id]
-    else
-      gov_delivery_response = Services.gov_delivery.create_topic(params[:title])
-      gov_delivery_response.to_param
-    end
   end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -36,6 +36,10 @@ class SubscriberList < ActiveRecord::Base
     super(methods: :subscription_url)
   end
 
+  def title=(title)
+    super(title && title[0..254])
+  end
+
 private
   def tag_values_are_valid
     unless self[:tags].all? { |_, v| v.is_a?(Array) }

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -21,6 +21,7 @@ private
   def base_scope
     @base_scope ||= begin
       scope = SubscriberList
+        .where.not(gov_delivery_id: [nil, ''])
         .where(document_type: @document_type)
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)

--- a/app/services/subscriber_list_creator.rb
+++ b/app/services/subscriber_list_creator.rb
@@ -1,0 +1,26 @@
+class SubscriberListCreator
+  attr_reader :record
+
+  def initialize(params)
+    @params = params
+  end
+
+  def save
+    @record = SubscriberList.new(@params)
+    return false unless @record.save
+
+    # if the topic_id is passed in use the provided title.
+    return true if @record.gov_delivery_id.present?
+
+    title_append_string = " (#{@record.id})"
+    @record.title = "#{@record.title[0..(254 - title_append_string.size)]}#{title_append_string}"
+    gov_delivery_id = build_on_gov_delivery(@record)
+    @record.gov_delivery_id = gov_delivery_id
+    @record.save
+  end
+
+  def build_on_gov_delivery(record)
+    gov_delivery_response = Services.gov_delivery.create_topic(record.title)
+    gov_delivery_response.to_param
+  end
+end

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -114,6 +114,18 @@ RSpec.describe FindExactQuery do
     expect(query.exact_match).to be_nil
   end
 
+  it "not matched when subscriber list does have a gov_delivery_id" do
+    query = build_query(email_document_supertype: 'publications')
+    subscriber_list = create_subscriber_list(email_document_supertype: 'publications', gov_delivery_id: nil)
+    expect(query.exact_match).not_to eq(subscriber_list)
+  end
+
+  it "not matched when subscriber list has a blank gov_delivery_id" do
+    query = build_query(email_document_supertype: 'publications')
+    subscriber_list = create_subscriber_list(email_document_supertype: 'publications', gov_delivery_id: '')
+    expect(query.exact_match).not_to eq(subscriber_list)
+  end
+
   def build_query(params={})
     defaults = {
       tags: {},

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
   it "creates the topic on gov delivery" do
     create_subscriber_list(tags: {topics: ["oil-and-gas/licensing"]})
-
+    subscriber_list_id = SubscriberList.last.id
     body = <<-XML.strip_heredoc
       <?xml version="1.0"?>
       <topic>
-        <name>This is a sample title</name>
-        <short-name>This is a sample title</short-name>
+        <name>This is a sample title (#{subscriber_list_id})</name>
+        <short-name>This is a sample title (#{subscriber_list_id})</short-name>
         <visibility>Unlisted</visibility>
         <pagewatch-enabled type="boolean">false</pagewatch-enabled>
         <rss-feed-url nil="true"/>

--- a/spec/services/subscriber_list_creator_spec.rb
+++ b/spec/services/subscriber_list_creator_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe SubscriberListCreator do
+  context "when gov delivery ID is not passed in" do
+    let(:params) do
+      {
+        title: "This is a short title",
+        enabled: true,
+        tags: {},
+        links: {},
+        migrated_from_gov_uk_delivery: false,
+        document_type: 'news-article',
+        email_document_supertype: 'publications',
+        government_document_supertype: 'news-articles',
+      }
+    end
+
+    before do
+      allow(Services.gov_delivery).to receive(:create_topic).and_return('TOPIC_123')
+    end
+
+    it "creates a subscriber list with title, containing the record ID" do
+      creator = described_class.new(params)
+      creator.save
+      expect(creator.record).to have_attributes(
+        title: "This is a short title (#{creator.record.id})",
+        enabled: true,
+        tags: {},
+        links: {},
+        migrated_from_gov_uk_delivery: false,
+        document_type: 'news-article',
+        email_document_supertype: 'publications',
+        government_document_supertype: 'news-articles',
+        gov_delivery_id: 'TOPIC_123',
+      )
+    end
+
+    it "creates the topic on gov_delivery" do
+      creator = described_class.new(params)
+      creator.save
+      expect(Services.gov_delivery).to have_received(:create_topic)
+        .with("This is a short title (#{creator.record.id})")
+    end
+
+    context "and the title is longer than 255 characters" do
+      it "trims the title" do
+        title = 'ABCDEFGHIJ' * 26
+        creator = described_class.new(params.merge(title: title))
+        creator.save
+
+        title = "#{title[0..(254 - " (#{creator.record.id})".size)]} (#{creator.record.id})"
+        expect(creator.record).to have_attributes(title: title)
+      end
+    end
+  end
+
+  context "when gov delivery ID is passed in" do
+    let(:params) do
+      {
+        title: "This is a short title",
+        enabled: true,
+        tags: {},
+        links: {},
+        migrated_from_gov_uk_delivery: false,
+        document_type: 'news-article',
+        email_document_supertype: 'publications',
+        government_document_supertype: 'news-articles',
+        gov_delivery_id: 'TOPIC_ABC',
+      }
+    end
+
+    it "creates a subscriber list with the provided title" do
+      creator = described_class.new(params)
+      creator.save
+      expect(creator.record).to have_attributes(
+        title: "This is a short title",
+        enabled: true,
+        tags: {},
+        links: {},
+        migrated_from_gov_uk_delivery: false,
+        document_type: 'news-article',
+        email_document_supertype: 'publications',
+        government_document_supertype: 'news-articles',
+        gov_delivery_id: 'TOPIC_ABC',
+      )
+    end
+
+    it "does not create a topic on gov_delivery" do
+      expect(Services.gov_delivery).not_to receive(:create_topic)
+      creator = described_class.new(params)
+      creator.save
+    end
+  end
+
+end


### PR DESCRIPTION
This is required to avoid name collisions which result in errors
as the name is required to be unique on gov delivery.