### PR TITLE
Treat requests as JSON

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.debug_exception_response_format = :api
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,15 @@
 Rails.application.routes.draw do
-  resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
-  get "/subscriber-lists", to: "subscriber_lists#show"
+  defaults format: :json do
+    resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
+    get "/subscriber-lists", to: "subscriber_lists#show"
 
-  resources :notifications, only: %i[create index show]
-  resources :status_updates, path: "status-updates", only: %i[create]
-  resources :subscriptions, only: %i[create]
-  get "subscribables/:gov_delivery_id", to: "subscribables#show"
+    resources :notifications, only: %i[create index show]
+    resources :status_updates, path: "status-updates", only: %i[create]
+    resources :subscriptions, only: %i[create]
+    get "subscribables/:gov_delivery_id", to: "subscribables#show"
 
-  get "/healthcheck", to: "healthcheck#check"
+    get "/healthcheck", to: "healthcheck#check"
 
-  post "/unsubscribe/:uuid", to: "unsubscribe#unsubscribe"
+    post "/unsubscribe/:uuid", to: "unsubscribe#unsubscribe"
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/hR6rkDdu/454-return-json-errors-from-email-alert-api

This sets all our requests to be treated as a JSON format, which means
we get JSON exceptions.

The config.debug_exception_response_format sets the debug exceptions to
be rendered in JSON rather than HTML.

This would all be slightly neater if we used Rails api_only mode however
GDS SSO is currently incompatible.