### PR TITLE
Allow configuring GOV.UK Notify base URL

### DIFF
--- a/app/services/email_sender_service/notify.rb
+++ b/app/services/email_sender_service/notify.rb
@@ -39,5 +39,9 @@ class EmailSenderService
     def template_id
       config.fetch(:template_id)
     end
+
+    def base_url
+      config.fetch(:base_url)
+    end
   end
 end

--- a/app/services/email_sender_service/notify.rb
+++ b/app/services/email_sender_service/notify.rb
@@ -21,7 +21,7 @@ class EmailSenderService
   private
 
     def client
-      @client ||= Notifications::Client.new(api_key)
+      @client ||= Notifications::Client.new(api_key, base_url)
     end
 
     def config

--- a/config/notify.yml
+++ b/config/notify.yml
@@ -1,11 +1,14 @@
 development:
   api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
   template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
+  base_url: <%= ENV['GOVUK_NOTIFY_BASE_URL'] %>
 
 test:
   api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
   template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
+  base_url: <%= ENV['GOVUK_NOTIFY_BASE_URL'] %>
 
 production:
   api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
   template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
+  base_url: <%= ENV['GOVUK_NOTIFY_BASE_URL'] %>

--- a/spec/services/email_sender_service/notify_spec.rb
+++ b/spec/services/email_sender_service/notify_spec.rb
@@ -3,21 +3,59 @@ require "notifications/client"
 
 RSpec.describe EmailSenderService::Notify do
   describe "#call" do
-    it "sends an email to the address passed in" do
-      client = double
+    let(:api_key) { nil }
+    let(:base_url) { nil }
+    let(:template_id) { "21a3289b-0074-4223-ad94-1cdc6d153da0" }
+
+    before do
+      allow(EmailAlertAPI.config).to receive(:notify).and_return(
+        api_key: api_key,
+        template_id: template_id,
+        base_url: base_url,
+      )
+    end
+
+    let(:client) { double }
+
+    before do
       allow(Notifications::Client)
         .to receive(:new)
         .and_return(client)
+
+      allow(client).to receive(:send_email)
+        .and_return(double(id: 0))
+    end
+
+    it "sends an email to the address passed in" do
       expect(client)
         .to receive(:send_email)
         .with(
           email_address: "email@address.com",
           personalisation: a_hash_including(subject: "subject", body: "body"),
-          template_id: anything,
+          template_id: template_id,
         )
-        .and_return(double(id: 0))
 
       subject.call(address: "email@address.com", subject: "subject", body: "body")
+    end
+
+    it "uses the default base url" do
+      expect(Notifications::Client)
+        .to receive(:new)
+        .with(api_key, nil)
+
+      subject.call(address: "email@address.com", subject: "subject", body: "body")
+    end
+
+    context "with a custom base url" do
+      let(:base_url) { "https://api.notifications" }
+
+      it "configures the client with the correct base url" do
+        expect(Notifications::Client)
+          .to receive(:new)
+          .with(api_key, base_url)
+
+        subject.call(address: "email@address.com", subject: "subject", body: "body")
+      end
     end
   end
 end


### PR DESCRIPTION
This allows us to use their staging environment for our load testing.

We're using an undocumented feature of GOV.UK Notify's Gem: https://github.com/alphagov/notifications-ruby-client/blob/master/lib/notifications/client/speaker.rb#L20

The next stage is to add support for this configuration option in Puppet.

[Trello Card](https://trello.com/c/7zoZKZkS/281-agree-approach-and-run-load-testing-with-notify)