### PR TITLE
Rename Notification Model to ContentChange

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -1,5 +1,5 @@
 require_relative "extensions/symbolize_json"
 
-class Notification < ApplicationRecord
+class ContentChange < ApplicationRecord
   include SymbolizeJSON
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,7 +1,5 @@
 class Email < ApplicationRecord
-  belongs_to :content_change
-
-  validates :address, :subject, :body, :content_change, presence: true
+  validates :address, :subject, :body, presence: true
 
   def self.create_from_params!(params)
     build_from_params(params).tap(&:save!)
@@ -11,7 +9,6 @@ class Email < ApplicationRecord
     renderer = EmailRenderer.new(params: params)
 
     new(
-      content_change_id: params[:content_change_id],
       address: params[:address],
       subject: renderer.subject,
       body: renderer.body

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,7 +1,7 @@
 class Email < ApplicationRecord
-  belongs_to :notification
+  belongs_to :content_change
 
-  validates :address, :subject, :body, :notification, presence: true
+  validates :address, :subject, :body, :content_change, presence: true
 
   def self.create_from_params!(params)
     build_from_params(params).tap(&:save!)
@@ -11,7 +11,7 @@ class Email < ApplicationRecord
     renderer = EmailRenderer.new(params: params)
 
     new(
-      notification_id: params[:notification_id],
+      content_change_id: params[:content_change_id],
       address: params[:address],
       subject: renderer.subject,
       body: renderer.body

--- a/db/migrate/20171113162352_rename_notifications_to_content_changes.rb
+++ b/db/migrate/20171113162352_rename_notifications_to_content_changes.rb
@@ -1,0 +1,5 @@
+class RenameNotificationsToContentChanges < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :notifications, :content_changes
+  end
+end

--- a/db/migrate/20171113163731_update_emails_reference_from_notifications_to_content_changes.rb
+++ b/db/migrate/20171113163731_update_emails_reference_from_notifications_to_content_changes.rb
@@ -1,6 +1,5 @@
 class UpdateEmailsReferenceFromNotificationsToContentChanges < ActiveRecord::Migration[5.1]
   def change
-    remove_column :emails, :notification_id
-    add_reference(:emails, :content_change, null: false, foreign_key: true)
+    remove_column :emails, :notification_id, :integer
   end
 end

--- a/db/migrate/20171113163731_update_emails_reference_from_notifications_to_content_changes.rb
+++ b/db/migrate/20171113163731_update_emails_reference_from_notifications_to_content_changes.rb
@@ -1,0 +1,6 @@
+class UpdateEmailsReferenceFromNotificationsToContentChanges < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :emails, :notification_id
+    add_reference(:emails, :content_change, null: false, foreign_key: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171110163345) do
+ActiveRecord::Schema.define(version: 20171113163731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "content_changes", force: :cascade do |t|
+    t.uuid "content_id", null: false
+    t.text "title", null: false
+    t.text "base_path", null: false
+    t.text "change_note", null: false
+    t.text "description", null: false
+    t.json "links", default: {}, null: false
+    t.json "tags", default: {}, null: false
+    t.datetime "public_updated_at", null: false
+    t.string "email_document_supertype", null: false
+    t.string "government_document_supertype", null: false
+    t.string "govuk_request_id", null: false
+    t.string "document_type", null: false
+    t.string "publishing_app", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "delivery_attempts", force: :cascade do |t|
     t.bigint "email_id", null: false
@@ -28,11 +46,11 @@ ActiveRecord::Schema.define(version: 20171110163345) do
   create_table "emails", force: :cascade do |t|
     t.string "subject", null: false
     t.text "body", null: false
-    t.bigint "notification_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
-    t.index ["notification_id"], name: "index_emails_on_notification_id"
+    t.bigint "content_change_id", null: false
+    t.index ["content_change_id"], name: "index_emails_on_content_change_id"
   end
 
   create_table "notification_logs", id: :serial, force: :cascade do |t|
@@ -50,24 +68,6 @@ ActiveRecord::Schema.define(version: 20171110163345) do
     t.string "government_document_supertype", default: ""
     t.index ["content_id", "public_updated_at"], name: "index_notification_logs_on_content_id_and_public_updated_at"
     t.index ["govuk_request_id"], name: "index_notification_logs_on_govuk_request_id"
-  end
-
-  create_table "notifications", force: :cascade do |t|
-    t.uuid "content_id", null: false
-    t.text "title", null: false
-    t.text "base_path", null: false
-    t.text "change_note", null: false
-    t.text "description", null: false
-    t.json "links", default: {}, null: false
-    t.json "tags", default: {}, null: false
-    t.datetime "public_updated_at", null: false
-    t.string "email_document_supertype", null: false
-    t.string "government_document_supertype", null: false
-    t.string "govuk_request_id", null: false
-    t.string "document_type", null: false
-    t.string "publishing_app", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
@@ -101,7 +101,7 @@ ActiveRecord::Schema.define(version: 20171110163345) do
   end
 
   add_foreign_key "delivery_attempts", "emails"
-  add_foreign_key "emails", "notifications"
+  add_foreign_key "emails", "content_changes"
   add_foreign_key "subscriptions", "subscriber_lists"
   add_foreign_key "subscriptions", "subscribers", on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,8 +49,6 @@ ActiveRecord::Schema.define(version: 20171113163731) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
-    t.bigint "content_change_id", null: false
-    t.index ["content_change_id"], name: "index_emails_on_content_change_id"
   end
 
   create_table "notification_logs", id: :serial, force: :cascade do |t|
@@ -101,7 +99,6 @@ ActiveRecord::Schema.define(version: 20171113163731) do
   end
 
   add_foreign_key "delivery_attempts", "emails"
-  add_foreign_key "emails", "content_changes"
   add_foreign_key "subscriptions", "subscriber_lists"
   add_foreign_key "subscriptions", "subscribers", on_delete: :cascade
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,7 +24,7 @@ FactoryGirl.define do
     subscriber_list
   end
 
-  factory :notification do
+  factory :content_change do
     content_id { SecureRandom.uuid }
     title "title"
     base_path "government/base_path"
@@ -44,7 +44,7 @@ FactoryGirl.define do
     address "test@example.com"
     subject "subject"
     body "body"
-    notification
+    content_change
   end
 
   factory :delivery_attempt do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -44,7 +44,6 @@ FactoryGirl.define do
     address "test@example.com"
     subject "subject"
     body "body"
-    content_change
   end
 
   factory :delivery_attempt do

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe Email do
       expect(subject.errors[:body]).not_to be_empty
     end
 
-    it "requires a notification" do
+    it "requires a content change" do
       subject.valid?
-      expect(subject.errors[:notification]).not_to be_empty
+      expect(subject.errors[:content_change]).not_to be_empty
     end
   end
 
   describe "create_from_params!" do
-    let(:notification) {
-      create(:notification)
+    let(:content_change) {
+      create(:content_change)
     }
 
     let(:email) {
@@ -30,7 +30,7 @@ RSpec.describe Email do
         change_note: "Change note",
         base_path: "/government/test",
         public_updated_at: DateTime.parse("1/1/2017"),
-        notification_id: notification.id,
+        content_change_id: content_change.id,
         address: "test@example.com",
       )
     }

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -11,11 +11,6 @@ RSpec.describe Email do
       subject.valid?
       expect(subject.errors[:body]).not_to be_empty
     end
-
-    it "requires a content change" do
-      subject.valid?
-      expect(subject.errors[:content_change]).not_to be_empty
-    end
   end
 
   describe "create_from_params!" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe Notification, type: :model do
+RSpec.describe ContentChange, type: :model do
   describe "validations" do
-    subject { FactoryGirl.create(:notification) }
+    subject { FactoryGirl.create(:content_change) }
 
     it "is valid for the default factory" do
       expect(subject).to be_valid

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "Sending a notification", type: :request do
     end
 
     it "creates a Notification" do
-      expect(Notification.count).to eq(1)
+      expect(ContentChange.count).to eq(1)
     end
   end
 end

--- a/spec/services/notification_handler_spec.rb
+++ b/spec/services/notification_handler_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe NotificationHandler do
   end
 
   describe ".call" do
-    it "calls create on Notification" do
+    it "calls create on ContentChange" do
       notification_params = {
         content_id: params[:content_id],
         title: params[:title],
@@ -49,7 +49,7 @@ RSpec.describe NotificationHandler do
         publishing_app: params[:publishing_app],
       }
 
-      expect(Notification).to receive(:create!)
+      expect(ContentChange).to receive(:create!)
         .with(notification_params)
         .and_return(double(id: 1, **notification_params))
 
@@ -62,9 +62,9 @@ RSpec.describe NotificationHandler do
       let!(:subscriber) { create(:subscriber, address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk") }
 
       it "calls create on Email" do
-        notification = create(:notification)
-        allow(Notification).to receive(:create!).and_return(
-          notification
+        content_change = create(:content_change)
+        allow(ContentChange).to receive(:create!).and_return(
+          content_change
         )
 
         expect(Email).to receive(:create_from_params!).with(
@@ -72,7 +72,7 @@ RSpec.describe NotificationHandler do
           description: "This is a description",
           change_note: "This is a change note",
           base_path: "/government/things",
-          notification_id: notification.id,
+          content_change_id: content_change.id,
           address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk",
         )
 
@@ -154,8 +154,8 @@ RSpec.describe NotificationHandler do
       end
     end
 
-    it "reports Notification errors to Sentry and swallows them" do
-      allow(Notification).to receive(:create!).and_raise(
+    it "reports ContentChange errors to Sentry and swallows them" do
+      allow(ContentChange).to receive(:create!).and_raise(
         ActiveRecord::RecordInvalid
       )
       expect(Raven).to receive(:capture_exception).with(


### PR DESCRIPTION
ran migrations to update the email reference associated with
notifications and update tests to now call upon ContentChange