### PR TITLE
Add a rake task that passes in an email address to send to Notify

### DIFF
--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -4,4 +4,10 @@ namespace :deliver do
     email = OpenStruct.new(subject: "Test email", body: "This is a test email.")
     DeliverToSubscriber.call(subscriber: subscriber, email: email)
   end
+
+  task :to_test_email, [:test_email_address] => :environment do |_t, args|
+    subscriber = Subscriber.new(address: args[:test_email_address])
+    email = OpenStruct.new(subject: "Test email", body: "This is a test email.")
+    DeliverToSubscriber.call(subscriber: subscriber, email: email)
+  end
 end


### PR DESCRIPTION
Uses a passed in email address to send a single email via Notify without
needing for the email address to be linked to an actual subscriber