### PR TITLE
Send email to `Subscriber`

### DIFF
--- a/app/commands/deliver_to_subscriber.rb
+++ b/app/commands/deliver_to_subscriber.rb
@@ -1,0 +1,22 @@
+class DeliverToSubscriber
+  attr_reader :subscriber
+
+  def initialize(subscriber:)
+    @subscriber = subscriber
+    raise ArgumentError, "subscriber cannot be nil" if subscriber.nil?
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    email_sender.call(address: subscriber.address)
+  end
+
+private
+
+  def email_sender
+    Services.email_sender
+  end
+end

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,0 +1,3 @@
+class Subscriber < ActiveRecord::Base
+
+end

--- a/db/migrate/20171016143522_create_subscribers.rb
+++ b/db/migrate/20171016143522_create_subscribers.rb
@@ -1,0 +1,8 @@
+class CreateSubscribers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :subscribers do |t|
+      t.string :address
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922091721) do
+ActiveRecord::Schema.define(version: 20171016143522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,12 @@ ActiveRecord::Schema.define(version: 20170922091721) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.integer "subscriber_count"
+  end
+
+  create_table "subscribers", force: :cascade do |t|
+    t.string "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -12,6 +12,6 @@ module Services
   end
 
   def self.email_sender
-    @email_sender ||= EmailSender::NotifySender.new
+    @email_sender ||= EmailSender::Notify.new
   end
 end

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -1,0 +1,6 @@
+namespace :deliver do
+  task :to_subscriber, [:id] => :environment do |_t, args|
+    subscriber = Subscriber.find(args[:id])
+    DeliverToSubscriber.call(subscriber: subscriber)
+  end
+end

--- a/spec/commands/deliver_to_subscriber_spec.rb
+++ b/spec/commands/deliver_to_subscriber_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe DeliverToSubscriber do
+  describe ".call" do
+    let(:email_sender){ double }
+    before do
+      allow(Services).to receive(:email_sender).and_return(
+        email_sender
+      )
+    end
+
+    it "calls email_sender with address" do
+      subscriber = double(address: "test@test.com")
+
+      expect(email_sender).to receive(:call)
+        .with(address: "test@test.com")
+
+      DeliverToSubscriber.call(
+        subscriber: subscriber,
+      )
+    end
+
+    it "requires subscriber" do
+      expect{
+        DeliverToSubscriber.call(subscriber: nil)
+      }.to raise_error(
+        ArgumentError,
+        "subscriber cannot be nil"
+      )
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,4 +14,7 @@ FactoryGirl.define do
     document_type "announcement"
     gov_delivery_ids %w(TOPIC_123 TOPIC_456)
   end
+
+  factory :subscriber do
+  end
 end

--- a/spec/integration/deliver_to_subscriber_spec.rb
+++ b/spec/integration/deliver_to_subscriber_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+require "notifications/client"
+
+RSpec.describe DeliverToSubscriber do
+  describe ".call" do
+    it "makes a call to Notify to send an email" do
+      subscriber = create(:subscriber, address: "test@test.com")
+      client = Notifications::Client.new("key")
+      allow(Notifications::Client).to receive(:new).and_return(client)
+
+      expect(client).to receive(:send_email).with(
+        hash_including(email_address: "test@test.com")
+      )
+
+      DeliverToSubscriber.call(subscriber: subscriber)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a basic concept of a `Subscriber` and the functionality to send an email to one. It is intended only as an initial implementation to be built upon. Validation on the model and retrying of the service call has intentionally been omitted as out of the scope for now.

[Trello](https://trello.com/c/R53XrWOI/229-email-alert-api-can-send-an-email-to-a-user)

This PR depends upon incoming PRs from [Trello](https://trello.com/c/E0FTbAS9/228-email-alert-api-can-send-an-email-via-notify) and [Trello](https://trello.com/c/4eOYL9WC/227-expose-notify-credentials-as-environment-variables)