### PR TITLE
Fix a warning

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -31,7 +31,7 @@ private
 
   def status
     ActiveRecord::Base.connected? &&
-      Sidekiq.redis { |conn| conn.info } ? 'ok' : 'critical'
+      Sidekiq.redis_info ? 'ok' : 'critical'
   end
 
   def govdelivery_status


### PR DESCRIPTION
>Passing 'info' command to redis as is; administrative commands cannot be
>effectively namespaced and should be called on the redis connection
>directly; passthrough has been deprecated and will be removed in
>redis-namespace 2.0 (at healthcheck_controller.rb:34:in `block in status')