### PR TITLE
Add processed at to content change

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -2,4 +2,8 @@ require_relative "extensions/symbolize_json"
 
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
+
+  def mark_processed!
+    update!(processed_at: Time.now)
+  end
 end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -7,6 +7,7 @@ class SubscriptionContentWorker
     content_change = ContentChange.find(content_change_id)
     queue_delivery_to_subscribers(content_change)
     queue_delivery_to_courtesy_subscribers(content_change)
+    content_change.mark_processed!
   end
 
 private

--- a/db/migrate/20171124093729_add_processed_at_to_content_change.rb
+++ b/db/migrate/20171124093729_add_processed_at_to_content_change.rb
@@ -1,0 +1,5 @@
+class AddProcessedAtToContentChange < ActiveRecord::Migration[5.1]
+  def change
+    add_column :content_changes, :processed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171123142518) do
+ActiveRecord::Schema.define(version: 20171124093729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20171123142518) do
     t.string "publishing_app", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "processed_at"
   end
 
   create_table "delivery_attempts", force: :cascade do |t|
@@ -50,6 +51,7 @@ ActiveRecord::Schema.define(version: 20171123142518) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
+    t.datetime "processed_at"
   end
 
   create_table "notification_logs", id: :serial, force: :cascade do |t|

--- a/spec/models/content_change_spec.rb
+++ b/spec/models/content_change_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/models/content_change_spec.rb
+++ b/spec/models/content_change_spec.rb
@@ -1,1 +1,15 @@
 require 'rails_helper'
+
+RSpec.describe ContentChange do
+  let(:content_change) { create(:content_change) }
+  describe "mark_processed!" do
+    it "sets processed_at" do
+      Timecop.freeze do
+        expect { content_change.mark_processed! }
+          .to change { content_change.processed_at }
+          .from(nil)
+          .to(Time.now)
+      end
+    end
+  end
+end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -74,6 +74,11 @@ RSpec.describe SubscriptionContentWorker do
 
       subject.perform(content_change_id: content_change.id, priority: :high)
     end
+
+    it "marks the content_change as processed" do
+      expect(content_change).to receive(:mark_processed!)
+      subject.perform(content_change_id: content_change.id, priority: :high)
+    end
   end
 
   context "with a courtesy subscription" do


### PR DESCRIPTION
We need some way of indicating that a `ContentChange` has been processed through the system so that we can build tooling, alerts etc. The processing of a `ContentChange` doesn't always result in other objects being created so we can't infer this from the absence or presence of other things. 

So... this PR adds a `processed_at` column that is set to `Time.now` when the `SubscriptionContentWorker` has finished doing its thing.

Part of [Trello](https://trello.com/c/BxtZNx5v/352-add-the-deliveryrequestworker)