### PR TITLE
Add pseudo email sender for use in dev vm

### DIFF
--- a/app/services/email_sender/pseudo.rb
+++ b/app/services/email_sender/pseudo.rb
@@ -10,8 +10,7 @@ Body: #{body}
   private
 
     def logger
-      @logger ||= Logger.new("#{Rails.root}/log/pseudo_email.log")
+      @logger ||= Logger.new("#{Rails.root}/log/pseudo_email.log", 5, 4194304)
     end
   end
 end
-

--- a/app/services/email_sender/pseudo.rb
+++ b/app/services/email_sender/pseudo.rb
@@ -1,0 +1,17 @@
+module EmailSender
+  class Pseudo
+    def call(address:, subject:, body:)
+      logger.info(%(Sending email to #{address}
+Subject: #{subject}
+Body: #{body}
+))
+    end
+
+  private
+
+    def logger
+      @logger ||= Logger.new("#{Rails.root}/log/pseudo_email.log")
+    end
+  end
+end
+

--- a/config/email_service_provider.yml
+++ b/config/email_service_provider.yml
@@ -1,0 +1,8 @@
+development:
+  provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "PSEUDO" %>
+
+test:
+  provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "PSEUDO" %>
+
+production:
+  provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "NOTIFY" %>

--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -23,6 +23,10 @@ module EmailAlertAPI
       @notify ||= notify_environment_config.symbolize_keys.freeze
     end
 
+    def email_service_provider
+      @email_service_provider ||= email_service_provider_config.fetch("provider").freeze
+    end
+
   private
 
     def redis_config_path
@@ -43,6 +47,14 @@ module EmailAlertAPI
 
     def notify_environment_config
       YAML.safe_load(ERB.new(File.read(notify_config_path)).result).fetch(@environment)
+    end
+
+    def email_service_provider_config_path
+      File.join(app_root, "config", "email_service_provider.yml")
+    end
+
+    def email_service_provider_config
+      YAML.safe_load(ERB.new(File.read(email_service_provider_config_path)).result).fetch(@environment)
     end
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -13,10 +13,8 @@ module Services
   end
 
   def self.email_sender
-    if Rails.env.production?
-      @email_sender ||= EmailSender::Notify.new
-    else
-      @email_sender ||= EmailSender::Pseudo.new
-    end
+    return @email_sender ||= EmailSender::Notify.new if EmailAlertAPI.config.email_service_provider == "NOTIFY"
+    return @email_sender ||= EmailSender::Pseudo.new if EmailAlertAPI.config.email_service_provider == "PSEUDO" || EmailAlertAPI.config.email_service_provider.nil?
+    raise "Email service provider #{EmailAlertAPI.config.email_service_provider} does not exist"
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,7 @@
 require "gov_delivery/client"
 require 'gds_api/content_store'
 require "email_sender/notify"
+require "email_sender/pseudo"
 
 module Services
   def self.gov_delivery
@@ -12,6 +13,10 @@ module Services
   end
 
   def self.email_sender
-    @email_sender ||= EmailSender::Notify.new
+    if Rails.env.production?
+      @email_sender ||= EmailSender::Notify.new
+    else
+      @email_sender ||= EmailSender::Pseudo.new
+    end
   end
 end

--- a/spec/integration/deliver_to_subscriber_spec.rb
+++ b/spec/integration/deliver_to_subscriber_spec.rb
@@ -2,18 +2,47 @@ require "rails_helper"
 require "notifications/client"
 
 RSpec.describe DeliverToSubscriber do
-  describe ".call" do
-    it "makes a call to Notify to send an email" do
-      subscriber = create(:subscriber, address: "test@test.com")
-      email = create(:email)
-      client = Notifications::Client.new("key")
-      allow(Notifications::Client).to receive(:new).and_return(client)
+  context "when sending through Notify" do
+    before(:example) do
+      expect(Services)
+        .to receive(:email_sender)
+        .and_return(EmailSender::Notify.new)
+    end
 
-      expect(client).to receive(:send_email).with(
-        hash_including(email_address: "test@test.com")
-      )
+    describe ".call" do
+      it "makes a call to Notify to send an email" do
+        subscriber = create(:subscriber, address: "test@test.com")
+        email = create(:email)
+        client = Notifications::Client.new("key")
+        allow(Notifications::Client).to receive(:new).and_return(client)
 
-      DeliverToSubscriber.call(subscriber: subscriber, email: email)
+        expect(client).to receive(:send_email).with(
+          hash_including(email_address: "test@test.com")
+        )
+
+        DeliverToSubscriber.call(subscriber: subscriber, email: email)
+      end
+    end
+  end
+
+  context "when sending through Pseudo" do
+    describe ".call" do
+      it "should send an info message to the logger" do
+        subscriber = create(:subscriber, address: "test@test.com")
+        email = create(:email)
+        fake_log = double
+
+        allow(Logger)
+          .to receive(:new)
+          .with("#{Rails.root}/log/pseudo_email.log")
+          .and_return(fake_log)
+
+        expect(fake_log)
+          .to receive(:info)
+          .with("Sending email to test@test.com\nSubject: subject\nBody: body\n")
+
+        DeliverToSubscriber.call(subscriber: subscriber, email: email)
+      end
     end
   end
 end

--- a/spec/integration/deliver_to_subscriber_spec.rb
+++ b/spec/integration/deliver_to_subscriber_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe DeliverToSubscriber do
   end
 
   context "when sending through Pseudo" do
+    before(:example) do
+      expect(Services)
+        .to receive(:email_sender)
+        .and_return(EmailSender::Pseudo.new)
+    end
+
     describe ".call" do
       it "should send an info message to the logger" do
         subscriber = create(:subscriber, address: "test@test.com")
@@ -34,7 +40,7 @@ RSpec.describe DeliverToSubscriber do
 
         allow(Logger)
           .to receive(:new)
-          .with("#{Rails.root}/log/pseudo_email.log")
+          .with("#{Rails.root}/log/pseudo_email.log", 5, 4194304)
           .and_return(fake_log)
 
         expect(fake_log)

--- a/spec/lib/services_spec.rb
+++ b/spec/lib/services_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Services do
+  context "when config specifies NOTIFY as the email provider" do
+    let(:services) { Services.clone }
+
+    it "returns an instance of the notify sender" do
+      expect(EmailAlertAPI.config)
+        .to receive(:email_service_provider)
+        .and_return("NOTIFY")
+
+      expect(services.email_sender)
+        .to be_an_instance_of(EmailSender::Notify)
+    end
+  end
+
+  context "when config specifies PSEUDO as the email provider" do
+    let(:services) { Services.clone }
+
+    it "returns an instance of the pseudo sender" do
+      expect(EmailAlertAPI.config)
+        .to receive(:email_service_provider)
+        .twice
+        .and_return("PSEUDO")
+
+      expect(services.email_sender)
+        .to be_an_instance_of(EmailSender::Pseudo)
+    end
+
+    context "when config returns `nil` as the email provider" do
+      let(:services) { Services.clone }
+
+      it "returns an instance of the pseudo sender" do
+        expect(EmailAlertAPI.config)
+          .to receive(:email_service_provider)
+          .thrice
+          .and_return(nil)
+
+        expect(services.email_sender)
+          .to be_an_instance_of(EmailSender::Pseudo)
+      end
+    end
+
+    context "when config returns an email provider we do not recognise" do
+      let(:services) { Services.clone }
+
+      it "returns an instance of the pseudo sender" do
+        expect(EmailAlertAPI.config)
+          .to receive(:email_service_provider)
+          .exactly(4).times
+          .and_return("UNRECOGNISED")
+
+        expect { services.email_sender }
+          .to raise_error("Email service provider UNRECOGNISED does not exist")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Developers need to run `email-alert-api` locally with minimal annoyance. We don't want to have every team setting up Notify accounts and api keys just to run the application in the dev vm.

To accomplish this we:

* Add a Pseudo email sender which implements the same interface as the Notify sender (i.e. responds to `.call` taking three arguments: `address`, `subject` and `body`).
* Log emails sent to the Pseudo email sender to a file.
* Expose a config value `email_sender_provider`.
* Default our provider based on environment - in production it will default to Notify, other environments default to Pseudo.
* Allow overriding of the defaults with an env var

[Trello](https://trello.com/c/yg3QHfM8/277-create-service-to-wrap-sending-emails-to-notify)