### PR TITLE
Fix running `rake db:migrate` against a new database

### DIFF
--- a/db/migrate/20141025105641_create_subscriber_list.rb
+++ b/db/migrate/20141025105641_create_subscriber_list.rb
@@ -1,8 +1,8 @@
 class CreateSubscriberList < ActiveRecord::Migration[4.2]
   def change
     create_table :subscriber_lists, force: true do |t|
-      t.string :title
-      t.string :gov_delivery_id
+      t.string :title, limit: 255
+      t.string :gov_delivery_id, limit: 255
       #t.hstore :tags
       t.timestamps
     end

--- a/db/migrate/20141025105641_create_subscriber_list.rb
+++ b/db/migrate/20141025105641_create_subscriber_list.rb
@@ -1,12 +1,12 @@
-class CreateSubscriberList < ActiveRecord::Migration
+class CreateSubscriberList < ActiveRecord::Migration[4.2]
   def change
     create_table :subscriber_lists, force: true do |t|
       t.string :title
       t.string :gov_delivery_id
-      t.hstore :tags
+      #t.hstore :tags
       t.timestamps
     end
 
-    add_index :subscriber_lists, :tags, using: :gin
+    #add_index :subscriber_lists, :tags, using: :gin
   end
 end

--- a/db/migrate/20150428072646_seed_policy_subscriptions.rb
+++ b/db/migrate/20150428072646_seed_policy_subscriptions.rb
@@ -1,7 +1,11 @@
+# rubocop:disable Lint/UnreachableCode
+
 require 'csv'
 
-class SeedPolicySubscriptions < ActiveRecord::Migration
+class SeedPolicySubscriptions < ActiveRecord::Migration[4.2]
   def change
+    return
+
     slug_mapping = {}
     mapping_csv_path = File.join(File.dirname(__FILE__), "20150428072646_seed_policy_subscriptions_mapping.csv")
     CSV.foreach(mapping_csv_path, headers: true) do |mapping|

--- a/db/migrate/20150508081921_reslug_social_equality.rb
+++ b/db/migrate/20150508081921_reslug_social_equality.rb
@@ -1,5 +1,9 @@
-class ReslugSocialEquality < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class ReslugSocialEquality < ActiveRecord::Migration[4.2]
   def up
+    return
+
     list = SubscriberListQuery.where_tags_equal(policies: ["social-equality"]).first
 
     if list

--- a/db/migrate/20151001102405_add_links_to_subscriber_list.rb
+++ b/db/migrate/20151001102405_add_links_to_subscriber_list.rb
@@ -1,7 +1,7 @@
-class AddLinksToSubscriberList < ActiveRecord::Migration
+class AddLinksToSubscriberList < ActiveRecord::Migration[4.2]
   def change
-    add_column :subscriber_lists, :links, :hstore, null: false, default: {}
+    #add_column :subscriber_lists, :links, :hstore, null: false, default: {}
 
-    add_index :subscriber_lists, :links, using: :gin
+    #add_index :subscriber_lists, :links, using: :gin
   end
 end

--- a/db/migrate/20151001154627_add_null_false_to_tags_field.rb
+++ b/db/migrate/20151001154627_add_null_false_to_tags_field.rb
@@ -1,5 +1,5 @@
-class AddNullFalseToTagsField < ActiveRecord::Migration
+class AddNullFalseToTagsField < ActiveRecord::Migration[4.2]
   def change
-    change_column :subscriber_lists, :tags, :hstore, null: false, default: {}
+    #change_column :subscriber_lists, :tags, :hstore, null: false, default: {}
   end
 end

--- a/db/migrate/20151019131359_remove_dead_subscriber_lists.rb
+++ b/db/migrate/20151019131359_remove_dead_subscriber_lists.rb
@@ -1,5 +1,9 @@
-class RemoveDeadSubscriberLists < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class RemoveDeadSubscriberLists < ActiveRecord::Migration[4.2]
   def up
+    return
+
     [
       # redirected to 'prisons-probation'
       'prisons-probation/researching-prisons',

--- a/db/migrate/20151019131428_update_outdated_topic_tags_on_subscriber_lists.rb
+++ b/db/migrate/20151019131428_update_outdated_topic_tags_on_subscriber_lists.rb
@@ -1,5 +1,9 @@
-class UpdateOutdatedTopicTagsOnSubscriberLists < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class UpdateOutdatedTopicTagsOnSubscriberLists < ActiveRecord::Migration[4.2]
   def up
+    return
+
     tag_mappings = [
       {
         from: 'schools-colleges/behaviour-attendance',

--- a/db/migrate/20151023151545_rename_policies_tag_on_a_subscriber_list.rb
+++ b/db/migrate/20151023151545_rename_policies_tag_on_a_subscriber_list.rb
@@ -1,5 +1,9 @@
-class RenamePoliciesTagOnASubscriberList < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class RenamePoliciesTagOnASubscriberList < ActiveRecord::Migration[4.2]
   def up
+    return
+
     target_list = FindExactMatch.new.call(
       policies: ["inspections-of-schools-colleges-and-children-s-services"]
     ).first

--- a/db/migrate/20151027155930_remove_dead_policy_subscriber_list.rb
+++ b/db/migrate/20151027155930_remove_dead_policy_subscriber_list.rb
@@ -1,5 +1,9 @@
-class RemoveDeadPolicySubscriberList < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class RemoveDeadPolicySubscriberList < ActiveRecord::Migration[4.2]
   def up
+    return
+
     # This list doesn't match anything except similarly named placeholders in
     # the Content Store.
     target_list = FindExactMatch.new.call(

--- a/db/migrate/20151102165117_rename_policy_links_to_parent.rb
+++ b/db/migrate/20151102165117_rename_policy_links_to_parent.rb
@@ -1,5 +1,9 @@
-class RenamePolicyLinksToParent < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class RenamePolicyLinksToParent < ActiveRecord::Migration[4.2]
   def up
+    return
+
     subscriber_lists_with_key(:policy).each do |list|
       content_id = list.links[:policy]
       list.links = { parent: content_id }

--- a/db/migrate/20151111124933_remove_policy_subscriber_lists_with_erroneous_links.rb
+++ b/db/migrate/20151111124933_remove_policy_subscriber_lists_with_erroneous_links.rb
@@ -1,5 +1,9 @@
-class RemovePolicySubscriberListsWithErroneousLinks < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class RemovePolicySubscriberListsWithErroneousLinks < ActiveRecord::Migration[4.2]
   def up
+    return
+
     subscriber_lists_with_key(:policies).each(&:destroy!)
   end
 

--- a/db/migrate/20151111150405_rename_parent_links_to_policies.rb
+++ b/db/migrate/20151111150405_rename_parent_links_to_policies.rb
@@ -1,5 +1,9 @@
-class RenameParentLinksToPolicies < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class RenameParentLinksToPolicies < ActiveRecord::Migration[4.2]
   def up
+    return
+
     subscriber_lists_with_key(:parent).each do |sl|
       sl.links = { policies: sl.links[:parent] }
       sl.save!

--- a/db/migrate/20151112144850_rename_policy_tags_to_policies.rb
+++ b/db/migrate/20151112144850_rename_policy_tags_to_policies.rb
@@ -1,5 +1,9 @@
-class RenamePolicyTagsToPolicies < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class RenamePolicyTagsToPolicies < ActiveRecord::Migration[4.2]
   def up
+    return
+
     subscriber_lists_with_key(:policy).each do |sl|
       sl.tags = { policies: sl.tags[:policy] }
       sl.save!

--- a/db/migrate/20160205102023_add_document_type_to_subscriber_list.rb
+++ b/db/migrate/20160205102023_add_document_type_to_subscriber_list.rb
@@ -1,4 +1,4 @@
-class AddDocumentTypeToSubscriberList < ActiveRecord::Migration
+class AddDocumentTypeToSubscriberList < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriber_lists, :document_type, :string, default: "", null: false
   end

--- a/db/migrate/20160209143102_add_foreign_travel_advice_subscriber_lists.rb
+++ b/db/migrate/20160209143102_add_foreign_travel_advice_subscriber_lists.rb
@@ -1,7 +1,11 @@
+# rubocop:disable Lint/UnreachableCode
+
 require 'csv'
 
-class AddForeignTravelAdviceSubscriberLists < ActiveRecord::Migration
+class AddForeignTravelAdviceSubscriberLists < ActiveRecord::Migration[4.2]
   def change
+    return
+
     csv_path = File.join(File.dirname(__FILE__), "20160209143102_add_foreign_travel_advice_subscriber_lists.csv")
 
     CSV.foreach(csv_path) do |gov_delivery_id, country_slug|

--- a/db/migrate/20160215144137_add_content_i_ds_to_travel_advice_topics.rb
+++ b/db/migrate/20160215144137_add_content_i_ds_to_travel_advice_topics.rb
@@ -1,7 +1,11 @@
+# rubocop:disable Lint/UnreachableCode
+
 require 'csv'
 
-class AddContentIDsToTravelAdviceTopics < ActiveRecord::Migration
+class AddContentIDsToTravelAdviceTopics < ActiveRecord::Migration[4.2]
   def change
+    return
+
     csv_path = File.join(File.dirname(__FILE__), "20160215144137_add_content_i_ds_to_travel_advice_topics.csv")
 
     # Clean up after last migration - delete the erroneous tags

--- a/db/migrate/20160224152054_add_all_countries_subscriber_list.rb
+++ b/db/migrate/20160224152054_add_all_countries_subscriber_list.rb
@@ -1,5 +1,9 @@
-class AddAllCountriesSubscriberList < ActiveRecord::Migration
+# rubocop:disable Lint/UnreachableCode
+
+class AddAllCountriesSubscriberList < ActiveRecord::Migration[4.2]
   def change
+    return
+
     SubscriberList.create!(
       gov_delivery_id: 'UKGOVUK_391',
       document_type: 'travel_advice'

--- a/db/migrate/20160718090427_add_json_columns_to_subscriber_list.rb
+++ b/db/migrate/20160718090427_add_json_columns_to_subscriber_list.rb
@@ -1,4 +1,4 @@
-class AddJsonColumnsToSubscriberList < ActiveRecord::Migration
+class AddJsonColumnsToSubscriberList < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriber_lists, :tags_json, :json, default: {}, null: false
     add_column :subscriber_lists, :links_json, :json, default: {}, null: false

--- a/db/migrate/20160905121642_remove_hstore.rb
+++ b/db/migrate/20160905121642_remove_hstore.rb
@@ -1,7 +1,7 @@
-class RemoveHstore < ActiveRecord::Migration
+class RemoveHstore < ActiveRecord::Migration[4.2]
   def up
-    remove_column :subscriber_lists, :tags
-    remove_column :subscriber_lists, :links
+    #remove_column :subscriber_lists, :tags
+    #remove_column :subscriber_lists, :links
     add_column :subscriber_lists, :tags, :json, default: {}, null: false
     add_column :subscriber_lists, :links, :json, default: {}, null: false
 

--- a/db/migrate/20170208150700_remove_temp_json_fields.rb
+++ b/db/migrate/20170208150700_remove_temp_json_fields.rb
@@ -1,4 +1,4 @@
-class RemoveTempJsonFields < ActiveRecord::Migration
+class RemoveTempJsonFields < ActiveRecord::Migration[4.2]
   def change
     remove_column :subscriber_lists, :links_json
     remove_column :subscriber_lists, :tags_json

--- a/db/migrate/20170221141514_create_notification_log.rb
+++ b/db/migrate/20170221141514_create_notification_log.rb
@@ -1,4 +1,4 @@
-class CreateNotificationLog < ActiveRecord::Migration
+class CreateNotificationLog < ActiveRecord::Migration[4.2]
   def change
     create_table :notification_logs do |t|
       t.string :govuk_request_id, index: true, default: ''

--- a/db/migrate/20170302162543_add_enabled_flag_to_subscriber_lists.rb
+++ b/db/migrate/20170302162543_add_enabled_flag_to_subscriber_lists.rb
@@ -1,4 +1,4 @@
-class AddEnabledFlagToSubscriberLists < ActiveRecord::Migration
+class AddEnabledFlagToSubscriberLists < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriber_lists, :enabled, :boolean, default: true, null: false
   end

--- a/db/migrate/20170302162818_add_enabled_disabled_gov_delivery_ids_to_notification_log.rb
+++ b/db/migrate/20170302162818_add_enabled_disabled_gov_delivery_ids_to_notification_log.rb
@@ -1,4 +1,4 @@
-class AddEnabledDisabledGovDeliveryIdsToNotificationLog < ActiveRecord::Migration
+class AddEnabledDisabledGovDeliveryIdsToNotificationLog < ActiveRecord::Migration[4.2]
   def change
     add_column :notification_logs, :enabled_gov_delivery_ids, :json, default: []
     add_column :notification_logs, :disabled_gov_delivery_ids, :json, default: []

--- a/db/migrate/20170320170223_add_supertype_fields.rb
+++ b/db/migrate/20170320170223_add_supertype_fields.rb
@@ -1,4 +1,4 @@
-class AddSupertypeFields < ActiveRecord::Migration
+class AddSupertypeFields < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriber_lists, :email_document_supertype, :string, default: '', null: false
     add_column :subscriber_lists, :government_document_supertype, :string, default: '', null: false

--- a/db/migrate/20170327104203_add_migrated_from_gov_uk_delivery_to_subscriber_list.rb
+++ b/db/migrate/20170327104203_add_migrated_from_gov_uk_delivery_to_subscriber_list.rb
@@ -1,4 +1,4 @@
-class AddMigratedFromGovUkDeliveryToSubscriberList < ActiveRecord::Migration
+class AddMigratedFromGovUkDeliveryToSubscriberList < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriber_lists, :migrated_from_gov_uk_delivery, :boolean, default: false, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,8 +71,8 @@ ActiveRecord::Schema.define(version: 20171109091838) do
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
-    t.string "title"
-    t.string "gov_delivery_id"
+    t.string "title", limit: 255
+    t.string "gov_delivery_id", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,8 +71,8 @@ ActiveRecord::Schema.define(version: 20171109091838) do
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
-    t.string "title", limit: 255
-    t.string "gov_delivery_id", limit: 255
+    t.string "title"
+    t.string "gov_delivery_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false


### PR DESCRIPTION
Database migrations were broken because:
- they didn’t include the Rails version number
- the hstore migrations require root access

We’re not using hstore anymore so I’ve commented
out the creation of these columns. This meant I
had to disable some data migrations that depend on
those columns.