### PR TITLE
Store statistics on Notify send_email requests

### DIFF
--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -11,8 +11,10 @@ class EmailSenderService
           body: body,
         },
       )
+      EmailAlertAPI.statsd.increment("notify.email_send_request.success")
       response.id
     rescue Notifications::Client::RequestError
+      EmailAlertAPI.statsd.increment("notify.email_send_request.failure")
       raise EmailSenderService::ClientError
     end
 


### PR DESCRIPTION
This increments a number for both successful requests to Notify and
failed ones. This can then be used to calculate the number of requests
to notify per second.

If needed in future we could store metrics around different types of
error responses.