### PR TITLE
Add subscriber list export task

### DIFF
--- a/lib/tasks/subscriber_list_export.rake
+++ b/lib/tasks/subscriber_list_export.rake
@@ -1,0 +1,36 @@
+require 'csv'
+
+namespace :subscriber_list do
+  task export: :environment do
+    links_keys = [
+      :service_manual_topics,
+      :countries,
+      :topics,
+      :organisations,
+      :policies,
+      :taxon_tree,
+      :policy_areas,
+      :world_locations,
+      :people,
+      :roles,
+      :topical_events,
+      :parent
+    ]
+
+    CSV.open('subscriber_list.csv', 'w') do | csv |
+      csv << %w(id title gov_delivery_id enabled subscriber_count) + links_keys.map(&:to_s)
+      SubscriberList.all.each do |list|
+        print "."
+        row = [
+          list.id,
+          list.title,
+          list.gov_delivery_id,
+          list.enabled,
+          list.subscriber_count,
+        ]
+        row += links_keys.map { |key| Array(list.links[key]).join(",") }
+        csv << row
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of the migration of email topic management from govuk_delivery
to email-alert-api we need to try a subset before switching them all
over. This rake task produces a CSV of all subscriber lists to help us
identify an initial group (or groups).

It can be removed once the migration is complete.

[Trello](https://trello.com/c/4y8S9j1S/85-transition-whitehalls-email-sending-to-use-email-alert-api)