### PR TITLE
Add cascades to the database

### DIFF
--- a/db/migrate/20171215154302_delivery_attempt_delete_cascade.rb
+++ b/db/migrate/20171215154302_delivery_attempt_delete_cascade.rb
@@ -1,0 +1,6 @@
+class DeliveryAttemptDeleteCascade < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :delivery_attempts, :emails
+    add_foreign_key :delivery_attempts, :emails, on_delete: :cascade
+  end
+end

--- a/db/migrate/20171215161358_cascade_nullify_subscription_contents_emails.rb
+++ b/db/migrate/20171215161358_cascade_nullify_subscription_contents_emails.rb
@@ -1,0 +1,6 @@
+class CascadeNullifySubscriptionContentsEmails < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :subscription_contents, :emails
+    add_foreign_key :subscription_contents, :emails, on_delete: :nullify
+  end
+end

--- a/db/migrate/20171215163908_cascade_nullify_subscription_contents_subscriptions.rb
+++ b/db/migrate/20171215163908_cascade_nullify_subscription_contents_subscriptions.rb
@@ -1,0 +1,6 @@
+class CascadeNullifySubscriptionContentsSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :subscription_contents, :subscriptions
+    add_foreign_key :subscription_contents, :subscriptions, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215161358) do
+ActiveRecord::Schema.define(version: 20171215163908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 20171215161358) do
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "subscription_contents", "content_changes"
   add_foreign_key "subscription_contents", "emails", on_delete: :nullify
-  add_foreign_key "subscription_contents", "subscriptions"
+  add_foreign_key "subscription_contents", "subscriptions", on_delete: :nullify
   add_foreign_key "subscriptions", "subscriber_lists"
   add_foreign_key "subscriptions", "subscribers", on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215154302) do
+ActiveRecord::Schema.define(version: 20171215161358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 20171215154302) do
 
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "subscription_contents", "content_changes"
-  add_foreign_key "subscription_contents", "emails"
+  add_foreign_key "subscription_contents", "emails", on_delete: :nullify
   add_foreign_key "subscription_contents", "subscriptions"
   add_foreign_key "subscriptions", "subscriber_lists"
   add_foreign_key "subscriptions", "subscribers", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171214113834) do
+ActiveRecord::Schema.define(version: 20171215154302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 20171214113834) do
     t.boolean "disabled", default: false
   end
 
-  add_foreign_key "delivery_attempts", "emails"
+  add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "subscription_contents", "content_changes"
   add_foreign_key "subscription_contents", "emails"
   add_foreign_key "subscription_contents", "subscriptions"


### PR DESCRIPTION
Off the back of the problems with https://github.com/alphagov/email-alert-api/pull/329 this PR will configure it so you can truncate the email table with just `Email.delete_all`.

- It sets up a cascade delete for DeliveryAttempt which removes them when Emails are removed, rather than restricting.
- It sets up a nullify on SubscriptionContent for when the associated Email is removed.
- I also noticed that we have a cascade from Subscriber to Subscriptions, but that would be restricted by SubscriptionContent, so this would allow that to nullify if you try delete Subscriptions.

@tuzz I wanted to ping you on this as we discussed this briefly on https://github.com/alphagov/email-alert-api/pull/305 but I felt like your objections there were based on model level visibility rather than db level constraints (where there is already visibility). Happy to break this up if it's somewhat contentious.