### PR TITLE
Disable asset debug mode and suppress asset logger output

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,10 +40,10 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  # config.assets.debug = true
 
   # Suppress logger output for asset requests.
-  config.assets.quiet = true
+  # config.assets.quiet = true
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
Since the asset pipeline is not being used, including the settings

`config.assets.debug = true`
`config.assets.quiet = true`

in `development.rb` prevents the app from running in dev and gives an error
(undefined method 'assets').