### PR TITLE
Make health checks less strict

### DIFF
--- a/app/models/healthcheck/queue_latency_healthcheck.rb
+++ b/app/models/healthcheck/queue_latency_healthcheck.rb
@@ -43,7 +43,7 @@ class Healthcheck
     end
 
     def warning_size
-      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_WARNING", 5).to_i
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_WARNING", 250).to_i
     end
   end
 end

--- a/app/models/healthcheck/queue_latency_healthcheck.rb
+++ b/app/models/healthcheck/queue_latency_healthcheck.rb
@@ -39,7 +39,7 @@ class Healthcheck
     end
 
     def critical_size
-      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_CRITICAL", 10).to_i
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_CRITICAL", 300).to_i
     end
 
     def warning_size

--- a/app/models/healthcheck/queue_size_healthcheck.rb
+++ b/app/models/healthcheck/queue_size_healthcheck.rb
@@ -29,7 +29,7 @@ class Healthcheck
     end
 
     def critical_size
-      ENV.fetch("SIDEKIQ_QUEUE_SIZE_CRITICAL", 5).to_i
+      ENV.fetch("SIDEKIQ_QUEUE_SIZE_CRITICAL", 100000).to_i
     end
 
     def warning_size

--- a/app/models/healthcheck/queue_size_healthcheck.rb
+++ b/app/models/healthcheck/queue_size_healthcheck.rb
@@ -33,7 +33,7 @@ class Healthcheck
     end
 
     def warning_size
-      ENV.fetch("SIDEKIQ_QUEUE_SIZE_WARNING", 2).to_i
+      ENV.fetch("SIDEKIQ_QUEUE_SIZE_WARNING", 75000).to_i
     end
   end
 end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe HealthcheckController, type: :controller do
     before do
       allow_any_instance_of(Healthcheck::QueueSizeHealthcheck)
         .to receive(:queues)
-        .and_return(default: 3)
+        .and_return(default: 80000)
     end
 
     it "returns a status of 'warning'" do

--- a/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Healthcheck::QueueLatencyHealthcheck do
   end
 
   context "when the warning threshold is reached" do
-    let(:latency) { 5 }
+    let(:latency) { 275 }
     specify { expect(subject.status).to eq(:warning) }
   end
 

--- a/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Healthcheck::QueueLatencyHealthcheck do
   end
 
   context "when the critical threshold is reached" do
-    let(:latency) { 10 }
+    let(:latency) { 500 }
     specify { expect(subject.status).to eq(:critical) }
   end
 end

--- a/spec/models/healthcheck/queue_size_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_size_healthcheck_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Healthcheck::QueueSizeHealthcheck do
   end
 
   context "when the critical threshold is reached" do
-    let(:size) { 5 }
+    let(:size) { 200000 }
     specify { expect(subject.status).to eq(:critical) }
   end
 

--- a/spec/models/healthcheck/queue_size_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_size_healthcheck_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Healthcheck::QueueSizeHealthcheck do
   end
 
   context "when the warning threshold is reached" do
-    let(:size) { 2 }
+    let(:size) { 80000 }
     specify { expect(subject.status).to eq(:warning) }
   end
 


### PR DESCRIPTION
We have some hilariously low thresholds at the moment. These numbers are likely to change in the future as we discover better thresholds, but this will at least stop icinga criticals appearing while we do load testing.