### PR TITLE
Small healthcheck test fix

### DIFF
--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe "Healthcheck", type: :request do
     expect(data.fetch(:checks)).to include(
       database:          { status: "ok" },
       govdelivery:       { status: "ok", ping_status: 200 },
-      queue_latency:     { status: "ok", queues: {} },
-      queue_size:        { status: "ok", queues: {} },
+      queue_latency:     { status: "ok", queues: a_kind_of(Hash) },
+      queue_size:        { status: "ok", queues: a_kind_of(Hash) },
       redis:             { status: "ok" },
       retry_size:        { status: "ok", retry_size: 0 },
 #      status_update:     hash_including(status: "ok", older_than_75_hours: 0),


### PR DESCRIPTION
After running the application locally, Sidekiq creates the necessary queues which means this test fails because it's looking for an empty hash.

It's a bit annoying that the tests are coupled to the local state of Redis, but this is a quick fix to solve the immediate problem.