### PR TITLE
Add a migration to delete subscriber lists with nil govdelivery_id

### DIFF
--- a/db/migrate/20171201082903_remove_null_gov_delivery_ids.rb
+++ b/db/migrate/20171201082903_remove_null_gov_delivery_ids.rb
@@ -1,0 +1,5 @@
+class RemoveNullGovDeliveryIds < ActiveRecord::Migration[5.1]
+  def up
+    SubscriberList.where(gov_delivery_id: nil).destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171124105714) do
+ActiveRecord::Schema.define(version: 20171201082903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
There are currently only 3 of them and they were last updated in 2014, so it doesn't seem necessary to keep them around.

They also happen to have `nil` titles.

[Trello Card](https://trello.com/c/GDln9WNI/405-add-titles-to-subscriber-lists-that-dont-have-titles)