### PR TITLE
Increase number workers

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 5
+  pool: 15
   # Necessary to allow creating a db with different encodings.
   # See http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html for details
   template: template0

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: true
-:concurrency:  2
+:concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :queues:
   - high_priority


### PR DESCRIPTION
To cope with the load, we're going to need at least 30 workers running concurrently. Since we have three machines the application gets deployed to, we can set the number of workers per instance to 10.

This means we also need to increase the database connection pool by 10, which means it will increase the number of connections in total by 30. This means we may need to look at increasing the connection limit on the database side.

[Trello Card](https://trello.com/c/7zoZKZkS/281-agree-approach-and-run-load-testing-with-notify)