### PR TITLE
Catch error code as a string

### DIFF
--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -13,7 +13,7 @@ module EmailSender
           },
         )
       rescue Notifications::Client::RequestError => ex
-        raise unless ex.code == 429
+        raise unless ex.code.to_s == "429"
       end
     end
 


### PR DESCRIPTION
We are catching and swallowing Notify 429 responses at the moment or at least, we're trying to but they are still being reported to Sentry.

This commit catches the code as a string rather than integer which could be the problem.