### PR TITLE
Add description to deliver rake tasks

### DIFF
--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -1,15 +1,19 @@
 namespace :deliver do
+  def test_email
+    OpenStruct.new(subject: "Test email", body: "This is a test email.")
+  end
+
   desc "Send a test email to a subscriber by id"
   task :to_subscriber, [:id] => :environment do |_t, args|
     subscriber = Subscriber.find(args[:id])
-    email = OpenStruct.new(subject: "Test email", body: "This is a test email.")
+    email = test_email
     DeliverToSubscriber.call(subscriber: subscriber, email: email)
   end
 
   desc "Send a test email to an email address"
   task :to_test_email, [:test_email_address] => :environment do |_t, args|
     subscriber = Subscriber.new(address: args[:test_email_address])
-    email = OpenStruct.new(subject: "Test email", body: "This is a test email.")
+    email = test_email
     DeliverToSubscriber.call(subscriber: subscriber, email: email)
   end
 end

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -1,10 +1,12 @@
 namespace :deliver do
+  desc "Send a test email to a subscriber by id"
   task :to_subscriber, [:id] => :environment do |_t, args|
     subscriber = Subscriber.find(args[:id])
     email = OpenStruct.new(subject: "Test email", body: "This is a test email.")
     DeliverToSubscriber.call(subscriber: subscriber, email: email)
   end
 
+  desc "Send a test email to an email address"
   task :to_test_email, [:test_email_address] => :environment do |_t, args|
     subscriber = Subscriber.new(address: args[:test_email_address])
     email = OpenStruct.new(subject: "Test email", body: "This is a test email.")


### PR DESCRIPTION
Add a description to `deliver:to_subscriber` and `deliver:to_test_email` rake tasks.
Refactor and extract the `test_email` into its own method.