### PR TITLE
Improve subscription content and email generation performance

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -2,17 +2,21 @@ class Email < ApplicationRecord
   validates :address, :subject, :body, presence: true
 
   def self.create_from_params!(params)
-    build_from_params(params).tap(&:save!)
+    new_from_params(params).tap(&:save!)
+  end
+
+  def self.new_from_params(params)
+    new(build_from_params(params))
   end
 
   def self.build_from_params(params)
     renderer = EmailRenderer.new(params: params)
     subscriber = params.fetch(:subscriber)
 
-    new(
+    {
       address: subscriber.address,
       subject: renderer.subject,
       body: renderer.body
-    )
+    }
   end
 end

--- a/app/services/email_generation_service.rb
+++ b/app/services/email_generation_service.rb
@@ -11,16 +11,16 @@ class EmailGenerationService
         to_queue = []
 
         SubscriptionContent.transaction do
-          emails = create_and_insert_emails(group)
+          email_ids = build_and_insert_emails(group).ids
 
-          values = group.zip(emails).map do |subscription_content, email|
-            to_queue << [email.id, subscription_content.content_change.priority.to_sym]
-            "(#{subscription_content.id}, #{email.id})"
-          end.join(",")
+          values = group.zip(email_ids).map do |subscription_content, email_id|
+            to_queue << [email_id, subscription_content.content_change.priority.to_sym]
+            "(#{subscription_content.id}, #{email_id})"
+          end
 
           ActiveRecord::Base.connection.execute(%(
             UPDATE subscription_contents SET email_id = v.email_id
-            FROM (VALUES #{values}) AS v(id, email_id)
+            FROM (VALUES #{values.join(',')}) AS v(id, email_id)
             WHERE subscription_contents.id = v.id
           ))
         end
@@ -48,19 +48,18 @@ private
       .where(email: nil)
   end
 
-  def create_many_emails(subscription_contents)
+  def build_many_emails(subscription_contents)
     subscription_contents.map do |subscription_content|
-      create_email(subscription_content: subscription_content)
+      build_email(subscription_content: subscription_content)
     end
   end
 
-  def create_and_insert_emails(subscription_contents)
-    emails = create_many_emails(subscription_contents)
+  def build_and_insert_emails(subscription_contents)
+    emails = build_many_emails(subscription_contents)
     Email.import!(emails)
-    emails
   end
 
-  def create_email(subscription_content:)
+  def build_email(subscription_content:)
     Email.build_from_params(email_params(subscription_content: subscription_content))
   end
 

--- a/app/services/email_generation_service.rb
+++ b/app/services/email_generation_service.rb
@@ -7,7 +7,7 @@ class EmailGenerationService
 
   def call
     SubscriptionContent.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
-      subscription_contents.find_in_batches(batch_size: 1000) do |group|
+      subscription_contents.find_in_batches do |group|
         to_queue = []
 
         SubscriptionContent.transaction do

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -13,10 +13,10 @@ private
   def queue_delivery_to_subscribers(content_change)
     subscriptions_for(content_change: content_change).find_in_batches do |group|
       records = group.map do |subscription|
-        SubscriptionContent.new(
-          content_change: content_change,
-          subscription: subscription,
-        )
+        {
+          content_change_id: content_change.id,
+          subscription_id: subscription.id,
+        }
       end
 
       begin

--- a/db/migrate/20171212130557_add_indexes_to_subscriber_list.rb
+++ b/db/migrate/20171212130557_add_indexes_to_subscriber_list.rb
@@ -1,0 +1,9 @@
+class AddIndexesToSubscriberList < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscriber_lists, [:document_type], algorithm: :concurrently
+    add_index :subscriber_lists, [:email_document_supertype], algorithm: :concurrently
+    add_index :subscriber_lists, [:government_document_supertype], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171208081924) do
+ActiveRecord::Schema.define(version: 20171212130557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,7 +82,10 @@ ActiveRecord::Schema.define(version: 20171208081924) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.integer "subscriber_count"
+    t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
+    t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true
+    t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
   end
 
   create_table "subscribers", force: :cascade do |t|

--- a/spec/units/services/email_generation_service_spec.rb
+++ b/spec/units/services/email_generation_service_spec.rb
@@ -7,6 +7,23 @@ RSpec.describe EmailGenerationService do
       end
     end
 
+    context "with many subscription contents" do
+      before do
+        50.times do
+          create(:subscription_content)
+        end
+      end
+
+      it "should match up with the right emails" do
+        perform_with_fake_sidekiq
+
+        SubscriptionContent.all.find_each do |subscription_content|
+          expect(subscription_content.email.address)
+            .to eq(subscription_content.subscription.subscriber.address)
+        end
+      end
+    end
+
     context "with a subscription content" do
       let!(:subscription_content) { create(:subscription_content) }
 

--- a/spec/units/workers/subscription_content_worker_spec.rb
+++ b/spec/units/workers/subscription_content_worker_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe SubscriptionContentWorker do
 
     it "creates subscription content for the content change" do
       expect(SubscriptionContent)
-        .to receive(:new)
-        .with(content_change: content_change, subscription: subscription)
+        .to receive(:import!)
+        .with([{ content_change_id: content_change.id, subscription_id: subscription.id }])
 
       subject.perform(content_change.id)
     end

--- a/spec/units/workers/subscription_content_worker_spec.rb
+++ b/spec/units/workers/subscription_content_worker_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SubscriptionContentWorker do
     context "when we error" do
       it "reports errors when creating a SubscriptionContent in the database to Sentry and swallows them" do
         allow(SubscriptionContent)
-          .to receive(:create!)
+          .to receive(:import!)
           .and_raise(ActiveRecord::RecordInvalid)
 
         expect(Raven)
@@ -43,7 +43,7 @@ RSpec.describe SubscriptionContentWorker do
 
     it "creates subscription content for the content change" do
       expect(SubscriptionContent)
-        .to receive(:create!)
+        .to receive(:new)
         .with(content_change: content_change, subscription: subscription)
 
       subject.perform(content_change.id)


### PR DESCRIPTION
This improves the performance of the subscription content matcher and the email generation worker.

I was able to get the subscription matcher to run in 50 seconds for 83,333 matches on my dev machine which is not impressively fast, but it's also not the bottle neck in our system so speeding it up won't dramatically improve the situation.

I was able to get the email generation worker to run in 148 seconds for 83,333 subscription contents which means it's also no longer the bottleneck.