### PR TITLE
Add a migration to fix subscriber lists with no title

### DIFF
--- a/db/migrate/20171201083844_fix_subscriber_lists_with_no_titles.rb
+++ b/db/migrate/20171201083844_fix_subscriber_lists_with_no_titles.rb
@@ -1,0 +1,28 @@
+class FixSubscriberListsWithNoTitles < ActiveRecord::Migration[5.1]
+  def up
+    return unless Rails.env.production?
+
+    deleted_count = 0
+    updated_count = 0
+
+    SubscriberList.where(title: nil).find_each do |subscriber_list|
+      begin
+        topic = Services.gov_delivery.fetch_topic(subscriber_list.gov_delivery_id)
+        subscribers_count = topic.subscribers_count.to_i
+      rescue GovDelivery::Client::TopicNotFound
+        subscribers_count = 0
+      end
+
+      if subscribers_count.zero?
+        subscriber_list.destroy
+        deleted_count += 1
+      else
+        subscriber_list.update(title: topic.name)
+        updated_count += 1
+      end
+    end
+
+    puts "Deleted #{deleted_count} subscriber lists."
+    puts "Updated #{updated_count} subscriber lists."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201082903) do
+ActiveRecord::Schema.define(version: 20171201083844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
For each subscriber list with no title, it fetches the topic from GovDelivery and either puts in the title or deletes the subscriber list if it has no subscribers.

In production there are 740 subscriber lists with no title, and out of them about half have no subscribers.

The migration takes about 15 minutes to run.

[Trello Card](https://trello.com/c/GDln9WNI/405-add-titles-to-subscriber-lists-that-dont-have-titles)