### PR TITLE
Fix a problem with comments when env-sync-and-backup runs

### DIFF
--- a/lib/data_hygiene/anonymise_email_addresses.sql
+++ b/lib/data_hygiene/anonymise_email_addresses.sql
@@ -1,40 +1,38 @@
-/*
-This SQL file anonymises email addresses in the email-alert-api database.
+# This SQL file anonymises email addresses in the email-alert-api database.
+#
+# It tries to preserve structure so that multiple occurences of the same address
+# are mapped to the same anonymous address.
+#
+# It runs when we copy data to integration:
+# https://deploy.publishing.service.gov.uk/job/Copy_Data_to_Integration/
+#
+# Please make changes to this script in email-alert-api where it is tested.
+# Then copy it to the env-sync-and-backup repository.
 
-It tries to preserve structure so that multiple occurences of the same address
-are mapped to the same anonymous address.
-
-It runs when we copy data to integration:
-https://deploy.publishing.service.gov.uk/job/Copy_Data_to_Integration/
-
-Please make changes to this script in email-alert-api where it is tested.
-Then copy it to the env-sync-and-backup repository.
-*/
-
-/* Create a table to store all email addresses. */
+# Create a table to store all email addresses.
 CREATE TABLE addresses (id SERIAL, address VARCHAR NOT NULL);
 
-/* Copy all email addresses into the table. */
+# Copy all email addresses into the table.
 INSERT INTO addresses (address)
   SELECT address FROM subscribers
   UNION DISTINCT
   SELECT address FROM emails;
 
-/* Index the table so we can efficiently lookup addresses. */
+# Index the table so we can efficiently lookup addresses.
 CREATE UNIQUE INDEX addresses_index ON addresses (lower(address));
 
-/* Set subscribers.address from the auto-incremented id in addresses table */
+# Set subscribers.address from the auto-incremented id in addresses table.
 UPDATE subscribers s
 SET address = CONCAT('anonymous-', a.id, '@example.com')
 FROM addresses a
 WHERE a.address = s.address;
 
-/* Set emails.address from the auto-incremented id in addresses table */
+# Set emails.address from the auto-incremented id in addresses table.
 UPDATE emails e
 SET address = CONCAT('anonymous-', a.id, '@example.com')
 FROM addresses a
 WHERE a.address = e.address;
 
-/* Clean up by deleting the addresses table and its index. */
+# Clean up by deleting the addresses table and its index.
 DROP INDEX addresses_index;
 DROP TABLE addresses;

--- a/spec/integration/anonymise_email_addresses_spec.rb
+++ b/spec/integration/anonymise_email_addresses_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Anonymising email addresses" do
   let(:column_names) { columns.map { |c| "#{c.table_name}.#{c.name}" } }
 
   def execute_sql
-    ActiveRecord::Base.connection.execute(sql)
+    ActiveRecord::Base.connection.execute(sql.gsub(/#.*$/, ""))
   end
 
   it "anonymises addresses in the subscribers table" do


### PR DESCRIPTION
The SQL file is being interpreted in both psql and bash. We need to
strip the comments out before executing. More context:
https://github.com/alphagov/env-sync-and-backup/pull/39/commits/27fb54dd456fd51d84d67e014b7f1c6751080d40