### PR TITLE
Validate the uniqueness of email address

### DIFF
--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,4 +1,5 @@
 class Subscriber < ActiveRecord::Base
   validates :address, presence: true
-  validates_format_of :address, with: /@/, message: "is not an email address"
+  validates :address, format: { with: /@/, message: "is not an email address" }
+  validates :address, uniqueness: true
 end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -41,5 +41,12 @@ RSpec.describe Subscriber, type: :model do
 
       expect(subject).to be_invalid
     end
+
+    it "is invalid if an email address is already taken" do
+      FactoryGirl.create(:subscriber, address: "foo@bar.com")
+
+      subject.address = "foo@bar.com"
+      expect(subject).to be_invalid
+    end
   end
 end


### PR DESCRIPTION
We have a unique index on the column, but the
error messages are friendlier if we add the
validation in as well.