### PR TITLE
Raise 409 on GovDelivery topic conflict

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -1,6 +1,10 @@
 require "gov_delivery/client"
 
 class SubscriberListsController < ApplicationController
+  rescue_from GovDelivery::Client::TopicAlreadyExistsError do
+    render json: { error: { message: "topic already exists" } }, status: :conflict
+  end
+
   def show
     subscriber_list = FindExactQuery.new(find_exact_query_params).exact_match
     if subscriber_list

--- a/spec/requests/create_subscriber_list_spec.rb
+++ b/spec/requests/create_subscriber_list_spec.rb
@@ -106,6 +106,23 @@ RSpec.describe "Creating a subscriber list", type: :request do
     expect(response.status).to eq(422)
   end
 
+  it "returns an error if creating the same topic" do
+    stub_request(:post, base_url + "/topics.xml")
+      .with(headers: { "Authorization" => "Basic #{http_auth}" })
+      .with(body: /This is a sample title/)
+      .to_return(body: %{
+        <?xml version="1.0" encoding="UTF-8"?>
+        <topic>
+          <code>GD-14004</code>
+          <error>conflict</error>
+        </topic>
+      })
+
+    create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
+
+    expect(response.status).to eq(409)
+  end
+
   it "returns an error if link isn't an array" do
     create_subscriber_list(
       links: { topics: "uuid-888" },


### PR DESCRIPTION
Currently when this happens we get a 500 which records the error in Sentry and makes it seem like a problem in this app when there is nothing we can do about it.

It seems better to raise a 409 here and leave it down to the clients to solve the issue.