### PR TITLE
Add `ready_to_send` status

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -3,7 +3,14 @@ class DeliveryAttempt < ApplicationRecord
 
   validates :email, :status, :provider, presence: true
 
-  enum status: %i(sending delivered permanent_failure temporary_failure technical_failure)
+  enum status: %i(
+    ready_to_send
+    sending
+    delivered
+    permanent_failure
+    temporary_failure
+    technical_failure
+  )
   enum provider: %i(pseudo notify)
 
   def self.latest_per_email

--- a/db/migrate/20171122130918_add_default_value_for_delivery_attempts_status.rb
+++ b/db/migrate/20171122130918_add_default_value_for_delivery_attempts_status.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueForDeliveryAttemptsStatus < ActiveRecord::Migration[5.1]
+  def change
+    change_column :delivery_attempts, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115162823) do
+ActiveRecord::Schema.define(version: 20171122130918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 20171115162823) do
 
   create_table "delivery_attempts", force: :cascade do |t|
     t.bigint "email_id", null: false
-    t.integer "status", null: false
+    t.integer "status", default: 0, null: false
     t.integer "provider", null: false
     t.string "reference", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Adds another value to the `status` enum of `DeliveryAttempt` and makes this the default value. This value should be used when the `DeliveryAttempt` is first created as per [the flow diagram](https://github.com/alphagov/email-alert-api/blob/master/doc/sequence_diagram.png).

This will change the integer value associated with all of the previously created `DeliveryAttempt` records. These will be deleted once this change is deployed.

We could do this without having to delete everything by just adding the new status value to the end of the enum but `ready_to_send` should be the default which should really be the 0 value. So... while we still have the opportunity to just delete everything I've opted to do that now. We'll probably need to delete all of the existing `DeliveryAttempt` records as some point anyway as they are all in `sending` state and that won't get updated.