### PR TITLE
Add unsubscribe link to email

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -9,7 +9,7 @@ class Email < ApplicationRecord
     renderer = EmailRenderer.new(params: params)
 
     new(
-      address: params[:address],
+      address: params[:subscriber].address,
       subject: renderer.subject,
       body: renderer.body
     )

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -7,9 +7,10 @@ class Email < ApplicationRecord
 
   def self.build_from_params(params)
     renderer = EmailRenderer.new(params: params)
+    subscriber = params.fetch(:subscriber)
 
     new(
-      address: params[:subscriber].address,
+      address: subscriber.address,
       subject: renderer.subject,
       body: renderer.body
     )

--- a/app/models/email_renderer.rb
+++ b/app/models/email_renderer.rb
@@ -14,7 +14,7 @@ class EmailRenderer
       #{url}
       Updated on #{public_updated_at}
 
-      Unsubscribe from #{title} - #{unsubscribe_url}
+      #{unsubscribe_links}
     BODY
   end
 
@@ -42,12 +42,23 @@ private
     params.fetch(:public_updated_at).strftime("%I:%M %P, %-d %B %Y")
   end
 
+  def subscriber
+    params.fetch(:subscriber)
+  end
+
   def url
     "#{website_root}#{base_path}"
   end
 
-  def unsubscribe_url
-    "#{website_root}/email/token/unsubscribe"
+  def unsubscribe_links
+    links = UnsubscribeLink.for(subscriber.subscriptions)
+    links.map { |l| present_unsubscribe_link(l) }.join("\n\n")
+  end
+
+  def present_unsubscribe_link(link)
+    presented_link = "Unsubscribe"
+    presented_link += " from '#{link.title}'" unless link.title.blank?
+    presented_link + ":\n#{link.url}"
   end
 
   def website_root

--- a/app/models/unsubscribe_link.rb
+++ b/app/models/unsubscribe_link.rb
@@ -17,8 +17,14 @@ private
   attr_reader :subscription
 
   def build_url
-    root = Plek.new.website_root
-    escaped_title = URI.encode(title, /\W/)
-    "#{root}/email/unsubscribe/#{subscription.uuid}?title=#{escaped_title}"
+    "#{root}/email/unsubscribe/#{subscription.uuid}#{title_param}"
+  end
+
+  def root
+    Plek.new.website_root
+  end
+
+  def title_param
+    "?title=#{URI.encode(title, /\W/)}" if title
   end
 end

--- a/app/models/unsubscribe_link.rb
+++ b/app/models/unsubscribe_link.rb
@@ -1,0 +1,24 @@
+class UnsubscribeLink
+  attr_reader :url, :title
+  def initialize(subscription)
+    @subscription = subscription
+    @title = subscription.subscriber_list.title
+    @url = build_url
+  end
+
+  def self.for(subscriptions)
+    Array(subscriptions).map do |subscription|
+      new(subscription)
+    end
+  end
+
+private
+
+  attr_reader :subscription
+
+  def build_url
+    root = Plek.new.website_root
+    escaped_title = URI.encode(title, /\W/)
+    "#{root}/email/unsubscribe/#{subscription.uuid}?title=#{escaped_title}"
+  end
+end

--- a/app/workers/email_generation_worker.rb
+++ b/app/workers/email_generation_worker.rb
@@ -25,7 +25,7 @@ private
       description: content_change.description,
       base_path: content_change.base_path,
       public_updated_at: content_change.public_updated_at,
-      address: subscription_content.subscription.subscriber.address,
+      subscriber: subscription_content.subscription.subscriber,
     }
   end
 end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -59,7 +59,7 @@ private
   def email_params(content_change, subscriber)
     {
       content_change_id: content_change.id,
-      address: subscriber.address,
+      subscriber: subscriber,
       title: content_change.title,
       change_note: content_change.change_note,
       description: content_change.description,

--- a/spec/models/email_renderer_spec.rb
+++ b/spec/models/email_renderer_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe EmailRenderer do
+  let(:subscriber) { double(:subscriber, subscriptions: subscriptions) }
+
+  let(:subscriptions) do
+    [
+      double(uuid: "1234", subscriber_list: double(title: "First Subscription")),
+      double(uuid: "5678", subscriber_list: double(title: "Second Subscription")),
+    ]
+  end
+
   let(:params) do
     {
       title: "Title",
@@ -8,6 +17,7 @@ RSpec.describe EmailRenderer do
       description: "Description",
       change_note: "Change note",
       base_path: "/base_path",
+      subscriber: subscriber,
     }
   end
 
@@ -28,9 +38,45 @@ RSpec.describe EmailRenderer do
           http://www.dev.gov.uk/base_path
           Updated on 12:00 am, 1 January 2017
 
-          Unsubscribe from Title - http://www.dev.gov.uk/email/token/unsubscribe
+          Unsubscribe from 'First Subscription':
+          http://www.dev.gov.uk/email/unsubscribe/1234?title=First%20Subscription
+
+          Unsubscribe from 'Second Subscription':
+          http://www.dev.gov.uk/email/unsubscribe/5678?title=Second%20Subscription
         BODY
       )
+    end
+  end
+
+  context "when there is no title" do
+    let(:subscriptions) {
+      [
+        double(uuid: "1234", subscriber_list: double(title: nil)),
+        double(uuid: "4567", subscriber_list: double(title: nil)),
+        double(uuid: "8910", subscriber_list: double(title: nil)),
+      ]
+    }
+
+    describe "body" do
+      it "should match the expected content" do
+        expect(subject.body).to eq(
+          <<~BODY
+            Change note: Description.
+
+            http://www.dev.gov.uk/base_path
+            Updated on 12:00 am, 1 January 2017
+
+            Unsubscribe:
+            http://www.dev.gov.uk/email/unsubscribe/1234
+
+            Unsubscribe:
+            http://www.dev.gov.uk/email/unsubscribe/4567
+
+            Unsubscribe:
+            http://www.dev.gov.uk/email/unsubscribe/8910
+          BODY
+        )
+      end
     end
   end
 end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Email do
 
   describe "create_from_params!" do
     let(:content_change) { create(:content_change) }
+    let(:subscriber) { double(address: "test@test.com") }
 
     let(:email) do
       Email.create_from_params!(
@@ -24,7 +25,7 @@ RSpec.describe Email do
         base_path: "/government/test",
         public_updated_at: DateTime.parse("1/1/2017"),
         content_change_id: content_change.id,
-        address: "test@example.com",
+        subscriber: subscriber,
       )
     end
 

--- a/spec/models/unsubscribe_link_spec.rb
+++ b/spec/models/unsubscribe_link_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe UnsubscribeLink do
+  let(:subscription) {
+    double(uuid: "1234", subscriber_list: double(title: "dave crocker & friends"))
+  }
+
+  let(:unsubscribe_link) {
+    UnsubscribeLink.new(subscription)
+  }
+
+  describe "#url" do
+    it "returns an unsubscribe url for the subscription" do
+      expect(unsubscribe_link.url).to eq(
+        "http://www.dev.gov.uk/email/unsubscribe/1234?title=dave%20crocker%20%26%20friends"
+      )
+    end
+  end
+
+  describe "#title" do
+    it "returns the name of the subscriber_list" do
+      expect(unsubscribe_link.title).to eq("dave crocker & friends")
+    end
+  end
+
+  describe ".for" do
+    let(:other_subscription) do
+      double(uuid: "5678", subscriber_list: double(title: "jarvis cocker & friends"))
+    end
+
+    let(:subscriptions) { [subscription, other_subscription] }
+
+    it "builds an unsubscribe link for each subscription" do
+      first, second = UnsubscribeLink.for(subscriptions)
+
+      expect(first.title).to eq("dave crocker & friends")
+      expect(second.title).to eq("jarvis cocker & friends")
+    end
+  end
+end

--- a/spec/models/unsubscribe_link_spec.rb
+++ b/spec/models/unsubscribe_link_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe UnsubscribeLink do
-  let(:subscription) {
-    double(uuid: "1234", subscriber_list: double(title: "dave crocker & friends"))
-  }
+  let(:subscription) { double(uuid: "1234", subscriber_list: double(title: title)) }
+  let(:title) { "dave crocker & friends" }
 
   let(:unsubscribe_link) {
     UnsubscribeLink.new(subscription)
@@ -14,6 +13,16 @@ RSpec.describe UnsubscribeLink do
       expect(unsubscribe_link.url).to eq(
         "http://www.dev.gov.uk/email/unsubscribe/1234?title=dave%20crocker%20%26%20friends"
       )
+    end
+
+    context "when title is nil" do
+      let(:title) { nil }
+
+      it "omits the title param" do
+        expect(unsubscribe_link.url).to eq(
+          "http://www.dev.gov.uk/email/unsubscribe/1234"
+        )
+      end
     end
   end
 

--- a/spec/workers/email_generation_worker_spec.rb
+++ b/spec/workers/email_generation_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe EmailGenerationWorker do
       let(:content_change) { create(:content_change, public_updated_at: DateTime.parse("2017/01/01 09:00")) }
       let(:subscription_content) { create(:subscription_content, content_change: content_change) }
 
-      before do
+      def perform_with_fake_sidekiq
         Sidekiq::Testing.fake! do
           DeliveryRequestWorker.jobs.clear
           described_class.new.perform(subscription_content_id: subscription_content.id, priority: priority)
@@ -16,19 +16,21 @@ RSpec.describe EmailGenerationWorker do
       end
 
       it "should create an email" do
-        expect(Email.count).to eq(1)
-
-        email = Email.first
-        expect(email.address).to eq(subscription_content.subscription.subscriber.address)
-        expect(email.subject).to eq("GOV.UK Update - title")
-        expect(email.body).to eq("change note: description.\n\nhttp://www.dev.gov.ukgovernment/base_path\nUpdated on 09:00 am, 1 January 2017\n\nUnsubscribe from title - http://www.dev.gov.uk/email/token/unsubscribe\n")
+        expect {
+          perform_with_fake_sidekiq
+        }
+          .to change { Email.count }
+          .from(0)
+          .to(1)
       end
 
       it "should associate the subscription content with the email" do
+        perform_with_fake_sidekiq
         expect(subscription_content.reload.email).to_not be_nil
       end
 
       it "should queue a delivery email job" do
+        perform_with_fake_sidekiq
         expect(DeliveryRequestWorker.jobs.size).to eq(1)
       end
     end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SubscriptionContentWorker do
     it "creates an email for the courtesy email group" do
       expect(Email)
         .to receive(:create_from_params!)
-        .with(hash_including(address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk"))
+        .with(hash_including(subscriber: subscriber))
         .and_return(email)
 
       subject.perform(content_change_id: content_change.id, priority: :low)


### PR DESCRIPTION
This PR adds an 'Unsubscribe' link to the bottom of sent email for each of a subscriber's subscriptions. This is an MVP implementation with some limitations.

* users with a large number of subscriptions are going to get a lot of links on each email
* there are > 700 subscriber list records that don't have a title. The implementation in this PR relies on the title to add context to the link. Where there is no title we are just rendering 'Unsubscribe'. This isn't ideal

[Trello](https://trello.com/c/hK432zt4/391-emails-contain-a-link-with-the-relevant-token-that-sends-the-user-to-the-unsubscription-page)