### PR TITLE
Add an endpoint to receive status updates for delivery attempts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'redis-namespace', '1.5.3'
 gem 'sidekiq', '5.0.0'
 gem 'sidekiq-logging-json', '0.0.18'
 gem 'sidekiq-statsd', '0.1.5'
+gem 'sidekiq-symbols', '~> 0.1'
 gem 'statsd-ruby', '1.4.0'
 gem 'unicorn', '5.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
       activesupport
       sidekiq (>= 2.6)
       statsd-ruby (>= 1.1.0)
+    sidekiq-symbols (0.1.1)
+      sidekiq
     slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -275,6 +277,7 @@ DEPENDENCIES
   sidekiq (= 5.0.0)
   sidekiq-logging-json (= 0.0.18)
   sidekiq-statsd (= 0.1.5)
+  sidekiq-symbols (~> 0.1)
   statsd-ruby (= 1.4.0)
   unicorn (= 5.3.0)
   webmock

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -2,13 +2,13 @@ class StatusUpdatesController < ApplicationController
   wrap_parameters false
 
   def create
-    StatusUpdateWorker.perform_async(status_update_params)
+    StatusUpdateWorker.perform_async(**status_update_params)
     render plain: "queued for processing", status: :accepted
   end
 
 private
 
   def status_update_params
-    params.permit(:reference, :status).to_h
+    params.permit(:reference, :status).to_h.symbolize_keys
   end
 end

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -1,0 +1,14 @@
+class StatusUpdatesController < ApplicationController
+  wrap_parameters false
+
+  def create
+    StatusUpdateWorker.perform_async(status_update_params)
+    render plain: "queued for processing", status: :accepted
+  end
+
+private
+
+  def status_update_params
+    params.permit(:reference, :status).to_h
+  end
+end

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,7 +1,8 @@
 class Subscriber < ActiveRecord::Base
-  validates :address, presence: true
-  validates :address, format: { with: /@/, message: "is not an email address" }
-  validates :address, uniqueness: true
+  with_options allow_nil: true do
+    validates :address, format: { with: /@/, message: "is not an email address" }
+    validates :address, uniqueness: true
+  end
 
   has_many :subscriptions, dependent: :destroy
   has_many :subscriber_lists, through: :subscriptions

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -6,4 +6,9 @@ class Subscriber < ActiveRecord::Base
 
   has_many :subscriptions, dependent: :destroy
   has_many :subscriber_lists, through: :subscriptions
+
+  def unsubscribe!
+    update!(address: nil)
+    subscriptions.destroy_all
+  end
 end

--- a/app/workers/status_update_worker.rb
+++ b/app/workers/status_update_worker.rb
@@ -1,38 +1,19 @@
 class StatusUpdateWorker
   include Sidekiq::Worker
+  include Sidekiq::Symbols
 
-  attr_accessor :reference, :status
+  def perform(reference:, status:)
+    delivery_attempt = DeliveryAttempt.find_by!(reference: reference)
+    delivery_attempt.update!(status: status.underscore)
 
-  def perform(params)
-    params.deep_symbolize_keys!
-
-    self.reference = params.fetch(:reference)
-    self.status = params.fetch(:status).underscore
-
-    set_status_on_delivery_attempt
-    unsubscribe_if_permanent_failure
+    subscriber = lookup_subscriber(delivery_attempt)
+    subscriber.unsubscribe! if subscriber && delivery_attempt.permanent_failure?
   end
 
 private
 
-  def set_status_on_delivery_attempt
-    delivery_attempt.status = status
-    delivery_attempt.save!
-  end
-
-  def unsubscribe_if_permanent_failure
-    return unless delivery_attempt.status == "permanent_failure" # TODO
-    return unless subscriber
-
-    subscriber.unsubscribe!
-  end
-
-  def delivery_attempt
-    @delivery_attempt ||= DeliveryAttempt.find_by!(reference: reference)
-  end
-
-  def subscriber
+  def lookup_subscriber(delivery_attempt)
     address = delivery_attempt.email.address
-    @subscriber ||= Subscriber.find_by(address: address)
+    Subscriber.find_by(address: address)
   end
 end

--- a/app/workers/status_update_worker.rb
+++ b/app/workers/status_update_worker.rb
@@ -1,14 +1,38 @@
 class StatusUpdateWorker
   include Sidekiq::Worker
 
+  attr_accessor :reference, :status
+
   def perform(params)
     params.deep_symbolize_keys!
 
-    reference = params.fetch(:reference)
-    status = params.fetch(:status).underscore
+    self.reference = params.fetch(:reference)
+    self.status = params.fetch(:status).underscore
 
-    attempt = DeliveryAttempt.find_by!(reference: reference)
-    attempt.status = status
-    attempt.save!
+    set_status_on_delivery_attempt
+    unsubscribe_if_permanent_failure
+  end
+
+private
+
+  def set_status_on_delivery_attempt
+    delivery_attempt.status = status
+    delivery_attempt.save!
+  end
+
+  def unsubscribe_if_permanent_failure
+    return unless delivery_attempt.status == "permanent_failure" # TODO
+    return unless subscriber
+
+    subscriber.unsubscribe!
+  end
+
+  def delivery_attempt
+    @delivery_attempt ||= DeliveryAttempt.find_by!(reference: reference)
+  end
+
+  def subscriber
+    address = delivery_attempt.email.address
+    @subscriber ||= Subscriber.find_by(address: address)
   end
 end

--- a/app/workers/status_update_worker.rb
+++ b/app/workers/status_update_worker.rb
@@ -1,0 +1,14 @@
+class StatusUpdateWorker
+  include Sidekiq::Worker
+
+  def perform(params)
+    params.deep_symbolize_keys!
+
+    reference = params.fetch(:reference)
+    status = params.fetch(:status).underscore
+
+    attempt = DeliveryAttempt.find_by!(reference: reference)
+    attempt.status = status
+    attempt.save!
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get "/subscriber-lists", to: "subscriber_lists#show"
 
   resources :notifications, only: %i[create index show]
+  resources :status_updates, only: %i[create]
 
   get "/healthcheck", to: "healthcheck#check"
 end

--- a/db/migrate/20171110163345_make_subscriber_address_nullable.rb
+++ b/db/migrate/20171110163345_make_subscriber_address_nullable.rb
@@ -1,0 +1,5 @@
+class MakeSubscriberAddressNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :subscribers, :address, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109091838) do
+ActiveRecord::Schema.define(version: 20171110163345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20171109091838) do
   end
 
   create_table "subscribers", force: :cascade do |t|
-    t.string "address", null: false
+    t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["address"], name: "index_subscribers_on_address", unique: true

--- a/spec/controllers/status_updates_controller_spec.rb
+++ b/spec/controllers/status_updates_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe StatusUpdatesController, type: :controller do
+  let!(:delivery_attempt) do
+    FactoryGirl.create(
+      :delivery_attempt,
+      reference: "ref-123",
+      status: "sending",
+    )
+  end
+
+  describe "#create" do
+    it "queues a job for processing" do
+      expect(StatusUpdateWorker).to receive(:perform_async).with(
+        reference: "ref-123",
+        status: "delivered",
+      )
+
+      post :create, params: { reference: "ref-123", status: "delivered" }
+    end
+
+    it "renders 202 accepted" do
+      post :create, params: { reference: "ref-123", status: "delivered" }
+
+      expect(response.status).to eq(202)
+      expect(response.body).to eq("queued for processing")
+    end
+  end
+end

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Receiving a status update for an email", type: :request do
+  let!(:delivery_attempt) do
+    FactoryGirl.create(
+      :delivery_attempt,
+      reference: "ref-123",
+      status: "sending",
+    )
+  end
+
+  it "sets the delivery attempt's status via a worker" do
+    params = { reference: "ref-123", status: "delivered" }
+    post "/status_updates", params: params
+
+    expect(response.status).to eq(202)
+    expect(response.body).to eq("queued for processing")
+
+    delivery_attempt.reload
+    expect(delivery_attempt.status).to eq("delivered")
+  end
+end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -30,9 +30,16 @@ RSpec.describe Subscriber, type: :model do
       end
     end
 
-    it "is invalid for a nil email address" do
+    it "is valid for a nil email address" do
       subject.address = nil
+      expect(subject).to be_valid
+    end
 
+    it "is invalid for an empty string email address" do
+      subject.address = ""
+      expect(subject).to be_invalid
+
+      subject.address = " "
       expect(subject).to be_invalid
     end
 
@@ -47,6 +54,13 @@ RSpec.describe Subscriber, type: :model do
 
       subject.address = "foo@bar.com"
       expect(subject).to be_invalid
+    end
+
+    it "is valid to have more than one nil email address" do
+      FactoryGirl.create(:subscriber, address: nil)
+
+      subject.address = nil
+      expect(subject).to be_valid
     end
   end
 

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -83,4 +83,26 @@ RSpec.describe Subscriber, type: :model do
       expect(SubscriberList.all.size).to eq(1)
     end
   end
+
+  describe "#unsubscribe!" do
+    subject { FactoryGirl.create(:subscriber, address: "foo@bar.com") }
+
+    before do
+      FactoryGirl.create_list(:subscription, 3, subscriber: subject)
+    end
+
+    it "nullifies the subscriber's email address" do
+      expect { subject.unsubscribe! }
+        .to change { subject.reload.address }
+        .from("foo@bar.com")
+        .to(nil)
+    end
+
+    it "removes the subscriber's subscriptions" do
+      expect { subject.unsubscribe! }
+        .to change { subject.subscriptions.count }
+        .from(3)
+        .to(0)
+    end
+  end
 end

--- a/spec/workers/status_update_worker_spec.rb
+++ b/spec/workers/status_update_worker_spec.rb
@@ -10,34 +10,24 @@ RSpec.describe StatusUpdateWorker do
   end
 
   it "updates the delivery attempt's status" do
-    expect { subject.perform(args) }
+    expect { subject.perform(**args) }
       .to change { delivery_attempt.reload.status }
       .to("delivered")
   end
 
   it "underscores statuses" do
-    expect { subject.perform(args.merge(status: "temporary-failure")) }
+    expect { subject.perform(**args.merge(status: "temporary-failure")) }
       .to change { delivery_attempt.reload.status }
       .to("temporary_failure")
   end
 
-  it "requires a reference" do
-    expect { subject.perform(args.without(:reference)) }
-      .to raise_error(KeyError)
-  end
-
-  it "requires a status" do
-    expect { subject.perform(args.without(:status)) }
-      .to raise_error(KeyError)
-  end
-
   it "raises an error if the delivery attempt doesn't exist" do
-    expect { subject.perform(args.merge(reference: "missing")) }
+    expect { subject.perform(**args.merge(reference: "missing")) }
       .to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it "raises an error if the status isn't recognised" do
-    expect { subject.perform(args.merge(status: "unknown")) }
+    expect { subject.perform(**args.merge(status: "unknown")) }
       .to raise_error(ArgumentError)
   end
 end

--- a/spec/workers/status_update_worker_spec.rb
+++ b/spec/workers/status_update_worker_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe StatusUpdateWorker do
+  let!(:delivery_attempt) do
+    create(:delivery_attempt, reference: "ref-123", status: "sending")
+  end
+
+  let(:args) do
+    { reference: "ref-123", status: "delivered" }
+  end
+
+  it "updates the delivery attempt's status" do
+    expect { subject.perform(args) }
+      .to change { delivery_attempt.reload.status }
+      .to("delivered")
+  end
+
+  it "underscores statuses" do
+    expect { subject.perform(args.merge(status: "temporary-failure")) }
+      .to change { delivery_attempt.reload.status }
+      .to("temporary_failure")
+  end
+
+  it "requires a reference" do
+    expect { subject.perform(args.without(:reference)) }
+      .to raise_error(KeyError)
+  end
+
+  it "requires a status" do
+    expect { subject.perform(args.without(:status)) }
+      .to raise_error(KeyError)
+  end
+
+  it "raises an error if the delivery attempt doesn't exist" do
+    expect { subject.perform(args.merge(reference: "missing")) }
+      .to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "raises an error if the status isn't recognised" do
+    expect { subject.perform(args.merge(status: "unknown")) }
+      .to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/oAaQvqQE/320-create-a-delivery-monitor-to-check-status-of-emails-sent-to-notify