### PR TITLE
Don’t alert on GD-12004 error

### DIFF
--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -55,14 +55,9 @@ private
     )
     Rails.logger.info "Email '#{params[:subject]}' sent"
   rescue GovDelivery::Client::UnknownError => e
-    # We want to to be notified when trying to send to a topic without
-    # any subscribers (GD-12004), however we want to swallow the error
-    # as otherwise the sidekiq job continue to retry, with the same error.
-    if e.message.match?(/GD-12004/)
-      GovukError.notify(e.message)
-    else
-      raise
-    end
+    # We don't want to to be notified or retry the job when trying to send to a
+    # topic without any subscribers (GD-12004).
+    raise unless e.message.match?(/GD-12004/)
   end
 
   def log_notification(notification_params, gov_delivery_ids:, links_hash:, tags_hash:)

--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -248,11 +248,6 @@ RSpec.describe NotificationWorker do
       it "does not raise an error" do
         expect { make_it_perform }.not_to raise_error
       end
-
-      it "sends a GovukError notification" do
-        expect(GovukError).to receive(:notify)
-        make_it_perform
-      end
     end
 
     context "given GovDelivery raises an error other than GD-12004" do


### PR DESCRIPTION
This commit disables alerting to Sentry for GD-12004 errors. This error is returned by GovDelivery if there are no subscribers for a particular email. Since there’s nothing we can do about this and it’s not an issue, we can ignore these errors.

Trello: https://trello.com/c/sJLbBYGa/362-dont-alert-sentry-for-gd-12004-errors-in-email-alert-api