### PR TITLE
Keep track of number of subscribers to lists

### DIFF
--- a/app/workers/update_subscriber_counts.rb
+++ b/app/workers/update_subscriber_counts.rb
@@ -1,0 +1,14 @@
+class UpdateSubscriberCounts
+  include Sidekiq::Worker
+
+  def perform
+    SubscriberList.find_each do |subscriber_list|
+      begin
+        topic = Services.gov_delivery.fetch_topic(subscriber_list.gov_delivery_id)
+        subscriber_list.update!(subscriber_count: topic["subscribers_count"])
+      rescue GovDelivery::Client::UnknownError => e
+        Rails.logger.info "Error fetching GovDelivery topic for SubscriberList##{subscriber_list.id}. Error: #{e.inspect}"
+      end
+    end
+  end
+end

--- a/db/migrate/20170720135533_add_subscriber_count_to_subscriber_lists.rb
+++ b/db/migrate/20170720135533_add_subscriber_count_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddSubscriberCountToSubscriberLists < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriber_lists, :subscriber_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170327104203) do
+ActiveRecord::Schema.define(version: 20170720135533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20170327104203) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.boolean "migrated_from_gov_uk_delivery", default: false, null: false
+    t.integer "subscriber_count"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -16,39 +15,38 @@ ActiveRecord::Schema.define(version: 20170327104203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "notification_logs", force: :cascade do |t|
-    t.string   "govuk_request_id",              default: ""
-    t.string   "content_id",                    default: ""
+  create_table "notification_logs", id: :serial, force: :cascade do |t|
+    t.string "govuk_request_id", default: ""
+    t.string "content_id", default: ""
     t.datetime "public_updated_at"
-    t.json     "links",                         default: {}
-    t.json     "tags",                          default: {}
-    t.string   "document_type",                 default: ""
-    t.string   "emailing_app",                  default: "", null: false
-    t.json     "gov_delivery_ids",              default: []
-    t.string   "publishing_app",                default: ""
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.json     "enabled_gov_delivery_ids",      default: []
-    t.json     "disabled_gov_delivery_ids",     default: []
-    t.string   "email_document_supertype",      default: ""
-    t.string   "government_document_supertype", default: ""
+    t.json "links", default: {}
+    t.json "tags", default: {}
+    t.string "document_type", default: ""
+    t.string "emailing_app", default: "", null: false
+    t.json "gov_delivery_ids", default: []
+    t.string "publishing_app", default: ""
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.json "enabled_gov_delivery_ids", default: []
+    t.json "disabled_gov_delivery_ids", default: []
+    t.string "email_document_supertype", default: ""
+    t.string "government_document_supertype", default: ""
+    t.index ["content_id", "public_updated_at"], name: "index_notification_logs_on_content_id_and_public_updated_at"
+    t.index ["govuk_request_id"], name: "index_notification_logs_on_govuk_request_id"
   end
 
-  add_index "notification_logs", ["content_id", "public_updated_at"], name: "index_notification_logs_on_content_id_and_public_updated_at", using: :btree
-  add_index "notification_logs", ["govuk_request_id"], name: "index_notification_logs_on_govuk_request_id", using: :btree
-
-  create_table "subscriber_lists", force: :cascade do |t|
-    t.string   "title",                         limit: 255
-    t.string   "gov_delivery_id",               limit: 255
+  create_table "subscriber_lists", id: :serial, force: :cascade do |t|
+    t.string "title", limit: 255
+    t.string "gov_delivery_id", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "document_type",                             default: "",    null: false
-    t.json     "tags",                                      default: {},    null: false
-    t.json     "links",                                     default: {},    null: false
-    t.boolean  "enabled",                                   default: true,  null: false
-    t.string   "email_document_supertype",                  default: "",    null: false
-    t.string   "government_document_supertype",             default: "",    null: false
-    t.boolean  "migrated_from_gov_uk_delivery",             default: false, null: false
+    t.string "document_type", default: "", null: false
+    t.json "tags", default: {}, null: false
+    t.json "links", default: {}, null: false
+    t.boolean "enabled", default: true, null: false
+    t.string "email_document_supertype", default: "", null: false
+    t.string "government_document_supertype", default: "", null: false
+    t.boolean "migrated_from_gov_uk_delivery", default: false, null: false
   end
 
 end

--- a/lib/tasks/update_subscriber_counts.rake
+++ b/lib/tasks/update_subscriber_counts.rake
@@ -1,0 +1,4 @@
+desc "Schedule a worker to update the subscriber list counts"
+task schedule_update_subscriber_counts: [:environment] do
+  UpdateSubscriberCounts.perform_async
+end

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
         id
         title
         document_type
+        subscriber_count
         subscription_url
         gov_delivery_id
         created_at

--- a/spec/workers/update_subscriber_counts_spec.rb
+++ b/spec/workers/update_subscriber_counts_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe UpdateSubscriberCounts do
+  describe '#perform' do
+    it "updates the counts" do
+      working_subscriber_list = create(:subscriber_list)
+      stub_govdelivery(working_subscriber_list)
+      error_list = create(:subscriber_list)
+      stub_govdelivery_error(error_list)
+
+      UpdateSubscriberCounts.new.perform
+
+      expect(working_subscriber_list.reload.subscriber_count).to eql(12345)
+    end
+
+    def stub_govdelivery(subscriber_list)
+      body = <<-XML.strip_heredoc
+        <?xml version="1.0" encoding="UTF-8"?>
+        <topic>
+          <subscribers-count type="integer">12345</subscribers-count>
+        </topic>
+      XML
+
+      stub_request(:get, "http://govdelivery-api.example.com/api/account/UKGOVUK/topics/#{subscriber_list.gov_delivery_id}.xml").
+        to_return(status: 200, body: body)
+    end
+
+    def stub_govdelivery_error(subscriber_list)
+      stub_request(:get, "http://govdelivery-api.example.com/api/account/UKGOVUK/topics/#{subscriber_list.gov_delivery_id}.xml").
+        to_return(status: 500)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a rake task that will update the "subscriber_count" of subscriber lists ("topics"). It does this by getting the data from GovDelivery. Separately we'll set up a rake task to periodically run the rake task so that the counts are refreshed regularly.

We're adding the counts because we're considering adding something to the content tagger UI that shows how many people are subscribed to a certain taxon. This can help the information architects determine the relative popularity of taxons.

The actual work happens in a sidekiq worker to make sure we're not tying up the rake task executors on Jenkins, and to make sure it's retried when an error occurs. We'll also get data from statsd on the job performance.

https://trello.com/c/YwfSmNQX