### PR TITLE
Add a rake task to fetch missing subscriber list titles from GovDelivery

### DIFF
--- a/lib/data_hygiene/title_fetcher.rb
+++ b/lib/data_hygiene/title_fetcher.rb
@@ -1,8 +1,8 @@
 module DataHygiene
   class TitleFetcher
-    # Fetch titles for subscriber lists from GovDelivery and update our database
-    # with them if we don't have a title already. Log when we have a title which
-    # doesn't match GovDelivery's.
+    # Fetch all topics from GovDelivery and update the subscriber lists in our
+    # database with the title for each if we don't have a title already. Log
+    # when we have a title which doesn't match GovDelivery's.
 
     attr_reader :client, :logger, :stats
 
@@ -13,11 +13,14 @@ module DataHygiene
     end
 
     def run
+      all_topics = fetch_all_topics
+
       count = subscriber_lists.count
+      logger.info "Updating titles for #{count} subscriber lists"
 
-      logger.info "Fetching and updating titles for #{count} subscriber lists"
-
-      subscriber_lists.each { |subscriber_list| update_title(subscriber_list) }
+      subscriber_lists.each do |subscriber_list|
+        update_title(subscriber_list, all_topics[subscriber_list.gov_delivery_id])
+      end
 
       logger.info ''
       logger.info "Done:"
@@ -32,12 +35,25 @@ module DataHygiene
       SubscriberList.all
     end
 
-    def update_title(subscriber_list)
+    def fetch_all_topics
+      logger.info "Fetching all topics from GovDelivery..."
+      all_topics = client.fetch_topics['topics']
+      logger.info "#{all_topics.size} topics found on GovDelivery"
+
+      all_topics.map { |topic| [topic['code'], topic['name']] }.to_h
+    end
+
+    def update_title(subscriber_list, gov_delivery_name)
       gov_delivery_id = subscriber_list.gov_delivery_id
-      return unless topic_name = fetch_topic_title(gov_delivery_id)
+
+      unless gov_delivery_name.present?
+        @stats[:not_found] += 1
+        logger.warn "#{gov_delivery_id}: no name found for topic from GovDelivery"
+        return
+      end
 
       if subscriber_list.title.blank?
-        subscriber_list.title = topic_name
+        subscriber_list.title = gov_delivery_name
         if subscriber_list.save
           @stats[:updated] += 1
           logger.info "#{gov_delivery_id}: title updated to match GovDelivery topic"
@@ -45,26 +61,12 @@ module DataHygiene
           @stats[:update_failed] += 1
           logger.warn "#{gov_delivery_id}: failed to update title"
         end
-      elsif subscriber_list.title == topic_name
+      elsif subscriber_list.title == gov_delivery_name
         @stats[:already_matching] += 1
         logger.info "#{gov_delivery_id}: already has matching title"
       else
         @stats[:different] += 1
-        logger.warn "#{gov_delivery_id}: has GD name #{topic_name} but EEA title #{subscriber_list.title}; not overwriting existing title with name"
-      end
-    end
-
-    def fetch_topic_title(gov_delivery_id)
-      begin
-        @client.fetch_topic(gov_delivery_id).name
-      rescue GovDelivery::Client::TopicNotFound
-        @stats[:not_found] += 1
-        logger.warn "#{gov_delivery_id}: topic not found on GovDelivery"
-        return nil
-      rescue GovDelivery::Client::UnknownError, GovDelivery::Client::UnexpectedResponseBodyError => e
-        @stats[:error_fetching] += 1
-        logger.warn "#{gov_delivery_id}: error fetching topic from GovDelivery: #{e.to_s}"
-        return nil
+        logger.warn "#{gov_delivery_id}: has GD name #{gov_delivery_name} but EEA title #{subscriber_list.title}; not overwriting existing title with name"
       end
     end
   end

--- a/lib/data_hygiene/title_fetcher.rb
+++ b/lib/data_hygiene/title_fetcher.rb
@@ -1,0 +1,72 @@
+module DataHygiene
+  class TitleFetcher
+    # Fetch titles for subscriber lists from GovDelivery and update our database
+    # with them if we don't have a title already. Log when we have a title which
+    # doesn't match GovDelivery's.
+
+    attr_reader :client, :logger, :stats
+
+    def initialize(client: Services.gov_delivery, logger: Logger.new(STDOUT))
+      @client = client
+      @logger ||= logger
+      @stats = Hash.new(0)
+    end
+
+    def run
+      count = subscriber_lists.count
+
+      logger.info "Fetching and updating titles for #{count} subscriber lists"
+
+      subscriber_lists.each { |subscriber_list| update_title(subscriber_list) }
+
+      logger.info ''
+      logger.info "Done:"
+      stats.each do |k, v|
+        logger.info "  #{k}: #{v}"
+      end
+    end
+
+  private
+
+    def subscriber_lists
+      SubscriberList.all
+    end
+
+    def update_title(subscriber_list)
+      gov_delivery_id = subscriber_list.gov_delivery_id
+      return unless topic_name = fetch_topic_title(gov_delivery_id)
+
+      if subscriber_list.title.blank?
+        subscriber_list.title = topic_name
+        if subscriber_list.save
+          @stats[:updated] += 1
+          logger.info "#{gov_delivery_id}: title updated to match GovDelivery topic"
+        else
+          @stats[:update_failed] += 1
+          logger.warn "#{gov_delivery_id}: failed to update title"
+        end
+      elsif subscriber_list.title == topic_name
+        @stats[:already_matching] += 1
+        logger.info "#{gov_delivery_id}: already has matching title"
+      else
+        @stats[:different] += 1
+        logger.warn "#{gov_delivery_id}: has GD name #{topic_name} but EEA title #{subscriber_list.title}; not overwriting existing title with name"
+      end
+    end
+
+    def fetch_topic_title(gov_delivery_id)
+      begin
+        @client.fetch_topic(gov_delivery_id).name
+      rescue GovDelivery::Client::TopicNotFound
+        @stats[:not_found] += 1
+        logger.warn "#{gov_delivery_id}: topic not found on GovDelivery"
+        return nil
+      rescue GovDelivery::Client::UnknownError, GovDelivery::Client::UnexpectedResponseBodyError => e
+        @stats[:error_fetching] += 1
+        logger.warn "#{gov_delivery_id}: error fetching topic from GovDelivery: #{e.to_s}"
+        return nil
+      end
+    end
+  end
+end
+

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -32,3 +32,10 @@ task sync_govdelivery_topic_mappings: :environment do
 
   DataHygiene::DataSync.new.run
 end
+
+desc "Fill in missing titles for subscriber lists from GovDelivery data"
+task fetch_titles: :environment do
+  require "data_hygiene/title_fetcher"
+
+  DataHygiene::TitleFetcher.new.run
+end

--- a/spec/lib/data_hygiene/title_fetcher_spec.rb
+++ b/spec/lib/data_hygiene/title_fetcher_spec.rb
@@ -1,0 +1,222 @@
+require 'rails_helper'
+require 'data_hygiene/title_fetcher'
+
+RSpec.describe DataHygiene::TitleFetcher do
+  let(:client) { double('GovDelivery::Client') }
+  let(:logger) { double(:logger, info: true, warn: true) }
+  subject { described_class.new(client: client, logger: logger) }
+
+  describe '#fetch_topic_title' do
+    let(:gov_delivery_id) { 'ID_1' }
+
+    context 'when the topic exists on GovDelivery' do
+      before do
+        allow(client).to receive(:fetch_topic)
+          .and_return(double(name: 'Education'))
+      end
+
+      it 'returns the name from the GovDelivery response' do
+        expect(subject.send(:fetch_topic_title, gov_delivery_id)).to eq('Education')
+      end
+    end
+
+    context 'when the topic does not exist on GovDelivery' do
+      before do
+        allow(client).to receive(:fetch_topic)
+          .and_raise(GovDelivery::Client::TopicNotFound)
+      end
+
+      it 'logs the error' do
+        expect(logger).to receive(:warn).with("ID_1: topic not found on GovDelivery")
+        subject.send(:fetch_topic_title, gov_delivery_id)
+        expect(subject.stats).to eq({ not_found: 1 })
+      end
+    end
+
+    context '#when the GovDelivery `fetch_topic` endpoint has an error' do
+      before do
+        allow(client).to receive(:fetch_topic)
+          .and_raise(GovDelivery::Client::UnknownError.new("Error message"))
+      end
+
+      it 'logs the error' do
+        expect(logger).to receive(:warn).with("ID_1: error fetching topic from GovDelivery: Error message")
+        subject.send(:fetch_topic_title, gov_delivery_id)
+        expect(subject.stats).to eq({ error_fetching: 1 })
+      end
+    end
+  end
+
+  describe '#update_title' do
+    let!(:subscriber_list) { create(:subscriber_list, gov_delivery_id: 'ABC_123', title: nil) }
+
+    context 'when the topic exists on GovDelivery' do
+      before do
+        allow(client).to receive(:fetch_topic)
+          .and_return(double(name: 'Education'))
+      end
+
+      context "when the subscriber list's title is missing" do
+        shared_examples 'updates the title' do |initial_title|
+          let!(:subscriber_list) { create(:subscriber_list, gov_delivery_id: 'ABC_123', title: initial_title) }
+
+          it "updates the subscriber list's title" do
+            expect { subject.send(:update_title, subscriber_list) }
+              .to change { subscriber_list.title }
+              .from(initial_title)
+              .to('Education')
+          end
+
+          it 'logs the change' do
+            expect(logger).to receive(:info).with("ABC_123: title updated to match GovDelivery topic")
+            subject.send(:update_title, subscriber_list)
+            expect(subject.stats).to eq({ updated: 1 })
+          end
+        end
+
+        it_behaves_like 'updates the title', nil
+        it_behaves_like 'updates the title', ''
+
+        context 'when saving fails' do
+          let!(:subscriber_list) { create(:subscriber_list, gov_delivery_id: 'ABC_123', title: nil) }
+          before do
+            allow(subscriber_list).to receive(:save).and_return(false)
+          end
+
+          it 'logs the failure' do
+            expect(logger).to receive(:warn).with("ABC_123: failed to update title")
+            subject.send(:update_title, subscriber_list)
+            expect(subject.stats).to eq({ update_failed: 1 })
+          end
+        end
+      end
+
+      context 'when the subscriber list has the same title already' do
+        let!(:subscriber_list) { create(:subscriber_list, gov_delivery_id: 'ABC_123', title: 'Education') }
+
+        it "doesn't change the title" do
+          expect { subject.send(:update_title, subscriber_list) }
+            .not_to change { subscriber_list.title }
+        end
+
+        it 'logs it' do
+          expect(logger).to receive(:info).with("ABC_123: already has matching title")
+          subject.send(:update_title, subscriber_list)
+          expect(subject.stats).to eq({ already_matching: 1 })
+        end
+      end
+
+      context 'when the subscriber list has a different title already' do
+        let!(:subscriber_list) { create(:subscriber_list, gov_delivery_id: 'ABC_123', title: 'Space') }
+
+        it "doesn't change the title" do
+          expect { subject.send(:update_title, subscriber_list) }
+            .not_to change { subscriber_list.title }
+        end
+
+        it 'logs it' do
+          expect(logger)
+            .to receive(:warn)
+            .with("ABC_123: has GD name Education but EEA title Space; not overwriting existing title with name")
+          subject.send(:update_title, subscriber_list)
+          expect(subject.stats).to eq({ different: 1 })
+        end
+      end
+    end
+
+    context 'when the topic does not exist on GovDelivery' do
+      before do
+        allow(client).to receive(:fetch_topic)
+          .and_raise(GovDelivery::Client::TopicNotFound)
+      end
+
+      it 'does not update the subscriber list' do
+        expect { subject.send(:update_title, subscriber_list) }.to_not change { subscriber_list.title }
+      end
+    end
+
+    context '#when the GovDelivery `fetch_topic` endpoint has an error' do
+      before do
+        allow(client).to receive(:fetch_topic)
+          .and_raise(GovDelivery::Client::UnknownError.new("Error message"))
+      end
+
+      it 'does not update the subscriber list' do
+        expect { subject.send(:update_title, subscriber_list) }.to_not change { subscriber_list.title }
+      end
+    end
+  end
+
+  describe '#run' do
+    let!(:missing_title_list) { create(:subscriber_list, title: nil) }
+    let!(:matching_title_list) { create(:subscriber_list, title: 'Education') }
+    let!(:different_title_list) { create(:subscriber_list, title: 'Space') }
+    let!(:not_on_govdelivery_list) { create(:subscriber_list, title: nil) }
+    let!(:errors_at_govdelivery_list) { create(:subscriber_list, title: nil) }
+
+    before do
+      allow(client).to receive(:fetch_topic).with(missing_title_list.gov_delivery_id)
+        .and_return(double(name: 'I have a name'))
+      allow(client).to receive(:fetch_topic).with(matching_title_list.gov_delivery_id)
+        .and_return(double(name: 'Education'))
+      allow(client).to receive(:fetch_topic).with(different_title_list.gov_delivery_id)
+        .and_return(double(name: 'Something else'))
+      allow(client).to receive(:fetch_topic).with(not_on_govdelivery_list.gov_delivery_id)
+        .and_raise(GovDelivery::Client::TopicNotFound)
+      allow(client).to receive(:fetch_topic).with(errors_at_govdelivery_list.gov_delivery_id)
+        .and_raise(GovDelivery::Client::UnknownError.new("Error message"))
+    end
+
+    it 'fetches each topic from GovDelivery' do
+      expect(client).to receive(:fetch_topic).exactly(5).times
+      subject.run
+    end
+
+    it 'adds the title to the list which was missing one' do
+      subject.run
+      missing_title_list.reload
+      expect(missing_title_list.title).to eq('I have a name')
+    end
+
+    it 'does not update the other lists' do
+      [
+        matching_title_list,
+        different_title_list,
+        not_on_govdelivery_list,
+        errors_at_govdelivery_list
+      ].each { |subscriber_list| subscriber_list.reload }
+
+      expect(matching_title_list.title).to eq('Education')
+      expect(different_title_list.title).to eq('Space')
+      expect(not_on_govdelivery_list.title).to eq(nil)
+      expect(errors_at_govdelivery_list.title).to eq(nil)
+    end
+
+    it 'logs everything at the appropriate level' do
+      [
+        "Fetching and updating titles for 5 subscriber lists",
+        "#{missing_title_list.gov_delivery_id}: title updated to match GovDelivery topic",
+        "#{matching_title_list.gov_delivery_id}: already has matching title",
+        "",
+        "Done:",
+        "  updated: 1",
+        "  already_matching: 1",
+        "  different: 1",
+        "  not_found: 1",
+        "  error_fetching: 1"
+      ].each do |message|
+        expect(logger).to receive(:info).with(message)
+      end
+
+      [
+        "#{different_title_list.gov_delivery_id}: has GD name Something else but EEA title Space; not overwriting existing title with name",
+        "#{not_on_govdelivery_list.gov_delivery_id}: topic not found on GovDelivery",
+        "#{errors_at_govdelivery_list.gov_delivery_id}: error fetching topic from GovDelivery: Error message"
+      ].each do |message|
+        expect(logger).to receive(:warn).with(message)
+      end
+
+      subject.run
+    end
+  end
+end


### PR DESCRIPTION
We have lots of subscriber lists in our database with missing titles, because they have been migrated to use email-alert-api from govuk-delivery which doesn't store titles for topics. This makes it harder to see from our data what a subscriber list is, and means that in our Staging and Integration GovDelivery accounts most topics have unhelpful ["MISSING TITLE [id]" names](https://github.com/alphagov/email-alert-api/blob/0dd0bae92ac39c66c0fca7f3cf0b99dc53c8e080/lib/data_hygiene/data_sync.rb#L83). GovDelivery requires a name for topics, so we can fetch the data from there in Production and update our database using it.

This task fetches all the topics in our database from GovDelivery, updates the title for lists which don't have one, and logs any discrepancies between the titles we have and the ones in GovDelivery.

I wrote this first to fetch every topic from GovDelivery individually, as we do in [`DeleteUnneededTopics`](https://github.com/alphagov/email-alert-api/blob/0dd0bae92ac39c66c0fca7f3cf0b99dc53c8e080/lib/data_hygiene/delete_unneeded_topics.rb), but then realised that getting the list of all topics would give us all the data we need for this task - `DeleteUnneededTopics` also needs the subscriber counts which aren't included in that response, but we only need the topic code and name here. I've updated this to do that instead, which should make it much faster overall, but have left the first version in an earlier commit in case we start getting timeouts when fetching all topics, in which case we may need to revert back to that method.