### PR TITLE
Return reference and errors from Email Sender

### DIFF
--- a/app/services/email_sender/email_sender_service.rb
+++ b/app/services/email_sender/email_sender_service.rb
@@ -1,4 +1,13 @@
 class EmailSenderService
+  class ClientError < StandardError
+    def initialize(status, original_exception)
+      @status = status
+      @original_exception = original_exception
+    end
+
+    attr_reader :status, :original_exception
+  end
+
   def initialize(config, email_service_provider)
     @email_address_override = config[:email_address_override]
     @provider = email_service_provider
@@ -12,6 +21,8 @@ class EmailSenderService
       subject: subject,
       body: body
     )
+  rescue ClientError => ex
+    raise ex.original_exception unless ex.status == :technical_failure
   end
 
 private

--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -3,18 +3,17 @@ require "notifications/client"
 class EmailSenderService
   class Notify
     def call(address:, subject:, body:)
-      begin
-        client.send_email(
-          email_address: address,
-          template_id: template_id,
-          personalisation: {
-            subject: subject,
-            body: body,
-          },
-        )
-      rescue Notifications::Client::RequestError => ex
-        raise unless ex.code.to_s == "429"
-      end
+      response = client.send_email(
+        email_address: address,
+        template_id: template_id,
+        personalisation: {
+          subject: subject,
+          body: body,
+        },
+      )
+      response.id
+    rescue Notifications::Client::RequestError => ex
+      raise unless ex.code.to_s == "429"
     end
 
   private

--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -13,7 +13,11 @@ class EmailSenderService
       )
       response.id
     rescue Notifications::Client::RequestError => ex
-      raise unless ex.code.to_s == "429"
+      if ex.code == 429
+        raise EmailSenderService::ClientError(:technical_failure, ex)
+      else
+        raise EmailSenderService::ClientError(:internal_failure, ex)
+      end
     end
 
   private

--- a/app/services/email_sender/pseudo.rb
+++ b/app/services/email_sender/pseudo.rb
@@ -5,6 +5,7 @@ class EmailSenderService
 Subject: #{subject}
 Body: #{body}
 ))
+      "" # provider reference
     end
 
   private

--- a/spec/integration/deliver_to_subscriber_spec.rb
+++ b/spec/integration/deliver_to_subscriber_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DeliverToSubscriber do
 
         expect(client).to receive(:send_email).with(
           hash_including(email_address: "test@test.com")
-        )
+        ).and_return(double(id: 0))
 
         DeliverToSubscriber.call(subscriber: subscriber, email: email)
       end

--- a/spec/services/email_sender/notify_spec.rb
+++ b/spec/services/email_sender/notify_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe EmailSenderService::Notify do
           personalisation: a_hash_including(subject: "subject", body: "body"),
           template_id: anything,
         )
+        .and_return(double(id: 0))
 
-      subject.call(address: "email@address.com", subject: "subject", body: "body")
+      expect(subject.call(address: "email@address.com", subject: "subject", body: "body")).to eq(0)
     end
   end
 end


### PR DESCRIPTION
This returns the provider reference on a successful email send call, and raises a common provider-agnostic `ClientError` exception when there is a failure. This should make it easier to build a `DeliveryAttempt` object from the response of the sender.

[Trello Card](https://trello.com/c/oAaQvqQE/320-create-a-delivery-monitor-to-check-status-of-emails-sent-to-notify)