### PR TITLE
Add an initial pseudo load test

### DIFF
--- a/lib/load_tester.rb
+++ b/lib/load_tester.rb
@@ -1,0 +1,28 @@
+class LoadTester
+  def self.test_delivery_request_workers(number)
+    new.test_delivery_request_workers(number)
+  end
+
+  def test_delivery_request_workers(number)
+    email = create_test_email(to: success_address(0))
+
+    number.times do
+      DeliveryRequestWorker.perform_async(email.id)
+    end
+  end
+
+private
+
+  def create_test_email(to:)
+    Email.create!(
+      address: to,
+      subject: "Subject",
+      body: "Body",
+    )
+  end
+
+  def success_address(n)
+    tag = n.to_s.rjust(8, "0")
+    "success+#{tag}@simulator.amazonses.com"
+  end
+end

--- a/lib/tasks/load_tests.rake
+++ b/lib/tasks/load_tests.rake
@@ -1,0 +1,13 @@
+require "benchmark"
+require "load_tester"
+
+namespace :load_tests do
+  desc "Run a load test of the DeliveryRequestWorker by triggering 83,333 requests"
+  task :delivery_request_worker, [] => :environment do |_t, _args|
+    results = Benchmark.measure do
+      LoadTester.test_delivery_request_workers(83_333)
+    end
+
+    puts results
+  end
+end


### PR DESCRIPTION
This will trigger 83,333 delivery request workers and time how long it takes to do so. We can then monitor the sidekiq queue to check how long it takes to finish all the jobs.

[Trello Card](https://trello.com/c/HBHdooWY/425-psuedo-load-test-from-deliveryrequestworker)