### PR TITLE
Rename DeliverEmailWorker

### DIFF
--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -1,0 +1,27 @@
+class DeliveryRequestWorker
+  include Sidekiq::Worker
+
+  def self.queue_for_priority(priority)
+    if priority == :high
+      :high_priority
+    elsif priority == :low
+      :default
+    else
+      raise ArgumentError, "priority should be :high or :low"
+    end
+  end
+
+  sidekiq_options retry: 3, queue: queue_for_priority(:low)
+
+  def perform(email_id)
+    Services.rate_limiter.run do
+      email = Email.find(email_id)
+      DeliverEmail.call(email: email)
+    end
+  end
+
+  def self.perform_async_with_priority(*args, priority:)
+    set(queue: queue_for_priority(priority))
+      .perform_async(*args)
+  end
+end

--- a/app/workers/email_generation_worker.rb
+++ b/app/workers/email_generation_worker.rb
@@ -9,7 +9,7 @@ class EmailGenerationWorker
 
     subscription_content.update!(email: email)
 
-    DeliverEmailWorker.perform_async_with_priority(
+    DeliveryRequestWorker.perform_async_with_priority(
       email.id, priority: priority.to_sym
     )
   end

--- a/spec/workers/delivery_request_worker_spec.rb
+++ b/spec/workers/delivery_request_worker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DeliverEmailWorker do
+RSpec.describe DeliveryRequestWorker do
   class FakeLimiter
     def run
       yield
@@ -46,11 +46,10 @@ RSpec.describe DeliverEmailWorker do
     let(:priority) { nil }
 
     before do
-      Sidekiq::Testing.fake! do
-        described_class.perform_async_with_priority(
-          email.id, priority: priority
-        )
-      end
+      Sidekiq::Testing.fake!
+      described_class.perform_async_with_priority(
+        email.id, priority: priority
+      )
     end
 
     context "with a low priority" do

--- a/spec/workers/email_generation_worker_spec.rb
+++ b/spec/workers/email_generation_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EmailGenerationWorker do
 
       before do
         Sidekiq::Testing.fake! do
-          DeliverEmailWorker.jobs.clear
+          DeliveryRequestWorker.jobs.clear
           described_class.new.perform(subscription_content_id: subscription_content.id, priority: priority)
         end
       end
@@ -29,7 +29,7 @@ RSpec.describe EmailGenerationWorker do
       end
 
       it "should queue a delivery email job" do
-        expect(DeliverEmailWorker.jobs.size).to eq(1)
+        expect(DeliveryRequestWorker.jobs.size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
The `DeliverEmailWorker` now does a bit more than delivery email so we're renaming it.

This PR creates a new `DeliveryRequestWorker` which is identical to the current `DeliverEmailWorker` at the moment and switches `NotificationHandler` to use the new one.

The old `DeliverEmailWorker` will be removed after this has been deployed.

Part of [Trello](https://trello.com/c/BxtZNx5v/352-add-the-deliveryrequestworker)