### PR TITLE
Extract the generation of Public URLs into a service

### DIFF
--- a/app/models/email_renderer.rb
+++ b/app/models/email_renderer.rb
@@ -11,7 +11,7 @@ class EmailRenderer
     <<~BODY
       #{change_note}: #{description}.
 
-      #{url}
+      #{content_url}
       Updated on #{public_updated_at}
 
       #{unsubscribe_links}
@@ -46,10 +46,6 @@ private
     params.fetch(:subscriber)
   end
 
-  def url
-    "#{website_root}#{base_path}"
-  end
-
   def unsubscribe_links
     links = UnsubscribeLink.for(subscriber.subscriptions)
     links.map { |l| present_unsubscribe_link(l) }.join("\n\n")
@@ -59,7 +55,7 @@ private
     "Unsubscribe from '#{link.title}':\n#{link.url}"
   end
 
-  def website_root
-    Plek.new.website_root
+  def content_url
+    PublicUrlService.content_url(base_path: base_path)
   end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -27,13 +27,7 @@ class SubscriberList < ApplicationRecord
   end
 
   def subscription_url
-    gov_delivery_config.fetch(:protocol) +
-      "://" +
-      gov_delivery_config.fetch(:public_hostname) +
-      "/accounts/" +
-      gov_delivery_config.fetch(:account_code) +
-      "/subscriber/new?topic_id=" +
-      self.gov_delivery_id
+    PublicUrlService.deprecated_subscription_url(gov_delivery_id: gov_delivery_id)
   end
 
   def to_json

--- a/app/models/unsubscribe_link.rb
+++ b/app/models/unsubscribe_link.rb
@@ -1,30 +1,21 @@
 class UnsubscribeLink
-  attr_reader :url, :title
-  def initialize(subscription)
-    @subscription = subscription
-    @title = subscription.subscriber_list.title
-    @url = build_url
+  def self.for(subscriptions)
+    subscriptions.map { |s| new(s) }
   end
 
-  def self.for(subscriptions)
-    Array(subscriptions).map do |subscription|
-      new(subscription)
-    end
+  def initialize(subscription)
+    self.subscription = subscription
+  end
+
+  def title
+    subscription.subscriber_list.title
+  end
+
+  def url
+    PublicUrlService.unsubscribe_url(uuid: subscription.uuid, title: title)
   end
 
 private
 
-  attr_reader :subscription
-
-  def build_url
-    "#{root}/email/unsubscribe/#{subscription.uuid}#{title_param}"
-  end
-
-  def root
-    Plek.new.website_root
-  end
-
-  def title_param
-    "?title=#{URI.encode(title, /\W/)}"
-  end
+  attr_accessor :subscription
 end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -1,0 +1,32 @@
+module PublicUrlService
+  class << self
+    def content_url(base_path:)
+      "#{website_root}#{base_path}"
+    end
+
+    def deprecated_subscription_url(gov_delivery_id:)
+      config = EmailAlertAPI.config.gov_delivery
+
+      proto = config.fetch(:protocol)
+      host = config.fetch(:public_hostname)
+      code = config.fetch(:account_code)
+      params = param(:topic_id, gov_delivery_id)
+
+      "#{proto}://#{host}/accounts/#{code}/subscriber/new?#{params}"
+    end
+
+    def unsubscribe_url(uuid:, title:)
+      "#{website_root}/email/unsubscribe/#{uuid}?#{param(:title, title)}"
+    end
+
+  private
+
+    def website_root
+      Plek.new.website_root
+    end
+
+    def param(key, value)
+      "#{key}=#{URI.encode(value, /\W/)}"
+    end
+  end
+end

--- a/spec/services/public_url_service_spec.rb
+++ b/spec/services/public_url_service_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe PublicUrlService do
+  describe ".content_url" do
+    it "returns the GOV.UK url for the content item" do
+      result = subject.content_url(base_path: "/foo/bar")
+      expect(result).to eq("http://www.dev.gov.uk/foo/bar")
+    end
+  end
+
+  describe ".deprecated_subscription_url" do
+    it "returns the govdelivery URL for creating a new subscription" do
+      result = subject.deprecated_subscription_url(gov_delivery_id: "foo_bar")
+
+      expect(result).to eq(
+        "http://govdelivery-public.example.com/accounts/UKGOVUK/subscriber/new?topic_id=foo_bar"
+      )
+    end
+  end
+
+  describe ".unsubscribe_url" do
+    it "returns the GOV.UK url to unsubscribe for a subscription" do
+      result = subject.unsubscribe_url(uuid: "foo-bar", title: "Foo & Bar")
+      expect(result).to eq("http://www.dev.gov.uk/email/unsubscribe/foo-bar?title=Foo%20%26%20Bar")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/bwRGOWZQ/409-add-feature-to-apps-that-serve-email-signup-pages-to-redirect-to-email-alert-frontend-for-email-address-collection

I'd like to add a new Public URL to email-alert-frontend to create
subscriptions. Before this, I think it make sense to group all these
together into one place.

There's further refactoring we couldo do, e.g.
- should SubscriberList have a method to construct a URL?
- is UnsubscribeLink still useful now it's simplified?

... but I've decided to leave these things as those questions are harder
questions to answer.