### PR TITLE
Don't raise an exception with getting multiple errors from GovDelivery

### DIFF
--- a/app/services/gov_delivery/response_parser.rb
+++ b/app/services/gov_delivery/response_parser.rb
@@ -30,11 +30,23 @@ module GovDelivery
     end
 
     def first_level_element_nodes
+      reject_duplicate_nodes(
+        reject_links(
+          xml_tree.root.element_children
+        )
+      )
+    end
+
+    def reject_links(nodes)
       # Remove <link> tags since there are many of them, we don't use them,
       # and they break the "no duplicates in a Struct" rule
-      xml_tree.root.element_children.reject do |node|
+      nodes.reject do |node|
         node.name == "link"
       end
+    end
+
+    def reject_duplicate_nodes(nodes)
+      nodes.uniq(&:name)
     end
 
     def xml_tree

--- a/app/services/gov_delivery/response_parser.rb
+++ b/app/services/gov_delivery/response_parser.rb
@@ -1,7 +1,6 @@
 module GovDelivery
   class ResponseParser
     def initialize(response_body)
-      @xml_parser = Nokogiri::XML.method(:parse)
       @response_body = response_body
     end
 
@@ -15,10 +14,7 @@ module GovDelivery
 
   private
 
-    attr_reader(
-      :xml_parser,
-      :response_body,
-    )
+    attr_reader :response_body
 
     def keys
       first_level_element_nodes
@@ -43,6 +39,10 @@ module GovDelivery
 
     def xml_tree
       @xml_tree ||= xml_parser.call(response_body)
+    end
+
+    def xml_parser
+      @xml_parser ||= Nokogiri::XML.method(:parse)
     end
   end
 end

--- a/spec/units/services/gov_delivery/response_parser_spec.rb
+++ b/spec/units/services/gov_delivery/response_parser_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe GovDelivery::ResponseParser do
+  let(:response_body) { nil }
+  subject(:response_parser) { described_class.new(response_body) }
+
+  context "with double keys" do
+    let(:response_body) do
+      %{
+        <?xml version="1.0"?>
+        <response>
+          <error>test</error>
+          <something_else>test</something_else>
+          <error>test</error>
+        </response>
+      }
+    end
+
+    it "should only parse the first key" do
+      expect(response_parser.parse.to_h).to eq(
+        Struct
+          .new(:error, :something_else)
+          .new("test", "test")
+          .to_h
+      )
+    end
+  end
+end


### PR DESCRIPTION
We currently load responses from GovDelivery into a `Struct` which makes it easy to use in code, but prevents loading any response with duplicate keys. It looks like GovDelivery is now sending responses with multiple error messages which then crashes the subscriber list codes task preventing it from handling the error and continuing. I'm unsure whether or not we should be expecting GovDelivery to send through multiple error keys, but it [seems](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/1675/console) [like](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/1674/console) [this](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/1670/console) [is](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/1685/console) [a](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/1667/console) [new](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/1663/console) [thing](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/1657/console) as we haven't had that problem in the past.

I opted to ignore any subsequent error keys as that avoids having to rewrite large amounts of the app to not use a `Struct`, having visibility of the first error in Jenkins and then being able to deal with it should mean we can avoid having both errors appear in the future.

[Trello Card](https://trello.com/c/uR6P64FF/441-investigate-why-syncgovdeliverytopicmappings-rake-task-is-regularly-failing)