### PR TITLE
Prefix subject for non-production environments

### DIFF
--- a/app/services/deliver_email_service.rb
+++ b/app/services/deliver_email_service.rb
@@ -13,7 +13,7 @@ class DeliverEmailService
   def call
     reference = email_sender.call(
       address: email.address,
-      subject: email.subject,
+      subject: "#{subject_prefix}#{email.subject}",
       body: email.body,
     )
 
@@ -44,5 +44,15 @@ private
 
   def email_sender
     @email_sender ||= Services.email_sender
+  end
+
+  def subject_prefix
+    env = ENV["GOVUK_APP_DOMAIN"]
+    case env
+    when /integration/
+      "INTEGRATION - "
+    when /staging/
+      "STAGING - "
+    end
   end
 end

--- a/spec/services/deliver_email_service_spec.rb
+++ b/spec/services/deliver_email_service_spec.rb
@@ -38,5 +38,37 @@ RSpec.describe DeliverEmailService do
       expect { described_class.call(email: nil) }
         .to raise_error(ArgumentError, "email cannot be nil")
     end
+
+    context "in other environments" do
+      after do
+        ENV["GOVUK_APP_DOMAIN"] = nil
+      end
+
+      it "prefixes INTEGRATION when in integration" do
+        ENV["GOVUK_APP_DOMAIN"] = "integration.publishing.service.gov.uk"
+        expect(email_sender).to receive(:call)
+          .with(
+            address: "test@example.com",
+            subject: "INTEGRATION - subject",
+            body: "body",
+        )
+          .and_return(double(id: 0))
+
+        described_class.call(email: email)
+      end
+
+      it "prefixes STAGING when in staging" do
+        ENV["GOVUK_APP_DOMAIN"] = "staging.publishing.service.gov.uk"
+        expect(email_sender).to receive(:call)
+          .with(
+            address: "test@example.com",
+            subject: "STAGING - subject",
+            body: "body",
+        )
+          .and_return(double(id: 0))
+
+        described_class.call(email: email)
+      end
+    end
   end
 end


### PR DESCRIPTION
We need to be able to send courtesy copies and some subscribed emails in the integration and staging environments to allow us to test changes before deployment. This commit introduces a prefix (INTEGRATION | STAGING) to the email subject so as we can tell the difference in the courtesy copy account.