### PR TITLE
Disable new healthchecks until we're further along with Notify

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -33,8 +33,8 @@ private
       QueueSizeHealthcheck.new,
       RedisHealthcheck.new,
       RetrySizeHealthcheck.new,
-      StatusUpdateHealthcheck.new,
-      TechnicalFailureHealthcheck.new,
+#      StatusUpdateHealthcheck.new,
+#      TechnicalFailureHealthcheck.new,
     ]
   end
 end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe HealthcheckController, type: :controller do
       queue_size:        { status: "ok", queues: {} },
       redis:             { status: "ok" },
       retry_size:        { status: "ok", retry_size: 0 },
-      status_update:     hash_including(status: "ok", older_than_75_hours: 0),
-      technical_failure: hash_including(status: "ok", last_3_hours: 0),
+#      status_update:     hash_including(status: "ok", older_than_75_hours: 0),
+#      technical_failure: hash_including(status: "ok", last_3_hours: 0),
     )
   end
 end


### PR DESCRIPTION
This will alert until we're integrated and receiving
callbacks from Notify.

We should re-enable in this ticket:
https://trello.com/c/31XA1mkY/248-integrate-email-alert-api-with-notifys-callback