### PR TITLE
Fix test data migration

### DIFF
--- a/db/migrate/20171214113834_delete_test_emails_and_delivery_attempts.rb
+++ b/db/migrate/20171214113834_delete_test_emails_and_delivery_attempts.rb
@@ -1,7 +1,7 @@
 class DeleteTestEmailsAndDeliveryAttempts < ActiveRecord::Migration[5.1]
   def up
     # Emails and DeliveryAttempts at this point are all test data
-    Email.destroy_all
     DeliveryAttempt.destroy_all
+    Email.destroy_all
   end
 end


### PR DESCRIPTION
This commit fixes the migration to delete test data by swapping the ordering to get around a foreign key violation.