### PR TITLE
Nullify subscription_contents.subscription_id when unsubscribing

### DIFF
--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -12,12 +12,20 @@ module UnsubscribeService
 
     def unsubscribe!(subscriber, subscriptions)
       ActiveRecord::Base.transaction do
+        nullify_references_to_subscriptions!(subscriptions)
+
         subscriptions.each(&:destroy)
 
         if no_other_subscriptions?(subscriber, subscriptions)
           subscriber.nullify_address!
         end
       end
+    end
+
+    def nullify_references_to_subscriptions!(subscriptions)
+      SubscriptionContent
+        .where(subscription: subscriptions)
+        .update_all(subscription_id: nil)
     end
 
     def no_other_subscriptions?(subscriber, subscriptions)

--- a/db/migrate/20171212133939_allow_nullable_subscription_contents_subscription_id.rb
+++ b/db/migrate/20171212133939_allow_nullable_subscription_contents_subscription_id.rb
@@ -1,0 +1,5 @@
+class AllowNullableSubscriptionContentsSubscriptionId < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :subscription_contents, :subscription_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212130557) do
+ActiveRecord::Schema.define(version: 20171212133939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 20171212130557) do
   end
 
   create_table "subscription_contents", force: :cascade do |t|
-    t.bigint "subscription_id", null: false
+    t.bigint "subscription_id"
     t.bigint "content_change_id", null: false
     t.bigint "email_id"
     t.datetime "created_at", null: false

--- a/spec/units/services/unsubscribe_service_spec.rb
+++ b/spec/units/services/unsubscribe_service_spec.rb
@@ -73,5 +73,18 @@ RSpec.describe UnsubscribeService do
         expect(subscriber.reload.address).not_to be_nil
       end
     end
+
+    context "when there are subscription contents for the subscription" do
+      let!(:subscription_content) do
+        create(:subscription_content, subscription: subscription)
+      end
+
+      it "nullifies the subscription on the subscription_content" do
+        expect { subject.subscription!(subscription) }
+          .to change { subscription_content.reload.subscription }
+          .from(subscription)
+          .to(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
This issue was discovered while working on:
https://trello.com/c/waCjUj3J/437-add-high-level-integration-tests-to-email-alert-api

(discussed with @thomasleese and @rubenarakelyan)

I decided to break it into a separate PR. Currently there's a unit test for this, but soon there will also be a feature test once the other PR associated with that Trello ticket is merged.

**Explanation:**

We delete subscription records when users
unsubscribe. This means we need to make this field
nullable on the subscription_contents table.

We considered also deleting the
subscription_contents associated with the deleted
subscription, but decided not to because the
subscription_content still points to the
content_change which is useful information.