### PR TITLE
Increase number of sidekiq workers

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: true
-:concurrency: 10
+:concurrency: 30
 :logfile: ./log/sidekiq.json.log
 :queues:
   - [high_delivery, 3]


### PR DESCRIPTION
We're hitting limits when talking to Notify with the overhead of communicating over HTTP. Notify suggests that we double the number of workers.

Not to be merged until we've increase the connection limit for Postgres in production. Depends on https://github.com/alphagov/govuk-puppet/pull/6954

[Trello Card](https://trello.com/c/JtjiwNpP/451-run-full-end-to-end-load-test)