### PR TITLE
Add authorisation and authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,35 +1,11 @@
 class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
 
-  before_action :log_missing_credentials
+  before_action :authorise
 
 private
 
-  def log_missing_credentials
-    auth_header = request.env["HTTP_AUTHORIZATION"]
-    if auth_header.present?
-      authenticate_user!
-      check_for_valid_and_permitted
-    else
-      logger.error "Missing bearer token from #{request_user_agent} - #{request_path}"
-    end
-  end
-
-  def check_for_valid_and_permitted
-    if user_signed_in?
-      unless current_user.has_permission?("internal_app")
-        logger.error "Missing internal_app permission from #{request_user_agent} - #{request_path}"
-      end
-    else
-      logger.error "Invalid bearer token from #{request_user_agent} - #{request_path}"
-    end
-  end
-
-  def request_user_agent
-    request.env["HTTP_USER_AGENT"]
-  end
-
-  def request_path
-    "#{controller_path}##{action_name}"
+  def authorise
+    authorise_user!("internal_app")
   end
 end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,4 +1,6 @@
 class HealthcheckController < ApplicationController
+  skip_before_action :authorise
+
   def check
     render json: healthcheck.details.merge(status: healthcheck.status)
   end

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -1,5 +1,4 @@
 class StatusUpdatesController < ApplicationController
-  before_action :authorise_for_status_updates
   wrap_parameters false
 
   def create
@@ -15,7 +14,7 @@ private
     params.permit(:reference, :status).to_h.symbolize_keys
   end
 
-  def authorise_for_status_updates
+  def authorise
     authorise_user!("status_updates")
   end
 end

--- a/spec/features/creating_subscribables_spec.rb
+++ b/spec/features/creating_subscribables_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Creating subscribables", type: :request do
   end
 
   scenario "creating and looking up subscribables" do
+    login_with(%w(internal_app status_updates))
+
     params = { title: "Example", tags: {}, links: { person: ["test-123"] } }
 
     lookup_subscribable("UKGOVUK_1234", expected_status: 404)

--- a/spec/features/delivery_success_spec.rb
+++ b/spec/features/delivery_success_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Delivering an email successfully via Notify", type: :request do
   end
 
   scenario "sending an email and receiving a 'delivered' status update" do
+    login_with(%w(internal_app status_updates))
+
     subscribable_id = create_subscribable
     subscribe_to_subscribable(subscribable_id)
     create_content_change

--- a/spec/features/missing_status_update_spec.rb
+++ b/spec/features/missing_status_update_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Missing a status update after three days", type: :request do
   end
 
   scenario "when no status update has been received for an email" do
+    login_with(%w(internal_app status_updates))
+
     subscribable_id = create_subscribable
     subscribe_to_subscribable(subscribable_id)
     create_content_change

--- a/spec/features/permanent_failure_spec.rb
+++ b/spec/features/permanent_failure_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Failing to deliver an email via Notify (permanent failure)", typ
   end
 
   scenario "automatically unsubscribing a user if delivery permanently failed" do
+    login_with(%w(internal_app status_updates))
+
     subscribable_id = create_subscribable
     subscribe_to_subscribable(subscribable_id)
     create_content_change

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Sending an email", type: :request do
   end
 
   scenario "sending an email for a subscription to a subscribable" do
+    login_with_internal_app
+
     subscribable_id = create_subscribable
     subscribe_to_subscribable(subscribable_id)
     create_content_change

--- a/spec/features/subscribing_spec.rb
+++ b/spec/features/subscribing_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Subscribing to a subscribable", type: :request do
   end
 
   scenario "subscribing to a subscribable" do
+    login_with_internal_app
+
     subscribable_id = create_subscribable
 
     subscribe_to_subscribable(subscribable_id, expected_status: 201)

--- a/spec/features/technical_failure_spec.rb
+++ b/spec/features/technical_failure_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Failing to deliver an email via Notify (technical failure)", typ
   end
 
   scenario "failing the healthcheck if delivery failed for a technical reason" do
+    login_with(%w(internal_app status_updates))
+
     subscribable_id = create_subscribable
     subscribe_to_subscribable(subscribable_id)
     create_content_change

--- a/spec/features/unsubscribing_spec.rb
+++ b/spec/features/unsubscribing_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Unsubscribing from a subscribable", type: :request do
   end
 
   scenario "unsubscribing from an email uuid, then no longer receiving emails" do
+    login_with_internal_app
+
     subscribable_id = create_subscribable
     subscribe_to_subscribable(subscribable_id)
     create_content_change

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -1,186 +1,205 @@
 RSpec.describe "Creating a subscriber list", type: :request do
-  let(:base_url) do
-    config = EmailAlertAPI.config.gov_delivery
-    "http://#{config.fetch(:hostname)}/api/account/#{config.fetch(:account_code)}"
-  end
+  context "with authentication and authorisation" do
+    let(:base_url) do
+      config = EmailAlertAPI.config.gov_delivery
+      "http://#{config.fetch(:hostname)}/api/account/#{config.fetch(:account_code)}"
+    end
 
-  let(:http_auth) do
-    config = EmailAlertAPI.config.gov_delivery
-    Base64.strict_encode64("#{config.fetch(:username)}:#{config.fetch(:password)}")
-  end
+    let(:http_auth) do
+      config = EmailAlertAPI.config.gov_delivery
+      Base64.strict_encode64("#{config.fetch(:username)}:#{config.fetch(:password)}")
+    end
 
-  before do
-    stub_request(:post, base_url + "/topics.xml")
-      .with(headers: { "Authorization" => "Basic #{http_auth}" })
-      .with(body: /This is a sample title/)
-      .to_return(body: %{
-        <?xml version="1.0" encoding="UTF-8"?>
+    before do
+      login_with_internal_app
+
+      stub_request(:post, base_url + "/topics.xml")
+        .with(headers: { "Authorization" => "Basic #{http_auth}" })
+        .with(body: /This is a sample title/)
+        .to_return(body: %{
+          <?xml version="1.0" encoding="UTF-8"?>
+          <topic>
+            <to-param>UKGOVUK_1234</to-param>
+            <topic-uri>/api/account/UKGOVUK/topics/UKGOVUK_1234.xml</topic-uri>
+            <link rel="self" href="/api/account/UKGOVUK/topics/UKGOVUK_1234"/>
+          </topic>
+        })
+    end
+
+    it "creates the topic on gov delivery" do
+      create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
+
+      body = <<-XML.strip_heredoc
+        <?xml version="1.0"?>
         <topic>
-          <to-param>UKGOVUK_1234</to-param>
-          <topic-uri>/api/account/UKGOVUK/topics/UKGOVUK_1234.xml</topic-uri>
-          <link rel="self" href="/api/account/UKGOVUK/topics/UKGOVUK_1234"/>
+          <name>This is a sample title</name>
+          <short-name>This is a sample title</short-name>
+          <visibility>Unlisted</visibility>
+          <pagewatch-enabled type="boolean">false</pagewatch-enabled>
+          <rss-feed-url nil="true"/>
+          <rss-feed-title nil="true"/>
+          <rss-feed-description nil="true"/>
         </topic>
-      })
-  end
+      XML
 
-  it "creates the topic on gov delivery" do
-    create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
+      assert_requested(
+        :post,
+        base_url + "/topics.xml",
+        headers: { 'Content-Type' => 'application/xml' },
+        body: body,
+        times: 1
+      )
+    end
 
-    body = <<-XML.strip_heredoc
-      <?xml version="1.0"?>
-      <topic>
-        <name>This is a sample title</name>
-        <short-name>This is a sample title</short-name>
-        <visibility>Unlisted</visibility>
-        <pagewatch-enabled type="boolean">false</pagewatch-enabled>
-        <rss-feed-url nil="true"/>
-        <rss-feed-title nil="true"/>
-        <rss-feed-description nil="true"/>
-      </topic>
-    XML
+    it "creates a subscriber_list" do
+      create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
 
-    assert_requested(
-      :post,
-      base_url + "/topics.xml",
-      headers: { 'Content-Type' => 'application/xml' },
-      body: body,
-      times: 1
-    )
-  end
+      subscriber_list = SubscriberList.last
+      expect(subscriber_list).to have_attributes(gov_delivery_id: 'UKGOVUK_1234')
+    end
 
-  it "creates a subscriber_list" do
-    create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
-
-    subscriber_list = SubscriberList.last
-    expect(subscriber_list).to have_attributes(gov_delivery_id: 'UKGOVUK_1234')
-  end
-
-  it "returns a 201" do
-    create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
-
-    expect(response.status).to eq(201)
-  end
-
-  it "returns the created subscriber list" do
-    create_subscriber_list(
-      tags: { topics: ["oil-and-gas/licensing"] },
-      links: { topics: ["uuid-888"] }
-    )
-    response_hash = JSON.parse(response.body)
-    subscriber_list = response_hash["subscriber_list"]
-
-    expect(subscriber_list.keys.to_set).to eq(
-      %w{
-        id
-        title
-        document_type
-        subscriber_count
-        subscription_url
-        gov_delivery_id
-        created_at
-        updated_at
-        tags
-        links
-        email_document_supertype
-        government_document_supertype
-      }.to_set
-    )
-    expect(subscriber_list).to include(
-      "tags" => {
-        "topics" => ["oil-and-gas/licensing"]
-      },
-      "links" => {
-        "topics" => ["uuid-888"]
-      }
-    )
-  end
-
-  it "returns an error if tag isn't an array" do
-    create_subscriber_list(
-      tags: { topics: "oil-and-gas/licensing" },
-    )
-
-    expect(response.status).to eq(422)
-  end
-
-  it "returns an error if creating the same topic" do
-    stub_request(:post, base_url + "/topics.xml")
-      .with(headers: { "Authorization" => "Basic #{http_auth}" })
-      .with(body: /This is a sample title/)
-      .to_return(body: %{
-        <?xml version="1.0" encoding="UTF-8"?>
-        <topic>
-          <code>GD-14004</code>
-          <error>conflict</error>
-        </topic>
-      })
-
-    create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
-
-    expect(response.status).to eq(409)
-  end
-
-  it "returns an error if link isn't an array" do
-    create_subscriber_list(
-      links: { topics: "uuid-888" },
-    )
-
-    expect(response.status).to eq(422)
-  end
-
-  describe "creating a subscriber list with a document_type" do
     it "returns a 201" do
-      create_subscriber_list(document_type: "travel_advice")
+      create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
 
       expect(response.status).to eq(201)
     end
 
-    it "sets the document_type on the subscriber list" do
+    it "returns the created subscriber list" do
       create_subscriber_list(
-        tags: { countries: ["andorra"] },
-        document_type: "travel_advice"
+        tags: { topics: ["oil-and-gas/licensing"] },
+        links: { topics: ["uuid-888"] }
+      )
+      response_hash = JSON.parse(response.body)
+      subscriber_list = response_hash["subscriber_list"]
+
+      expect(subscriber_list.keys.to_set).to eq(
+        %w{
+          id
+          title
+          document_type
+          subscriber_count
+          subscription_url
+          gov_delivery_id
+          created_at
+          updated_at
+          tags
+          links
+          email_document_supertype
+          government_document_supertype
+        }.to_set
+      )
+      expect(subscriber_list).to include(
+        "tags" => {
+          "topics" => ["oil-and-gas/licensing"]
+        },
+        "links" => {
+          "topics" => ["uuid-888"]
+        }
+      )
+    end
+
+    it "returns an error if tag isn't an array" do
+      create_subscriber_list(
+        tags: { topics: "oil-and-gas/licensing" },
       )
 
-      subscriber_list = SubscriberList.last
-      expect(subscriber_list.document_type).to eq("travel_advice")
+      expect(response.status).to eq(422)
     end
-  end
 
-  context "when creating a subscriber list with no tags or links" do
-    context "and a document_type is provided" do
+    it "returns an error if creating the same topic" do
+      stub_request(:post, base_url + "/topics.xml")
+        .with(headers: { "Authorization" => "Basic #{http_auth}" })
+        .with(body: /This is a sample title/)
+        .to_return(body: %{
+          <?xml version="1.0" encoding="UTF-8"?>
+          <topic>
+            <code>GD-14004</code>
+            <error>conflict</error>
+          </topic>
+        })
+
+      create_subscriber_list(tags: { topics: ["oil-and-gas/licensing"] })
+
+      expect(response.status).to eq(409)
+    end
+
+    it "returns an error if link isn't an array" do
+      create_subscriber_list(
+        links: { topics: "uuid-888" },
+      )
+
+      expect(response.status).to eq(422)
+    end
+
+    describe "creating a subscriber list with a document_type" do
       it "returns a 201" do
         create_subscriber_list(document_type: "travel_advice")
 
         expect(response.status).to eq(201)
       end
+
+      it "sets the document_type on the subscriber list" do
+        create_subscriber_list(
+          tags: { countries: ["andorra"] },
+          document_type: "travel_advice"
+        )
+
+        subscriber_list = SubscriberList.last
+        expect(subscriber_list.document_type).to eq("travel_advice")
+      end
+    end
+
+    context "when creating a subscriber list with no tags or links" do
+      context "and a document_type is provided" do
+        it "returns a 201" do
+          create_subscriber_list(document_type: "travel_advice")
+
+          expect(response.status).to eq(201)
+        end
+      end
+    end
+
+    context "when creating a subscriber list with 'email' and 'government' document supertypes" do
+      it "returns a 201" do
+        create_subscriber_list(
+          email_document_supertype: "publications",
+          government_document_supertype: "news_stories",
+        )
+
+        expect(response.status).to eq(201)
+
+        expect(SubscriberList.last).to have_attributes(
+          email_document_supertype: "publications",
+          government_document_supertype: "news_stories",
+        )
+      end
+    end
+
+    def create_subscriber_list(payload = {})
+      defaults = {
+        title: "This is a sample title",
+        tags: {},
+        links: {},
+      }
+
+      request_body = JSON.dump(defaults.merge(payload))
+
+      post "/subscriber-lists", params: request_body, headers: JSON_HEADERS
     end
   end
 
-  context "when creating a subscriber list with 'email' and 'government' document supertypes" do
-    it "returns a 201" do
-      create_subscriber_list(
-        email_document_supertype: "publications",
-        government_document_supertype: "news_stories",
-      )
-
-      expect(response.status).to eq(201)
-
-      expect(SubscriberList.last).to have_attributes(
-        email_document_supertype: "publications",
-        government_document_supertype: "news_stories",
-      )
+  context "without authentication" do
+    it "returns a 403" do
+      post "/subscriber-lists", params: {}, headers: {}
+      expect(response.status).to eq(403)
     end
   end
 
-  def create_subscriber_list(payload = {})
-    defaults = {
-      title: "This is a sample title",
-      tags: {},
-      links: {},
-    }
-
-    request_body = JSON.dump(defaults.merge(payload))
-
-    post "/subscriber-lists", params: request_body, headers: JSON_HEADERS
+  context "without authorisation" do
+    it "returns a 403" do
+      login_with_signin
+      post "/subscriber-lists", params: {}, headers: {}
+      expect(response.status).to eq(403)
+    end
   end
 end

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -1,12 +1,33 @@
 RSpec.describe "Creating a subscription", type: :request do
-  context "with a subscribable" do
-    let(:subscribable) { create(:subscriber_list) }
+  context "with authentication and authorisation" do
+    before do
+      login_with_internal_app
+    end
 
-    it "returns a 201" do
-      params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id)
-      post "/subscriptions", params: params, headers: JSON_HEADERS
+    context "with a subscribable" do
+      let(:subscribable) { create(:subscriber_list) }
 
-      expect(response.status).to eq(201)
+      it "returns a 201" do
+        params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id)
+        post "/subscriptions", params: params, headers: JSON_HEADERS
+
+        expect(response.status).to eq(201)
+      end
+    end
+  end
+
+  context "without authentication" do
+    it "returns a 403" do
+      post "/subscriptions", params: {}, headers: {}
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context "without authorisation" do
+    it "returns a 403" do
+      login_with_signin
+      post "/subscriptions", params: {}, headers: {}
+      expect(response.status).to eq(403)
     end
   end
 end

--- a/spec/integration/get_subscriber_list_spec.rb
+++ b/spec/integration/get_subscriber_list_spec.rb
@@ -1,183 +1,204 @@
 RSpec.describe "Getting a subscriber list", type: :request do
-  let!(:subscriber_list_links_only) do
-    create(
-      :subscriber_list,
-      links: {
-        topics: ["oil-and-gas/licensing", "drug-device-alert"]
-      },
-      tags: {},
-      document_type: "",
-    )
-  end
-
-  let!(:subscriber_list_tags_only) do
-    create(
-      :subscriber_list,
-      links: {},
-      tags: {
-        topics: ["oil-and-gas/licensing", "drug-device-alert"]
-      },
-      document_type: "",
-    )
-  end
-
-  let!(:subscriber_list_document_type_only) do
-    create(
-      :subscriber_list,
-      links: {},
-      tags: {},
-      document_type: "travel_advice",
-    )
-  end
-
-  let!(:subscriber_list_links_and_document_type) do
-    create(
-      :subscriber_list,
-      links: {
-        topics: ["vat-rates"],
-      },
-      tags: {},
-      document_type: "tax",
-    )
-  end
-
-  let!(:subscriber_list_tags_and_document_type) do
-    create(
-      :subscriber_list,
-      links: {},
-      tags: {
-        topics: ["vat-rates"],
-      },
-      document_type: "tax",
-    )
-  end
-
-  it "responds with the matching subscriber list" do
-    get_subscriber_list(links: { topics: ["drug-device-alert", "oil-and-gas/licensing"] })
-
-    database_subscriber_list = subscriber_list_links_only
-    response_subscriber_list = JSON.parse(response.body).fetch("subscriber_list").deep_symbolize_keys
-
-    expect(response_subscriber_list).to include(
-      id: database_subscriber_list.id,
-      links: database_subscriber_list.links,
-      tags: database_subscriber_list.tags,
-      document_type: database_subscriber_list.document_type,
-      gov_delivery_id: database_subscriber_list.gov_delivery_id,
-      subscription_url: database_subscriber_list.subscription_url,
-      title: database_subscriber_list.title,
-    )
-  end
-
-  it "finds subscriber lists that match all of the links" do
-    get_subscriber_list(links: { topics: ["drug-device-alert", "oil-and-gas/licensing"] })
-    expect(response.status).to eq(200)
-
-    subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
-    expect(subscriber_list.fetch("id")).to eq(subscriber_list_links_only.id)
-  end
-
-  it "finds subscriber lists that match all of the tags" do
-    get_subscriber_list(tags: { topics: ["drug-device-alert", "oil-and-gas/licensing"] })
-    expect(response.status).to eq(200)
-
-    subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
-    expect(subscriber_list.fetch("id")).to eq(subscriber_list_tags_only.id)
-  end
-
-  it "finds subscriber lists that match document type only" do
-    get_subscriber_list(document_type: "travel_advice")
-    expect(response.status).to eq(200)
-
-    subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
-    expect(subscriber_list.fetch("id")).to eq(subscriber_list_document_type_only.id)
-  end
-
-  it "finds subscriber lists that match links and document type" do
-    get_subscriber_list(
-      links: { topics: ["vat-rates"] },
-      document_type: "tax",
-    )
-    expect(response.status).to eq(200)
-
-    subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
-    expect(subscriber_list.fetch("id")).to eq(subscriber_list_links_and_document_type.id)
-  end
-
-  it "finds subscriber lists that match tags and document type" do
-    get_subscriber_list(
-      tags: { topics: ["vat-rates"] },
-      document_type: "tax",
-    )
-    expect(response.status).to eq(200)
-
-    subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
-    expect(subscriber_list.fetch("id")).to eq(subscriber_list_tags_and_document_type.id)
-  end
-
-  it "does not find subscriber lists that match some of the links" do
-    get_subscriber_list(links: { topics: ["drug-device-alert"] })
-    expect(response.status).to eq(404)
-  end
-
-  it "does not find subscriber lists that match some of the tags" do
-    get_subscriber_list(tags: { topics: ["drug-device-alert"] })
-    expect(response.status).to eq(404)
-  end
-
-  it "does not find subscriber lists that with a different document type" do
-    get_subscriber_list(document_type: "something_else")
-    expect(response.status).to eq(404)
-  end
-
-  it "does not find subscriber lists that match links but not document type" do
-    get_subscriber_list(links: { topics: ["vat-rates"] })
-    expect(response.status).to eq(404)
-  end
-
-  it "does not find subscriber lists that match document type but not links" do
-    get_subscriber_list(document_type: "tax")
-    expect(response.status).to eq(404)
-  end
-
-  it "does not find subscriber lists that match tags but not document type" do
-    get_subscriber_list(tags: { topics: ["vat-rates"] })
-    expect(response.status).to eq(404)
-  end
-
-  it "does not find subscriber lists that match document type but not tags" do
-    get_subscriber_list(document_type: "tax")
-    expect(response.status).to eq(404)
-  end
-
-  it "does not find subscriber lists when no query keys are provided" do
-    get_subscriber_list({})
-    expect(response.status).to eq(404)
-  end
-
-  context "when passing in gov_delivery_id" do
-    it "does not find a subscriber list of the gov_delivery_id does not match" do
-      get_subscriber_list(
-        tags: { topics: ["vat-rates"] },
-        document_type: "tax",
-        gov_delivery_id: "NEW-TOPIC"
-      )
-      expect(response.status).to eq(404)
+  context "with authentication and authorisation" do
+    before do
+      login_with_internal_app
     end
 
-    it "finds the subscriber list if the gov_delivery_id matches" do
-      _alpha = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "alpha")
-      beta = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "beta")
-      _gamma = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "gamma")
+    let!(:subscriber_list_links_only) do
+      create(
+        :subscriber_list,
+        links: {
+          topics: ["oil-and-gas/licensing", "drug-device-alert"]
+        },
+        tags: {},
+        document_type: "",
+      )
+    end
 
+    let!(:subscriber_list_tags_only) do
+      create(
+        :subscriber_list,
+        links: {},
+        tags: {
+          topics: ["oil-and-gas/licensing", "drug-device-alert"]
+        },
+        document_type: "",
+      )
+    end
+
+    let!(:subscriber_list_document_type_only) do
+      create(
+        :subscriber_list,
+        links: {},
+        tags: {},
+        document_type: "travel_advice",
+      )
+    end
+
+    let!(:subscriber_list_links_and_document_type) do
+      create(
+        :subscriber_list,
+        links: {
+          topics: ["vat-rates"],
+        },
+        tags: {},
+        document_type: "tax",
+      )
+    end
+
+    let!(:subscriber_list_tags_and_document_type) do
+      create(
+        :subscriber_list,
+        links: {},
+        tags: {
+          topics: ["vat-rates"],
+        },
+        document_type: "tax",
+      )
+    end
+
+    it "responds with the matching subscriber list" do
+      get_subscriber_list(links: { topics: ["drug-device-alert", "oil-and-gas/licensing"] })
+
+      database_subscriber_list = subscriber_list_links_only
+      response_subscriber_list = JSON.parse(response.body).fetch("subscriber_list").deep_symbolize_keys
+
+      expect(response_subscriber_list).to include(
+        id: database_subscriber_list.id,
+        links: database_subscriber_list.links,
+        tags: database_subscriber_list.tags,
+        document_type: database_subscriber_list.document_type,
+        gov_delivery_id: database_subscriber_list.gov_delivery_id,
+        subscription_url: database_subscriber_list.subscription_url,
+        title: database_subscriber_list.title,
+      )
+    end
+
+    it "finds subscriber lists that match all of the links" do
+      get_subscriber_list(links: { topics: ["drug-device-alert", "oil-and-gas/licensing"] })
+      expect(response.status).to eq(200)
+
+      subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+      expect(subscriber_list.fetch("id")).to eq(subscriber_list_links_only.id)
+    end
+
+    it "finds subscriber lists that match all of the tags" do
+      get_subscriber_list(tags: { topics: ["drug-device-alert", "oil-and-gas/licensing"] })
+      expect(response.status).to eq(200)
+
+      subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+      expect(subscriber_list.fetch("id")).to eq(subscriber_list_tags_only.id)
+    end
+
+    it "finds subscriber lists that match document type only" do
+      get_subscriber_list(document_type: "travel_advice")
+      expect(response.status).to eq(200)
+
+      subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+      expect(subscriber_list.fetch("id")).to eq(subscriber_list_document_type_only.id)
+    end
+
+    it "finds subscriber lists that match links and document type" do
       get_subscriber_list(
-        tags: { topics: ["vat-rates"] },
-        gov_delivery_id: "beta"
+        links: { topics: ["vat-rates"] },
+        document_type: "tax",
       )
       expect(response.status).to eq(200)
 
       subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
-      expect(subscriber_list.fetch("id")).to eq(beta.id)
+      expect(subscriber_list.fetch("id")).to eq(subscriber_list_links_and_document_type.id)
+    end
+
+    it "finds subscriber lists that match tags and document type" do
+      get_subscriber_list(
+        tags: { topics: ["vat-rates"] },
+        document_type: "tax",
+      )
+      expect(response.status).to eq(200)
+
+      subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+      expect(subscriber_list.fetch("id")).to eq(subscriber_list_tags_and_document_type.id)
+    end
+
+    it "does not find subscriber lists that match some of the links" do
+      get_subscriber_list(links: { topics: ["drug-device-alert"] })
+      expect(response.status).to eq(404)
+    end
+
+    it "does not find subscriber lists that match some of the tags" do
+      get_subscriber_list(tags: { topics: ["drug-device-alert"] })
+      expect(response.status).to eq(404)
+    end
+
+    it "does not find subscriber lists that with a different document type" do
+      get_subscriber_list(document_type: "something_else")
+      expect(response.status).to eq(404)
+    end
+
+    it "does not find subscriber lists that match links but not document type" do
+      get_subscriber_list(links: { topics: ["vat-rates"] })
+      expect(response.status).to eq(404)
+    end
+
+    it "does not find subscriber lists that match document type but not links" do
+      get_subscriber_list(document_type: "tax")
+      expect(response.status).to eq(404)
+    end
+
+    it "does not find subscriber lists that match tags but not document type" do
+      get_subscriber_list(tags: { topics: ["vat-rates"] })
+      expect(response.status).to eq(404)
+    end
+
+    it "does not find subscriber lists that match document type but not tags" do
+      get_subscriber_list(document_type: "tax")
+      expect(response.status).to eq(404)
+    end
+
+    it "does not find subscriber lists when no query keys are provided" do
+      get_subscriber_list({})
+      expect(response.status).to eq(404)
+    end
+
+    context "when passing in gov_delivery_id" do
+      it "does not find a subscriber list of the gov_delivery_id does not match" do
+        get_subscriber_list(
+          tags: { topics: ["vat-rates"] },
+          document_type: "tax",
+          gov_delivery_id: "NEW-TOPIC"
+        )
+        expect(response.status).to eq(404)
+      end
+
+      it "finds the subscriber list if the gov_delivery_id matches" do
+        _alpha = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "alpha")
+        beta = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "beta")
+        _gamma = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "gamma")
+
+        get_subscriber_list(
+          tags: { topics: ["vat-rates"] },
+          gov_delivery_id: "beta"
+        )
+        expect(response.status).to eq(200)
+
+        subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+        expect(subscriber_list.fetch("id")).to eq(beta.id)
+      end
+    end
+  end
+
+  context "without authentication" do
+    it "returns a 403" do
+      get_subscriber_list({})
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context "without authorisation" do
+    it "returns a 403" do
+      login_with_signin
+      get_subscriber_list({})
+      expect(response.status).to eq(403)
     end
   end
 

--- a/spec/integration/send_notification_spec.rb
+++ b/spec/integration/send_notification_spec.rb
@@ -1,169 +1,221 @@
 RSpec.describe "Sending a notification", type: :request do
   context "v1" do
-    before do
-      Sidekiq::Testing.fake!
-      @gov_delivery = double(:gov_delivery, send_bulletin: nil)
-      allow(Services).to receive(:gov_delivery).and_return(@gov_delivery)
-      allow(NotificationHandlerService).to receive(:call)
-    end
+    context "with authentication and authorisation" do
+      before do
+        login_with_internal_app
+        Sidekiq::Testing.fake!
+        @gov_delivery = double(:gov_delivery, send_bulletin: nil)
+        allow(Services).to receive(:gov_delivery).and_return(@gov_delivery)
+        allow(NotificationHandlerService).to receive(:call)
+      end
 
-    after do
-      Sidekiq::Worker.clear_all
-    end
+      after do
+        Sidekiq::Worker.clear_all
+      end
 
-    it "returns a 202" do
-      send_notification(topics: ["oil-and-gas/licensing"])
-
-      expect(response.status).to eq(202)
-    end
-
-    it "kicks off a notification job" do
-      expect {
+      it "returns a 202" do
         send_notification(topics: ["oil-and-gas/licensing"])
-      }.to change(NotificationWorker.jobs, :count).from(0).to(1)
-    end
 
-    it "sends notifications for the right subscriber lists" do
-      relevant_list_ids, _irrelevant_list_ids = create_many_lists
+        expect(response.status).to eq(202)
+      end
 
-      send_notification(topics: ["oil-and-gas/licensing"],
-        organisations: ["environment-agency", "hm-revenue-customs"])
+      it "kicks off a notification job" do
+        expect {
+          send_notification(topics: ["oil-and-gas/licensing"])
+        }.to change(NotificationWorker.jobs, :count).from(0).to(1)
+      end
 
-      NotificationWorker.drain
+      it "sends notifications for the right subscriber lists" do
+        relevant_list_ids, _irrelevant_list_ids = create_many_lists
 
-      expect(@gov_delivery).to have_received(:send_bulletin)
-        .with(
-          relevant_list_ids,
-          "This is a sample subject",
-          "Here is some body copy<span data-govuk-request-id=\"request-id\"></span>",
-          {},
+        send_notification(
+          topics: ["oil-and-gas/licensing"],
+          organisations: ["environment-agency", "hm-revenue-customs"]
         )
-    end
 
-    it "sends notifications with options if given" do
-      relevant_list_ids, _irrelevant_list_ids = create_many_lists
+        NotificationWorker.drain
 
-      send_notification({
-        topics: ["oil-and-gas/licensing"],
-        organisations: ["environment-agency", "hm-revenue-customs"]
-      },
-            from_address_id: "12345",
+        expect(@gov_delivery).to have_received(:send_bulletin)
+          .with(
+            relevant_list_ids,
+            "This is a sample subject",
+            "Here is some body copy<span data-govuk-request-id=\"request-id\"></span>",
+            {},
+        )
+      end
+
+      it "sends notifications with options if given" do
+        relevant_list_ids, _irrelevant_list_ids = create_many_lists
+
+        send_notification({
+          topics: ["oil-and-gas/licensing"],
+          organisations: ["environment-agency", "hm-revenue-customs"]
+        },
+        from_address_id: "12345",
         urgent: true,
         header: "foo",
         footer: "bar")
 
-      NotificationWorker.drain
+        NotificationWorker.drain
 
-      expect(@gov_delivery).to have_received(:send_bulletin)
-        .with(
-          relevant_list_ids,
-          "This is a sample subject",
-          "Here is some body copy<span data-govuk-request-id=\"request-id\"></span>",
-                    "from_address_id" => "12345",
+        expect(@gov_delivery).to have_received(:send_bulletin)
+          .with(
+            relevant_list_ids,
+            "This is a sample subject",
+            "Here is some body copy<span data-govuk-request-id=\"request-id\"></span>",
+            "from_address_id" => "12345",
             "urgent" => true,
             "header" => "foo",
             "footer" => "bar"
         )
-    end
+      end
 
-    it "doesn't send notifications if there's no lists" do
-      send_notification(topics: ["oil-and-gas/licensing"],
-        organisations: ["environment-agency", "hm-revenue-customs"])
-
-      NotificationWorker.drain
-
-      expect(@gov_delivery).not_to have_received(:send_bulletin)
-    end
-
-    def create_many_lists
-      all_match = create(:subscriber_list,
-        tags: {
+      it "doesn't send notifications if there's no lists" do
+        send_notification(
           topics: ["oil-and-gas/licensing"],
           organisations: ["environment-agency", "hm-revenue-customs"]
-        })
+        )
 
-      partial_type_match = create(:subscriber_list, tags: {
-        topics: ["oil-and-gas/licensing"],
-        browse_pages: ["tax/vat"]
-      })
+        NotificationWorker.drain
 
-      full_type_partial_tag_match = create(:subscriber_list,
-        tags: {
-          topics: ["oil-and-gas/licensing"],
-          organisations: ["environment-agency"]
-        })
+        expect(@gov_delivery).not_to have_received(:send_bulletin)
+      end
 
-      full_type_no_tag_match = create(:subscriber_list, tags: {
-        topics: ["schools-colleges/administration-finance"],
-        organisations: ["department-for-education"]
-      })
+      def create_many_lists
+        all_match = create(
+          :subscriber_list,
+          tags: {
+            topics: ["oil-and-gas/licensing"],
+            organisations: ["environment-agency", "hm-revenue-customs"]
+          }
+        )
 
-      full_type_but_empty = create(:subscriber_list, tags: {
-        topics: [],
-        organisations: ["environment-agency", "hm-revenue-customs"]
-      })
+        partial_type_match = create(
+          :subscriber_list,
+          tags: {
+            topics: ["oil-and-gas/licensing"],
+            browse_pages: ["tax/vat"]
+          }
+        )
 
-      relevant_lists = [
-        all_match,
-        full_type_partial_tag_match
-      ]
+        full_type_partial_tag_match = create(
+          :subscriber_list,
+          tags: {
+            topics: ["oil-and-gas/licensing"],
+            organisations: ["environment-agency"]
+          }
+        )
 
-      irrelevant_lists = [
-        partial_type_match,
-        full_type_no_tag_match,
-        full_type_but_empty
-      ]
+        full_type_no_tag_match = create(
+          :subscriber_list, tags: {
+            topics: ["schools-colleges/administration-finance"],
+            organisations: ["department-for-education"]
+          }
+        )
 
-      [
-        relevant_lists.map(&:gov_delivery_id).uniq,
-        irrelevant_lists.map(&:gov_delivery_id).uniq
-      ]
+        full_type_but_empty = create(
+          :subscriber_list, tags: {
+            topics: [],
+            organisations: ["environment-agency", "hm-revenue-customs"]
+          }
+        )
+
+        relevant_lists = [
+          all_match,
+          full_type_partial_tag_match
+        ]
+
+        irrelevant_lists = [
+          partial_type_match,
+          full_type_no_tag_match,
+          full_type_but_empty
+        ]
+
+        [
+          relevant_lists.map(&:gov_delivery_id).uniq,
+          irrelevant_lists.map(&:gov_delivery_id).uniq
+        ]
+      end
+
+      def send_notification(tags, options = {})
+        request_body = JSON.dump({
+          subject: "This is a sample subject",
+          body: "Here is some body copy",
+          tags: tags,
+        }.merge(options))
+
+        post "/notifications", params: request_body, headers: JSON_HEADERS
+      end
+    end
+    context "without authentication" do
+      it "returns a 403" do
+        post "/notifications", params: {}, headers: {}
+        expect(response.status).to eq(403)
+      end
     end
 
-    def send_notification(tags, options = {})
-      request_body = JSON.dump({
-        subject: "This is a sample subject",
-        body: "Here is some body copy",
-        tags: tags,
-      }.merge(options))
-
-      post "/notifications", params: request_body, headers: JSON_HEADERS
+    context "without authorisation" do
+      it "returns a 403" do
+        login_with_signin
+        post "/notifications", params: {}, headers: {}
+        expect(response.status).to eq(403)
+      end
     end
   end
 
   context "v2" do
-    let(:request_params) {
-      {
-        subject: "This is a subject",
-        body: "body stuff",
-        tags: {
-          topics: ["oil-and-gas/licensing"]
-        },
-        links: {
-          organisations: [
-            "c380ea42-5d91-41cc-b3cd-0a4cfe439461"
-          ]
-        },
-        content_id: "afe78383-6b27-45a4-92ae-a579e416373a",
-        title: "Travel advice",
-        change_note: "This is a change note",
-        description: "This is a description",
-        base_path: "/government/things",
-        public_updated_at: Time.now.to_s,
-        email_document_supertype: "email document supertype",
-        government_document_supertype: "government document supertype",
-        document_type: "document type",
-        publishing_app: "publishing app",
-      }.to_json
-    }
+    context "with authentication and authorisation" do
+      let(:request_params) {
+        {
+          subject: "This is a subject",
+          body: "body stuff",
+          tags: {
+            topics: ["oil-and-gas/licensing"]
+          },
+          links: {
+            organisations: [
+              "c380ea42-5d91-41cc-b3cd-0a4cfe439461"
+            ]
+          },
+          content_id: "afe78383-6b27-45a4-92ae-a579e416373a",
+          title: "Travel advice",
+          change_note: "This is a change note",
+          description: "This is a description",
+          base_path: "/government/things",
+          public_updated_at: Time.now.to_s,
+          email_document_supertype: "email document supertype",
+          government_document_supertype: "government document supertype",
+          document_type: "document type",
+          publishing_app: "publishing app",
+        }.to_json
+      }
 
-    before do
-      allow(NotificationWorker).to receive(:perform_async)
-      post "/notifications", params: request_params, headers: JSON_HEADERS
+      before do
+        login_with_internal_app
+        allow(NotificationWorker).to receive(:perform_async)
+        post "/notifications", params: request_params, headers: JSON_HEADERS
+      end
+
+      it "creates a Notification" do
+        expect(ContentChange.count).to eq(1)
+      end
     end
 
-    it "creates a Notification" do
-      expect(ContentChange.count).to eq(1)
+    context "without authentication" do
+      it "returns 403" do
+        post "/notifications", params: {}, headers: {}
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "without authorisation" do
+      it "returns 403" do
+        login_with_signin
+        post "/notifications", params: {}, headers: {}
+
+        expect(response.status).to eq(403)
+      end
     end
   end
 end

--- a/spec/integration/subscribables_controller_spec.rb
+++ b/spec/integration/subscribables_controller_spec.rb
@@ -1,22 +1,46 @@
 RSpec.describe "Getting a subscribable", type: :request do
   describe "GET /subscribables/<govuk_delivery_id>" do
-    context "the subscribable exists" do
-      let!(:subscribable) { create(:subscriber_list, gov_delivery_id: "test135") }
+    context "with authentication and authorisation" do
+      before do
+        login_with_internal_app
+      end
 
-      it "returns it" do
-        get "/subscribables/test135"
+      context "the subscribable exists" do
+        let!(:subscribable) { create(:subscriber_list, gov_delivery_id: "test135") }
 
-        subscribable_response = JSON.parse(response.body).deep_symbolize_keys[:subscribable]
+        it "returns it" do
+          get "/subscribables/test135"
 
-        expect(subscribable_response[:id]).to eq(subscribable.id)
+          subscribable_response = JSON.parse(response.body).deep_symbolize_keys[:subscribable]
+
+          expect(subscribable_response[:id]).to eq(subscribable.id)
+        end
+      end
+
+      context "the subscribable doesn't exist" do
+        it "returns a 404" do
+          get "/subscribables/test135"
+
+          expect(response.status).to eq(404)
+        end
       end
     end
 
-    context "the subscribable doesn't exist" do
-      it "returns a 404" do
+    context "without authentication" do
+      it "returns a 403" do
         get "/subscribables/test135"
 
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "without authorisation" do
+      it "returns a 403" do
+        login_with_signin
+
+        get "/subscribables/test135"
+
+        expect(response.status).to eq(403)
       end
     end
   end

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -1,96 +1,117 @@
 RSpec.describe "Subscriptions", type: :request do
-  it "requires an address parameter" do
-    post "/subscriptions", params: { subscribable_id: 10 }
-    expect(response.status).to eq(400)
-  end
-
-  it "requires a subscribable_id parameter" do
-    post "/subscriptions", params: { address: "test@example.com" }
-    expect(response.status).to eq(400)
-  end
-
-  it "fails with an invalid subscribable" do
-    post "/subscriptions", params: { subscribable_id: 10, address: "test@example.com" }
-    expect(response.status).to eq(404)
-  end
-
-  context "with an existing subscription" do
-    let(:subscribable) { create(:subscriber_list) }
-    let(:subscriber) { create(:subscriber, address: "test@example.com") }
-    let!(:subscription) { create(:subscription, subscriber_list: subscribable, subscriber: subscriber) }
-
-    def create_subscription
-      post "/subscriptions", params: { subscribable_id: subscribable.id, address: subscriber.address }
+  context "with authentication and authorisation" do
+    before do
+      login_with_internal_app
     end
 
-    it "doesn't create a new subscription" do
-      expect { create_subscription }.not_to change(Subscription, :count)
+    it "requires an address parameter" do
+      post "/subscriptions", params: { subscribable_id: 10 }
+      expect(response.status).to eq(400)
     end
 
-    it "returns status code 201" do
-      create_subscription
-      expect(response.status).to eq(200)
+    it "requires a subscribable_id parameter" do
+      post "/subscriptions", params: { address: "test@example.com" }
+      expect(response.status).to eq(400)
     end
 
-    it "returns the ID of the existing subscription" do
-      create_subscription
-      expect(data[:id]).to eq(subscription.id)
+    it "fails with an invalid subscribable" do
+      post "/subscriptions", params: { subscribable_id: 10, address: "test@example.com" }
+      expect(response.status).to eq(404)
     end
-  end
 
-  context "without an existing subscription" do
-    context "with a subscribable" do
+    context "with an existing subscription" do
       let(:subscribable) { create(:subscriber_list) }
+      let(:subscriber) { create(:subscriber, address: "test@example.com") }
+      let!(:subscription) { create(:subscription, subscriber_list: subscribable, subscriber: subscriber) }
 
       def create_subscription
-        post "/subscriptions", params: { subscribable_id: subscribable.id, address: "test@example.com" }
+        post "/subscriptions", params: { subscribable_id: subscribable.id, address: subscriber.address }
       end
 
-      context "with an existing subscriber" do
-        before do
-          create(:subscriber, address: "test@example.com")
-        end
-
-        it "does not create another subscriber" do
-          expect { create_subscription }.not_to change(Subscriber, :count)
-        end
-      end
-
-      context "without an existing subscriber" do
-        it "creates a new subscriber" do
-          expect { create_subscription }.to change(Subscriber, :count).by(1)
-          expect(Subscriber.first.address).to eq("test@example.com")
-        end
-      end
-
-      it "creates the subscription" do
-        expect { create_subscription }.to change(Subscription, :count).by(1)
-        expect(Subscription.first.subscriber_list).to eq(subscribable)
+      it "doesn't create a new subscription" do
+        expect { create_subscription }.not_to change(Subscription, :count)
       end
 
       it "returns status code 201" do
         create_subscription
-        expect(response.status).to eq(201)
+        expect(response.status).to eq(200)
       end
 
-      it "returns JSON" do
+      it "returns the ID of the existing subscription" do
         create_subscription
-        expect(response.content_type).to eq("application/json")
+        expect(data[:id]).to eq(subscription.id)
       end
+    end
 
-      it "returns the ID of the new subscription" do
-        create_subscription
-        expect(data[:id]).not_to be_nil
+    context "without an existing subscription" do
+      context "with a subscribable" do
+        let(:subscribable) { create(:subscriber_list) }
+
+        def create_subscription
+          post "/subscriptions", params: { subscribable_id: subscribable.id, address: "test@example.com" }
+        end
+
+        context "with an existing subscriber" do
+          before do
+            create(:subscriber, address: "test@example.com")
+          end
+
+          it "does not create another subscriber" do
+            expect { create_subscription }.not_to change(Subscriber, :count)
+          end
+        end
+
+        context "without an existing subscriber" do
+          it "creates a new subscriber" do
+            expect { create_subscription }.to change(Subscriber, :count).by(1)
+            expect(Subscriber.first.address).to eq("test@example.com")
+          end
+        end
+
+        it "creates the subscription" do
+          expect { create_subscription }.to change(Subscription, :count).by(1)
+          expect(Subscription.first.subscriber_list).to eq(subscribable)
+        end
+
+        it "returns status code 201" do
+          create_subscription
+          expect(response.status).to eq(201)
+        end
+
+        it "returns JSON" do
+          create_subscription
+          expect(response.content_type).to eq("application/json")
+        end
+
+        it "returns the ID of the new subscription" do
+          create_subscription
+          expect(data[:id]).not_to be_nil
+        end
+      end
+    end
+
+    context "with an invalid email address" do
+      let(:subscribable) { create(:subscriber_list) }
+
+      it "cannot process the request" do
+        post "/subscriptions", params: { subscribable_id: subscribable.id, address: "invalid" }
+        expect(response.status).to eq(422)
       end
     end
   end
 
-  context "with an invalid email address" do
-    let(:subscribable) { create(:subscriber_list) }
+  context "without authentication" do
+    it "returns a 403" do
+      post "/subscriptions", params: { subscribable_id: 10, address: "test@example.com" }
+      expect(response.status).to eq(403)
+    end
+  end
 
-    it "cannot process the request" do
-      post "/subscriptions", params: { subscribable_id: subscribable.id, address: "invalid" }
-      expect(response.status).to eq(422)
+  context "without authorisation" do
+    it "returns a 403" do
+      login_with_signin
+      post "/subscriptions", params: { subscribable_id: 10, address: "test@example.com" }
+      expect(response.status).to eq(403)
     end
   end
 end

--- a/spec/integration/unsubscribe_spec.rb
+++ b/spec/integration/unsubscribe_spec.rb
@@ -1,29 +1,50 @@
 RSpec.describe "Unsubscribing", type: :request do
-  describe "POST" do
-    context "when the subscription exists" do
-      let(:subscription) { create(:subscription) }
-
-      before do
-        post "/unsubscribe/#{subscription.uuid}"
-      end
-
-      it "deletes the subscription" do
-        expect(Subscription.count).to eq(0)
-      end
-
-      it "responds with a 200 status" do
-        expect(response.status).to eq(204)
-      end
+  context "with authentication and authorisation" do
+    before do
+      login_as(create(:user, permissions: %w[internal_app]))
     end
 
-    context "when the subscription doesn't exist" do
-      before do
-        post "/unsubscribe/123"
+    describe "POST" do
+      context "when the subscription exists" do
+        let(:subscription) { create(:subscription) }
+
+        before do
+          post "/unsubscribe/#{subscription.uuid}"
+        end
+
+        it "deletes the subscription" do
+          expect(Subscription.count).to eq(0)
+        end
+
+        it "responds with a 200 status" do
+          expect(response.status).to eq(204)
+        end
       end
 
-      it "responds with a 404 status" do
-        expect(response.status).to eq(404)
+      context "when the subscription doesn't exist" do
+        before do
+          post "/unsubscribe/123"
+        end
+
+        it "responds with a 404 status" do
+          expect(response.status).to eq(404)
+        end
       end
+    end
+  end
+
+  context "without authentication" do
+    it "returns a 403" do
+      post "/unsubscribe/123"
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context "without authorisation" do
+    it "returns a 403" do
+      login_with_signin
+      post "/unsubscribe/123"
+      expect(response.status).to eq(403)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,10 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.include FactoryBot::Syntax::Methods
   config.include SharedSteps, type: :request
+
+  config.after do
+    logout
+  end
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ require "gds-sso/lint/user_spec"
 require "spec/features/_shared_steps"
 require "db/seeds"
 
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.use_transactional_fixtures = true
@@ -28,10 +30,6 @@ JSON_HEADERS = {
   "ACCEPT" => "application/json",
   "HTTP_GOVUK_REQUEST_ID" => "request-id",
 }.freeze
-
-def login_as(user)
-  GDS::SSO.test_user = user
-end
 
 def data(body = response.body)
   JSON.parse(body).deep_symbolize_keys

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,29 @@
+module AuthenticationHelpers
+  def login_with_internal_app
+    login_with("internal_app")
+  end
+
+  def login_with_signin
+    login_with("signin")
+  end
+
+  def login_with_status_updates
+    login_with("status_updates")
+  end
+
+  def login_with(permissions)
+    login_as(create(:user, permissions: Array(permissions)))
+  end
+
+  def login_as(user)
+    GDS::SSO.test_user = user
+  end
+
+  def logout
+    GDS::SSO.test_user = nil
+  end
+end
+
+RSpec.configure do |config|
+  config.include AuthenticationHelpers
+end


### PR DESCRIPTION
This PR adds a requirement for `internal_app` permission to all endpoints except status_updates, which requires the aptly entitled `status_updates` permission and healthcheck which doesn't require authentication.

The diffs are a bit messy but there aren't actually that many significant changes in each of the files. In the integration specs I've added a 'with authentication and authorisation' context that logs in with the necessary permissions and then 'without authentication' and 'without authorisation' contexts that just check for a 403.

I've also added login steps to the functional tests but have not tested the negative cases there. Some of those logins are a bit contrived in that they needed `status_updates` and `internal_app` permissions which doesn't happen in reality currently.

We've been logging permissions in production today and all of the following apps are correctly configured for these changes.

* travel advice publisher
* collections
* email-alert-frontend
* specialist-publisher
* whitehall
* finder-frontend

There are three other 'clients' making requests. The notify callback which has the status_updates permission and two things calling `/healthcheck` without a bearer token which is fine.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)