### PR TITLE
Notification handling

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,0 +1,26 @@
+class Email < ApplicationRecord
+  belongs_to :notification
+  validates :subject, :body, :notification, presence: true
+
+  def self.create_from_params!(params)
+    build_from_params(params).tap(&:save!)
+  end
+
+  def self.build_from_params(params)
+    new.tap do |instance|
+      instance.notification_id = params[:notification_id]
+      instance.subject = params[:title]
+      instance.body = <<~BODY
+        description: #{params[:description]}
+        change_note: #{params[:change_note]}
+        base_path: #{params[:base_path]}
+        updated: #{instance.format_date(params[:public_updated_at])}
+      BODY
+    end
+  end
+
+  def format_date(date)
+    return unless date
+    date.strftime("%H:%M %-d %B %Y")
+  end
+end

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+class NotificationHandler
+  def self.call(params)
+    notification = Notification.create(params)
+
+    email = Email.create(some_params)
+
+    (Matcher/Deliverer).perform_async(notification.id, email.id)
+  end
+end

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -9,13 +9,17 @@ class NotificationHandler
   end
 
   def call
-    notification = Notification.create!(
-      notification_params
-    )
+    begin
+      notification = Notification.create!(
+        notification_params
+      )
 
-    Email.create_from_params!(
-      email_params.merge(notification_id: notification.id)
-    )
+      Email.create_from_params!(
+        email_params.merge(notification_id: notification.id)
+      )
+    rescue StandardError => ex
+      Raven.capture_exception(ex, tags: { version: 2 })
+    end
   end
 
 private

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -1,10 +1,49 @@
-require 'rails_helper'
 class NotificationHandler
-  def self.call(params)
-    notification = Notification.create(params)
+  attr_reader :params
+  def initialize(params:)
+    @params = params
+  end
 
-    email = Email.create(some_params)
+  def self.call(*args)
+    new(*args).call
+  end
 
-    (Matcher/Deliverer).perform_async(notification.id, email.id)
+  def call
+    notification = Notification.create!(
+      notification_params
+    )
+
+    Email.create_from_params!(
+      email_params.merge(notification_id: notification.id)
+    )
+  end
+
+private
+
+  def notification_params
+    {
+      content_id: params[:content_id],
+      title: params[:title],
+      change_note: params[:change_note],
+      description: params[:description],
+      base_path: params[:base_path],
+      links: params[:links],
+      tags: params[:tags],
+      public_updated_at: params[:public_updated_at],
+      email_document_supertype: params[:email_document_supertype],
+      government_document_supertype: params[:government_document_supertype],
+      govuk_request_id: params[:govuk_request_id],
+      document_type: params[:document_type],
+      publishing_app: params[:publishing_app],
+    }
+  end
+
+  def email_params
+    {
+      title: params[:title],
+      change_note: params[:change_note],
+      description: params[:description],
+      base_path: params[:base_path],
+    }
   end
 end

--- a/db/migrate/20171023094334_create_emails.rb
+++ b/db/migrate/20171023094334_create_emails.rb
@@ -1,0 +1,10 @@
+class CreateEmails < ActiveRecord::Migration[5.1]
+  def change
+    create_table :emails do |t|
+      t.string :subject, null: false
+      t.text :body, null: false
+      t.references :notification, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171020091213) do
+ActiveRecord::Schema.define(version: 20171023094334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "emails", force: :cascade do |t|
+    t.string "subject", null: false
+    t.text "body", null: false
+    t.bigint "notification_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notification_id"], name: "index_emails_on_notification_id"
+  end
 
   create_table "notification_logs", id: :serial, force: :cascade do |t|
     t.string "govuk_request_id", default: ""
@@ -80,6 +89,7 @@ ActiveRecord::Schema.define(version: 20171020091213) do
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"
   end
 
+  add_foreign_key "emails", "notifications"
   add_foreign_key "subscriptions", "subscriber_lists"
   add_foreign_key "subscriptions", "subscribers", on_delete: :cascade
 end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Email do
+  describe "validations" do
+    it "requires subject" do
+      subject.valid?
+      expect(subject.errors[:subject]).not_to be_empty
+    end
+
+    it "requires body" do
+      subject.valid?
+      expect(subject.errors[:body]).not_to be_empty
+    end
+
+    it "requires a notification" do
+      subject.valid?
+      expect(subject.errors[:notification]).not_to be_empty
+    end
+  end
+
+  describe "create_from_params!" do
+    let(:notification) {
+      create(:notification)
+    }
+
+    let(:email) {
+      Email.create_from_params!(
+        title: "Title",
+        description: "Description",
+        change_note: "Change note",
+        base_path: "/government/test",
+        public_updated_at: DateTime.parse("1/1/2017"),
+        notification_id: notification.id,
+      )
+    }
+
+    it "sets subject" do
+      expect(email.subject).to eq("Title")
+    end
+
+    it "sets body" do
+      expect(email.body).to eq(
+        <<~BODY
+          description: Description
+          change_note: Change note
+          base_path: /government/test
+          updated: 00:00 1 January 2017
+        BODY
+      )
+    end
+  end
+end

--- a/spec/services/notification_handler_spec.rb
+++ b/spec/services/notification_handler_spec.rb
@@ -66,5 +66,33 @@ RSpec.describe NotificationHandler do
 
       NotificationHandler.call(params: params)
     end
+
+    it "reports Notification errors to Sentry and swallows them" do
+      allow(Notification).to receive(:create!).and_raise(
+        ActiveRecord::RecordInvalid
+      )
+      expect(Raven).to receive(:capture_exception).with(
+        instance_of(ActiveRecord::RecordInvalid),
+        tags: { version: 2 }
+      )
+
+      expect {
+        NotificationHandler.call(params: params)
+      }.not_to raise_error
+    end
+
+    it "reports Email errors to Sentry and swallows them" do
+      allow(Email).to receive(:create_from_params!).and_raise(
+        ActiveRecord::RecordInvalid
+      )
+      expect(Raven).to receive(:capture_exception).with(
+        instance_of(ActiveRecord::RecordInvalid),
+        tags: { version: 2 }
+      )
+
+      expect {
+        NotificationHandler.call(params: params)
+      }.not_to raise_error
+    end
   end
 end

--- a/spec/services/notification_handler_spec.rb
+++ b/spec/services/notification_handler_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe NotificationHandler do
+  let(:params) {
+    {
+      subject: "This is a subject",
+      body: "body stuff",
+      tags: {
+        topics: ["oil-and-gas/licensing"]
+      },
+      links: {
+        organisations: [
+          "c380ea42-5d91-41cc-b3cd-0a4cfe439461"
+        ]
+      },
+      content_id: "afe78383-6b27-45a4-92ae-a579e416373a",
+      title: "Travel advice",
+      change_note: "This is a change note",
+      description: "This is a description",
+      base_path: "/government/things",
+      public_updated_at: Time.now.to_s,
+      email_document_supertype: "email document supertype",
+      government_document_supertype: "government document supertype",
+      document_type: "document type",
+      publishing_app: "publishing app",
+      govuk_request_id: "request-id",
+    }
+  }
+
+  describe ".call" do
+    it "calls create on Notification" do
+      expect(Notification).to receive(:create!).with(
+        content_id: params[:content_id],
+        title: params[:title],
+        change_note: params[:change_note],
+        description: params[:description],
+        base_path: params[:base_path],
+        links: params[:links],
+        tags: params[:tags],
+        public_updated_at: params[:public_updated_at],
+        email_document_supertype: params[:email_document_supertype],
+        government_document_supertype: params[:government_document_supertype],
+        govuk_request_id: params[:govuk_request_id],
+        document_type: params[:document_type],
+        publishing_app: params[:publishing_app],
+      ).and_return(double(id: 1))
+
+      allow(Email).to receive(:create_from_params!)
+
+      NotificationHandler.call(params: params)
+    end
+
+    it "calls create on Email" do
+      notification = create(:notification)
+      allow(Notification).to receive(:create!).and_return(
+        notification
+      )
+
+      expect(Email).to receive(:create_from_params!).with(
+        title: "Travel advice",
+        description: "This is a description",
+        change_note: "This is a change note",
+        base_path: "/government/things",
+        notification_id: notification.id,
+      )
+
+      NotificationHandler.call(params: params)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a second path for handling the POST request to `notifications#create`. This is implemented with a `NoficationHandler` which currently just creates a `Notification` object and an `Email` object.

We're effectively adding a v2 of the endpoint but haven't taken the decision to actually version the API so there are a few bits to this PR that result from this. The error handling currently catches everything and sends to Sentry without returning to the caller. This is the first good reason for considering a v2 endpoint that we've encountered as once we start to implement the response it will be difficult to do. For now I've stubbed each path out in each path's request specs, and the new stuff in the controller spec. 


[Trello](https://trello.com/c/DgNo1WHQ/267-create-an-email-on-receipt-of-a-notification)
