### PR TITLE
Create subscription endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ and it will respond with the JSON response for the `GET` call above.
 and it will respond with `202 Accepted` (the call is queued to prevent slowness
 in the external notifications API).
 
+* `POST /subscriptions` with data:
+
+```json
+{
+  "address": "email@address.com",
+  "subscribable_id": "The id of a subscriber list"
+}
+```
+
+and it will create a new subscription between the email address and the
+subscriber list. It will respond with a `201 Created` if it's a new
+subscription or a `200 OK` if the subscription already exists.
+
 ### healthcheck API
 
 A queue health check endpoint is available at /healthcheck

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,4 +2,12 @@ class SubscriptionsController < ActionController::Base
   def create
     render json: {}, status: :created
   end
+
+private
+
+  def subscription_params
+    params.require(:address)
+    params.require(:subscribable_id)
+    params.permit(:address, :subscribable_id)
+  end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,11 +1,18 @@
 class SubscriptionsController < ActionController::Base
   def create
-    subscription = Subscription.create!(
+    subscription = Subscription.find_or_initialize_by(
       subscriber: subscriber,
       subscriber_list: subscribable,
     )
 
-    render json: { id: subscription.id }, status: :created
+    if subscription.new_record?
+      subscription.save!
+      status = :created
+    else
+      status = :ok
+    end
+
+    render json: { id: subscription.id }, status: status
   end
 
 private

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,5 @@
+class SubscriptionsController < ActionController::Base
+  def create
+    render json: {}, status: :created
+  end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,9 +1,22 @@
 class SubscriptionsController < ActionController::Base
   def create
-    render json: {}, status: :created
+    subscription = Subscription.create!(
+      subscriber: subscriber,
+      subscriber_list: subscribable,
+    )
+
+    render json: { id: subscription.id }, status: :created
   end
 
 private
+
+  def subscriber
+    Subscriber.find_or_create_by(address: subscription_params[:address])
+  end
+
+  def subscribable
+    SubscriberList.find(subscription_params[:subscribable_id])
+  end
 
   def subscription_params
     params.require(:address)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
-  resources :subscriber_lists, path: "subscriber-lists", only: [:create]
+  resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
   get "/subscriber-lists", to: "subscriber_lists#show"
 
   resources :notifications, only: %i[create index show]
   resources :status_updates, path: "status-updates", only: %i[create]
+  resources :subscriptions, only: %i[create]
 
   get "/healthcheck", to: "healthcheck#check"
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -3,8 +3,20 @@ require "rails_helper"
 RSpec.describe SubscriptionsController, type: :controller do
   let(:data) { JSON.parse(response.body).deep_symbolize_keys }
 
+  it "requires an address parameter" do
+    expect {
+      post :create, params: { subscribable_id: 10 }
+    }.to raise_error(ActionController::ParameterMissing)
+  end
+
+  it "requires a subscribable_id parameter" do
+    expect {
+      post :create, params: { address: "test@example.com" }
+    }.to raise_error(ActionController::ParameterMissing)
+  end
+
   it "responds with JSON" do
-    post :create, format: :json
+    post :create, params: { subscribable_id: 10, address: "test@example.com" }, format: :json
 
     expect(response.status).to eq(201)
     expect(response.content_type).to eq("application/json")

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -21,50 +21,74 @@ RSpec.describe SubscriptionsController, type: :controller do
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
-  context "with a subscribable" do
+  context "with an existing subscription" do
     let(:subscribable) { create(:subscriber_list) }
-
-    let(:data) { JSON.parse(response.body).deep_symbolize_keys }
+    let(:subscriber) { create(:subscriber, address: "test@example.com") }
+    let!(:subscription) { create(:subscription, subscriber_list: subscribable, subscriber: subscriber) }
 
     def create_subscription
-      post :create, params: { subscribable_id: subscribable.id, address: "test@example.com" }, format: :json
+      post :create, params: { subscribable_id: subscribable.id, address: subscriber.address }, format: :json
     end
 
-    context "with an existing subscriber" do
-      before do
-        create(:subscriber, address: "test@example.com")
-      end
-
-      it "does not create another subscriber" do
-        expect { create_subscription }.to_not(change { Subscriber.count })
-      end
-    end
-
-    context "without an existing subscriber" do
-      it "creates a new subscriber" do
-        expect { create_subscription }.to change { Subscriber.count }.by(1)
-        expect(Subscriber.first.address).to eq("test@example.com")
-      end
-    end
-
-    it "creates the subscription" do
-      expect { create_subscription }.to change { Subscription.count }.by(1)
-      expect(Subscription.first.subscriber_list).to eq(subscribable)
+    it "doesn't create a new subscription" do
+      expect { create_subscription }.to_not(change { Subscription.count })
     end
 
     it "returns status code 201" do
       create_subscription
-      expect(response.status).to eq(201)
+      expect(response.status).to eq(200)
     end
 
-    it "returns JSON" do
+    it "returns the ID of the existing subscription" do
       create_subscription
-      expect(response.content_type).to eq("application/json")
+      expect(data[:id]).to eq(subscription.id)
     end
+  end
 
-    it "returns the ID of the new subscription" do
-      create_subscription
-      expect(data[:id]).to_not be_nil
+  context "without an existing subscription" do
+    context "with a subscribable" do
+      let(:subscribable) { create(:subscriber_list) }
+
+      def create_subscription
+        post :create, params: { subscribable_id: subscribable.id, address: "test@example.com" }, format: :json
+      end
+
+      context "with an existing subscriber" do
+        before do
+          create(:subscriber, address: "test@example.com")
+        end
+
+        it "does not create another subscriber" do
+          expect { create_subscription }.to_not(change { Subscriber.count })
+        end
+      end
+
+      context "without an existing subscriber" do
+        it "creates a new subscriber" do
+          expect { create_subscription }.to change { Subscriber.count }.by(1)
+          expect(Subscriber.first.address).to eq("test@example.com")
+        end
+      end
+
+      it "creates the subscription" do
+        expect { create_subscription }.to change { Subscription.count }.by(1)
+        expect(Subscription.first.subscriber_list).to eq(subscribable)
+      end
+
+      it "returns status code 201" do
+        create_subscription
+        expect(response.status).to eq(201)
+      end
+
+      it "returns JSON" do
+        create_subscription
+        expect(response.content_type).to eq("application/json")
+      end
+
+      it "returns the ID of the new subscription" do
+        create_subscription
+        expect(data[:id]).to_not be_nil
+      end
     end
   end
 end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe SubscriptionsController, type: :controller do
+  let(:data) { JSON.parse(response.body).deep_symbolize_keys }
+
+  it "responds with JSON" do
+    post :create, format: :json
+
+    expect(response.status).to eq(201)
+    expect(response.content_type).to eq("application/json")
+    expect { data }.to_not raise_error
+  end
+end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -15,11 +15,56 @@ RSpec.describe SubscriptionsController, type: :controller do
     }.to raise_error(ActionController::ParameterMissing)
   end
 
-  it "responds with JSON" do
-    post :create, params: { subscribable_id: 10, address: "test@example.com" }, format: :json
+  it "fails with an invalid subscribable" do
+    expect {
+      post :create, params: { subscribable_id: 10, address: "test@example.com" }
+    }.to raise_error(ActiveRecord::RecordNotFound)
+  end
 
-    expect(response.status).to eq(201)
-    expect(response.content_type).to eq("application/json")
-    expect { data }.to_not raise_error
+  context "with a subscribable" do
+    let(:subscribable) { create(:subscriber_list) }
+
+    let(:data) { JSON.parse(response.body).deep_symbolize_keys }
+
+    def create_subscription
+      post :create, params: { subscribable_id: subscribable.id, address: "test@example.com" }, format: :json
+    end
+
+    context "with an existing subscriber" do
+      before do
+        create(:subscriber, address: "test@example.com")
+      end
+
+      it "does not create another subscriber" do
+        expect { create_subscription }.to_not(change { Subscriber.count })
+      end
+    end
+
+    context "without an existing subscriber" do
+      it "creates a new subscriber" do
+        expect { create_subscription }.to change { Subscriber.count }.by(1)
+        expect(Subscriber.first.address).to eq("test@example.com")
+      end
+    end
+
+    it "creates the subscription" do
+      expect { create_subscription }.to change { Subscription.count }.by(1)
+      expect(Subscription.first.subscriber_list).to eq(subscribable)
+    end
+
+    it "returns status code 201" do
+      create_subscription
+      expect(response.status).to eq(201)
+    end
+
+    it "returns JSON" do
+      create_subscription
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it "returns the ID of the new subscription" do
+      create_subscription
+      expect(data[:id]).to_not be_nil
+    end
   end
 end

--- a/spec/requests/create_subscription_spec.rb
+++ b/spec/requests/create_subscription_spec.rb
@@ -2,9 +2,14 @@ require "rails_helper"
 require "base64"
 
 RSpec.describe "Creating a subscription", type: :request do
-  it "returns a 201" do
-    post "/subscriptions", params: JSON.dump({ address: "test@example.com", subscribable_id: 10 }), headers: json_headers
+  context "with a subscribable" do
+    let(:subscribable) { create(:subscriber_list) }
 
-    expect(response.status).to eq(201)
+    it "returns a 201" do
+      params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id)
+      post "/subscriptions", params: params, headers: json_headers
+
+      expect(response.status).to eq(201)
+    end
   end
 end

--- a/spec/requests/create_subscription_spec.rb
+++ b/spec/requests/create_subscription_spec.rb
@@ -3,7 +3,7 @@ require "base64"
 
 RSpec.describe "Creating a subscription", type: :request do
   it "returns a 201" do
-    post "/subscriptions", params: {}, headers: json_headers
+    post "/subscriptions", params: JSON.dump({ address: "test@example.com", subscribable_id: 10 }), headers: json_headers
 
     expect(response.status).to eq(201)
   end

--- a/spec/requests/create_subscription_spec.rb
+++ b/spec/requests/create_subscription_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+require "base64"
+
+RSpec.describe "Creating a subscription", type: :request do
+  it "returns a 201" do
+    post "/subscriptions", params: {}, headers: json_headers
+
+    expect(response.status).to eq(201)
+  end
+end


### PR DESCRIPTION
This creates a new subscriptions controller with an endpoint (`POST /subscriptions`) which can be used to create new subscriptions.

I made a decision to name the variables and fields `subscribable`s to follow our idealised model, although I realise this may be confusing to mix the two, so we may decide to not do this.

Users of the API are expected to know about the subscriber list IDs which means we're still tied to them being created in GovDelivery in this PR, but that feels like something which should be dealt with in a later PR.

[Trello Card](https://trello.com/c/GpyQh4gq/407-add-a-subscription-creation-endpoint-to-email-alert-api)