### PR TITLE
Add default notify template_id for production

### DIFF
--- a/config/notify.yml
+++ b/config/notify.yml
@@ -8,4 +8,4 @@ test:
 
 production:
   api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] %>
+  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "a5583ad3-adab-4c76-b85d-f88bd4a3dc69" %>


### PR DESCRIPTION
We should have a sensible default for production as well.