### PR TITLE
Make sure priority is passed as a symbol

### DIFF
--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -23,7 +23,7 @@ private
 
         EmailGenerationWorker.perform_async(
           subscription_content_id: subscription_content.id,
-          priority: priority
+          priority: priority.to_sym
         )
       rescue StandardError => ex
         Raven.capture_exception(ex, tags: { version: 2 })
@@ -43,7 +43,7 @@ private
         )
 
         DeliveryRequestWorker.perform_async_with_priority(
-          email.id, priority: priority
+          email.id, priority: priority.to_sym
         )
       rescue StandardError => ex
         Raven.capture_exception(ex, tags: { version: 2 })


### PR DESCRIPTION
Currently, the priority gets turned into a string by Sidekiq so we need to turn it back into a symbol when using it. I spotted this issue by deploying the app in staging.

There is actually a test that would have caught this, but we send all exceptions to Sentry rather than raising them. This still feels right to have for the moment, so I decided against adding a new test for this that would then just get removed when we remove explicit Sentry integration.