### PR TITLE
When deleting unneeded topics, only consider lists older than a day

### DIFF
--- a/lib/data_hygiene/delete_unneeded_topics.rb
+++ b/lib/data_hygiene/delete_unneeded_topics.rb
@@ -115,8 +115,8 @@ module DataHygiene
       end
 
       def call
-        group_size = [(SubscriberList.count.to_f / MAX_THREAD_COUNT).ceil, MIN_BATCH_SIZE].max
-        subscriber_list_sets = SubscriberList.all.each_slice(group_size)
+        group_size = [(subscriber_lists_to_consider.count.to_f / MAX_THREAD_COUNT).ceil, MIN_BATCH_SIZE].max
+        subscriber_list_sets = subscriber_lists_to_consider.each_slice(group_size)
 
         results = []
         semaphore = Mutex.new
@@ -129,6 +129,10 @@ module DataHygiene
         threads.each(&:join)
         puts ''
         results
+      end
+
+      def subscriber_lists_to_consider
+        SubscriberList.where('created_at < ?', 1.day.ago)
       end
 
       def add_count_of_subscribers(subscriber_lists)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :subscriber_list do
     sequence(:gov_delivery_id) {|n| "UKGOVUK_#{n}" }
     tags({ topics: ["motoring/road_rage"] })
+    created_at { 1.year.ago }
   end
 end

--- a/spec/lib/data_hygiene/delete_unneeded_topics_spec.rb
+++ b/spec/lib/data_hygiene/delete_unneeded_topics_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe DataHygiene::DeleteUnneededTopics do
       it 'is included in the list' do
         expect(subject.with_zero_subscribers).to include(subscriber_list)
       end
+
+      context 'when the subscriber list was created recently' do
+        let!(:subscriber_list) { create(:subscriber_list, title: 'Test', created_at: 1.hour.ago) }
+
+        it 'is not included in the list' do
+          expect(subject.with_zero_subscribers).not_to include(subscriber_list)
+        end
+      end
     end
 
     context 'when the topic has subscribers' do
@@ -91,6 +99,14 @@ RSpec.describe DataHygiene::DeleteUnneededTopics do
       it 'is included in the list' do
         expect(subject.with_missing_topic).to include(subscriber_list)
       end
+
+      context 'when the subscriber list was created recently' do
+        let!(:subscriber_list) { create(:subscriber_list, title: 'Test', created_at: 1.hour.ago) }
+
+        it 'is not included in the list' do
+          expect(subject.with_missing_topic).not_to include(subscriber_list)
+        end
+      end
     end
 
     context 'when fetching the topic raises another error' do
@@ -147,6 +163,14 @@ RSpec.describe DataHygiene::DeleteUnneededTopics do
 
       it 'is included in the list' do
         expect(subject.with_gov_delivery_error).to include(subscriber_list)
+      end
+
+      context 'when the subscriber list was created recently' do
+        let!(:subscriber_list) { create(:subscriber_list, title: 'Test', created_at: 1.hour.ago) }
+
+        it 'is not included in the list' do
+          expect(subject.with_gov_delivery_error).not_to include(subscriber_list)
+        end
       end
     end
   end


### PR DESCRIPTION
Now that we're creating new subscriber lists for taxons and Whitehall things,
we want to avoid accidentally deleting a topic while the first user is trying
to subscribe to it. Only considering lists older than a day for deletion
should do this comfortably while still letting us clear up unneeded data.

We really only need to change this behaviour for lists with 0 subscribers
rather than for the other categories as well, but it was much simpler to
exclude them from the start rather than having to check each one as we're
deleting, or word all the logging differently to make it clear that we're
making this change only for lists with 0 subscribers. I've added tests for the
other cases to document the new behaviour.

Nothing else in the app cares about `created_at` so it's safe to change it in
the default factory.