### PR TITLE
Introduce more statistics

### DIFF
--- a/app/queries/content_changes_for_email_query.rb
+++ b/app/queries/content_changes_for_email_query.rb
@@ -1,0 +1,9 @@
+class ContentChangesForEmailQuery
+  def self.call(email)
+    subscription_content = SubscriptionContent
+      .where("subscription_contents.content_change_id = content_changes.id")
+      .where(email: email)
+      .exists
+    ContentChange.where(subscription_content)
+  end
+end

--- a/app/services/deliver_email_service.rb
+++ b/app/services/deliver_email_service.rb
@@ -17,6 +17,8 @@ class DeliverEmailService
       body: email.body,
     )
 
+    EmailTimingStatsService.first_delivery_attempt(email, Time.now.utc)
+
     record_delivery_attempt(
       email: email,
       status: :sending,

--- a/app/services/email_timing_stats_service.rb
+++ b/app/services/email_timing_stats_service.rb
@@ -1,0 +1,26 @@
+class EmailTimingStatsService
+  def self.first_delivery_attempt(email, time)
+    return if DeliveryAttempt.exists?(email: email)
+    store_time_to_send_email(email, time)
+    store_time_to_send_content_change(email, time)
+  end
+
+  def self.store_time_to_send_email(email, time)
+    difference = (time - email.created_at) * 1000
+    namespace = "#{Socket.gethostname}.email_created_to_first_delivery_attempt"
+    EmailAlertAPI.statsd.timing(namespace, difference)
+  end
+
+  def self.store_time_to_send_content_change(email, time)
+    # We don't want to store this statistic for emails that have more than one
+    # content change associated with them. Since they don't exist yet this
+    # does just a crude check.
+    content_changes = ContentChangesForEmailQuery.call(email).all
+    return unless content_changes.count == 1
+
+    content_change = content_changes.first
+    difference = (time - content_change.created_at) * 1000
+    namespace = "#{Socket.gethostname}.content_change_created_to_first_delivery_attempt"
+    EmailAlertAPI.statsd.timing(namespace, difference)
+  end
+end

--- a/spec/models/content_change_spec.rb
+++ b/spec/models/content_change_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ContentChange do
-  let(:content_change) { create(:content_change) }
-  describe "mark_processed!" do
+  describe "#mark_processed!" do
+    let(:content_change) { create(:content_change) }
     it "sets processed_at" do
       Timecop.freeze do
         expect { content_change.mark_processed! }

--- a/spec/queries/content_changes_for_email_query_spec.rb
+++ b/spec/queries/content_changes_for_email_query_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ContentChangesForEmailQuery do
+  describe ".call" do
+    let!(:email) { create(:email) }
+    subject(:content_changes) { described_class.call(email) }
+
+    context "when there are no subscription content associations" do
+      it "returns an empty scope" do
+        expect(content_changes.exists?).to be false
+      end
+    end
+
+    context "when there are multiple subscription content associations" do
+      let(:content_change) { create(:content_change) }
+      before do
+        create(:subscription_content, email: email, content_change: content_change)
+        create(:subscription_content, email: email, content_change: content_change)
+      end
+
+      it "returns a scope of the unique content changes" do
+        expect(content_changes.count).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
This includes
- Stats for how many content changes are entering the system
- Timing for the time between when an email is created and when we first send it to a third party service
- Timing for the time between a content change being created and the eventual email being sent to a third party service

See commit messages for further details

It was quite tricky in this to work out what the component should be that has the cross cutting concern of Email through to ContentChange - so I went for `EmailTimingStatsService` which acts kind of like a module, it didn't feel too great. So suggestions welcome on improving the modelling of it (without creating too many classes)