### PR TITLE
Store priority on content change

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -3,6 +3,8 @@ require_relative "extensions/symbolize_json"
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
 
+  enum priority: %i(low high)
+
   def mark_processed!
     update!(processed_at: Time.now)
   end

--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -35,6 +35,7 @@ private
       govuk_request_id: params[:govuk_request_id],
       document_type: params[:document_type],
       publishing_app: params[:publishing_app],
+      priority: priority,
     }
   end
 

--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -12,7 +12,7 @@ class NotificationHandlerService
     begin
       content_change = ContentChange.create!(content_change_params)
       increment_statsd
-      SubscriptionContentWorker.perform_async(content_change.id, priority)
+      SubscriptionContentWorker.perform_async(content_change.id)
     rescue StandardError => ex
       Raven.capture_exception(ex, tags: { version: 2 })
     end
@@ -35,12 +35,8 @@ private
       govuk_request_id: params[:govuk_request_id],
       document_type: params[:document_type],
       publishing_app: params[:publishing_app],
-      priority: priority,
+      priority: params.fetch(:priority, "low").to_sym,
     }
-  end
-
-  def priority
-    params.fetch(:priority, "low").to_sym
   end
 
   def increment_statsd

--- a/app/workers/email_generation_worker.rb
+++ b/app/workers/email_generation_worker.rb
@@ -1,7 +1,7 @@
 class EmailGenerationWorker
   include Sidekiq::Worker
 
-  def perform(subscription_content_id, priority)
+  def perform(subscription_content_id)
     subscription_content = SubscriptionContent.find(subscription_content_id)
 
     email = Email.create_from_params!(email_params(subscription_content))
@@ -9,7 +9,7 @@ class EmailGenerationWorker
     subscription_content.update!(email: email)
 
     DeliveryRequestWorker.perform_async_with_priority(
-      email.id, priority: priority.to_sym
+      email.id, priority: subscription_content.content_change.priority.to_sym,
     )
   end
 

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -18,10 +18,7 @@ private
           subscription: subscription,
         )
 
-        EmailGenerationWorker.perform_async(
-          subscription_content.id,
-          content_change.priority.to_sym,
-        )
+        EmailGenerationWorker.perform_async(subscription_content.id)
       rescue StandardError => ex
         Raven.capture_exception(ex, tags: { version: 2 })
       end

--- a/db/migrate/20171208081924_add_priority_to_change_content.rb
+++ b/db/migrate/20171208081924_add_priority_to_change_content.rb
@@ -1,0 +1,5 @@
+class AddPriorityToChangeContent < ActiveRecord::Migration[5.1]
+  def change
+    add_column :content_changes, :priority, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171205114740) do
+ActiveRecord::Schema.define(version: 20171208081924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20171205114740) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "processed_at"
+    t.integer "priority", default: 0
   end
 
   create_table "delivery_attempts", force: :cascade do |t|

--- a/spec/services/notification_handler_service_spec.rb
+++ b/spec/services/notification_handler_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe NotificationHandlerService do
       allow(ContentChange).to receive(:create!).and_return(double(id: 1))
       expect(SubscriptionContentWorker)
         .to receive(:perform_async)
-        .with(1, :low)
+        .with(1)
 
       described_class.call(params: params)
     end

--- a/spec/services/notification_handler_service_spec.rb
+++ b/spec/services/notification_handler_service_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe NotificationHandlerService do
         govuk_request_id: params[:govuk_request_id],
         document_type: params[:document_type],
         publishing_app: params[:publishing_app],
+        priority: :low,
       }
 
       expect(ContentChange).to receive(:create!)

--- a/spec/workers/email_generation_worker_spec.rb
+++ b/spec/workers/email_generation_worker_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe EmailGenerationWorker do
-  let(:priority) { :low }
-
   describe ".perform" do
     context "with a subscription content" do
       let(:content_change) { create(:content_change, public_updated_at: DateTime.parse("2017/01/01 09:00")) }
@@ -11,7 +9,7 @@ RSpec.describe EmailGenerationWorker do
       def perform_with_fake_sidekiq
         Sidekiq::Testing.fake! do
           DeliveryRequestWorker.jobs.clear
-          described_class.new.perform(subscription_content.id, priority)
+          described_class.new.perform(subscription_content.id)
         end
       end
 

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -52,9 +52,7 @@ RSpec.describe SubscriptionContentWorker do
     end
 
     it "queues the email through the EmailGenerationWorker" do
-      expect(EmailGenerationWorker).to receive(:perform_async).with(
-        kind_of(Integer), :low,
-      )
+      expect(EmailGenerationWorker).to receive(:perform_async).with(kind_of(Integer))
 
       subject.perform(content_change.id)
     end
@@ -65,20 +63,6 @@ RSpec.describe SubscriptionContentWorker do
       expect(EmailGenerationWorker).to receive(:perform_async).once
 
       subject.perform(content_change.id)
-    end
-
-    context "with a high priority content change" do
-      before do
-        content_change.update(priority: "high")
-      end
-
-      it "enqueues an email with the correct priority" do
-        expect(EmailGenerationWorker)
-          .to receive(:perform_async)
-          .with(kind_of(Integer), :high)
-
-        subject.perform(content_change.id)
-      end
     end
 
     it "marks the content_change as processed" do

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SubscriptionContentWorker do
       it "does not raise an error" do
         expect {
           Sidekiq::Testing.fake! do
-            SubscriptionContentWorker.perform_async(content_change.id, :low)
+            SubscriptionContentWorker.perform_async(content_change.id)
             described_class.drain
           end
         }.not_to raise_error
@@ -38,7 +38,7 @@ RSpec.describe SubscriptionContentWorker do
           )
 
         expect {
-          subject.perform(content_change.id, :low)
+          subject.perform(content_change.id)
         }.not_to raise_error
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe SubscriptionContentWorker do
         .to receive(:create!)
         .with(content_change: content_change, subscription: subscription)
 
-      subject.perform(content_change.id, :low)
+      subject.perform(content_change.id)
     end
 
     it "queues the email through the EmailGenerationWorker" do
@@ -56,7 +56,7 @@ RSpec.describe SubscriptionContentWorker do
         kind_of(Integer), :low,
       )
 
-      subject.perform(content_change.id, :low)
+      subject.perform(content_change.id)
     end
 
     it "does not enqueue an email to subscribers without a subscription to this content" do
@@ -64,20 +64,26 @@ RSpec.describe SubscriptionContentWorker do
 
       expect(EmailGenerationWorker).to receive(:perform_async).once
 
-      subject.perform(content_change.id, :low)
+      subject.perform(content_change.id)
     end
 
-    it "enqueues an email with the injected priority" do
-      expect(EmailGenerationWorker)
-        .to receive(:perform_async)
-        .with(kind_of(Integer), :high)
+    context "with a high priority content change" do
+      before do
+        content_change.update(priority: "high")
+      end
 
-      subject.perform(content_change.id, :high)
+      it "enqueues an email with the correct priority" do
+        expect(EmailGenerationWorker)
+          .to receive(:perform_async)
+          .with(kind_of(Integer), :high)
+
+        subject.perform(content_change.id)
+      end
     end
 
     it "marks the content_change as processed" do
       expect(content_change).to receive(:mark_processed!)
-      subject.perform(content_change.id, :high)
+      subject.perform(content_change.id)
     end
   end
 
@@ -92,7 +98,7 @@ RSpec.describe SubscriptionContentWorker do
         .with(hash_including(subscriber: subscriber))
         .and_return(email)
 
-      subject.perform(content_change.id, :low)
+      subject.perform(content_change.id)
     end
 
     it "enqueues the email to send to the courtesy subscription group" do
@@ -100,7 +106,7 @@ RSpec.describe SubscriptionContentWorker do
         .to receive(:perform_async_with_priority)
         .with(kind_of(Integer), priority: :low)
 
-      subject.perform(content_change.id, :low)
+      subject.perform(content_change.id)
     end
   end
 end


### PR DESCRIPTION
For the new email generation worker, we're not going to be passing in the subscription content or the priority, so we need to get the priority from the initial content change.

Depends on #292.