### PR TITLE
Remove a comment causing production errors

### DIFF
--- a/config/notify.yml
+++ b/config/notify.yml
@@ -13,7 +13,6 @@ test:
   template_id: <%= ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', template_id) %>
 
 production:
-  <% # Don't use fakes in production, which causes Notifications::Client.new to fail %>
   api_key: <%= ENV.fetch('GOVUK_NOTIFY_API_KEY', nil) %>
   base_url: <%= ENV.fetch('GOVUK_NOTIFY_BASE_URL', nil) %>
   template_id: <%= ENV.fetch('GOVUK_NOTIFY_TEMPLATE_ID', template_id) %>


### PR DESCRIPTION
This was causing a Psych error in production even though it works
on the development machine. This might be caused by a difference in a
gem dependency between environments.