### PR TITLE
Add a 'priority' parameter to the /notifications endpoint

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -23,7 +23,7 @@ private
     permitted_params = params.permit!.to_h
     permitted_params.slice(:subject, :from_address_id, :urgent, :header, :footer, :document_type,
       :content_id, :public_updated_at, :publishing_app, :email_document_supertype,
-      :government_document_supertype, :title, :description, :change_note, :base_path)
+      :government_document_supertype, :title, :description, :change_note, :base_path, :priority)
       .merge(tags: permitted_params.fetch(:tags, {}))
       .merge(links: permitted_params.fetch(:links, {}))
       .merge(body: notification_body)

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -28,8 +28,8 @@ private
 
   def deliver_to_all_subscribers(email)
     Subscriber.all.each do |subscriber|
-      DeliverToSubscriberWorker.perform_async(
-        subscriber.id, email.id
+      DeliverToSubscriberWorker.perform_async_with_priority(
+        subscriber.id, email.id, priority: priority
       )
     end
   end
@@ -59,5 +59,9 @@ private
       description: params[:description],
       base_path: params[:base_path],
     }
+  end
+
+  def priority
+    params.fetch(:priority, "low").to_sym
   end
 end


### PR DESCRIPTION
This can either be "low" or "high" and is used to decide which queue to place the delivery job in. It defaults to "low".

[Trello Card](https://trello.com/c/2vIrpbFX/255-email-delivery-queue)