### PR TITLE
Update DeliverEmailWorker reference

### DIFF
--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -42,7 +42,7 @@ private
           email_params(content_change, subscriber)
         )
 
-        DeliverEmailWorker.perform_async_with_priority(
+        DeliveryRequestWorker.perform_async_with_priority(
           email.id, priority: priority
         )
       rescue StandardError => ex

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SubscriptionContentWorker do
     end
 
     it "enqueues the email to send to the courtesy subscription group" do
-      expect(DeliverEmailWorker)
+      expect(DeliveryRequestWorker)
         .to receive(:perform_async_with_priority)
         .with(kind_of(Integer), priority: :low)
 


### PR DESCRIPTION
DeliverEmailWorker has been deprecated and will be removed. This PR updates a couple of references to it.

[Trello](https://trello.com/c/BxtZNx5v/352-add-the-deliveryrequestworker)