### PR TITLE
Set a fake Notify api_key / base_url

### DIFF
--- a/config/notify.yml
+++ b/config/notify.yml
@@ -1,14 +1,19 @@
+<% fake_api_key = "fake_api_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000" %>
+<% fake_base_url = "http://fake-notify.com" %>
+<% template_id = "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
+
 development:
-  api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
-  base_url: <%= ENV['GOVUK_NOTIFY_BASE_URL'] %>
+  api_key: <%= ENV.fetch('GOVUK_NOTIFY_API_KEY', fake_api_key) %>
+  base_url: <%= ENV.fetch('GOVUK_NOTIFY_BASE_URL', fake_base_url) %>
+  template_id: <%= ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', template_id) %>
 
 test:
-  api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
-  base_url: <%= ENV['GOVUK_NOTIFY_BASE_URL'] %>
+  api_key: <%= ENV.fetch('GOVUK_NOTIFY_API_KEY', fake_api_key) %>
+  base_url: <%= ENV.fetch('GOVUK_NOTIFY_BASE_URL', fake_base_url) %>
+  template_id: <%= ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', template_id) %>
 
 production:
-  api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] || "cb633abc-6ae6-4843-ae6f-82ca500b6de2" %>
-  base_url: <%= ENV['GOVUK_NOTIFY_BASE_URL'] %>
+  <% # Don't use fakes in production, which causes Notifications::Client.new to fail %>
+  api_key: <%= ENV.fetch('GOVUK_NOTIFY_API_KEY', nil) %>
+  base_url: <%= ENV.fetch('GOVUK_NOTIFY_BASE_URL', nil) %>
+  template_id: <%= ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', template_id) %>


### PR DESCRIPTION
If we set these credentials to `nil`, we can't instantiate the Notify client in the test-suite which is problematic when setting message expectations on it.

I'd like to merge this separately as I want to rebase two PRs on top of it:

- https://github.com/alphagov/email-alert-api/pull/302
- https://github.com/alphagov/email-alert-api/pull/307

