### PR TITLE
Implement email generation worker as per design

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gem 'pg', '0.20.0'
 gem 'rails', '5.1.0'
 
+gem 'with_advisory_lock', '~> 3.2'
+
 gem 'faraday', '0.12.1'
 gem 'gds-api-adapters', '~> 47.9.0'
 gem 'gds-sso', '~> 13.2'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'pg', '0.20.0'
 gem 'rails', '5.1.0'
 
+gem 'activerecord-import', '~> 0.21'
 gem 'with_advisory_lock', '~> 3.2'
 
 gem 'faraday', '0.12.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
       activemodel (= 5.1.0)
       activesupport (= 5.1.0)
       arel (~> 8.0)
+    activerecord-import (0.21.0)
+      activerecord (>= 3.2)
     activesupport (5.1.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -311,6 +313,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import (~> 0.21)
   equivalent-xml
   factory_girl_rails
   faraday (= 0.12.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    with_advisory_lock (3.2.0)
+      activerecord (>= 3.2)
 
 PLATFORMS
   ruby
@@ -331,6 +333,7 @@ DEPENDENCIES
   sidekiq-unique-jobs (~> 5.0)
   timecop
   webmock
+  with_advisory_lock (~> 3.2)
 
 BUNDLED WITH
    1.16.0

--- a/app/models/unsubscribe_link.rb
+++ b/app/models/unsubscribe_link.rb
@@ -1,22 +1,21 @@
 class UnsubscribeLink
   def self.for(subscriptions)
-    subscriptions.includes(:subscriber_list).pluck(:title, :uuid).map do |title, uuid|
-      new(title: title, uuid: uuid)
-    end
+    subscriptions.map { |s| new(s) }
   end
 
-  attr_reader :title
+  def initialize(subscription)
+    self.subscription = subscription
+  end
 
-  def initialize(title:, uuid:)
-    @title = title
-    @uuid = uuid
+  def title
+    subscription.subscriber_list.title
   end
 
   def url
-    PublicUrlService.unsubscribe_url(uuid: uuid, title: title)
+    PublicUrlService.unsubscribe_url(uuid: subscription.uuid, title: title)
   end
 
 private
 
-  attr_reader :uuid
+  attr_accessor :subscription
 end

--- a/app/workers/email_generation_worker.rb
+++ b/app/workers/email_generation_worker.rb
@@ -1,3 +1,5 @@
+require "sidekiq-scheduler"
+
 class EmailGenerationWorker
   include Sidekiq::Worker
 

--- a/app/workers/email_generation_worker.rb
+++ b/app/workers/email_generation_worker.rb
@@ -5,6 +5,8 @@ class EmailGenerationWorker
 
   LOCK_NAME = "email_generation_worker".freeze
 
+  sidekiq_options unique: :until_and_while_executing
+
   def perform
     SubscriptionContent.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
       subscription_contents.find_each do |subscription_content|

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -13,16 +13,16 @@ private
   def queue_delivery_to_subscribers(content_change)
     subscriptions_for(content_change: content_change).find_each do |subscription|
       begin
-        subscription_content = SubscriptionContent.create!(
+        SubscriptionContent.create!(
           content_change: content_change,
           subscription: subscription,
         )
-
-        EmailGenerationWorker.perform_async(subscription_content.id)
       rescue StandardError => ex
         Raven.capture_exception(ex, tags: { version: 2 })
       end
     end
+
+    EmailGenerationWorker.perform_async
   end
 
   def queue_delivery_to_courtesy_subscribers(content_change)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,3 +6,7 @@
   - [high_delivery, 3]
   - [low_delivery, 2]
   - [default, 1]
+:schedule:
+  email_generation:
+    every: '5s'
+    class: EmailGenerationWorker

--- a/db/migrate/20171208173101_add_lock_version_to_subscription_content.rb
+++ b/db/migrate/20171208173101_add_lock_version_to_subscription_content.rb
@@ -1,0 +1,5 @@
+class AddLockVersionToSubscriptionContent < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscription_contents, :lock_version, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171208081924) do
+ActiveRecord::Schema.define(version: 20171208173101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20171208081924) do
     t.bigint "email_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "lock_version", default: 0, null: false
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"

--- a/lib/load_tester.rb
+++ b/lib/load_tester.rb
@@ -156,19 +156,23 @@ private
     puts "Creating #{subscribers.length} subscriptions"
 
     records = subscribers.map do |subscriber|
-      { subscriber_id: subscriber.id, subscriber_list_id: subscriber_list.id }
+      Subscription.new(uuid: SecureRandom.uuid, subscriber_id: subscriber.id, subscriber_list_id: subscriber_list.id)
     end
 
-    Subscription.create!(records)
+    Subscription.import!(records)
+
+    records
   end
 
   def create_subscription_contents(subscriptions:, content_change:)
     puts "Creating #{subscriptions.length} subscription contents"
 
     records = subscriptions.map do |subscription|
-      { content_change_id: content_change.id, subscription_id: subscription.id }
+      SubscriptionContent.new(content_change_id: content_change.id, subscription_id: subscription.id)
     end
 
-    SubscriptionContent.create!(records)
+    SubscriptionContent.import!(records)
+
+    records
   end
 end

--- a/spec/models/email_renderer_spec.rb
+++ b/spec/models/email_renderer_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe EmailRenderer do
   let(:subscriber) { double(:subscriber, subscriptions: subscriptions) }
 
-  before do
-    create(:subscription, uuid: "ad22a6f8-d6dd-4989-98e0-29a7c1049173", subscriber_list: create(:subscriber_list, title: "First Subscription"))
-    create(:subscription, uuid: "6fabfabd-8d02-4dc3-8190-a647ae69aef2", subscriber_list: create(:subscriber_list, title: "Second Subscription"))
+  let(:subscriptions) do
+    [
+      double(uuid: "1234", subscriber_list: double(title: "First Subscription")),
+      double(uuid: "5678", subscriber_list: double(title: "Second Subscription")),
+    ]
   end
-
-  let(:subscriptions) { Subscription.all }
 
   let(:params) do
     {
@@ -37,10 +37,10 @@ RSpec.describe EmailRenderer do
           Updated on 12:00 am, 1 January 2017
 
           Unsubscribe from 'First Subscription':
-          http://www.dev.gov.uk/email/unsubscribe/ad22a6f8-d6dd-4989-98e0-29a7c1049173?title=First%20Subscription
+          http://www.dev.gov.uk/email/unsubscribe/1234?title=First%20Subscription
 
           Unsubscribe from 'Second Subscription':
-          http://www.dev.gov.uk/email/unsubscribe/6fabfabd-8d02-4dc3-8190-a647ae69aef2?title=Second%20Subscription
+          http://www.dev.gov.uk/email/unsubscribe/5678?title=Second%20Subscription
         BODY
       )
     end

--- a/spec/models/unsubscribe_link_spec.rb
+++ b/spec/models/unsubscribe_link_spec.rb
@@ -1,16 +1,15 @@
 RSpec.describe UnsubscribeLink do
-  let!(:subscription) { create(:subscription, uuid: "e7883dd9-b690-41c9-8fa6-2857c3fff3bd", subscriber_list: create(:subscriber_list, title: title)) }
-
+  let(:subscription) { double(uuid: "1234", subscriber_list: double(title: title)) }
   let(:title) { "dave crocker & friends" }
 
   let(:unsubscribe_link) {
-    UnsubscribeLink.new(title: subscription.subscriber_list.title, uuid: subscription.uuid)
+    UnsubscribeLink.new(subscription)
   }
 
   describe "#url" do
     it "returns an unsubscribe url for the subscription" do
       expect(unsubscribe_link.url).to eq(
-        "http://www.dev.gov.uk/email/unsubscribe/e7883dd9-b690-41c9-8fa6-2857c3fff3bd?title=dave%20crocker%20%26%20friends"
+        "http://www.dev.gov.uk/email/unsubscribe/1234?title=dave%20crocker%20%26%20friends"
       )
     end
   end
@@ -22,11 +21,11 @@ RSpec.describe UnsubscribeLink do
   end
 
   describe ".for" do
-    before do
-      create(:subscription, subscriber_list: create(:subscriber_list, title: "jarvis cocker & friends"))
+    let(:other_subscription) do
+      double(uuid: "5678", subscriber_list: double(title: "jarvis cocker & friends"))
     end
 
-    let(:subscriptions) { Subscription.all }
+    let(:subscriptions) { [subscription, other_subscription] }
 
     it "builds an unsubscribe link for each subscription" do
       first, second = UnsubscribeLink.for(subscriptions)

--- a/spec/workers/email_generation_worker_spec.rb
+++ b/spec/workers/email_generation_worker_spec.rb
@@ -1,18 +1,18 @@
 RSpec.describe EmailGenerationWorker do
   describe ".perform" do
+    def perform_with_fake_sidekiq
+      Sidekiq::Testing.fake! do
+        DeliveryRequestWorker.jobs.clear
+        described_class.new.perform
+      end
+    end
+
     context "with a subscription content" do
       let!(:subscription_content) { create(:subscription_content) }
 
       before do
         create(:subscription_content, email: create(:email))
         create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, address: nil)))
-      end
-
-      def perform_with_fake_sidekiq
-        Sidekiq::Testing.fake! do
-          DeliveryRequestWorker.jobs.clear
-          described_class.new.perform
-        end
       end
 
       it "should create an email" do
@@ -32,6 +32,30 @@ RSpec.describe EmailGenerationWorker do
       it "should queue a delivery email job" do
         perform_with_fake_sidekiq
         expect(DeliveryRequestWorker.jobs.size).to eq(1)
+      end
+    end
+
+    context "with many subscription contents running concurrently" do
+      before do
+        100.times do
+          create(:subscription_content)
+        end
+      end
+
+      def run_worker
+        Sidekiq::Testing.fake! { described_class.new.perform }
+      end
+
+      def run_worker_threads
+        Rails.application.eager_load! # needed as autoload is not thread safe
+
+        3.times
+          .map { Thread.new { run_worker } }
+          .each(&:join)
+      end
+
+      it "will raise a stale object exception" do
+        expect { run_worker_threads }.to raise_error(ActiveRecord::StaleObjectError)
       end
     end
   end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SubscriptionContentWorker do
     end
 
     it "queues the email through the EmailGenerationWorker" do
-      expect(EmailGenerationWorker).to receive(:perform_async).with(kind_of(Integer))
+      expect(EmailGenerationWorker).to receive(:perform_async)
 
       subject.perform(content_change.id)
     end


### PR DESCRIPTION
The email generation worker we've got at the moment does not match the design we had of it running as a regular task and handling many subscription contents in one go. By making it work like this design we should improve performance as the query can act on many subscription contents per worker rather than currently by having one worker for one query.

This enables us to achieve the 83,333 in 5 minutes goal for this worker.