### PR TITLE
Add a stat on recording pseudo delivery attempts

### DIFF
--- a/app/services/email_sender_service/pseudo.rb
+++ b/app/services/email_sender_service/pseudo.rb
@@ -5,6 +5,8 @@ class EmailSenderService
 Subject: #{subject}
 Body: #{body}
 ))
+      GovukStatsd.increment("pseudo.email_send_request")
+
       "" # provider reference
     end
 


### PR DESCRIPTION
This is useful in giving us visibility during load testing.

[Trello Card](https://trello.com/c/FDFoXpf0/424-increase-visibility-of-metrics-for-load-testing)