### PR TITLE
Configure delivery workers to use a separate queue

### DIFF
--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -3,9 +3,9 @@ class DeliveryRequestWorker
 
   def self.queue_for_priority(priority)
     if priority == :high
-      :high_priority
+      :high_delivery
     elsif priority == :low
-      :default
+      :low_delivery
     else
       raise ArgumentError, "priority should be :high or :low"
     end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,5 +3,6 @@
 :concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - high_priority
-  - default
+  - [default, 10]
+  - [high_delivery, 5]
+  - [low_delivery, 1]

--- a/spec/workers/delivery_request_worker_spec.rb
+++ b/spec/workers/delivery_request_worker_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe DeliveryRequestWorker do
       let(:priority) { :low }
 
       it "adds a worker to the low priority queue" do
-        expect(Sidekiq::Queues["default"].size).to eq(1)
+        expect(Sidekiq::Queues["low_delivery"].size).to eq(1)
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe DeliveryRequestWorker do
       let(:priority) { :high }
 
       it "adds a worker to the high priority queue" do
-        expect(Sidekiq::Queues["high_priority"].size).to eq(1)
+        expect(Sidekiq::Queues["high_delivery"].size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
This will mean that 10 other workers are picked for every 5 high priority delivery worker and every 1 low priority delivery worker.

The aim of this is to solve a problem we've noticed in load testing where the delivery request workers are sleeping a lot which prevents other workers from performing actions.

I've picked these numbers for lack of a better idea, feel free to make suggestions or we'll just have to experiment and see what happens.