### PR TITLE
Add logging of missing bearer tokens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,35 @@
 class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
+
+  before_action :log_missing_credentials
+
+private
+
+  def log_missing_credentials
+    auth_header = request.env["HTTP_AUTHORIZATION"]
+    if auth_header.present?
+      authenticate_user!
+      check_for_valid_and_permitted
+    else
+      logger.error "Missing bearer token from #{request_user_agent} - #{request_path}"
+    end
+  end
+
+  def check_for_valid_and_permitted
+    if user_signed_in?
+      unless current_user.has_permission?("internal_app")
+        logger.error "Missing internal_app permission from #{request_user_agent} - #{request_path}"
+      end
+    else
+      logger.error "Invalid bearer token from #{request_user_agent} - #{request_path}"
+    end
+  end
+
+  def request_user_agent
+    request.env["HTTP_USER_AGENT"]
+  end
+
+  def request_path
+    "#{controller_path}##{action_name}"
+  end
 end


### PR DESCRIPTION
All apps should now be sending a bearer token with `internal_app` permission. Prior to enforcing this, this commit adds logging which we can deploy for a while just to ensure we haven't missed any clients.

This is a temporary commit that will be superseded by enforcing the authentication.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)