### PR TITLE
Add UUID to Subscription

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,5 +2,13 @@ class Subscription < ApplicationRecord
   belongs_to :subscriber
   belongs_to :subscriber_list
 
+  before_validation :set_uuid
+
   validates :subscriber, uniqueness: { scope: :subscriber_list }
+
+private
+
+  def set_uuid
+    self.uuid ||= SecureRandom.uuid
+  end
 end

--- a/db/migrate/20171123142518_add_uuid_to_subscriptions.rb
+++ b/db/migrate/20171123142518_add_uuid_to_subscriptions.rb
@@ -1,0 +1,6 @@
+class AddUuidToSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriptions, :uuid, :uuid
+    add_index :subscriptions, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115162823) do
+ActiveRecord::Schema.define(version: 20171123142518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,9 +105,11 @@ ActiveRecord::Schema.define(version: 20171115162823) do
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"
+    t.index ["uuid"], name: "index_subscriptions_on_uuid"
   end
 
   add_foreign_key "delivery_attempts", "emails"

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -18,4 +18,23 @@ RSpec.describe Subscription, type: :model do
       expect(subject).to be_invalid
     end
   end
+
+  describe "callbacks" do
+    subject { FactoryGirl.build(:subscription) }
+
+    it "sets a uuid before validation" do
+      expect(subject.uuid).to be_nil
+
+      expect(subject).to be_valid
+      expect(subject.uuid).not_to be_nil
+    end
+
+    it "preserves the same uuid" do
+      subject.valid?
+      uuid = subject.uuid
+
+      subject.valid?
+      expect(subject.uuid).to eq(uuid)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/o5ffFODH/386-add-an-endpoint-to-email-alert-api-to-process-unsubscriptions

We're going to use this column to refer to a subscription when unsubscribing.

We don't want to expose internal database ids.