### PR TITLE
Add an endpoint for retrieving topic matches

### DIFF
--- a/app/controllers/topic_matches_controller.rb
+++ b/app/controllers/topic_matches_controller.rb
@@ -1,0 +1,30 @@
+class TopicMatchesController < ApplicationController
+  def show
+    respond_to do |format|
+      format.json { render json: topic_matches }
+    end
+  end
+
+private
+
+  def topic_matches
+    hash = params.permit!.to_h
+
+    query = SubscriberListQuery.new(
+      tags: hash[:tags] || {},
+      links: hash[:links] || {},
+      document_type: hash[:document_type],
+      email_document_supertype: hash[:email_document_supertype],
+      government_document_supertype: hash[:government_document_supertype],
+    )
+
+    topics = query.lists
+    enabled, disabled = topics.partition(&:enabled?)
+
+    {
+      topics: topics.map(&:gov_delivery_id),
+      enabled: enabled.map(&:gov_delivery_id),
+      disabled: disabled.map(&:gov_delivery_id),
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :notification_logs, only: [:create]
   resources :subscriber_lists, path: "subscriber-lists", only: [:create]
   get "/subscriber-lists", to: "subscriber_lists#show"
+  get "/topic-matches", to: "topic_matches#show"
 
   resources :notifications, only: [:create, :index, :show]
 

--- a/spec/controllers/topic_matches_controller_spec.rb
+++ b/spec/controllers/topic_matches_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TopicMatchesController, type: :controller do
+  it "returns topics, enabled, disabled for a subscriber list query" do
+    FactoryGirl.create(
+      :subscriber_list,
+      links: { organisation: ["content-id-123"] },
+      gov_delivery_id: "TOPIC_123",
+    )
+
+    params = { links: { organisation: ["content-id-123"] } }
+    get :show, params: params, format: :json
+    data = JSON.parse(response.body).symbolize_keys
+
+    expect(data).to eq(
+      topics: ["TOPIC_123"],
+      enabled: ["TOPIC_123"],
+      disabled: [],
+    )
+  end
+
+  it "returns empty arrays if the query returns nothing" do
+    get :show, params: {}, format: :json
+    data = JSON.parse(response.body).symbolize_keys
+    expect(data).to eq(topics: [], enabled: [], disabled: [])
+  end
+end


### PR DESCRIPTION
We want to see which topics are matched against
query parameters so we can cross-reference these
against govuk-delivery.

This provides an endpoint which will be used in
a Whitehall rake task that generates a report.