### PR TITLE
Remove created delivery attempt status

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -3,19 +3,15 @@ class DeliveryAttempt < ApplicationRecord
 
   validates :email, :status, :provider, :reference, presence: true
 
-  enum status: %i(sending delivered permanent_failure temporary_failure technical_failure internal_failure)
+  enum status: %i(sending delivered permanent_failure temporary_failure technical_failure)
   enum provider: %i(psuedo notify)
 
   def failure?
-    permanent_failure? || temporary_failure? || technical_failure? || internal_failure?
-  end
-
-  def should_retry?
-    temporary_failure? || technical_failure?
+    permanent_failure? || temporary_failure? || technical_failure?
   end
 
   def should_report_failure?
-    internal_failure?
+    technical_failure?
   end
 
   def should_remove_subscriber?

--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -3,7 +3,7 @@ class DeliveryAttempt < ApplicationRecord
 
   validates :email, :status, :provider, :reference, presence: true
 
-  enum status: %i(created sending delivered permanent_failure temporary_failure technical_failure internal_failure)
+  enum status: %i(sending delivered permanent_failure temporary_failure technical_failure internal_failure)
   enum provider: %i(psuedo notify)
 
   def failure?

--- a/spec/models/delivery_attempt_spec.rb
+++ b/spec/models/delivery_attempt_spec.rb
@@ -7,18 +7,6 @@ RSpec.describe DeliveryAttempt, type: :model do
     end
   end
 
-  shared_examples "is marked as should retry" do
-    it "is marked as should retry" do
-      expect(subject.should_retry?).to be_truthy
-    end
-  end
-
-  shared_examples "is not marked as should retry" do
-    it "is not marked as should retry" do
-      expect(subject.should_retry?).to be_falsey
-    end
-  end
-
   describe "validations" do
     subject { create(:delivery_attempt) }
 
@@ -31,7 +19,6 @@ RSpec.describe DeliveryAttempt, type: :model do
     subject { create(:delivery_attempt, status: :permanent_failure) }
 
     include_examples "is marked as a failure"
-    include_examples "is not marked as should retry"
 
     it "is marked as remove the subscriber" do
       expect(subject.should_remove_subscriber?).to be_truthy
@@ -42,21 +29,12 @@ RSpec.describe DeliveryAttempt, type: :model do
     subject { create(:delivery_attempt, status: :temporary_failure) }
 
     include_examples "is marked as a failure"
-    include_examples "is marked as should retry"
   end
 
   context "with a technical failure" do
     subject { create(:delivery_attempt, status: :technical_failure) }
 
     include_examples "is marked as a failure"
-    include_examples "is marked as should retry"
-  end
-
-  context "with an internal failure" do
-    subject { create(:delivery_attempt, status: :internal_failure) }
-
-    include_examples "is marked as a failure"
-    include_examples "is not marked as should retry"
 
     it "is marked as should report failure" do
       expect(subject.should_report_failure?).to be_truthy


### PR DESCRIPTION
We will not need this status since we can start it in the sending state.