### PR TITLE
Fix the data sync task

### DIFF
--- a/db/migrate/20171219103753_remove_duplicate_subscriber_list.rb
+++ b/db/migrate/20171219103753_remove_duplicate_subscriber_list.rb
@@ -1,0 +1,15 @@
+class RemoveDuplicateSubscriberList < ActiveRecord::Migration[5.1]
+  def change
+    # production & staging
+    SubscriberList.where(
+      title: "news stories related to UK Visas and Immigration and China",
+      gov_delivery_id: "UKGOVUK_35116"
+    ).delete_all
+
+    # integration
+    SubscriberList.where(
+      title: "news stories related to UK Visas and Immigration and China",
+      gov_delivery_id: "UKGOVUKDUP_35116"
+    ).delete_all
+  end
+end

--- a/db/migrate/20171219104253_make_subscriber_list_title_unique.rb
+++ b/db/migrate/20171219104253_make_subscriber_list_title_unique.rb
@@ -1,0 +1,7 @@
+class MakeSubscriberListTitleUnique < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscriber_lists, [:title], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215163908) do
+ActiveRecord::Schema.define(version: 20171219103753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219103753) do
+ActiveRecord::Schema.define(version: 20171219104253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 20171219103753) do
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
+    t.index ["title"], name: "index_subscriber_lists_on_title", unique: true
   end
 
   create_table "subscribers", force: :cascade do |t|

--- a/lib/data_hygiene/data_sync.rb
+++ b/lib/data_hygiene/data_sync.rb
@@ -23,7 +23,6 @@ module DataHygiene
       to_be_deleted = topics - subscriber_lists
       to_be_created = subscriber_lists - topics
 
-
       # Handle rows with duplicate codes but different titles, because one of those may
       # exist in GovDelivery already so we don't want to try to create/delete another
       # topic with the same id
@@ -115,7 +114,7 @@ module DataHygiene
 
         @delete_wait.times do
           sleep 1
-          print '.'
+          print "."
         end
       end
     end
@@ -132,8 +131,8 @@ module DataHygiene
           sleep 2
         end
 
-        logger.warn 'Failed to create all topics'
-        raise 'Failed to create all topics'
+        logger.warn "Failed to create all topics"
+        raise "Failed to create all topics"
       end
     end
 

--- a/lib/data_hygiene/data_sync.rb
+++ b/lib/data_hygiene/data_sync.rb
@@ -80,14 +80,14 @@ module DataHygiene
         .distinct
         .pluck(:title, :gov_delivery_id)
         .map do |title, gov_delivery_id|
-          [(title || "MISSING TITLE #{gov_delivery_id}").strip, gov_delivery_id]
+          [title.strip, gov_delivery_id]
         end
     end
 
     def topics
       @topics ||= Services.gov_delivery
                     .fetch_topics["topics"]
-                    .map { |topic| [topic["name"], topic["code"]] }
+                    .map { |topic| [topic["name"].strip, topic["code"]] }
     end
 
     def delete_topics_from_gov_delivery(list)
@@ -140,7 +140,6 @@ module DataHygiene
     def create_topics(list)
       retry_create = []
       list.each do |title, gov_delivery_id|
-        title = title || "MISSING TITLE #{gov_delivery_id}"
         logger.info "-- Creating #{title} (#{gov_delivery_id}) in GovDelivery"
         begin
           Services.gov_delivery.create_topic(title, gov_delivery_id)

--- a/lib/data_hygiene/data_sync.rb
+++ b/lib/data_hygiene/data_sync.rb
@@ -2,10 +2,11 @@ module DataHygiene
   class DataSync
     PRODUCTION_ACCOUNT_CODE = "UKGOVUK".freeze
     THREAD_COUNT = 40
+    DEFAULT_DELETE_WAIT = 60 # time to wait for all deletions to complete
 
     attr_reader :logger
 
-    def initialize(logger = Logger.new(STDOUT), delete_wait = 30)
+    def initialize(logger = Logger.new(STDOUT), delete_wait = DEFAULT_DELETE_WAIT)
       @logger ||= logger
       @delete_wait = delete_wait
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :subscriber_list do
-    title "title"
+    sequence(:title) { |n| "title #{n}" }
     sequence(:gov_delivery_id) { |n| "UKGOVUK_#{n}" }
     tags(topics: ["motoring/road_rage"])
     created_at { 1.year.ago }


### PR DESCRIPTION
The data sync task was falling over because we had two subscriber lists with the same title but with different GovDelivery IDs (one matching the one in GovDelivery and one not). When the task did an array difference, the subscriber list wouldn't be included in the list of topics to delete, but it would be included in the list of topics to add. GovDelivery requires that titles are unique which meant that it was unable to add in the topic and would fail the task. I've added a migration to delete the extra duplicate subscriber list and then add in a unique constraint on the title so it doesn't happen again. I could have updated the data sync task to cope with this situation, but it feels like the data is wrong in this case and we should prevent it from getting into this state again.

See individual commits for more details on how this fixes the data sync task.

[Trello Card](https://trello.com/c/uR6P64FF/441-investigate-why-syncgovdeliverytopicmappings-rake-task-is-regularly-failing)