### PR TITLE
Support sending instances of the email model

### DIFF
--- a/app/commands/deliver_to_subscriber.rb
+++ b/app/commands/deliver_to_subscriber.rb
@@ -1,9 +1,12 @@
 class DeliverToSubscriber
   attr_reader :subscriber
+  attr_reader :email
 
-  def initialize(subscriber:)
+  def initialize(subscriber:, email:)
     @subscriber = subscriber
+    @email = email
     raise ArgumentError, "subscriber cannot be nil" if subscriber.nil?
+    raise ArgumentError, "email cannot be nil" if email.nil?
   end
 
   def self.call(*args)
@@ -11,7 +14,11 @@ class DeliverToSubscriber
   end
 
   def call
-    email_sender.call(address: subscriber.address, subject: "", body: "")
+    email_sender.call(
+      address: subscriber.address,
+      subject: email.subject,
+      body: email.body,
+    )
   end
 
 private

--- a/app/commands/deliver_to_subscriber.rb
+++ b/app/commands/deliver_to_subscriber.rb
@@ -11,7 +11,7 @@ class DeliverToSubscriber
   end
 
   def call
-    email_sender.call(address: subscriber.address)
+    email_sender.call(address: subscriber.address, subject: "", body: "")
   end
 
 private

--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -2,33 +2,33 @@ require "notifications/client"
 
 module EmailSender
   class Notify
-    def call(address:, **keyword_args)
-      send_to_notify(address: address, **keyword_args)
+    def call(address:, subject:, body:)
+      client.send_email(
+        email_address: address,
+        template_id: template_id,
+        personalisation: {
+          subject: subject,
+          body: body,
+        },
+      )
     end
 
   private
 
-    def send_to_notify(address:, **keyword_args)
-      client.send_email(
-        email_address: address,
-        template_id: template_id(keyword_args)
-      )
-    end
-
     def client
-      @client ||= Notifications::Client.new(notify_api_key)
+      @client ||= Notifications::Client.new(api_key)
     end
 
-    def notify_config
+    def config
       EmailAlertAPI.config.notify
     end
 
-    def notify_api_key
-      notify_config.fetch(:api_key)
+    def api_key
+      config.fetch(:api_key)
     end
 
-    def template_id(template_id: nil, **_)
-      template_id || notify_config.fetch(:template_id)
+    def template_id
+      config.fetch(:template_id)
     end
   end
 end

--- a/config/notify.yml
+++ b/config/notify.yml
@@ -1,11 +1,11 @@
 development:
   api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "a5583ad3-adab-4c76-b85d-f88bd4a3dc69" %>
+  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
 
 test:
   api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "a5583ad3-adab-4c76-b85d-f88bd4a3dc69" %>
+  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
 
 production:
   api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "a5583ad3-adab-4c76-b85d-f88bd4a3dc69" %>
+  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -1,6 +1,7 @@
 namespace :deliver do
   task :to_subscriber, [:id] => :environment do |_t, args|
     subscriber = Subscriber.find(args[:id])
-    DeliverToSubscriber.call(subscriber: subscriber)
+    email = OpenStruct.new(subject: "Test email", body: "This is a test email.")
+    DeliverToSubscriber.call(subscriber: subscriber, email: email)
   end
 end

--- a/spec/commands/deliver_to_subscriber_spec.rb
+++ b/spec/commands/deliver_to_subscriber_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DeliverToSubscriber do
       subscriber = double(address: "test@test.com")
 
       expect(email_sender).to receive(:call)
-        .with(address: "test@test.com")
+        .with(address: "test@test.com", subject: "", body: "")
 
       DeliverToSubscriber.call(
         subscriber: subscriber,

--- a/spec/commands/deliver_to_subscriber_spec.rb
+++ b/spec/commands/deliver_to_subscriber_spec.rb
@@ -11,21 +11,36 @@ RSpec.describe DeliverToSubscriber do
 
     it "calls email_sender with address" do
       subscriber = double(address: "test@test.com")
+      email = double(subject: "test subject", body: "test body")
 
       expect(email_sender).to receive(:call)
-        .with(address: "test@test.com", subject: "", body: "")
+        .with(
+          address: "test@test.com",
+          subject: "test subject",
+          body: "test body",
+        )
 
       DeliverToSubscriber.call(
         subscriber: subscriber,
+        email: email,
       )
     end
 
     it "requires subscriber" do
       expect {
-        DeliverToSubscriber.call(subscriber: nil)
+        DeliverToSubscriber.call(subscriber: nil, email: double)
       }.to raise_error(
         ArgumentError,
         "subscriber cannot be nil"
+      )
+    end
+
+    it "requires email" do
+      expect {
+        DeliverToSubscriber.call(subscriber: double, email: nil)
+      }.to raise_error(
+        ArgumentError,
+        "email cannot be nil"
       )
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,4 +39,10 @@ FactoryGirl.define do
     document_type "document type"
     publishing_app "publishing app"
   end
+
+  factory :email do
+    subject "subject"
+    body "body"
+    notification
+  end
 end

--- a/spec/integration/deliver_to_subscriber_spec.rb
+++ b/spec/integration/deliver_to_subscriber_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe DeliverToSubscriber do
   describe ".call" do
     it "makes a call to Notify to send an email" do
       subscriber = create(:subscriber, address: "test@test.com")
+      email = create(:email)
       client = Notifications::Client.new("key")
       allow(Notifications::Client).to receive(:new).and_return(client)
 
@@ -12,7 +13,7 @@ RSpec.describe DeliverToSubscriber do
         hash_including(email_address: "test@test.com")
       )
 
-      DeliverToSubscriber.call(subscriber: subscriber)
+      DeliverToSubscriber.call(subscriber: subscriber, email: email)
     end
   end
 end

--- a/spec/services/email_sender/notify_sender_spec.rb
+++ b/spec/services/email_sender/notify_sender_spec.rb
@@ -10,9 +10,13 @@ RSpec.describe EmailSender::Notify do
         .and_return(client)
       expect(client)
         .to receive(:send_email)
-        .with(email_address: "email@address.com", template_id: anything)
+        .with(
+          email_address: "email@address.com",
+          personalisation: a_hash_including(subject: "subject", body: "body"),
+          template_id: anything,
+        )
 
-      subject.call(address: "email@address.com")
+      subject.call(address: "email@address.com", subject: "subject", body: "body")
     end
   end
 end


### PR DESCRIPTION
Depends on the new `Email` model in [Trello Card](https://trello.com/c/DgNo1WHQ/267-create-an-email-on-receipt-of-a-notification).

[Trello Card](https://trello.com/c/2vIrpbFX/255-email-delivery-queue)