### PR TITLE
Implement some initial load tests for all the workers

### DIFF
--- a/lib/load_tester.rb
+++ b/lib/load_tester.rb
@@ -44,14 +44,25 @@ private
     Email.create!(address: to, body: "body", subject: "subject")
   end
 
-  def create_test_subscriber_list
+  def create_test_subscriber_list(document_type: nil)
+    document_type = SecureRandom.uuid unless document_type
+
     SubscriberList.create!(
       title: "title",
       gov_delivery_id: SecureRandom.uuid,
+      document_type: document_type,
     )
   end
 
-  def create_test_content_change
+  def create_test_subscriber_lists(number, document_type_prefix:)
+    number.times.map do |i|
+      create_test_subscriber_list(document_type: "#{document_type_prefix}-#{i}")
+    end
+  end
+
+  def create_test_content_change(document_type: nil)
+    document_type = SecureRandom.uuid unless document_type
+
     ContentChange.create!(
       content_id: SecureRandom.uuid,
       title: "title",
@@ -62,9 +73,15 @@ private
       email_document_supertype: "email document supertype",
       government_document_supertype: "government document supertype",
       govuk_request_id: SecureRandom.uuid,
-      document_type: "document type",
+      document_type: document_type,
       publishing_app: "publishing app",
     )
+  end
+
+  def create_test_content_changes(number, document_type_prefix:)
+    number.times.map do |i|
+      create_test_content_change(document_type: "#{document_type_prefix}-#{i}")
+    end
   end
 
   def create_test_subscribers(n)

--- a/lib/load_tester.rb
+++ b/lib/load_tester.rb
@@ -4,7 +4,7 @@ class LoadTester
   end
 
   def test_delivery_request_workers(number)
-    email = create_email(to: test_address(0))
+    email = create_test_email(to: test_address(0))
 
     number.times do
       DeliveryRequestWorker.perform_async(email.id)
@@ -14,15 +14,60 @@ class LoadTester
 private
 
   def create_test_email(to:)
-    Email.create!(
-      address: to,
-      subject: "Subject",
-      body: "Body",
+    Email.create!(address: to, body: "body", subject: "subject")
+  end
+
+  def create_test_subscriber_list
+    SubscriberList.create!(
+      title: "title",
+      gov_delivery_id: SecureRandom.uuid,
     )
+  end
+
+  def create_test_content_change
+    ContentChange.create!(
+      content_id: SecureRandom.uuid,
+      title: "title",
+      base_path: "base path",
+      change_note: "change note",
+      description: "description",
+      public_updated_at: DateTime.now,
+      email_document_supertype: "email document supertype",
+      government_document_supertype: "government document supertype",
+      govuk_request_id: SecureRandom.uuid,
+      document_type: "document type",
+      publishing_app: "publishing app",
+    )
+  end
+
+  def create_test_subscribers(n)
+    n.times.map do |i|
+      create_test_subscriber(number: i)
+    end
   end
 
   def test_address(n)
     tag = n.to_s.rjust(8, "0")
     "success+#{tag}@simulator.amazonses.com"
+  end
+
+  def create_test_subscriber(number:)
+    Subscriber.find_or_create_by!(address: test_address(number))
+  end
+
+  def create_subscriptions(subscribers:, subscriber_list:)
+    records = subscribers.map do |subscriber|
+      {subscriber_id: subscriber.id, subscriber_list_id: subscriber_list.id}
+    end
+
+    Subscription.create!(records)
+  end
+
+  def create_subscription_contents(subscriptions:, content_change:)
+    records = subscriptions.map do |subscription|
+      {content_change_id: content_change.id, subscription_id: subscription.id}
+    end
+
+    SubscriptionContent.create!(records)
   end
 end

--- a/lib/load_tester.rb
+++ b/lib/load_tester.rb
@@ -1,28 +1,30 @@
 class LoadTester
-  def self.test_delivery_request_workers(number)
-    new.test_delivery_request_workers(number)
+  def self.test_delivery_request_worker(number)
+    new.test_delivery_request_worker(number)
   end
 
-  def test_delivery_request_workers(number)
+  def test_delivery_request_worker(number)
+    puts "Creating email"
     email = create_test_email(to: test_address(0))
 
+    puts "Running workers"
     number.times do
       DeliveryRequestWorker.perform_async(email.id)
     end
   end
 
-  def self.test_email_generation_workers(number)
-    new.test_email_generation_workers(number)
+  def self.test_email_generation_worker(number)
+    new.test_email_generation_worker(number)
   end
 
-  def test_email_generation_workers(number)
-    puts "Creating subscriber list and content change"
-
+  def test_email_generation_worker(number)
+    puts "Creating subscriber list"
     subscriber_list = create_test_subscriber_list
+
+    puts "Creating content change"
     content_change = create_test_content_change
 
     puts "Creating #{number} subscribers"
-
     subscribers = create_test_subscribers(number)
 
     puts "Creating #{number} subscriptions"
@@ -32,37 +34,32 @@ class LoadTester
     subscription_contents = create_subscription_contents(subscriptions: subscriptions, content_change: content_change)
 
     puts "Running workers"
-
     subscription_contents.each do |subscription_content|
       EmailGenerationWorker.perform_async(subscription_content_id: subscription_content.id, priority: :low)
     end
   end
 
-  def self.test_subscription_content_workers(number)
-    new.test_subscription_content_workers(number)
+  def self.test_subscription_content_worker(number)
+    new.test_subscription_content_worker(number)
   end
 
-  def test_subscription_content_workers(number)
-    document_type_prefix = SecureRandom.uuid
+  def test_subscription_content_worker(number)
+    document_type = SecureRandom.uuid
 
     puts "Creating #{number} subscribers"
     subscribers = create_test_subscribers(number)
 
-    puts "Creating #{number} subscriber lists"
-    subscriber_lists = create_test_subscriber_lists(number, document_type_prefix: document_type_prefix)
+    puts "Creating subscriber list"
+    subscriber_list = create_test_subscriber_list(document_type)
 
     puts "Creating #{number} subscriptions"
-    subscriptions = subscribers.zip(subscriber_lists).map do |subscriber, subscriber_list|
-      Subscription.create!(subscriber: subscriber, subscriber_list: subscriber_list)
-    end
+    create_subscriptions(subscribers: subscribers, subscriber_list: subscriber_list)
 
-    puts "Creating #{number} content changes"
-    content_changes = create_test_content_changes(number, document_type_prefix: document_type_prefix)
+    puts "Creating content change"
+    content_change = create_test_content_change(document_type)
 
-    puts "Running workers"
-    content_changes.each do |content_change|
-      SubscriptionContentWorker.perform_async(content_change_id: content_change.id, priority: :low)
-    end
+    puts "Running worker"
+    SubscriptionContentWorker.perform_async(content_change_id: content_change.id, priority: :low)
   end
 
   def self.test_notification_handler_service(number)
@@ -70,47 +67,40 @@ class LoadTester
   end
 
   def test_notification_handler_service(number)
-    document_type_prefix = SecureRandom.uuid
+    document_type = SecureRandom.uuid
 
     puts "Creating #{number} subscribers"
     subscribers = create_test_subscribers(number)
 
-    puts "Creating #{number} subscriber lists"
-    subscriber_lists = create_test_subscriber_lists(number, document_type_prefix: document_type_prefix)
+    puts "Creating subscriber list"
+    subscriber_list = create_test_subscriber_list(document_type)
 
     puts "Creating #{number} subscriptions"
-    subscriptions = subscribers.zip(subscriber_lists).map do |subscriber, subscriber_list|
-      Subscription.create!(subscriber: subscriber, subscriber_list: subscriber_list)
-    end
+    create_subscriptions(subscribers: subscribers, subscriber_list: subscriber_list)
 
-    puts "Creating #{number} content changes"
-    content_changes = create_test_content_changes(number, document_type_prefix: document_type_prefix)
+    puts "Creating content change"
+    content_change = create_test_content_change(document_type)
 
     puts "Converting content changes into params"
-    content_changes_params = content_changes.map do |content_change|
-      params = {
-        content_id: content_change.content_id,
-        title: content_change.title,
-        change_note: content_change.change_note,
-        description: content_change.description,
-        base_path: content_change.base_path,
-        links: content_change.links,
-        tags: content_change.tags,
-        public_updated_at: content_change.public_updated_at.to_s,
-        email_document_supertype: content_change.email_document_supertype,
-        government_document_supertype: content_change.government_document_supertype,
-        govuk_request_id: content_change.govuk_request_id,
-        document_type: content_change.document_type,
-        publishing_app: content_change.publishing_app,
-      }
-      content_change.delete
-      params
-    end
+    params = {
+      content_id: content_change.content_id,
+      title: content_change.title,
+      change_note: content_change.change_note,
+      description: content_change.description,
+      base_path: content_change.base_path,
+      links: content_change.links,
+      tags: content_change.tags,
+      public_updated_at: content_change.public_updated_at.to_s,
+      email_document_supertype: content_change.email_document_supertype,
+      government_document_supertype: content_change.government_document_supertype,
+      govuk_request_id: content_change.govuk_request_id,
+      document_type: content_change.document_type,
+      publishing_app: content_change.publishing_app,
+    }
+    content_change.delete
 
     puts "Running service"
-    content_changes_params.each do |params|
-      NotificationHandlerService.call(params: params)
-    end
+    NotificationHandlerService.call(params: params)
   end
 
 private
@@ -119,7 +109,7 @@ private
     Email.create!(address: to, body: "body", subject: "subject")
   end
 
-  def create_test_subscriber_list(document_type: nil)
+  def create_test_subscriber_list(document_type = nil)
     document_type = SecureRandom.uuid unless document_type
 
     SubscriberList.create!(
@@ -129,13 +119,7 @@ private
     )
   end
 
-  def create_test_subscriber_lists(number, document_type_prefix:)
-    number.times.map do |i|
-      create_test_subscriber_list(document_type: "#{document_type_prefix}-#{i}")
-    end
-  end
-
-  def create_test_content_change(document_type: nil)
+  def create_test_content_change(document_type = nil)
     document_type = SecureRandom.uuid unless document_type
 
     ContentChange.create!(
@@ -151,12 +135,6 @@ private
       document_type: document_type,
       publishing_app: "publishing app",
     )
-  end
-
-  def create_test_content_changes(number, document_type_prefix:)
-    number.times.map do |i|
-      create_test_content_change(document_type: "#{document_type_prefix}-#{i}")
-    end
   end
 
   def create_test_subscribers(n)
@@ -176,7 +154,7 @@ private
 
   def create_subscriptions(subscribers:, subscriber_list:)
     records = subscribers.map do |subscriber|
-      {subscriber_id: subscriber.id, subscriber_list_id: subscriber_list.id}
+      { subscriber_id: subscriber.id, subscriber_list_id: subscriber_list.id }
     end
 
     Subscription.create!(records)
@@ -184,7 +162,7 @@ private
 
   def create_subscription_contents(subscriptions:, content_change:)
     records = subscriptions.map do |subscription|
-      {content_change_id: content_change.id, subscription_id: subscription.id}
+      { content_change_id: content_change.id, subscription_id: subscription.id }
     end
 
     SubscriptionContent.create!(records)

--- a/lib/load_tester.rb
+++ b/lib/load_tester.rb
@@ -11,6 +11,33 @@ class LoadTester
     end
   end
 
+  def self.test_email_generation_workers(number)
+    new.test_email_generation_workers(number)
+  end
+
+  def test_email_generation_workers(number)
+    puts "Creating subscriber list and content change"
+
+    subscriber_list = create_test_subscriber_list
+    content_change = create_test_content_change
+
+    puts "Creating #{number} subscribers"
+
+    subscribers = create_test_subscribers(number)
+
+    puts "Creating #{number} subscriptions"
+    subscriptions = create_subscriptions(subscribers: subscribers, subscriber_list: subscriber_list)
+
+    puts "Creating #{number} subscription contents"
+    subscription_contents = create_subscription_contents(subscriptions: subscriptions, content_change: content_change)
+
+    puts "Running workers"
+
+    subscription_contents.each do |subscription_content|
+      EmailGenerationWorker.perform_async(subscription_content_id: subscription_content.id, priority: :low)
+    end
+  end
+
 private
 
   def create_test_email(to:)

--- a/lib/load_tester.rb
+++ b/lib/load_tester.rb
@@ -4,7 +4,7 @@ class LoadTester
   end
 
   def test_delivery_request_workers(number)
-    email = create_test_email(to: success_address(0))
+    email = create_email(to: test_address(0))
 
     number.times do
       DeliveryRequestWorker.perform_async(email.id)
@@ -21,7 +21,7 @@ private
     )
   end
 
-  def success_address(n)
+  def test_address(n)
     tag = n.to_s.rjust(8, "0")
     "success+#{tag}@simulator.amazonses.com"
   end

--- a/lib/tasks/load_tests.rake
+++ b/lib/tasks/load_tests.rake
@@ -2,10 +2,10 @@ require "benchmark"
 require "load_tester"
 
 namespace :load_tests do
-  desc "Run a load test of the DeliveryRequestWorker by triggering 83,333 requests"
-  task :delivery_request_worker, [] => :environment do |_t, _args|
+  desc "Run a load test of the DeliveryRequestWorker by triggering requests"
+  task :delivery_request_workers, [:number] => :environment do |_t, args|
     results = Benchmark.measure do
-      LoadTester.test_delivery_request_workers(83_333)
+      LoadTester.test_delivery_request_workers(args[:number].to_i)
     end
 
     puts results

--- a/lib/tasks/load_tests.rake
+++ b/lib/tasks/load_tests.rake
@@ -19,4 +19,13 @@ namespace :load_tests do
 
     puts results
   end
+
+  desc "Run a load test of the SubscriptionContentWorker by triggering requests"
+  task :subscription_content_worker, [:number] => :environment do |_t, args|
+    results = Benchmark.measure do
+      LoadTester.test_subscription_content_workers(args[:number].to_i)
+    end
+
+    puts results
+  end
 end

--- a/lib/tasks/load_tests.rake
+++ b/lib/tasks/load_tests.rake
@@ -28,4 +28,13 @@ namespace :load_tests do
 
     puts results
   end
+
+  desc "Run a load test of the NotificationHandlerService by triggering requests"
+  task :notification_handler_service, [:number] => :environment do |_t, args|
+    results = Benchmark.measure do
+      LoadTester.test_notification_handler_service(args[:number].to_i)
+    end
+
+    puts results
+  end
 end

--- a/lib/tasks/load_tests.rake
+++ b/lib/tasks/load_tests.rake
@@ -1,40 +1,40 @@
 require "benchmark"
 require "load_tester"
 
+def benchmark_and_print
+  results = Benchmark.measure do
+    yield
+  end
+
+  puts results
+end
+
 namespace :load_tests do
   desc "Run a load test of the DeliveryRequestWorker by triggering requests"
   task :delivery_request_worker, [:number] => :environment do |_t, args|
-    results = Benchmark.measure do
+    benchmark_and_print do
       LoadTester.test_delivery_request_worker(args[:number].to_i)
     end
-
-    puts results
   end
 
   desc "Run a load test of the EmailGenerationWorker by triggering requests"
   task :email_generation_worker, [:number] => :environment do |_t, args|
-    results = Benchmark.measure do
+    benchmark_and_print do
       LoadTester.test_email_generation_worker(args[:number].to_i)
     end
-
-    puts results
   end
 
   desc "Run a load test of the SubscriptionContentWorker by triggering requests"
   task :subscription_content_worker, [:number] => :environment do |_t, args|
-    results = Benchmark.measure do
+    benchmark_and_print do
       LoadTester.test_subscription_content_worker(args[:number].to_i)
     end
-
-    puts results
   end
 
   desc "Run a load test of the NotificationHandlerService by triggering requests"
   task :notification_handler_service, [:number] => :environment do |_t, args|
-    results = Benchmark.measure do
+    benchmark_and_print do
       LoadTester.test_notification_handler_service(args[:number].to_i)
     end
-
-    puts results
   end
 end

--- a/lib/tasks/load_tests.rake
+++ b/lib/tasks/load_tests.rake
@@ -5,7 +5,7 @@ namespace :load_tests do
   desc "Run a load test of the DeliveryRequestWorker by triggering requests"
   task :delivery_request_worker, [:number] => :environment do |_t, args|
     results = Benchmark.measure do
-      LoadTester.test_delivery_request_workers(args[:number].to_i)
+      LoadTester.test_delivery_request_worker(args[:number].to_i)
     end
 
     puts results
@@ -14,7 +14,7 @@ namespace :load_tests do
   desc "Run a load test of the EmailGenerationWorker by triggering requests"
   task :email_generation_worker, [:number] => :environment do |_t, args|
     results = Benchmark.measure do
-      LoadTester.test_email_generation_workers(args[:number].to_i)
+      LoadTester.test_email_generation_worker(args[:number].to_i)
     end
 
     puts results
@@ -23,7 +23,7 @@ namespace :load_tests do
   desc "Run a load test of the SubscriptionContentWorker by triggering requests"
   task :subscription_content_worker, [:number] => :environment do |_t, args|
     results = Benchmark.measure do
-      LoadTester.test_subscription_content_workers(args[:number].to_i)
+      LoadTester.test_subscription_content_worker(args[:number].to_i)
     end
 
     puts results

--- a/lib/tasks/load_tests.rake
+++ b/lib/tasks/load_tests.rake
@@ -3,9 +3,18 @@ require "load_tester"
 
 namespace :load_tests do
   desc "Run a load test of the DeliveryRequestWorker by triggering requests"
-  task :delivery_request_workers, [:number] => :environment do |_t, args|
+  task :delivery_request_worker, [:number] => :environment do |_t, args|
     results = Benchmark.measure do
       LoadTester.test_delivery_request_workers(args[:number].to_i)
+    end
+
+    puts results
+  end
+
+  desc "Run a load test of the EmailGenerationWorker by triggering requests"
+  task :email_generation_worker, [:number] => :environment do |_t, args|
+    results = Benchmark.measure do
+      LoadTester.test_email_generation_workers(args[:number].to_i)
     end
 
     puts results


### PR DESCRIPTION
This adds in some initial load tests for all the workers we want to test. The outline of what each test does:

`DeliveryRequestWorker`
- Create 1 email
- Trigger 83,333 workers

`EmailGenerationWorker`
- Create 1 subscriber list
- Create 1 content change
- Create 83,333 subscribers
- Create 83,333 subscriptions
- Create 83,333 subscription contents
- Trigger 83,333 workers

`SubscriptionContentWorker`
- Create 1 subscriber lists
- Create 83,333 subscribers
- Create 83,333 subscriptions
- Create 1 content changes
- Trigger 1 workers

`NotificationHandlerService`
- Create 1 subscriber list
- Create 83,333 subscribers
- Create 83,333 subscriptions
- Trigger 1 workers

We may decide that we want to change the tests in the future to use a more complex subscription matching query involving the tags and links, but I think that's best left for a different PR. These initial tests will still give us some useful numbers and if any of the workers aren't able to cope with the load we want, we'll need to fix that first anyway before doing more complex tests.