### PR TITLE
Add Email Generation Worker

### DIFF
--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -27,14 +27,9 @@ private
         subscription: subscription,
       )
 
-      email = Email.create_from_params!(
-        email_params.merge(address: subscription.subscriber.address)
-      )
-
-      subscription_content.update!(email: email)
-
-      DeliverEmailWorker.perform_async_with_priority(
-        email.id, priority: priority
+      EmailGenerationWorker.perform_async(
+        subscription_content_id: subscription_content.id,
+        priority: priority
       )
     end
   end

--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -76,13 +76,7 @@ private
   end
 
   def email_params
-    {
-      title: params[:title],
-      change_note: params[:change_note],
-      description: params[:description],
-      base_path: params[:base_path],
-      public_updated_at: DateTime.parse(params[:public_updated_at]),
-    }
+    content_change_params.slice(:title, :change_note, :description, :base_path, :public_updated_at)
   end
 
   def priority

--- a/app/workers/email_generation_worker.rb
+++ b/app/workers/email_generation_worker.rb
@@ -1,0 +1,31 @@
+class EmailGenerationWorker
+  include Sidekiq::Worker
+  include Sidekiq::Symbols
+
+  def perform(subscription_content_id:, priority:)
+    subscription_content = SubscriptionContent.find(subscription_content_id)
+
+    email = Email.create_from_params!(email_params(subscription_content))
+
+    subscription_content.update!(email: email)
+
+    DeliverEmailWorker.perform_async_with_priority(
+      email.id, priority: priority.to_sym
+    )
+  end
+
+private
+
+  def email_params(subscription_content)
+    content_change = subscription_content.content_change
+
+    {
+      title: content_change.title,
+      change_note: content_change.change_note,
+      description: content_change.description,
+      base_path: content_change.base_path,
+      public_updated_at: content_change.public_updated_at,
+      address: subscription_content.subscription.subscriber.address,
+    }
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
   end
 
   factory :subscriber do
-    address "test@example.com"
+    sequence(:address) { |i| "test-#{i}@example.com" }
   end
 
   factory :subscription do

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,6 +1,10 @@
 require 'sidekiq/testing'
 
 RSpec.configure do |config|
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
+
   config.before(:example) do
     Sidekiq::Testing.inline!
   end

--- a/spec/workers/deliver_email_worker_spec.rb
+++ b/spec/workers/deliver_email_worker_spec.rb
@@ -45,10 +45,11 @@ RSpec.describe DeliverEmailWorker do
     let(:priority) { nil }
 
     before do
-      Sidekiq::Testing.fake!
-      described_class.perform_async_with_priority(
-        email.id, priority: priority
-      )
+      Sidekiq::Testing.fake! do
+        described_class.perform_async_with_priority(
+          email.id, priority: priority
+        )
+      end
     end
 
     context "with a low priority" do

--- a/spec/workers/email_generation_worker_spec.rb
+++ b/spec/workers/email_generation_worker_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe EmailGenerationWorker do
+  let(:priority) { :low }
+
+  describe ".perform" do
+    context "with a subscription content" do
+      let(:content_change) { create(:content_change, public_updated_at: DateTime.parse("2017/01/01 09:00")) }
+      let(:subscription_content) { create(:subscription_content, content_change: content_change) }
+
+      before do
+        Sidekiq::Testing.fake! do
+          DeliverEmailWorker.jobs.clear
+          described_class.new.perform(subscription_content_id: subscription_content.id, priority: priority)
+        end
+      end
+
+      it "should create an email" do
+        expect(Email.count).to eq(1)
+
+        email = Email.first
+        expect(email.address).to eq(subscription_content.subscription.subscriber.address)
+        expect(email.subject).to eq("GOV.UK Update - title")
+        expect(email.body).to eq("change note: description.\n\nhttp://www.dev.gov.ukgovernment/base_path\nUpdated on 09:00 am, 1 January 2017\n\nUnsubscribe from title - http://www.dev.gov.uk/email/token/unsubscribe\n")
+      end
+
+      it "should associate the subscription content with the email" do
+        expect(subscription_content.reload.email).to_not be_nil
+      end
+
+      it "should queue a delivery email job" do
+        expect(DeliverEmailWorker.jobs.size).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces a new Email Generation Worker responsible for taking Subscription Content instances and turning them into emails for the Delivery Worker to send them.

[Trello Card](https://trello.com/c/dZd19B5G/347-add-the-emailgenerationworker)