### PR TITLE
Store all GovDelivery config in a file

### DIFF
--- a/config/gov_delivery.yml
+++ b/config/gov_delivery.yml
@@ -13,3 +13,11 @@ test:
   protocol: http
   hostname: govdelivery-api.example.com
   public_hostname: govdelivery-public.example.com
+
+production:
+  username: <%= ENV['GOVDELIVERY_USERNAME'] %>
+  password: <%= ENV['GOVDELIVERY_PASSWORD'] %>
+  account_code: <%= ENV['GOVDELIVERY_ACCOUNT_CODE'] %>
+  protocol: <%= ENV['GOVDELIVERY_PROTOCOL'] %>
+  hostname: <%= ENV['GOVDELIVERY_HOSTNAME'] %>
+  public_hostname: <%= ENV['GOVDELIVERY_PUBLIC_HOSTNAME'] %>

--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -30,22 +30,7 @@ module EmailAlertAPI
     end
 
     def environment_config
-      all_configs = YAML.load(File.open(gov_delivery_config_path))
-
-      all_configs.fetch(@environment).tap do |env_config|
-        env_config.merge!(environment_credentials)
-      end
-    end
-
-    def environment_credentials
-      {
-        username: ENV["GOVDELIVERY_USERNAME"],
-        password: ENV["GOVDELIVERY_PASSWORD"],
-        account_code: ENV["GOVDELIVERY_ACCOUNT_CODE"],
-        protocol: ENV["GOVDELIVERY_PROTOCOL"],
-        hostname: ENV["GOVDELIVERY_HOSTNAME"],
-        public_hostname: ENV["GOVDELIVERY_PUBLIC_HOSTNAME"],
-      }.stringify_keys.compact
+      YAML.load(ERB.new(File.read(gov_delivery_config_path)).result).fetch(@environment)
     end
   end
 end


### PR DESCRIPTION
Now that the configuration is gone from alphagov-deployment, the file no longer gets overwritten so we can use it to store the production configuration too.

[Trello Card](https://trello.com/c/QRXDQQab/214-put-email-alert-api-govdelivery-credentials-into-environment-variables-and-remove-from-alphagov-deployment)