### PR TITLE
Add the SubscriptionContent model

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -5,14 +5,6 @@ class Email < ApplicationRecord
     build_from_params(params).tap(&:save!)
   end
 
-  def self.create_from_subscription_content!(params, subscription_content)
-    create_from_params!(
-      params.merge(
-        address: subscription_content.subscription.subscriber.address
-      )
-    )
-  end
-
   def self.build_from_params(params)
     renderer = EmailRenderer.new(params: params)
 

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -5,6 +5,14 @@ class Email < ApplicationRecord
     build_from_params(params).tap(&:save!)
   end
 
+  def self.create_from_subscription_content!(params, subscription_content)
+    create_from_params!(
+      params.merge(
+        address: subscription_content.subscription.subscriber.address,
+      )
+    )
+  end
+
   def self.build_from_params(params)
     renderer = EmailRenderer.new(params: params)
 

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -8,7 +8,7 @@ class Email < ApplicationRecord
   def self.create_from_subscription_content!(params, subscription_content)
     create_from_params!(
       params.merge(
-        address: subscription_content.subscription.subscriber.address,
+        address: subscription_content.subscription.subscriber.address
       )
     )
   end

--- a/app/models/subscription_content.rb
+++ b/app/models/subscription_content.rb
@@ -1,5 +1,5 @@
 class SubscriptionContent < ApplicationRecord
   belongs_to :subscription
-  belongs_to :notification
+  belongs_to :content_change
   belongs_to :email, optional: true
 end

--- a/app/models/subscription_content.rb
+++ b/app/models/subscription_content.rb
@@ -1,0 +1,5 @@
+class SubscriptionContent < ApplicationRecord
+  belongs_to :subscription
+  belongs_to :notification
+  belongs_to :email, optional: true
+end

--- a/app/queries/subscription_matcher.rb
+++ b/app/queries/subscription_matcher.rb
@@ -1,0 +1,17 @@
+class SubscriptionMatcher
+  def self.call(content_change:)
+    Subscription.where(
+      subscriber_list: subscribables_for(content_change: content_change)
+    ).distinct
+  end
+
+  def self.subscribables_for(content_change:)
+    SubscriberListQuery.new(
+      tags: content_change.tags,
+      links: content_change.links,
+      document_type: content_change.document_type,
+      email_document_supertype: content_change.email_document_supertype,
+      government_document_supertype: content_change.government_document_supertype,
+    ).lists
+  end
+end

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -10,7 +10,7 @@ class NotificationHandler
 
   def call
     begin
-      content_change = ContentChange.create!(notification_params)
+      content_change = ContentChange.create!(content_change_params)
       deliver_to_subscribers(content_change)
       deliver_to_courtesy_subscribers
     rescue StandardError => ex
@@ -55,7 +55,7 @@ private
     SubscriptionMatcher.call(content_change: content_change)
   end
 
-  def notification_params
+  def content_change_params
     {
       content_id: params[:content_id],
       title: params[:title],

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -24,9 +24,18 @@ private
     Email.create_from_params!(email_params.merge(address: subscriber.address))
   end
 
-  def deliver_to_subscribers(content_change)
-    subscribers_for(content_change: content_change).find_each do |subscriber|
-      email = create_email(subscriber)
+  def create_subscription_content(notification, subscription, email)
+    SubscriptionContent.create!(
+      notification: notification,
+      subscription: subscription,
+      email: email,
+    )
+  end
+
+  def deliver_to_subscribers(notification)
+    subscriptions_for(content_change: content_change).find_each do |subscription|
+      email = create_email(subscription.subscriber)
+      create_subscription_content(content_change, subscription, email)
       DeliverEmailWorker.perform_async_with_priority(
         email.id, priority: priority
       )

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -46,22 +46,8 @@ private
     end
   end
 
-  def subscribers_for(content_change:)
-    Subscriber.joins(:subscriptions).where(
-      subscriptions: {
-        subscriber_list: subscriber_lists_for(content_change: content_change)
-      }
-    ).distinct
-  end
-
-  def subscriber_lists_for(content_change:)
-    SubscriberListQuery.new(
-      tags: content_change.tags,
-      links: content_change.links,
-      document_type: content_change.document_type,
-      email_document_supertype: content_change.email_document_supertype,
-      government_document_supertype: content_change.government_document_supertype,
-    ).lists
+  def subscriptions_for(content_change:)
+    SubscriptionMatcher.call(content_change: content_change)
   end
 
   def notification_params

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -27,7 +27,9 @@ private
         subscription: subscription,
       )
 
-      email = Email.create_from_subscription_content!(email_params, subscription_content)
+      email = Email.create_from_params!(
+        email_params.merge(address: subscription.subscriber.address)
+      )
 
       subscription_content.update!(email: email)
 

--- a/db/migrate/20171114171050_add_subscription_content.rb
+++ b/db/migrate/20171114171050_add_subscription_content.rb
@@ -1,0 +1,10 @@
+class AddSubscriptionContent < ActiveRecord::Migration[5.1]
+  def change
+    create_table :subscription_contents do |t|
+      t.references :subscription, null: false, foreign_key: true
+      t.references :content_change, null: false, foreign_key: true
+      t.references :email, null: true, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,6 +89,17 @@ ActiveRecord::Schema.define(version: 20171115162823) do
     t.index ["address"], name: "index_subscribers_on_address", unique: true
   end
 
+  create_table "subscription_contents", force: :cascade do |t|
+    t.bigint "subscription_id", null: false
+    t.bigint "content_change_id", null: false
+    t.bigint "email_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
+    t.index ["email_id"], name: "index_subscription_contents_on_email_id"
+    t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"
+  end
+
   create_table "subscriptions", force: :cascade do |t|
     t.bigint "subscriber_id", null: false
     t.bigint "subscriber_list_id", null: false
@@ -100,6 +111,9 @@ ActiveRecord::Schema.define(version: 20171115162823) do
   end
 
   add_foreign_key "delivery_attempts", "emails"
+  add_foreign_key "subscription_contents", "content_changes"
+  add_foreign_key "subscription_contents", "emails"
+  add_foreign_key "subscription_contents", "subscriptions"
   add_foreign_key "subscriptions", "subscriber_lists"
   add_foreign_key "subscriptions", "subscribers", on_delete: :cascade
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -42,7 +42,7 @@ FactoryGirl.define do
 
   factory :subscription_content do
     subscription
-    notification
+    content_change
   end
 
   factory :email do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,6 +40,11 @@ FactoryGirl.define do
     publishing_app "publishing app"
   end
 
+  factory :subscription_content do
+    subscription
+    notification
+  end
+
   factory :email do
     address "test@example.com"
     subject "subject"

--- a/spec/models/subscription_content_spec.rb
+++ b/spec/models/subscription_content_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe SubscriptionContent do
+  describe "validations" do
+    subject { FactoryGirl.build(:subscription_content) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+
+    it "requires a subscription" do
+      subject.subscription = nil
+      expect(subject).to be_invalid
+    end
+
+    it "requires a notification" do
+      subject.notification = nil
+      expect(subject).to be_invalid
+    end
+  end
+end

--- a/spec/models/subscription_content_spec.rb
+++ b/spec/models/subscription_content_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SubscriptionContent do
   describe "validations" do
-    subject { FactoryGirl.build(:subscription_content) }
+    subject { build(:subscription_content) }
 
     it "is valid for the default factory" do
       expect(subject).to be_valid
@@ -13,8 +13,8 @@ RSpec.describe SubscriptionContent do
       expect(subject).to be_invalid
     end
 
-    it "requires a notification" do
-      subject.notification = nil
+    it "requires a content change" do
+      subject.content_change = nil
       expect(subject).to be_invalid
     end
   end

--- a/spec/queries/subscription_matcher_spec.rb
+++ b/spec/queries/subscription_matcher_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe SubscriptionMatcher do
+  let(:content_change) do
+    create(:notification, tags: { topics: ["oil-and-gas/licensing"] })
+  end
+
+  let(:subscribable) do
+    create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] })
+  end
+
+  subject { described_class.call(content_change: content_change) }
+
+  describe ".call" do
+    context "with a subscription" do
+      before do
+        create(:subscription, subscriber_list: subscribable)
+      end
+
+      it "returns the subscriptions" do
+        expect(subject.count).to eq(1)
+      end
+    end
+
+    context "with two subscriptions" do
+      before do
+        create(:subscription, subscriber_list: subscribable)
+        create(:subscription, subscriber_list: subscribable, subscriber: create(:subscriber, address: "test2@example.com"))
+      end
+
+      it "returns the subscriptions" do
+        expect(subject.count).to eq(2)
+      end
+    end
+
+    context "with no subscriptions" do
+      before do
+        create(:subscription)
+      end
+
+      it "returns no subscriptions" do
+        expect(subject.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/queries/subscription_matcher_spec.rb
+++ b/spec/queries/subscription_matcher_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SubscriptionMatcher do
   let(:content_change) do
-    create(:notification, tags: { topics: ["oil-and-gas/licensing"] })
+    create(:content_change, tags: { topics: ["oil-and-gas/licensing"] })
   end
 
   let(:subscribable) do

--- a/spec/services/notification_handler_spec.rb
+++ b/spec/services/notification_handler_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe NotificationHandler do
 
         expect(SubscriptionContent.count).to eq(1)
         expect(SubscriptionContent.first.subscription).to eq(subscription)
+        expect(SubscriptionContent.first.email).to_not be_nil
       end
 
       context "with a low priority" do

--- a/spec/services/notification_handler_spec.rb
+++ b/spec/services/notification_handler_spec.rb
@@ -98,8 +98,7 @@ RSpec.describe NotificationHandler do
 
     context "with a subscription" do
       let(:subscriber) { create(:subscriber) }
-
-      before do
+      let!(:subscription) do
         create(:subscription, subscriber_list: subscriber_list, subscriber: subscriber)
       end
 
@@ -117,6 +116,13 @@ RSpec.describe NotificationHandler do
         expect(DeliverEmailWorker).to receive(:perform_async_with_priority).once
 
         NotificationHandler.call(params: params)
+      end
+
+      it "creates a subscription content" do
+        NotificationHandler.call(params: params)
+
+        expect(SubscriptionContent.count).to eq(1)
+        expect(SubscriptionContent.first.subscription).to eq(subscription)
       end
 
       context "with a low priority" do


### PR DESCRIPTION
This adds the model and connects it up to how the system would look, but synchronously. Splitting the `NotificationHandler` up into the appropriate workers feels like something for a different PR.

[Trello Card](https://trello.com/c/bjVnCN7D/328-create-the-subscriptioncontent-model)