### PR TITLE
Reduce priority of other workers

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,6 +3,6 @@
 :concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - [default, 10]
-  - [high_delivery, 5]
+  - [default, 5]
+  - [high_delivery, 4]
   - [low_delivery, 1]


### PR DESCRIPTION
After running a load test we found that more workers were able to be processed, but there was still spare capacity available for rate limiting.