### PR TITLE
Require status update parameters

### DIFF
--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -9,6 +9,8 @@ class StatusUpdatesController < ApplicationController
 private
 
   def status_update_params
+    params.require(:reference)
+    params.require(:status)
     params.permit(:reference, :status).to_h.symbolize_keys
   end
 end


### PR DESCRIPTION
This ensures we avoid an ArgumentError exception coming through to Sentry and means the Sidekiq job doesn't keep retrying.

I decided not to include tests for this since I figured the parameters we get for this will all change when Notify has implemented the web hooks on their side.