### PR TITLE
Create notification model

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,5 @@
+require_relative "extensions/symbolize_json"
+
+class Notification < ApplicationRecord
+  include SymbolizeJSON
+end

--- a/db/migrate/20171020091213_create_notifications.rb
+++ b/db/migrate/20171020091213_create_notifications.rb
@@ -1,0 +1,20 @@
+class CreateNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :notifications do |t|
+      t.uuid :content_id, null: false
+      t.text :title, null: false
+      t.text :base_path, null: false
+      t.text :change_note, null: false
+      t.text :description, null: false
+      t.json :links, null: false, default: {}
+      t.json :tags, null: false, default: {}
+      t.datetime :public_updated_at, null: false
+      t.string :email_document_supertype, null: false
+      t.string :government_document_supertype, null: false
+      t.string :govuk_request_id, null: false
+      t.string :document_type, null: false
+      t.string :publishing_app, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171020071004) do
+ActiveRecord::Schema.define(version: 20171020091213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,24 @@ ActiveRecord::Schema.define(version: 20171020071004) do
     t.string "government_document_supertype", default: ""
     t.index ["content_id", "public_updated_at"], name: "index_notification_logs_on_content_id_and_public_updated_at"
     t.index ["govuk_request_id"], name: "index_notification_logs_on_govuk_request_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.uuid "content_id", null: false
+    t.text "title", null: false
+    t.text "base_path", null: false
+    t.text "change_note", null: false
+    t.text "description", null: false
+    t.json "links", default: {}, null: false
+    t.json "tags", default: {}, null: false
+    t.datetime "public_updated_at", null: false
+    t.string "email_document_supertype", null: false
+    t.string "government_document_supertype", null: false
+    t.string "govuk_request_id", null: false
+    t.string "document_type", null: false
+    t.string "publishing_app", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,4 +23,20 @@ FactoryGirl.define do
     subscriber
     subscriber_list
   end
+
+  factory :notification do
+    content_id { SecureRandom.uuid }
+    title "title"
+    base_path "government/base_path"
+    change_note "change note"
+    description "description"
+    links Hash.new
+    tags Hash.new
+    public_updated_at { Time.now.to_s }
+    email_document_supertype "email document supertype"
+    government_document_supertype "government document supertype"
+    sequence(:govuk_request_id) { |i| "request-id-#{i}" }
+    document_type "document type"
+    publishing_app "publishing app"
+  end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Notification, type: :model do
+  describe "validations" do
+    subject { FactoryGirl.create(:notification) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This model will be used to store the input we get from the `email-alert-service`.

This is the first part of [this Trello Card](https://trello.com/c/J7TCm10I/254-persist-notification-in-email-alert-api), the next part will be to actually create instances of this model when we receive a notification, which depends on [this Trello Card](https://trello.com/c/10k5XPez/264-add-title-and-changenote-to-email-alert-service).

This probably warrants some discussion on the fields we currently have in the model, since this is based on what we currently have in `NotificationLog` and some of the fields may not be necessary. It may also be necessary for us to store the priority in this model.