### PR TITLE
Remove erroneous 'processed_at' from emails

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,6 @@ ActiveRecord::Schema.define(version: 20171124093729) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
-    t.datetime "processed_at"
   end
 
   create_table "notification_logs", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
It looks like this was mistakenly added to the emails table:
https://github.com/alphagov/email-alert-api/commit/79ed91c84fb939a3d76d3d909994edbed1f3ebd1#diff-1acd2e7e27a227829d5d14a91c863bb6R54