### PR TITLE
Fix email sender notify sender

### DIFF
--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -1,7 +1,7 @@
 require "notifications/client"
 
 module EmailSender
-  class NotifySender
+  class Notify
     def call(address:, **keyword_args)
       send_to_notify(address: address, **keyword_args)
     end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,6 @@
 require "gov_delivery/client"
 require 'gds_api/content_store'
-require "email_sender/notify_sender"
+require "email_sender/notify"
 
 module Services
   def self.gov_delivery

--- a/spec/services/email_sender/notify_sender_spec.rb
+++ b/spec/services/email_sender/notify_sender_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "notifications/client"
 
-RSpec.describe EmailSender::NotifySender do
+RSpec.describe EmailSender::Notify do
   describe "#call" do
     it "sends an email to the address passed in" do
       client = double

--- a/spec/services/email_sender/notify_sender_spec.rb
+++ b/spec/services/email_sender/notify_sender_spec.rb
@@ -4,34 +4,15 @@ require "notifications/client"
 RSpec.describe EmailSender::NotifySender do
   describe "#call" do
     it "sends an email to the address passed in" do
-      client = Notifications::Client.new("key")
+      client = double
       allow(Notifications::Client)
         .to receive(:new)
         .and_return(client)
-
       expect(client)
         .to receive(:send_email)
         .with(email_address: "email@address.com", template_id: anything())
-        .and_return(Notifications::Client::ResponseNotification)
 
-      Services.email_sender.call(address: "email@address.com")
-    end
-
-    it "returns false if the notify gem raises a Notifications::Client::RequestError" do
-      client = Notifications::Client.new("key")
-      allow(Notifications::Client)
-        .to receive(:new)
-        .and_return(client)
-
-      allow(client)
-        .to receive(:send_email)
-        .and_raise(Notifications::Client::RequestError)
-
-      expect(Services.email_sender)
-        .to receive(:call)
-        .and_return(false)
-
-      Services.email_sender.call(address: "email@address.com")
+      subject.call(address: "email@address.com")
     end
   end
 end


### PR DESCRIPTION
This PR fixes some issues with the tests of `EmailSender::NotifySender` that were missed earlier (see commit message for details)

Also renamed `EmailSender::NotifySender` to `EmailSender::Notify`.