### PR TITLE
Use hostname in metrics

### DIFF
--- a/app/services/email_sender/notify.rb
+++ b/app/services/email_sender/notify.rb
@@ -11,10 +11,10 @@ class EmailSenderService
           body: body,
         },
       )
-      EmailAlertAPI.statsd.increment("notify.email_send_request.success")
+      EmailAlertAPI.statsd.increment("#{metrics_namespace}.success")
       response.id
     rescue Notifications::Client::RequestError
-      EmailAlertAPI.statsd.increment("notify.email_send_request.failure")
+      EmailAlertAPI.statsd.increment("#{metrics_namespace}.failure")
       raise EmailSenderService::ClientError
     end
 
@@ -26,6 +26,10 @@ class EmailSenderService
 
     def config
       EmailAlertAPI.config.notify
+    end
+
+    def metrics_namespace
+      "#{Socket.gethostname}.notify.email_send_request"
     end
 
     def api_key


### PR DESCRIPTION
Trello: https://trello.com/c/u20s96bS/353-set-up-statistics-monitoring-to-inform-product-decisions

[An issue has been identified][statsd-pr] with the way statsd reports
statistics that can lead to incorrect values for high frequency counts.
A work around this issue is to include the hostname in the key which is
sent to statsd, doing this also gives us the advantage that we can
compare the rates of usage for particular hosts.

[statsd-pr]: https://github.com/alphagov/govuk-puppet/pull/6834