### PR TITLE
Add subscribables#show endpoint

### DIFF
--- a/app/controllers/subscribables_controller.rb
+++ b/app/controllers/subscribables_controller.rb
@@ -1,0 +1,12 @@
+class SubscribablesController < ApplicationController
+  def show
+    render json: subscribable_json
+  end
+
+private
+
+  def subscribable_json
+    subscriber_list = SubscriberList.find_by(gov_delivery_id: params[:gov_delivery_id])
+    { subscribable: subscriber_list.attributes }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :notifications, only: %i[create index show]
   resources :status_updates, path: "status-updates", only: %i[create]
   resources :subscriptions, only: %i[create]
+  get "subscribables/:gov_delivery_id", to: "subscribables#show"
 
   get "/healthcheck", to: "healthcheck#check"
 

--- a/spec/requests/subscribables_controller_spec.rb
+++ b/spec/requests/subscribables_controller_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe SubscribablesController, type: :request do
+  describe "GET /subscribables/<govuk_delivery_id>" do
+    it "returns the subscribable" do
+      subscribable = create(:subscriber_list, gov_delivery_id: "test135")
+      get "/subscribables/test135"
+
+      subscribable_response = JSON.parse(response.body).deep_symbolize_keys[:subscribable]
+
+      expect(subscribable_response[:id]).to eq(subscribable.id)
+    end
+  end
+end


### PR DESCRIPTION
We need to be able to retrieve a `SubscriberList` by gov_delivery_id as that is all we currently have in the frontend.

There is an existing `SubscriberListsController#show` but when only the `gov_delivery_id` param is passed it always returns the same `SubscriberList` as the existing action performs a complex lookup query on other params in addition to the `gov_delivery_id`. This could be considered a bug but we will be changing `SubscriberList` to `Subscribable` at some point soon and to avoid changing existing code that is running in production until we're ready to replace this I've added this `Subscribables` controller.

There is also a bit of an issue with using `gov_delivery_id` but the existing functionality in the frontends relies on it so we should probably continue with that naming for now to avoid too much change in the frontend for the MVP stuff.

`SubscriberList` serialises to `subscriber_list: <attributes>` so there is a bit of funkiness to avoid that.

[Trello](https://trello.com/c/YtmHgU3b/408-add-page-to-email-alert-frontend-to-capture-a-users-email-address)