### PR TITLE
One to Many Emails

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,6 +1,6 @@
 class Email < ApplicationRecord
   belongs_to :notification
-  validates :subject, :body, :notification, presence: true
+  validates :address, :subject, :body, :notification, presence: true
 
   def self.create_from_params!(params)
     build_from_params(params).tap(&:save!)
@@ -11,6 +11,7 @@ class Email < ApplicationRecord
 
     new(
       notification_id: params[:notification_id],
+      address: params[:address],
       subject: renderer.subject,
       body: renderer.body
     )

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -20,15 +20,15 @@ class NotificationHandler
 
 private
 
-  def create_email(notification)
+  def create_email(notification, subscriber)
     Email.create_from_params!(
-      email_params.merge(notification_id: notification.id)
+      email_params.merge(notification_id: notification.id, address: subscriber.address)
     )
   end
 
   def deliver_to_subscribers(notification)
     subscribers_for(notification: notification).find_each do |subscriber|
-      email = create_email(notification)
+      email = create_email(notification, subscriber)
       DeliverToSubscriberWorker.perform_async_with_priority(
         subscriber.id, email.id, priority: priority
       )
@@ -41,7 +41,7 @@ private
     ]
 
     Subscriber.where(address: addresses).find_each do |subscriber|
-      email = create_email(notification)
+      email = create_email(notification, subscriber)
       DeliverToSubscriberWorker.perform_async_with_priority(
         subscriber.id, email.id, priority: priority
       )

--- a/db/migrate/20171109091838_add_address_to_email.rb
+++ b/db/migrate/20171109091838_add_address_to_email.rb
@@ -1,5 +1,6 @@
 class AddAddressToEmail < ActiveRecord::Migration[5.1]
   def change
     add_column :emails, :address, :string, default: '', null: false
+    change_column_default :emails, :address, nil
   end
 end

--- a/db/migrate/20171109091838_add_address_to_email.rb
+++ b/db/migrate/20171109091838_add_address_to_email.rb
@@ -1,0 +1,5 @@
+class AddAddressToEmail < ActiveRecord::Migration[5.1]
+  def change
+    add_column :emails, :address, :string, default: '', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20171109091838) do
     t.bigint "notification_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "address", default: "", null: false
+    t.string "address", null: false
     t.index ["notification_id"], name: "index_emails_on_notification_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023094334) do
+ActiveRecord::Schema.define(version: 20171109091838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20171023094334) do
     t.bigint "notification_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "address", default: "", null: false
     t.index ["notification_id"], name: "index_emails_on_notification_id"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -41,6 +41,7 @@ FactoryGirl.define do
   end
 
   factory :email do
+    address "test@example.com"
     subject "subject"
     body "body"
     notification

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Email do
         base_path: "/government/test",
         public_updated_at: DateTime.parse("1/1/2017"),
         notification_id: notification.id,
+        address: "test@example.com",
       )
     }
 

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -171,10 +171,6 @@ RSpec.describe "Sending a notification", type: :request do
         headers: json_headers.merge("HTTP_GOVUK_REQUEST_ID" => "request_id")
     end
 
-    it "creates an Email" do
-      expect(Email.count).to eq(1)
-    end
-
     it "creates a Notification" do
       expect(Notification.count).to eq(1)
     end

--- a/spec/services/notification_handler_spec.rb
+++ b/spec/services/notification_handler_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe NotificationHandler do
           change_note: "This is a change note",
           base_path: "/government/things",
           notification_id: notification.id,
+          address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk",
         )
 
         NotificationHandler.call(params: params)


### PR DESCRIPTION
Instead of storing emails as a one to one mapping between notifications, we now store them as a one to many mapping.

I decided to leave emails created before this point with an empty string `address` rather than making up a fake email address. This means that I decided to not include validation that the address is a real email address, since they will always be populated from a subscriber which does have the validation.

The aim of this PR is to enable a lot of future work with regards to delivery attempts, not to improve how these emails are created which will come as part of future architecture improvement work.