### PR TITLE
Return 404 if Subscribable not found

### DIFF
--- a/app/controllers/subscribables_controller.rb
+++ b/app/controllers/subscribables_controller.rb
@@ -1,12 +1,19 @@
 class SubscribablesController < ApplicationController
   def show
-    render json: subscribable_json
+    render json: { subscribable: subscribable_attributes }, status: status
   end
 
 private
 
-  def subscribable_json
-    subscriber_list = SubscriberList.find_by(gov_delivery_id: params[:gov_delivery_id])
-    { subscribable: subscriber_list.attributes }
+  def subscribable
+    @subscribable ||= SubscriberList.find_by(gov_delivery_id: params[:gov_delivery_id])
+  end
+
+  def subscribable_attributes
+    subscribable.nil? ? nil : subscribable.attributes
+  end
+
+  def status
+    subscribable.nil? ? 404 : 200
   end
 end

--- a/spec/requests/subscribables_controller_spec.rb
+++ b/spec/requests/subscribables_controller_spec.rb
@@ -2,13 +2,24 @@ require "rails_helper"
 
 RSpec.describe SubscribablesController, type: :request do
   describe "GET /subscribables/<govuk_delivery_id>" do
-    it "returns the subscribable" do
-      subscribable = create(:subscriber_list, gov_delivery_id: "test135")
-      get "/subscribables/test135"
+    context "the subscribable exists" do
+      let!(:subscribable) { create(:subscriber_list, gov_delivery_id: "test135") }
 
-      subscribable_response = JSON.parse(response.body).deep_symbolize_keys[:subscribable]
+      it "returns it" do
+        get "/subscribables/test135"
 
-      expect(subscribable_response[:id]).to eq(subscribable.id)
+        subscribable_response = JSON.parse(response.body).deep_symbolize_keys[:subscribable]
+
+        expect(subscribable_response[:id]).to eq(subscribable.id)
+      end
+    end
+
+    context "the subscribable doesn't exist" do
+      it "returns a 404" do
+        get "/subscribables/test135"
+
+        expect(response.status).to eq(404)
+      end
     end
   end
 end


### PR DESCRIPTION
As we are retrieving `SubscriberList` using `find_by` it can be `nil` when not found. This commit returns `nil` and 404 in this scenario rather than letting a 500 happen when we try to get the attributes.

Part of [Trello](https://trello.com/c/YtmHgU3b/408-add-page-to-email-alert-frontend-to-capture-a-users-email-address)