### PR TITLE
Add hyperlinked title to email body

### DIFF
--- a/app/models/email_renderer.rb
+++ b/app/models/email_renderer.rb
@@ -9,10 +9,13 @@ class EmailRenderer
 
   def body
     <<~BODY
+      [#{title}](#{content_url})
+
       #{change_note}: #{description}.
 
-      #{content_url}
-      Updated on #{public_updated_at}
+      Updated at #{public_updated_at}
+
+      ----
 
       #{unsubscribe_links}
     BODY
@@ -39,7 +42,7 @@ private
   end
 
   def public_updated_at
-    params.fetch(:public_updated_at).strftime("%I:%M %P, %-d %B %Y")
+    params.fetch(:public_updated_at).strftime("%I:%M %P on %-d %B %Y")
   end
 
   def subscriber
@@ -52,7 +55,7 @@ private
   end
 
   def present_unsubscribe_link(link)
-    "Unsubscribe from '#{link.title}':\n#{link.url}"
+    "Unsubscribe from [#{link.title}](#{link.url})"
   end
 
   def content_url

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe "Sending an email", type: :request do
 
     expect(body).to include("Change note: Description")
     expect(body).to include("gov.uk/base-path")
-    expect(body).to include("Updated on 12:00 am, 1 January 2017")
+    expect(body).to include("Updated at 12:00 am on 1 January 2017")
 
-    expect(body).to include("Unsubscribe from 'Example'")
+    expect(body).to include("Unsubscribe from [Example]")
     expect(body).to include("gov.uk/email/unsubscribe/")
   end
 end

--- a/spec/units/models/email_renderer_spec.rb
+++ b/spec/units/models/email_renderer_spec.rb
@@ -31,16 +31,17 @@ RSpec.describe EmailRenderer do
     it "should match the expected content" do
       expect(subject.body).to eq(
         <<~BODY
+          [Title](http://www.dev.gov.uk/base_path)
+
           Change note: Description.
 
-          http://www.dev.gov.uk/base_path
-          Updated on 12:00 am, 1 January 2017
+          Updated at 12:00 am on 1 January 2017
 
-          Unsubscribe from 'First Subscription':
-          http://www.dev.gov.uk/email/unsubscribe/1234?title=First%20Subscription
+          ----
 
-          Unsubscribe from 'Second Subscription':
-          http://www.dev.gov.uk/email/unsubscribe/5678?title=Second%20Subscription
+          Unsubscribe from [First Subscription](http://www.dev.gov.uk/email/unsubscribe/1234?title=First%20Subscription)
+
+          Unsubscribe from [Second Subscription](http://www.dev.gov.uk/email/unsubscribe/5678?title=Second%20Subscription)
         BODY
       )
     end


### PR DESCRIPTION
This commit adds a hyperlinked title to the email body. This makes the email body more readable than currently, where links are shown in their entirety.

Trello: https://trello.com/c/3KbUAUXK/484-change-links-in-email-template-to-link-the-title-to-the-relevant-govuk-page