### PR TITLE
Add a feature flag to use email-alert-frontend for email collection

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -27,7 +27,11 @@ class SubscriberList < ApplicationRecord
   end
 
   def subscription_url
-    PublicUrlService.deprecated_subscription_url(gov_delivery_id: gov_delivery_id)
+    if use_email_alert_frontend_for_email_collection?
+      PublicUrlService.subscription_url(gov_delivery_id: gov_delivery_id)
+    else
+      PublicUrlService.deprecated_subscription_url(gov_delivery_id: gov_delivery_id)
+    end
   end
 
   def to_json
@@ -50,5 +54,10 @@ private
 
   def gov_delivery_config
     EmailAlertAPI.config.gov_delivery
+  end
+
+  # We could make this more sophisticated if needed, e.g. check document_type.
+  def use_email_alert_frontend_for_email_collection?
+    ENV.include?("USE_EMAIL_ALERT_FRONTEND_FOR_EMAIL_COLLECTION")
   end
 end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -4,6 +4,17 @@ module PublicUrlService
       "#{website_root}#{base_path}"
     end
 
+    # This url is for the page mid-way through the signup journey where the user
+    # enters their email address. At present, multiple frontends start the
+    # journey, e.g. collections, but eventually all these will be consolidated
+    # into email-alert-frontend and this URL will no longer be needed.
+    def subscription_url(gov_delivery_id:)
+      params = param(:topic_id, gov_delivery_id)
+      "#{website_root}/email/subscriptions/new?#{params}"
+    end
+
+    # This url is for the page mid-way through the signup journey where the user
+    # enters their email address. This is where we handover to govdelivery.
     def deprecated_subscription_url(gov_delivery_id:)
       config = EmailAlertAPI.config.gov_delivery
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -99,12 +99,28 @@ RSpec.describe SubscriberList, type: :model do
   end
 
   describe "#subscription_url" do
-    it "provides the subscription URL based on the gov_delivery_id" do
-      list = SubscriberList.new(gov_delivery_id: "UKGOVUK_4567")
+    subject { SubscriberList.new(gov_delivery_id: "UKGOVUK_4567") }
 
-      expect(list.subscription_url).to eq(
+    it "returns the govdelivery subscription URL" do
+      expect(subject.subscription_url).to eq(
         "http://govdelivery-public.example.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_4567"
       )
+    end
+
+    context "when switching over to use email alert frontend for email collection" do
+      before do
+        allow(ENV).to receive(:include?).and_call_original
+
+        allow(ENV).to receive(:include?)
+          .with("USE_EMAIL_ALERT_FRONTEND_FOR_EMAIL_COLLECTION")
+          .and_return(true)
+      end
+
+      it "returns the email alert frontend subscription URL" do
+        expect(subject.subscription_url).to eq(
+          "http://www.dev.gov.uk/email/subscriptions/new?topic_id=UKGOVUK_4567"
+        )
+      end
     end
   end
 end

--- a/spec/services/public_url_service_spec.rb
+++ b/spec/services/public_url_service_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe PublicUrlService do
     end
   end
 
+  describe ".subscription_url" do
+    it "returns the GOV.UK for the new subscription page" do
+      result = subject.subscription_url(gov_delivery_id: "foo_bar")
+      expect(result).to eq("http://www.dev.gov.uk/email/subscriptions/new?topic_id=foo_bar")
+    end
+  end
+
   describe ".deprecated_subscription_url" do
     it "returns the govdelivery URL for creating a new subscription" do
       result = subject.deprecated_subscription_url(gov_delivery_id: "foo_bar")


### PR DESCRIPTION
https://trello.com/c/bwRGOWZQ/409-add-feature-to-apps-that-serve-email-signup-pages-to-redirect-to-email-alert-frontend-for-email-address-collection

We serve the subscription_url as a field in the
JSON response when clients call
find_or_create_subscriber_list. That means we can
toggle the subscription_url in email-alert-api to
affect all apps.

If we need more granular control, we can switch
over a few document_types at a time.

Here's where we use `subscription_url` in each client app:

- [collections](https://github.com/alphagov/collections/blob/60fcda67508170fe51b8227139fe217bfa47ca65/app/models/email_signup.rb#L16)
- [finder-frontend](https://github.com/alphagov/finder-frontend/blob/b0fd3ce2aa6405dc9ffd50912b832e471cc7cb37/lib/email_alert_signup_api.rb#L14)
- [whitehall](https://github.com/alphagov/whitehall/blob/a53f622a3e8fb5aa296bc532ae0d48a29e614a38/app/models/email_signup.rb#L41)