### PR TITLE
Remove data from SubscriptionContents too

### DIFF
--- a/db/migrate/20171214113834_delete_test_emails_and_delivery_attempts.rb
+++ b/db/migrate/20171214113834_delete_test_emails_and_delivery_attempts.rb
@@ -1,7 +1,8 @@
 class DeleteTestEmailsAndDeliveryAttempts < ActiveRecord::Migration[5.1]
   def up
-    # Emails and DeliveryAttempts at this point are all test data
-    DeliveryAttempt.destroy_all
-    Email.destroy_all
+    # Emails, DeliveryAttempts and SubscriptionContents at this point are all test data
+    SubscriptionContent.delete_all
+    DeliveryAttempt.delete_all
+    Email.delete_all
   end
 end


### PR DESCRIPTION
This migration was failing due to there being foreign keys in
SubscriptionContents to Email. This removes them first.

It also uses delete_all rather than destroy_all as that will loop
through every item, whereas delete_all will just run a delete query to
truncate the table.