### PR TITLE
Don't raise a 500 server error when subscribing with no email address

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,4 +1,4 @@
-class HealthcheckController < ActionController::Base
+class HealthcheckController < ApplicationController
   def check
     render json: healthcheck.details.merge(status: healthcheck.status)
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,4 +1,4 @@
-class SubscriptionsController < ActionController::Base
+class SubscriptionsController < ApplicationController
   def create
     subscription = Subscription.find_or_initialize_by(
       subscriber: subscriber,
@@ -18,7 +18,7 @@ class SubscriptionsController < ActionController::Base
 private
 
   def subscriber
-    Subscriber.find_or_create_by(address: subscription_params[:address])
+    Subscriber.find_or_create_by!(address: subscription_params[:address])
   end
 
   def subscribable

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -91,4 +91,16 @@ RSpec.describe SubscriptionsController, type: :controller do
       end
     end
   end
+
+  context "with an invalid email address" do
+    let(:subscribable) { create(:subscriber_list) }
+
+    def create_subscription
+      post :create, params: { subscribable_id: subscribable.id, address: "invalid" }, format: :json
+    end
+
+    it "raises an error" do
+      expect { create_subscription }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/amAa5HkV/444-handle-error-cases-for-capturing-a-users-email-address

Previously, the `find_or_create_by` would fail because the address is
invalid but still instantiate a Subscriber object which later causes
errors in the controller. This change fails early and responds with a
422 error when this happens.

This makes use of Rails default error handling as per
config.action_dispatch.rescue_responses