### PR TITLE
Set processed at

### DIFF
--- a/app/commands/deliver_email.rb
+++ b/app/commands/deliver_email.rb
@@ -17,6 +17,8 @@ class DeliverEmail
       body: email.body,
     )
 
+    email.mark_processed!
+
     record_delivery_attempt(
       email: email,
       status: :sending,

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -14,4 +14,8 @@ class Email < ApplicationRecord
       body: renderer.body
     )
   end
+
+  def mark_processed!
+    update_attribute(:processed_at, Time.now)
+  end
 end

--- a/db/migrate/20171122135347_add_processed_at_to_emails.rb
+++ b/db/migrate/20171122135347_add_processed_at_to_emails.rb
@@ -1,0 +1,5 @@
+class AddProcessedAtToEmails < ActiveRecord::Migration[5.1]
+  def change
+    add_column :emails, :processed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115162823) do
+ActiveRecord::Schema.define(version: 20171122135347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20171115162823) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
+    t.datetime "processed_at"
   end
 
   create_table "notification_logs", id: :serial, force: :cascade do |t|

--- a/spec/commands/deliver_email_spec.rb
+++ b/spec/commands/deliver_email_spec.rb
@@ -42,5 +42,13 @@ RSpec.describe DeliverEmail do
         "email cannot be nil"
       )
     end
+
+    it "marks the email processed" do
+      allow(email_sender).to receive(:call)
+        .and_return(double(id: 0))
+
+      expect(email).to receive(:mark_processed!)
+      DeliverEmail.call(email: email)
+    end
   end
 end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Email do
+  let(:content_change) { create(:content_change) }
+  let(:email) do
+    Email.create_from_params!(
+      title: "Title",
+      description: "Description",
+      change_note: "Change note",
+      base_path: "/government/test",
+      public_updated_at: DateTime.parse("1/1/2017"),
+      content_change_id: content_change.id,
+      address: "test@example.com",
+    )
+  end
+
   describe "validations" do
     it "requires subject" do
       subject.valid?
@@ -14,20 +27,6 @@ RSpec.describe Email do
   end
 
   describe "create_from_params!" do
-    let(:content_change) { create(:content_change) }
-
-    let(:email) do
-      Email.create_from_params!(
-        title: "Title",
-        description: "Description",
-        change_note: "Change note",
-        base_path: "/government/test",
-        public_updated_at: DateTime.parse("1/1/2017"),
-        content_change_id: content_change.id,
-        address: "test@example.com",
-      )
-    end
-
     let(:email_renderer) { double }
 
     before do
@@ -42,6 +41,16 @@ RSpec.describe Email do
 
     it "sets body" do
       expect(email.body).to eq("a body")
+    end
+  end
+
+  describe "mark_processed!" do
+    it "sets processed_at" do
+      Timecop.freeze do
+        now = Time.now
+        email.mark_processed!
+        expect(email.processed_at).to eq(now)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a call to `Email#mark_processed!` in the `DeliverEmail` command which updates the `Email` record adding a timestamp.

We did consider doing this within a transaction but having thought about it a partially complete set of data and an exception reported would be more useful than just the exception so I've omitted the transaction for now.

We also discussed changing the order or events within the `DeliverEmail` command and adding a `ready_to_send` state to `DeliveryRequest` but after some discussion within the team we decided that that state is implied by the presence of an `Email` object without a corresponding `DeliveryAttempt` so the extra bit of complexity is probably unnecessary.

[Trello](https://trello.com/c/BxtZNx5v/352-add-the-deliveryrequestworker)