### PR TITLE
Add a retry limit on the deliver to subscriber worker

### DIFF
--- a/app/workers/deliver_to_subscriber_worker.rb
+++ b/app/workers/deliver_to_subscriber_worker.rb
@@ -1,6 +1,8 @@
 class DeliverToSubscriberWorker
   include Sidekiq::Worker
 
+  sidekiq_options retry: 3
+
   def perform(subscriber_id, email_id)
     subscriber = Subscriber.find(subscriber_id)
     email = Email.find(email_id)


### PR DESCRIPTION
This just stops us from spamming GOV.UK Notify while we're working on the code.