### PR TITLE
Add rake tasks to retire open/closed consultation topics

### DIFF
--- a/lib/open_closed_retirer.rb
+++ b/lib/open_closed_retirer.rb
@@ -1,0 +1,66 @@
+# We're retiring topics for open/closed consultation subscriptions from the
+# GOV.UK publications page. Instead, people who sign up to any of these lists
+# will receive notifications for all consultations.
+#
+# This class notifies subscribers of those topics about what is changing and
+# performs the cleanup operation in govdelivery and deletes the subscriber lists
+# from this application's database.
+
+class OpenClosedRetirer
+  TOPIC_FOR_MANUAL_TESTING = "UKGOVUK_55555"
+
+  attr_accessor :topics_to_retire
+
+  def initialize(run_for_real: false)
+    if run_for_real
+      self.topics_to_retire = open_consultation_topics + closed_consultation_topics
+    else
+      puts "Manual test mode: #{TOPIC_FOR_MANUAL_TESTING}."
+      self.topics_to_retire = [TOPIC_FOR_MANUAL_TESTING]
+    end
+  end
+
+  def notify_subscribers_about_retirement!
+    args = [topics_to_retire, subject, body]
+    puts "Sending bulletin with args: #{args.inspect}"
+
+    Services.gov_delivery.send_bulletin(*args)
+  end
+
+  def remove_subscriber_lists_and_topics!
+    topics_to_retire.each do |topic|
+      begin
+        Services.gov_delivery.delete_topic(topic)
+        SubscriberList.find_by!(gov_delivery_id: topic).destroy
+        puts "#{topic} removed"
+      rescue => e
+        puts "Failed to remove #{topic}: #{e.message}"
+      end
+    end
+  end
+
+  private
+
+  def subject
+    "Changes to your email subscription"
+  end
+
+  def body
+    <<-HTML
+      <h1>Changes to your subscription</h1>
+      <p>We’re changing the way we send out emails about consultations.</p>
+      <p>The list you’re currently subscribed to is being retired.</p>
+      <h2>Resubscribe to get emails about all consultations</h2>
+      <p>You can <a href="https://www.gov.uk/government/publications?publication_filter_option=consultations">sign up to get email alerts about all consultations</a> instead.</p>
+      <p><a href="[[SUBSCRIBER_PREFERENCES_URL]]">Update your email preferences</a> to change the kind of emails you get and how often you get them.</p>
+    HTML
+  end
+
+  def open_consultation_topics
+    SubscriberList.where(government_document_supertype: "open-consultations").pluck(:gov_delivery_id)
+  end
+
+  def closed_consultation_topics
+    SubscriberList.where(government_document_supertype: "closed-consultations").pluck(:gov_delivery_id)
+  end
+end

--- a/lib/tasks/open_closed.rake
+++ b/lib/tasks/open_closed.rake
@@ -1,0 +1,13 @@
+namespace :open_closed do
+  desc "Notify subscribers about the retirement of open/closed consultation topics"
+  task notify_subscribers_about_retirement: [:environment] do
+    retirer = OpenClosedRetirer.new(run_for_real: ENV["RUN_FOR_REAL"])
+    retirer.notify_subscribers_about_retirement!
+  end
+
+  desc "Remove open/closed consultation topics from govdelivery and the database"
+  task remove_subscriber_lists_and_topics: [:environment] do
+    retirer = OpenClosedRetirer.new(run_for_real: ENV["RUN_FOR_REAL"])
+    retirer.remove_subscriber_lists_and_topics!
+  end
+end

--- a/spec/lib/open_closed_retirer_spec.rb
+++ b/spec/lib/open_closed_retirer_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe OpenClosedRetirer do
+  let(:manual_test_topic) { "UKGOVUK_55555" }
+
+  before do
+    FactoryGirl.create(
+      :subscriber_list,
+      government_document_supertype: "open-consultations",
+      gov_delivery_id: "TEST_123",
+    )
+
+    FactoryGirl.create(
+      :subscriber_list,
+      government_document_supertype: "closed-consultations",
+      gov_delivery_id: "TEST_456",
+    )
+  end
+
+  describe "#notify_subscribers_about_retirement!" do
+    it "sends an email to the topics to retire" do
+
+      expect(Services.gov_delivery).to receive(:send_bulletin) do |*args|
+        topics, subject, body = args
+
+        expect(topics).to eq([manual_test_topic])
+        expect(subject).to match("Changes to your email subscription")
+        expect(body).to include("We’re changing the way we send out emails about consultations.")
+      end
+
+      expect { subject.notify_subscribers_about_retirement! }
+        .to output(/Sending bulletin with args/).to_stdout
+    end
+
+    context "when 'run_for_real' is set" do
+      subject { described_class.new(run_for_real: true) }
+
+      it "sends bulletins to the real open/closed consultation topics" do
+        expect(Services.gov_delivery).to receive(:send_bulletin) do |*args|
+          topics, _ = args
+          expect(topics).to eq(%w(TEST_123 TEST_456))
+        end
+
+        expect { subject.notify_subscribers_about_retirement! }
+          .to output(/Sending bulletin with args/).to_stdout
+      end
+    end
+  end
+
+  describe "#remove_subscriber_lists_and_topics!" do
+    before do
+      FactoryGirl.create(:subscriber_list, gov_delivery_id: manual_test_topic)
+    end
+
+    it "removes the govdelivery topics and subscriber list records" do
+      expect(Services.gov_delivery).to receive(:delete_topic)
+        .with(manual_test_topic)
+
+      expect { subject.remove_subscriber_lists_and_topics! }
+        .to change(SubscriberList, :count).by(-1)
+        .and output(/#{manual_test_topic} removed/).to_stdout
+    end
+
+    context "when 'run_for_real' is set" do
+      subject { described_class.new(run_for_real: true) }
+
+      it "deletes the real open/closed consultation topics" do
+        expect(Services.gov_delivery).to receive(:delete_topic)
+          .with("TEST_123")
+
+        expect(Services.gov_delivery).to receive(:delete_topic)
+          .with("TEST_456")
+
+        expect { subject.remove_subscriber_lists_and_topics! }
+          .to change(SubscriberList, :count).by(-2)
+          .and output(/TEST_456 removed/).to_stdout
+      end
+    end
+
+    context "when something went wrong" do
+      before do
+        allow(Services.gov_delivery).to receive(:delete_topic)
+          .and_raise("something went wrong")
+      end
+
+      it "prints the error message" do
+        expect { subject.remove_subscriber_lists_and_topics! }
+          .to change(SubscriberList, :count).by(0)
+          .and output(/#{manual_test_topic}: something went wrong/).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/qv1l3WBy/119-documents-that-are-open-or-closed-consultations-dont-match-all-consultations-topics-in-email-alert-api

We're retiring topics for open/closed consultation
subscriptions from the GOV.UK publications page.
Instead, people who sign up to any of these lists
will receive notifications for all consultations.

This class notifies subscribers of those topics
about what is changing and performs the cleanup
operation in govdelivery and deletes the
subscriber lists from this application's database.

Rake tasks:

`rake open_closed:notify_subscribers_about_retirement`
`rake open_closed:remove_subscriber_lists_and_topics`

For extra safety, the `RUN_FOR_REAL=1` environment
variable must be set to run against the real
subscriber lists. Otherwise `UKGOVUK_55555` will be
the only topic used. I have set this topic up in
integration/staging/production govdelivery and
added my email as the only subscriber.