### PR TITLE
Add a metric to store how long we're sleeping for rate limiting

### DIFF
--- a/app/services/rate_sleeper_service.rb
+++ b/app/services/rate_sleeper_service.rb
@@ -13,6 +13,8 @@ class RateSleeperService
       execution_time_in_milliseconds: duration_in_milliseconds
     )
 
+    GovukStatsd.timing("rate_sleeper_service.required_sleep_time", required_sleep_time)
+
     sleep(required_sleep_time) if required_sleep_time.positive?
   end
 


### PR DESCRIPTION
This will allow us to see how much time we're sleeping in jobs and therefore not processing anything else.