### PR TITLE
Specify port as Env var for Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rails s -p 3088
+web: PORT=3088 bundle exec rails s
 worker: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Foreman sets an ENV var of PORT which rails uses over the argument of `-p`

Before:
```
email-alert-api git:(master) ✗ bundle exec foreman start
14:45:22 web.1    | started with pid 12956
14:45:22 worker.1 | started with pid 12958
14:45:23 worker.1 | I, [2017-11-29T14:45:23.220303 #12958]  INFO -- sentry: ** [Raven] Raven 2.6.3 configured not to capture errors: DSN not set
14:45:24 web.1    | [2017-11-29 14:45:24] INFO  WEBrick 1.3.1
14:45:24 web.1    | [2017-11-29 14:45:24] INFO  ruby 2.4.0 (2016-12-24) [x86_64-linux]
14:45:24 web.1    | [2017-11-29 14:45:24] INFO  WEBrick::HTTPServer#start: pid=12957 port=5000
```

After:
```
email-alert-api git:(fix-startup) ✗ bundle exec foreman start
14:48:42 web.1    | started with pid 13188
14:48:42 worker.1 | started with pid 13190
14:48:42 worker.1 | I, [2017-11-29T14:48:42.896702 #13190]  INFO -- sentry: ** [Raven] Raven 2.6.3 configured not to capture errors: DSN not set
14:48:43 web.1    | [2017-11-29 14:48:43] INFO  WEBrick 1.3.1
14:48:43 web.1    | [2017-11-29 14:48:43] INFO  ruby 2.4.0 (2016-12-24) [x86_64-linux]
14:48:43 web.1    | [2017-11-29 14:48:43] INFO  WEBrick::HTTPServer#start: pid=13189 port=3088
```