### PR TITLE
Add sidekiqued subscription content worker

### DIFF
--- a/app/services/notification_handler.rb
+++ b/app/services/notification_handler.rb
@@ -11,46 +11,13 @@ class NotificationHandler
   def call
     begin
       content_change = ContentChange.create!(content_change_params)
-      deliver_to_subscribers(content_change)
-      deliver_to_courtesy_subscribers
+      SubscriptionContentWorker.perform_async(content_change_id: content_change.id, priority: priority)
     rescue StandardError => ex
       Raven.capture_exception(ex, tags: { version: 2 })
     end
   end
 
 private
-
-  def deliver_to_subscribers(content_change)
-    subscriptions_for(content_change: content_change).find_each do |subscription|
-      subscription_content = SubscriptionContent.create!(
-        content_change: content_change,
-        subscription: subscription,
-      )
-
-      EmailGenerationWorker.perform_async(
-        subscription_content_id: subscription_content.id,
-        priority: priority
-      )
-    end
-  end
-
-  def deliver_to_courtesy_subscribers
-    addresses = [
-      "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk",
-    ]
-
-    Subscriber.where(address: addresses).find_each do |subscriber|
-      email = Email.create_from_params!(email_params.merge(address: subscriber.address))
-
-      DeliverEmailWorker.perform_async_with_priority(
-        email.id, priority: priority
-      )
-    end
-  end
-
-  def subscriptions_for(content_change:)
-    SubscriptionMatcher.call(content_change: content_change)
-  end
 
   def content_change_params
     {
@@ -68,10 +35,6 @@ private
       document_type: params[:document_type],
       publishing_app: params[:publishing_app],
     }
-  end
-
-  def email_params
-    content_change_params.slice(:title, :change_note, :description, :base_path, :public_updated_at)
   end
 
   def priority

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -1,0 +1,9 @@
+class SubscriptionContentWorker
+  include Sidekiq::Worker
+
+  def perform(content_change_id:)
+  end
+
+private
+
+end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -1,5 +1,6 @@
 class SubscriptionContentWorker
   include Sidekiq::Worker
+  include Sidekiq::Symbols
 
   def perform(content_change_id:, priority:)
     @priority = priority

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -21,14 +21,9 @@ private
           subscription: subscription,
         )
 
-        email = Email.create_from_params!(
-          email_params(content_change, subscription.subscriber)
-        )
-
-        subscription_content.update!(email: email)
-
-        DeliverEmailWorker.perform_async_with_priority(
-          email.id, priority: priority
+        EmailGenerationWorker.perform_async(
+          subscription_content_id: subscription_content.id,
+          priority: priority
         )
       rescue StandardError => ex
         Raven.capture_exception(ex, tags: { version: 2 })

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -2,8 +2,75 @@ class SubscriptionContentWorker
   include Sidekiq::Worker
 
   def perform(content_change_id:)
+    content_change = ContentChange.find(content_change_id)
+    queue_delivery_to_subscribers(content_change)
+    queue_delivery_to_courtesy_subscribers(content_change)
   end
 
 private
 
+  attr_reader :priority
+
+  def queue_delivery_to_subscribers(content_change)
+    subscriptions_for(content_change: content_change).find_each do |subscription|
+      begin
+        subscription_content = SubscriptionContent.create!(
+          content_change: content_change,
+          subscription: subscription,
+        )
+
+        email = Email.create_from_params!(
+          email_params(content_change, subscription.subscriber)
+        )
+
+        subscription_content.update!(email: email)
+
+        DeliverEmailWorker.perform_async_with_priority(
+          email.id, priority: priority
+        )
+      rescue StandardError => ex
+        Raven.capture_exception(ex, tags: { version: 2 })
+      end
+    end
+  end
+
+  def queue_delivery_to_courtesy_subscribers(content_change)
+    addresses = [
+      "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk",
+    ]
+
+    Subscriber.where(address: addresses).find_each do |subscriber|
+      begin
+        email = Email.create_from_params!(
+          email_params(content_change, subscriber)
+        )
+
+        DeliverEmailWorker.perform_async_with_priority(
+          email.id, priority: priority
+        )
+      rescue StandardError => ex
+        Raven.capture_exception(ex, tags: { version: 2 })
+      end
+    end
+  end
+
+  def subscriptions_for(content_change:)
+    SubscriptionMatcher.call(content_change: content_change)
+  end
+
+  def email_params(content_change, subscriber)
+    {
+      content_change_id: content_change.id,
+      address: subscriber.address,
+      title: content_change.title,
+      change_note: content_change.change_note,
+      description: content_change.description,
+      base_path: content_change.base_path,
+      public_updated_at: content_change.public_updated_at,
+    }
+  end
+
+  def priority
+    params.fetch(:priority, "low").to_sym
+  end
 end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -1,7 +1,8 @@
 class SubscriptionContentWorker
   include Sidekiq::Worker
 
-  def perform(content_change_id:)
+  def perform(content_change_id:, priority:)
+    @priority = priority
     content_change = ContentChange.find(content_change_id)
     queue_delivery_to_subscribers(content_change)
     queue_delivery_to_courtesy_subscribers(content_change)
@@ -68,9 +69,5 @@ private
       base_path: content_change.base_path,
       public_updated_at: content_change.public_updated_at,
     }
-  end
-
-  def priority
-    params.fetch(:priority, "low").to_sym
   end
 end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -14,15 +14,13 @@ RSpec.describe SubscriptionContentWorker do
     let!(:subscription) { FactoryGirl.create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
 
     context "asynchronously" do
-      it "should create an email" do
-        Sidekiq::Testing.fake! do
-          SubscriptionContentWorker.perform_async(content_change_id: content_change.id, priority: :low)
-
-          expect(EmailGenerationWorker)
-            .to receive(:perform_async)
-
-          described_class.drain
-        end
+      it "does not raise an error" do
+        expect {
+          Sidekiq::Testing.fake! do
+            SubscriptionContentWorker.perform_async(content_change_id: content_change.id, priority: :low)
+            described_class.drain
+          end
+        }.not_to raise_error
       end
     end
 

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe SubscriptionContentWorker do
+  let(:content_change) { FactoryGirl.create(:content_change, tags: { topics: ["oil-and-gas/licensing"] }) }
+  let(:email) { FactoryGirl.create(:email) }
+
+  before do
+    allow(ContentChange).to receive(:find).with(content_change.id).and_return(content_change)
+  end
+
+  context "with a subscription" do
+    let(:subscriber) { FactoryGirl.create(:subscriber) }
+    let(:subscriber_list) { FactoryGirl.create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] }) }
+    let!(:subscription) { FactoryGirl.create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
+
+    context "when we error" do
+      def swallow_errors
+        expect(Raven)
+          .to receive(:capture_exception)
+          .with(
+            instance_of(ActiveRecord::RecordInvalid),
+            tags: { version: 2 }
+          )
+
+        expect {
+          subject.perform(content_change_id: content_change.id, priority: :low)
+        }.not_to raise_error
+      end
+
+      it "reports errors when creating a SubscriptionContent in the database to Sentry and swallows them" do
+        allow(SubscriptionContent)
+          .to receive(:create!)
+          .and_raise(ActiveRecord::RecordInvalid)
+
+        swallow_errors
+      end
+
+      it "reports errors when creating an Email in the database to Sentry and swallows them" do
+        allow(Email)
+          .to receive(:create_from_params!)
+          .and_raise(ActiveRecord::RecordInvalid)
+
+        swallow_errors
+      end
+    end
+
+    it "creates subscription content for the content change" do
+      expect(SubscriptionContent)
+        .to receive(:create!)
+        .with(content_change: content_change, subscription: subscription)
+
+      subject.perform(content_change_id: content_change.id, priority: :low)
+    end
+
+    it "creates an email with a title of the content change" do
+      expect(Email)
+        .to receive(:create_from_params!)
+        .with(hash_including(title: content_change.title))
+        .and_return(email)
+
+      subject.perform(content_change_id: content_change.id, priority: :low)
+    end
+
+    it "creates an email to send to the subscriber in the list" do
+      expect(Email)
+        .to receive(:create_from_params!)
+        .with(hash_including(address: subscriber.address))
+        .and_return(email)
+
+      subject.perform(content_change_id: content_change.id, priority: :low)
+    end
+
+    it "enqueues the email to send to the subscriber" do
+      expect(DeliverEmailWorker).to receive(:perform_async_with_priority).with(
+        kind_of(Integer), priority: :low,
+      )
+
+      subject.perform(content_change_id: content_change.id, priority: :low)
+    end
+
+    it "does not enqueue an email to subscribers without a subscription to this content" do
+      FactoryGirl.create(:subscriber, address: "should_not_receive_email@example.com")
+
+      expect(DeliverEmailWorker).to receive(:perform_async_with_priority).once
+
+      subject.perform(content_change_id: content_change.id, priority: :low)
+    end
+
+    it "enqueues an email with the injected priority" do
+      expect(DeliverEmailWorker)
+        .to receive(:perform_async_with_priority)
+        .with(kind_of(Integer), priority: :high)
+
+      subject.perform(content_change_id: content_change.id, priority: :high)
+    end
+  end
+
+  context "with a courtesy subscription" do
+    let!(:subscriber) { FactoryGirl.create(:subscriber, address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk") }
+
+    it "creates an email for the courtesy email group" do
+      expect(Email)
+        .to receive(:create_from_params!)
+        .with(hash_including(address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk"))
+        .and_return(email)
+
+      subject.perform(content_change_id: content_change.id, priority: :low)
+    end
+
+    it "enqueues the email to send to the courtesy subscription group" do
+      expect(DeliverEmailWorker)
+        .to receive(:perform_async_with_priority)
+        .with(kind_of(Integer), priority: :low)
+
+      subject.perform(content_change_id: content_change.id, priority: :low)
+    end
+  end
+end


### PR DESCRIPTION
Create a SubscriptionContentWorker - a Sidekiq worker that takes a content change id and a priority and then matches subscribers to the content change and queues emails for delivery to said subscribers.

Remove the code from NotificationHandler that was doing this previously and instead call the new Sidekiq worker.

[Trello](https://trello.com/c/nKLn1k1E/350-add-the-subscriptioncontentworker)
