### PR TITLE
Delete duplicate subscriber lists

### DIFF
--- a/db/migrate/20171205114740_remove_duplicate_subscriber_lists_and_add_unique_constraint.rb
+++ b/db/migrate/20171205114740_remove_duplicate_subscriber_lists_and_add_unique_constraint.rb
@@ -1,0 +1,91 @@
+class RemoveDuplicateSubscriberListsAndAddUniqueConstraint < ActiveRecord::Migration[5.1]
+  # List of SubscriberList with duplicates
+  # - - 26
+  #   - UKGOVUK_13446
+  #   - :topics:
+  #     - environmental-management/boating
+  #   - :topics:
+  #     - 5679543e-81eb-4737-8f33-64e4131fa753
+  # - - 27
+  #   - UKGOVUK_13446
+  #   - :topics:
+  #     - environmental-management/boating
+  #   - :topics:
+  #     - 5679543e-81eb-4737-8f33-64e4131fa753
+  # - - 28
+  #   - UKGOVUK_13446
+  #   - :topics:
+  #     - environmental-management/boating
+  #   - :topics:
+  #     - 5679543e-81eb-4737-8f33-64e4131fa753
+  # - - 29
+  #   - UKGOVUK_13446
+  #   - :topics:
+  #     - environmental-management/boating
+  #   - :topics:
+  #     - 5679543e-81eb-4737-8f33-64e4131fa753
+    # KEEP THIS ONE
+    # - - 30
+    #   - UKGOVUK_13446
+    #   - :topics:
+    #     - environmental-management/boating
+    #   - :topics:
+    #     - 5679543e-81eb-4737-8f33-64e4131fa753
+  # - - 43
+  #   - UKGOVUK_16827
+  #   - :topics:
+  #     - business-tax/construction-industry-scheme
+  #   - :topics:
+  #     - 741f41c9-9083-48e2-bb9a-55b1649fc3bf
+  # - - 45
+  #   - UKGOVUK_16827
+  #   - :topics:
+  #     - business-tax/construction-industry-scheme
+  #   - :topics:
+  #     - 741f41c9-9083-48e2-bb9a-55b1649fc3bf
+    # KEEP THIS ONE
+    # - - 46
+    #   - UKGOVUK_16827
+    #   - :topics:
+    #     - business-tax/construction-industry-scheme
+    #   - :topics:
+    #     - 741f41c9-9083-48e2-bb9a-55b1649fc3bf
+  # - - 44
+  #   - UKGOVUK_16830
+  #   - :topics:
+  #     - business-tax/employment-related-securities
+  #   - :topics:
+  #     - 27426f9e-8bd9-4785-aab5-5f8f1f9a470d
+  # - - 48
+  #   - UKGOVUK_16830
+  #   - :topics:
+  #     - business-tax/employment-related-securities
+  #   - :topics:
+  #     - 27426f9e-8bd9-4785-aab5-5f8f1f9a470d
+    # KEEP THIS ONE
+    # - - 49
+    #   - UKGOVUK_16830
+    #   - :topics:
+    #     - business-tax/employment-related-securities
+    #   - :topics:
+    #     - 27426f9e-8bd9-4785-aab5-5f8f1f9a470d
+  # - - 153
+  #   - UKGOVUK_16938
+  #   - :topics:
+  #     - personal-tax/savings-investment-tax
+  #   - :topics:
+  #     - 11f92608-272a-4c96-8b24-e19a8c6da3bc
+    # KEEP THIS ONE
+    # - - 155
+    #   - UKGOVUK_16938
+    #   - :topics:
+    #     - personal-tax/savings-investment-tax
+    #   - :topics:
+    #     - 11f92608-272a-4c96-8b24-e19a8c6da3bc
+  def up
+    duplicate_subscriber_list_ids = [26, 27, 28, 29, 43, 45, 44, 48, 153]
+    SubscriberList.where(id: duplicate_subscriber_list_ids).destroy_all
+
+    add_index :subscriber_lists, :gov_delivery_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201094128) do
+ActiveRecord::Schema.define(version: 20171205114740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20171201094128) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.integer "subscriber_count"
+    t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true
   end
 
   create_table "subscribers", force: :cascade do |t|

--- a/spec/lib/data_hygiene/data_sync_spec.rb
+++ b/spec/lib/data_hygiene/data_sync_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe DataHygiene::DataSync do
     end
 
     it "won't delete and recreate topics that don't match on title and gov_delivery_id if a record exists that does match on title and gov_delivery_id" do
-      create(:subscriber_list, title: 'Topic alpha', gov_delivery_id: 'TA')
       create(:subscriber_list, title: 'Topic A', gov_delivery_id: 'TA')
       create(:subscriber_list, title: 'Topic B', gov_delivery_id: 'TB')
 

--- a/spec/requests/send_notification_spec.rb
+++ b/spec/requests/send_notification_spec.rb
@@ -79,10 +79,7 @@ RSpec.describe "Sending a notification", type: :request do
     end
 
     def create_many_lists
-      duplicate_topic_id = "UKGOVUK_DUPLICATE"
-
       all_match = create(:subscriber_list,
-        gov_delivery_id: duplicate_topic_id,
         tags: {
           topics: ["oil-and-gas/licensing"],
           organisations: ["environment-agency", "hm-revenue-customs"]
@@ -94,7 +91,6 @@ RSpec.describe "Sending a notification", type: :request do
       })
 
       full_type_partial_tag_match = create(:subscriber_list,
-        gov_delivery_id: duplicate_topic_id,
         tags: {
           topics: ["oil-and-gas/licensing"],
           organisations: ["environment-agency"]


### PR DESCRIPTION
There should be only one `SubscriberList` record per `gov_delivery_id` but there were a few old duplicates.

This PR deletes the duplicates leaving one record per `gov_delivery_id` and adds a uniqueness constraint.

This of course broke a few things so it fixes them as well. spec/requests/send_notification_spec.rb did have a somewhat unsettling reference to `duplicate_topic_id = "UKGOVUK_DUPLICATE"` which suggested that it being a duplicate was significant. I can't see why it would be and the test passes without it anyway but I'd appreciate a bit of extra reviewer scrutiny there please 😺 

Part of [Trello](https://trello.com/c/YtmHgU3b/408-add-page-to-email-alert-frontend-to-capture-a-users-email-address)