### PR TITLE
Re-enable the status update healthchecks

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -33,8 +33,8 @@ private
       QueueSizeHealthcheck.new,
       RedisHealthcheck.new,
       RetrySizeHealthcheck.new,
-#      StatusUpdateHealthcheck.new,
-#      TechnicalFailureHealthcheck.new,
+      StatusUpdateHealthcheck.new,
+      TechnicalFailureHealthcheck.new,
     ]
   end
 end

--- a/app/models/healthcheck/status_update_healthcheck.rb
+++ b/app/models/healthcheck/status_update_healthcheck.rb
@@ -7,6 +7,8 @@ class Healthcheck
     end
 
     def status
+      return :ok unless expect_status_update_callbacks?
+
       if sending_after(critical_time.ago).exists?
         :critical
       elsif sending_after(warning_time.ago).exists?
@@ -41,6 +43,10 @@ class Healthcheck
     # Both systems use queueing, so build in some tolerance.
     def warning_time
       NOTIFY_DELAY.hours + 10.minutes
+    end
+
+    def expect_status_update_callbacks?
+      EmailAlertAPI.config.email_service.fetch(:expect_status_update_callbacks)
     end
   end
 end

--- a/app/models/healthcheck/technical_failure_healthcheck.rb
+++ b/app/models/healthcheck/technical_failure_healthcheck.rb
@@ -5,6 +5,8 @@ class Healthcheck
     end
 
     def status
+      return :ok unless expect_status_update_callbacks?
+
       if failures_since(1.hour.ago).exists?
         :critical
       elsif failures_since(1.day.ago).exists?
@@ -27,6 +29,10 @@ class Healthcheck
         .latest_per_email
         .where(status: :technical_failure)
         .where("updated_at > ?", datetime)
+    end
+
+    def expect_status_update_callbacks?
+      EmailAlertAPI.config.email_service.fetch(:expect_status_update_callbacks)
     end
   end
 end

--- a/config/email_service.yml
+++ b/config/email_service.yml
@@ -1,18 +1,22 @@
 <% app_domain = ENV.fetch("GOVUK_APP_DOMAIN", "") %>
 <% env = %w(integration staging).detect { |s| app_domain.include?(s) } %>
 <% email_subject_prefix = "#{env.upcase} - " if env %>
+<% expect_status_update_callbacks = !env %>
 
 development:
   provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "PSEUDO" %>
   email_subject_prefix: <%= email_subject_prefix %>
   email_address_override: <%= ENV["EMAIL_ADDRESS_OVERRIDE"] %>
+  expect_status_update_callbacks: false
 
 test:
   provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "PSEUDO" %>
   email_subject_prefix: <%= email_subject_prefix %>
   email_address_override: <%= ENV["EMAIL_ADDRESS_OVERRIDE"] %>
+  expect_status_update_callbacks: true
 
 production:
   provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "NOTIFY" %>
   email_subject_prefix: <%= email_subject_prefix %>
   email_address_override: <%= ENV["EMAIL_ADDRESS_OVERRIDE"] %>
+  expect_status_update_callbacks: <%= expect_status_update_callbacks %>

--- a/db/migrate/20171214113834_delete_test_emails_and_delivery_attempts.rb
+++ b/db/migrate/20171214113834_delete_test_emails_and_delivery_attempts.rb
@@ -1,0 +1,7 @@
+class DeleteTestEmailsAndDeliveryAttempts < ActiveRecord::Migration[5.1]
+  def up
+    # Emails and DeliveryAttempts at this point are all test data
+    Email.destroy_all
+    DeliveryAttempt.destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212133939) do
+ActiveRecord::Schema.define(version: 20171214113834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe "Healthcheck", type: :request do
       queue_size:        { status: "ok", queues: a_kind_of(Hash) },
       redis:             { status: "ok" },
       retry_size:        { status: "ok", retry_size: 0 },
-#      status_update:     hash_including(status: "ok", older_than_75_hours: 0),
-#      technical_failure: hash_including(status: "ok", last_3_hours: 0),
+      status_update:     hash_including(status: "ok", older_than_75_hours: 0),
+      technical_failure: hash_including(status: "ok", last_3_hours: 0),
     )
   end
 end

--- a/spec/units/models/healthcheck/status_update_healthcheck_spec.rb
+++ b/spec/units/models/healthcheck/status_update_healthcheck_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe Healthcheck::StatusUpdateHealthcheck do
     create(:delivery_attempt, status: status, updated_at: updated, email: email)
   end
 
+  context "when status update callbacks are not expected" do
+    before do
+      allow(subject).to receive(:expect_status_update_callbacks?).and_return(false)
+      create_delivery_attempt(:sending, 75.hours.ago)
+    end
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
   context "when delivery attempts haven't received status updates" do
     context "in less than 72 hours" do
       before { create_delivery_attempt(:sending, 71.hours.ago) }

--- a/spec/units/models/healthcheck/technical_failure_healthcheck_spec.rb
+++ b/spec/units/models/healthcheck/technical_failure_healthcheck_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe Healthcheck::TechnicalFailureHealthcheck do
     create(:delivery_attempt, status: status, updated_at: updated, email: email)
   end
 
+  context "when status update callbacks are not expected" do
+    before do
+      allow(subject).to receive(:expect_status_update_callbacks?).and_return(false)
+      create_delivery_attempt(:technical_failure, 59.minutes.ago)
+    end
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
   context "when there are no technical failures" do
     before { create_delivery_attempt(:delivered, 1.minute.ago) }
     specify { expect(subject.status).to eq(:ok) }


### PR DESCRIPTION
This PR reverts https://github.com/alphagov/email-alert-api/pull/238 to re-enable the healthchecks since we are now getting status update callbacks from Notify. It also ignores the healthchecks in non-production environments where we don't receive status update callbacks from Notify.

Trello: https://trello.com/c/31XA1mkY/449-integrate-email-alert-api-with-notifys-callback