### PR TITLE
Add rake tasks to enable/disable lists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'unicorn', '5.3.0'
 gem 'logstasher', '1.2.1'
 gem 'sidekiq-logging-json', '0.0.18'
 gem 'statsd-ruby', '1.4.0'
-gem 'gds-api-adapters', '45.0.0'
+gem 'gds-api-adapters', '47.5.0'
 gem 'sidekiq-statsd', '0.1.5'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     ffi (1.9.18)
     foreman (0.84.0)
       thor (~> 0.19.1)
-    gds-api-adapters (45.0.0)
+    gds-api-adapters (47.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -229,7 +229,7 @@ DEPENDENCIES
   factory_girl_rails
   faraday (= 0.12.1)
   foreman (= 0.84.0)
-  gds-api-adapters (= 45.0.0)
+  gds-api-adapters (= 47.5.0)
   listen (= 3.1.5)
   logstasher (= 1.2.1)
   nokogiri (= 1.7.2)

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,5 +1,6 @@
 require "gov_delivery/client"
 require 'gds_api/content_store'
+require 'gds_api/gov_uk_delivery'
 
 module Services
   def self.gov_delivery
@@ -8,5 +9,9 @@ module Services
 
   def self.content_store
     @content_store ||= GdsApi::ContentStore.new(Plek.new.find('content-store'))
+  end
+
+  def self.govuk_delivery
+    @govuk_delivery ||= GdsApi::GovUkDelivery.new(Plek.new.find('govuk-delivery'))
   end
 end

--- a/lib/tasks/switch_list_to_email_alert_api.rake
+++ b/lib/tasks/switch_list_to_email_alert_api.rake
@@ -1,0 +1,34 @@
+desc "Switch a subscriber list to email-alert-api from govuk-delivery"
+task switch_list_to_email_alert_api: [:environment] do |_, args|
+  TICK = "\e[32m✓\e[0m"
+  CROSS = "\e[31m✗\e[0m"
+
+  args.extras.each do |gov_delivery_id|
+    # Enable the list in email-alert-api
+    subscriber_list = SubscriberList.where(gov_delivery_id: gov_delivery_id).first
+    subscriber_list.enabled = true
+
+    if subscriber_list.save
+      puts "#{TICK} #{gov_delivery_id} has been enabled in email-alert-api"
+    else
+      puts "#{CROSS} #{gov_delivery_id} could not be enabled in email-alert-api"
+
+      # We don't want to disable the list in govuk-delivery if we couldn't
+      # successfully enable it in email-alert-api
+      exit
+    end
+
+    # Disable the list in govuk-delivery
+    response = Services.govuk_delivery.disable_list(gov_delivery_id).to_hash
+
+    if !response['enabled']
+      puts "#{TICK} #{gov_delivery_id} has been disabled in govuk-delivery"
+    else
+      puts "#{CROSS} #{gov_delivery_id} could not be disabled in govuk-delivery - disabling in email-alert-api"
+
+      # Disable the list in email-alert-api to keep consistency
+      subscriber_list.enabled = false
+      subscriber_list.save
+    end
+  end
+end

--- a/lib/tasks/switch_list_to_govuk_delivery.rake
+++ b/lib/tasks/switch_list_to_govuk_delivery.rake
@@ -1,0 +1,33 @@
+desc "Switch a subscriber list to govuk-delivery from email-alert-api"
+task switch_list_to_govuk_delivery: [:environment] do |_, args|
+  TICK = "\e[32m✓\e[0m"
+  CROSS = "\e[31m✗\e[0m"
+
+  args.extras.each do |gov_delivery_id|
+    # Enable the list in govuk-delivery
+    response = Services.govuk_delivery.enable_list(gov_delivery_id).to_hash
+
+    if response['enabled'].nil? || response['enabled']
+      puts "#{TICK} #{gov_delivery_id} has been enabled in govuk-delivery"
+    else
+      puts "#{CROSS} #{gov_delivery_id} could not be enabled in govuk-delivery"
+
+      # We don't want to disable the list in email-alert-api if we couldn't
+      # successfully enable it in govuk-delivery
+      exit
+    end
+
+    # Disable the list in email-alert-api
+    subscriber_list = SubscriberList.where(gov_delivery_id: gov_delivery_id).first
+    subscriber_list.enabled = false
+
+    if subscriber_list.save
+      puts "#{TICK} #{gov_delivery_id} has been disabled in email-alert-api"
+    else
+      puts "#{CROSS} #{gov_delivery_id} could not be disabled in email-alert-api - disabling in govuk-delivery"
+
+      # Disable the list in govuk-delivery to keep consistency
+      Services.govuk_delivery.disable_list(gov_delivery_id)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two rake tasks that enable/disable subscriber lists in email-alert-api and govuk-delivery to facilitate the migration of all email lists to email-alert-api.

Trello: https://trello.com/c/CaD3UZFZ/69-make-sure-toggling-enabled-disabled-across-systems-works-quickly-and-reliably-1