### PR TITLE
Send emails to courtesy subscribers

### DIFF
--- a/spec/services/notification_handler_spec.rb
+++ b/spec/services/notification_handler_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe NotificationHandler do
       NotificationHandler.call(params: params)
     end
 
+    context "with a courtesy subscription" do
+      let(:subscriber) { create(:subscriber, address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk") }
+
+      it "sends the email to the subscriber" do
+        expect(DeliverToSubscriberWorker).to receive(:perform_async_with_priority).with(
+          subscriber.id, kind_of(Integer), priority: :low,
+        )
+
+        NotificationHandler.call(params: params)
+      end
+    end
+
     context "with a subscription" do
       let(:subscriber) { create(:subscriber) }
 


### PR DESCRIPTION
This allows us to have a list of email addresses who will always receive a courtsey copy of every email which gets sent out.

This code is not meant to stay around for a long time, it should get replaced by a more conrete solution rather than an array of email addresses.