### PR TITLE
Add CSV output for notification log reports

### DIFF
--- a/lib/tasks/notification_log_reporting.rake
+++ b/lib/tasks/notification_log_reporting.rake
@@ -10,3 +10,14 @@ task :notification_log_reporting, [:from, :to] => :environment do |_task, args|
   scope = NotificationLog.where(created_at: from..to)
   NotificationReport.new(scope).print
 end
+
+desc "CSV Report for notification logs with optional `from` and `to` date params (e.g. `rake notification_log_reporting[2015-01-01,2016-02-02]`)"
+task :notification_log_reporting_to_csv, [:from, :to] => :environment do |_task, args|
+  args.with_defaults(from: "2017-06-01", to: Time.now.to_s)
+
+  from = Time.parse(args.from)
+  to = Time.parse(args.to)
+
+  scope = NotificationLog.where(created_at: from..to)
+  NotificationReport.new(scope).export_csv
+end


### PR DESCRIPTION
This allows for exporting the notification logs to CSV. It will export a CSV file to the `/public/data` folder which can then be copied and viewed with any spreadsheet application. It will make it easier to spot patterns when identifying different mismatches, as we will be able to sort by different columns (eg created_at).

The code has been copied and adapted from [LocalLinksManager’s export_links rake task](https://github.com/alphagov/local-links-manager/blob/master/lib/tasks/export/link_exporter.rake)

Related to https://trello.com/c/UVYYmT7t/67-understand-the-differences-between-email-alert-apis-subscriber-lists-and-govuk-deliverys-feedurls-and-decide-what-to-do-about-th