### PR TITLE
Ignore 429s from Notify

### DIFF
--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -3,14 +3,18 @@ require "notifications/client"
 module EmailSender
   class Notify
     def call(address:, subject:, body:)
-      client.send_email(
-        email_address: address,
-        template_id: template_id,
-        personalisation: {
-          subject: subject,
-          body: body,
-        },
-      )
+      begin
+        client.send_email(
+          email_address: address,
+          template_id: template_id,
+          personalisation: {
+            subject: subject,
+            body: body,
+          },
+        )
+      rescue Notifications::Client::RequestError => ex
+        raise unless ex.code == 429
+      end
     end
 
   private


### PR DESCRIPTION
While we are testing with our rate limited account we are getting a lot of 429 responses which are being repeatedly retried and reported to Sentry.

This commit temporarily catches those errors and fails silently to reduce the volume of errors.