### PR TITLE
Add subscription model

### DIFF
--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -2,4 +2,7 @@ class Subscriber < ActiveRecord::Base
   validates :address, presence: true
   validates :address, format: { with: /@/, message: "is not an email address" }
   validates :address, uniqueness: true
+
+  has_many :subscriptions, dependent: :destroy
+  has_many :subscriber_lists, through: :subscriptions
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -9,6 +9,9 @@ class SubscriberList < ApplicationRecord
   validate :tag_values_are_valid
   validate :link_values_are_valid
 
+  has_many :subscriptions
+  has_many :subscribers, through: :subscriptions
+
   def self.build_from(params:, gov_delivery_id:)
     new(
       title: params[:title],

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,3 @@
+class Subscription < ApplicationRecord
+  
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,4 +1,6 @@
 class Subscription < ApplicationRecord
   belongs_to :subscriber
   belongs_to :subscriber_list
+
+  validates :subscriber, uniqueness: { scope: :subscriber_list }
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,3 +1,4 @@
 class Subscription < ApplicationRecord
-  
+  belongs_to :subscriber
+  belongs_to :subscriber_list
 end

--- a/db/migrate/20171020071004_create_subscriptions.rb
+++ b/db/migrate/20171020071004_create_subscriptions.rb
@@ -1,0 +1,11 @@
+class CreateSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :subscriptions do |t|
+      t.references :subscriber, null: false, foreign_key: { on_delete: :cascade }
+      t.references :subscriber_list, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :subscriptions, %i(subscriber_id subscriber_list_id), unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171019072924) do
+ActiveRecord::Schema.define(version: 20171020071004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,4 +52,16 @@ ActiveRecord::Schema.define(version: 20171019072924) do
     t.index ["address"], name: "index_subscribers_on_address", unique: true
   end
 
+  create_table "subscriptions", force: :cascade do |t|
+    t.bigint "subscriber_id", null: false
+    t.bigint "subscriber_list_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
+    t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
+    t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"
+  end
+
+  add_foreign_key "subscriptions", "subscriber_lists"
+  add_foreign_key "subscriptions", "subscribers", on_delete: :cascade
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,4 +18,9 @@ FactoryGirl.define do
   factory :subscriber do
     address "test@example.com"
   end
+
+  factory :subscription do
+    subscriber
+    subscriber_list
+  end
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SubscriberList, type: :model do
     end
   end
 
-  context "associations" do
+  context "with a subscription" do
     subject { FactoryGirl.create(:subscriber_list) }
 
     before do
@@ -82,6 +82,12 @@ RSpec.describe SubscriberList, type: :model do
 
     it "can access the subscribers" do
       expect(subject.subscribers.size).to eq(1)
+    end
+
+    it "cannot be deleted" do
+      expect {
+        subject.destroy
+      }.to raise_error(ActiveRecord::InvalidForeignKey)
     end
   end
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe SubscriberList, type: :model do
     end
   end
 
+  context "associations" do
+    subject { FactoryGirl.create(:subscriber_list) }
+
+    before do
+      FactoryGirl.create(:subscription, subscriber_list: subject)
+    end
+
+    it "can access the subscribers" do
+      expect(subject.subscribers.size).to eq(1)
+    end
+  end
+
   describe "#tags" do
     it "deserializes the tag arrays" do
       list = create(:subscriber_list, tags: { topics: ["environmental-management/boating"] })

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -49,4 +49,16 @@ RSpec.describe Subscriber, type: :model do
       expect(subject).to be_invalid
     end
   end
+
+  context "associations" do
+    subject { FactoryGirl.create(:subscriber) }
+
+    before do
+      FactoryGirl.create(:subscription, subscriber: subject)
+    end
+
+    it "can access the subscriber lists" do
+      expect(subject.subscriber_lists.size).to eq(1)
+    end
+  end
 end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Subscriber, type: :model do
     end
   end
 
-  context "associations" do
+  context "with a subscriber list" do
     subject { FactoryGirl.create(:subscriber) }
 
     before do
@@ -59,6 +59,14 @@ RSpec.describe Subscriber, type: :model do
 
     it "can access the subscriber lists" do
       expect(subject.subscriber_lists.size).to eq(1)
+    end
+
+    it "can be deleted and won't delete the subscriber list" do
+      expect {
+        subject.destroy
+      }.to_not raise_error
+
+      expect(SubscriberList.all.size).to eq(1)
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -7,5 +7,15 @@ RSpec.describe Subscription, type: :model do
     it "is valid for the default factory" do
       expect(subject).to be_valid
     end
+
+    it "must be unique between subscriber and subscriber lists" do
+      FactoryGirl.create(
+        :subscription,
+        subscriber: subject.subscriber,
+        subscriber_list: subject.subscriber_list
+      )
+
+      expect(subject).to be_invalid
+    end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Subscription, type: :model do
+  describe "validations" do
+    subject { FactoryGirl.build(:subscription) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This adds a subscription model which is used to link together the subscriber and the subscriber list classes. 

[Trello Card](https://trello.com/c/JmOA1348/256-subscription-model)