### PR TITLE
Make each of the healthchecks influence overall status

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,91 +1,11 @@
-require 'sidekiq/api'
-
 class HealthcheckController < ActionController::Base
   def check
-    respond_to do |format|
-      format.json {
-        render json: {
-          checks: {
-            queue_size: {
-              queues: sidekiq_queues,
-              status: queue_size_status
-            },
-            queue_age:  {
-              queues: queue_latencies,
-              status: queue_age_status
-            },
-            queue_retry_size: {
-              status: queue_retry_size_status
-            },
-            govdelivery: {
-              status: govdelivery_status
-            },
-          },
-          status: status
-        }
-      }
-    end
+    render json: healthcheck.details.merge(status: healthcheck.status)
   end
 
 private
 
-  def status
-    ActiveRecord::Base.connected? && Sidekiq.redis_info ? 'ok' : 'critical'
-  end
-
-  def govdelivery_status
-    if Services.gov_delivery.ping.status == 200
-      'ok'
-    else
-      'critical'
-    end
-  end
-
-  def queue_retry_size_status
-    sidekiq_retry_size = sidekiq_stats.retry_size
-    if sidekiq_retry_size >= ENV.fetch('SIDEKIQ_RETRY_SIZE_CRITICAL').to_i
-      'critical'
-    elsif sidekiq_retry_size >= ENV.fetch('SIDEKIQ_RETRY_SIZE_WARNING').to_i
-      'warning'
-    else
-      'ok'
-    end
-  end
-
-  def queue_size_status
-    queues = sidekiq_queues
-    if queues.values.any? { |v| v >= ENV.fetch('SIDEKIQ_QUEUE_SIZE_CRITICAL').to_i }
-      'critical'
-    elsif queues.values.any? { |v| v >= ENV.fetch('SIDEKIQ_QUEUE_SIZE_WARNING').to_i }
-      'warning'
-    else
-      'ok'
-    end
-  end
-
-  def queue_age_status
-    queue_age = queue_latencies
-    if queue_age.values.any? { |v| v >= ENV.fetch('SIDEKIQ_QUEUE_LATENCY_CRITICAL').to_i }
-      'critical'
-    elsif queue_age.values.any? { |v| v >= ENV.fetch('SIDEKIQ_QUEUE_LATENCY_WARNING').to_i }
-      'warning'
-    else
-      'ok'
-    end
-  end
-
-  def sidekiq_stats
-    Sidekiq::Stats.new
-  end
-
-  def sidekiq_queues
-    sidekiq_stats.queues
-  end
-
-  def queue_latencies
-    sidekiq_queues.keys.inject({}) do |memo, queue|
-      memo[queue] = Sidekiq::Queue.new(queue).latency
-      memo
-    end
+  def healthcheck
+    @healthcheck ||= Healthcheck.new
   end
 end

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -1,0 +1,38 @@
+class Healthcheck
+  def status
+    if statuses.include?(:critical)
+      :critical
+    elsif statuses.include?(:warning)
+      :warning
+    else
+      :ok
+    end
+  end
+
+  def details
+    { checks: checks }
+  end
+
+private
+
+  def checks
+    all.each.with_object({}) do |check, hash|
+      hash[check.name] = check.details.merge(status: check.status)
+    end
+  end
+
+  def statuses
+    @statuses ||= all.map(&:status)
+  end
+
+  def all
+    @all ||= [
+      DatabaseHealthcheck.new,
+      GovdeliveryHealthcheck.new,
+      QueueLatencyHealthcheck.new,
+      QueueSizeHealthcheck.new,
+      RedisHealthcheck.new,
+      RetrySizeHealthcheck.new,
+    ]
+  end
+end

--- a/app/models/healthcheck/database_healthcheck.rb
+++ b/app/models/healthcheck/database_healthcheck.rb
@@ -1,0 +1,15 @@
+class Healthcheck
+  class DatabaseHealthcheck
+    def name
+      :database
+    end
+
+    def status
+      ActiveRecord::Base.connected? ? :ok : :critical
+    end
+
+    def details
+      {}
+    end
+  end
+end

--- a/app/models/healthcheck/govdelivery_healthcheck.rb
+++ b/app/models/healthcheck/govdelivery_healthcheck.rb
@@ -1,0 +1,21 @@
+class Healthcheck
+  class GovdeliveryHealthcheck
+    def name
+      :govdelivery
+    end
+
+    def status
+      ping_status == 200 ? :ok : :critical
+    end
+
+    def details
+      { ping_status: ping_status }
+    end
+
+  private
+
+    def ping_status
+      @ping_status ||= Services.gov_delivery.ping.status
+    end
+  end
+end

--- a/app/models/healthcheck/queue_latency_healthcheck.rb
+++ b/app/models/healthcheck/queue_latency_healthcheck.rb
@@ -1,0 +1,49 @@
+class Healthcheck
+  class QueueLatencyHealthcheck
+    def name
+      :queue_latency
+    end
+
+    def status
+      if queue_latencies.any? { |s| s >= critical_size }
+        :critical
+      elsif queue_latencies.any? { |s| s >= warning_size }
+        :warning
+      else
+        :ok
+      end
+    end
+
+    def details
+      { queues: queues }
+    end
+
+  private
+
+    def queue_latencies
+      queues.values
+    end
+
+    def queues
+      @queues ||= queue_names.each.with_object({}) do |name, hash|
+        hash[name] = latency_for(name)
+      end
+    end
+
+    def latency_for(name)
+      Sidekiq::Queue.new(name).latency
+    end
+
+    def queue_names
+      @queues ||= Sidekiq::Stats.new.queues.keys
+    end
+
+    def critical_size
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_CRITICAL", 10).to_i
+    end
+
+    def warning_size
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_WARNING", 5).to_i
+    end
+  end
+end

--- a/app/models/healthcheck/queue_size_healthcheck.rb
+++ b/app/models/healthcheck/queue_size_healthcheck.rb
@@ -1,0 +1,39 @@
+class Healthcheck
+  class QueueSizeHealthcheck
+    def name
+      :queue_size
+    end
+
+    def status
+      if queue_sizes.any? { |s| s >= critical_size }
+        :critical
+      elsif queue_sizes.any? { |s| s >= warning_size }
+        :warning
+      else
+        :ok
+      end
+    end
+
+    def details
+      { queues: queues }
+    end
+
+  private
+
+    def queue_sizes
+      queues.values
+    end
+
+    def queues
+      @queues ||= Sidekiq::Stats.new.queues
+    end
+
+    def critical_size
+      ENV.fetch("SIDEKIQ_QUEUE_SIZE_CRITICAL", 5).to_i
+    end
+
+    def warning_size
+      ENV.fetch("SIDEKIQ_QUEUE_SIZE_WARNING", 2).to_i
+    end
+  end
+end

--- a/app/models/healthcheck/redis_healthcheck.rb
+++ b/app/models/healthcheck/redis_healthcheck.rb
@@ -1,0 +1,15 @@
+class Healthcheck
+  class RedisHealthcheck
+    def name
+      :redis
+    end
+
+    def status
+      Sidekiq.redis_info ? :ok : :critical
+    end
+
+    def details
+      {}
+    end
+  end
+end

--- a/app/models/healthcheck/retry_size_healthcheck.rb
+++ b/app/models/healthcheck/retry_size_healthcheck.rb
@@ -1,0 +1,35 @@
+class Healthcheck
+  class RetrySizeHealthcheck
+    def name
+      :retry_size
+    end
+
+    def status
+      if retry_size >= critical_size
+        :critical
+      elsif retry_size >= warning_size
+        :warning
+      else
+        :ok
+      end
+    end
+
+    def details
+      { retry_size: retry_size }
+    end
+
+  private
+
+    def retry_size
+      @retry_size ||= Sidekiq::Stats.new.retry_size
+    end
+
+    def critical_size
+      ENV.fetch("SIDEKIQ_RETRY_SIZE_CRITICAL", 10).to_i
+    end
+
+    def warning_size
+      ENV.fetch("SIDEKIQ_RETRY_SIZE_WARNING", 5).to_i
+    end
+  end
+end

--- a/spec/models/healthcheck/database_healthcheck_spec.rb
+++ b/spec/models/healthcheck/database_healthcheck_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck::DatabaseHealthcheck do
+  let(:db) { ActiveRecord::Base }
+
+  context "when the database is connected" do
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when the database is not connected" do
+    before { allow(db).to receive(:connected?).and_return(false) }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+end

--- a/spec/models/healthcheck/govdelivery_healthcheck_spec.rb
+++ b/spec/models/healthcheck/govdelivery_healthcheck_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck::GovdeliveryHealthcheck do
+  let(:url) { "http://govdelivery-api.example.com/api/account/UKGOVUK/categories.xml" }
+  let(:headers) { { "Authorization" => "Basic #{HTTP_AUTH_CREDENTIALS}" } }
+  let(:status) { 200 }
+
+  before do
+    stub_request(:get, url).with(headers: headers).to_return(status: status)
+  end
+
+  context "when a ping succeeds" do
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when a ping fails" do
+    let(:status) { 410 }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+
+  it "returns the ping status in details" do
+    expect(subject.details).to eq(ping_status: status)
+  end
+end

--- a/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck::QueueLatencyHealthcheck do
+  before { allow(subject).to receive(:queue_latencies).and_return [latency] }
+
+  context "when it is quick to respond" do
+    let(:latency) { 2 }
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when the warning threshold is reached" do
+    let(:latency) { 5 }
+    specify { expect(subject.status).to eq(:warning) }
+  end
+
+  context "when the critical threshold is reached" do
+    let(:latency) { 10 }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+end

--- a/spec/models/healthcheck/queue_size_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_size_healthcheck_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck::QueueSizeHealthcheck do
+  before { allow(subject).to receive(:queue_sizes).and_return [size] }
+
+  context "when there aren't many jobs" do
+    let(:size) { 1 }
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when the warning threshold is reached" do
+    let(:size) { 2 }
+    specify { expect(subject.status).to eq(:warning) }
+  end
+
+  context "when the critical threshold is reached" do
+    let(:size) { 5 }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+
+  describe "#details" do
+    let(:size) { 3 }
+    let(:queues) { { default: size } }
+
+    it "returns a hash of the queues and their sizes" do
+      allow(subject).to receive(:queues).and_return(queues)
+      expect(subject.details).to eq(queues: queues)
+    end
+  end
+end

--- a/spec/models/healthcheck/redis_healthcheck_spec.rb
+++ b/spec/models/healthcheck/redis_healthcheck_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck::RedisHealthcheck do
+  context "when redis is available" do
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when redis is not available" do
+    before { allow(Sidekiq).to receive(:redis_info).and_return(false) }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+end

--- a/spec/models/healthcheck/retry_size_healthcheck_spec.rb
+++ b/spec/models/healthcheck/retry_size_healthcheck_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck::RetrySizeHealthcheck do
+  before { allow(subject).to receive(:retry_size).and_return(size) }
+
+  context "when there aren't many retries" do
+    let(:size) { 2 }
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when the warning threshold is reached" do
+    let(:size) { 5 }
+    specify { expect(subject.status).to eq(:warning) }
+  end
+
+  context "when the critical threshold is reached" do
+    let(:size) { 10 }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+
+  describe "#details" do
+    let(:size) { 3 }
+
+    it "returns the number of retries" do
+      expect(subject.details).to eq(retry_size: 3)
+    end
+  end
+end

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck do
+  let(:critical) do
+    double(:healthcheck, name: :foo, status: :critical, details: {})
+  end
+
+  let(:warning) do
+    double(:healthcheck, name: :bar, status: :warning, details: { errors: 7 })
+  end
+
+  let(:ok) do
+    double(:healthcheck, name: :baz, status: :ok, details: { https: true })
+  end
+
+  before { allow(subject).to receive(:all).and_return(healthchecks) }
+
+  context "when one of the checks is critical" do
+    let(:healthchecks) { [warning, critical, ok] }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+
+  context "when no checks are critical but one is warning" do
+    let(:healthchecks) { [ok, ok, warning] }
+    specify { expect(subject.status).to eq(:warning) }
+  end
+
+  context "when all the checks are ok" do
+    let(:healthchecks) { [ok, ok, ok] }
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  describe "#details" do
+    let(:healthchecks) { [critical, warning, ok] }
+
+    it "returns a hash containing statuses and details for the checks" do
+      expect(subject.details).to eq(
+        checks: {
+          foo: { status: :critical },
+          bar: { status: :warning, errors: 7 },
+          baz: { status: :ok, https: true },
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/sehNMIbL/339-make-healthcheck-test-for-technicalfailure

Previously, the only healthchecks that influenced
the overall status of the `/healtcheck` endpoint
were the database and redis connections.

This change makes it so that the status is set to
the most severe status of the individual checks.
It also substantially refactors the controller and
extracts lots of `Healthcheck` models for each of 
the checks.

Each of these models has a uniform interface
responding to `#name`, `#status` and `#details` and
the top-level Healthcheck also has the interface
and combines everything into one.

---

Responds with this JSON on integration:
```json
{
  "status": "ok",
  "checks": {
    "database": {
      "status": "ok"
    },
    "govdelivery": {
      "status": "ok",
      "ping_status": 200
    },
    "queue_latency": {
      "status": "ok",
      "queues": {
        "default": 0
      }
    },
    "queue_size": {
      "status": "ok",
      "queues": {
        "default": 0
      }
    },
    "redis": {
      "status": "ok"
    },
    "retry_size": {
      "status": "ok",
      "retry_size": 0
    }
  }
}
```