### PR TITLE
Rescue ActiveRecord::NotFound

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
+
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+private
+
+  def render_404
+    render json: { error: "record not found" }, status: 404
+  end
 end


### PR DESCRIPTION
Rescue by default and return `status: 404`