### PR TITLE
Associate a user with authenticated actions

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,10 @@ class NotificationsController < ApplicationController
   def create
     NotificationWorker.perform_async(notification_params)
 
-    NotificationHandlerService.call(params: notification_params)
+    NotificationHandlerService.call(
+      params: notification_params,
+      user: current_user,
+    )
 
     render json: { message: "Notification queued for sending" }, status: 202
   end

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -2,17 +2,15 @@ class StatusUpdatesController < ApplicationController
   wrap_parameters false
 
   def create
-    StatusUpdateService.call(**status_update_params)
+    StatusUpdateService.call(
+      reference: params.require(:reference),
+      status: params.require(:status),
+      user: current_user,
+    )
     head :no_content
   end
 
 private
-
-  def status_update_params
-    params.require(:reference)
-    params.require(:status)
-    params.permit(:reference, :status).to_h.symbolize_keys
-  end
 
   def authorise
     authorise_user!("status_updates")

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -29,6 +29,7 @@ private
     find_exact_query_params.merge(
       title: params[:title],
       gov_delivery_id: gov_delivery_id,
+      signon_user_uid: current_user.uid,
     )
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,15 +5,11 @@ class SubscriptionsController < ApplicationController
       subscriber_list: subscribable,
     )
 
-    subscription.frequency = frequency
+    status = subscription.new_record? ? :created : :ok
 
-    if subscription.new_record?
-      subscription.signon_user_uid = current_user.uid
-      subscription.save!
-      status = :created
-    else
-      status = :ok
-    end
+    subscription.frequency = frequency
+    subscription.signon_user_uid = current_user.uid
+    subscription.save!
 
     render json: { id: subscription.id }, status: status
   end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -31,8 +31,10 @@ class SubscriberList < ApplicationRecord
     end
   end
 
-  def to_json
-    super(methods: :subscription_url)
+  def to_json(options = {})
+    options[:except] ||= %i{signon_user_uid}
+    options[:methods] ||= %i{subscription_url}
+    super(options)
   end
 
 private

--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -1,7 +1,8 @@
 class NotificationHandlerService
-  attr_reader :params
-  def initialize(params:)
+  attr_reader :params, :user
+  def initialize(params:, user: nil)
     @params = params
+    @user = user
   end
 
   def self.call(*args)
@@ -36,6 +37,7 @@ private
       document_type: params[:document_type],
       publishing_app: params[:publishing_app],
       priority: params.fetch(:priority, "low").to_sym,
+      signon_user_uid: user&.uid,
     }
   end
 end

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -1,7 +1,8 @@
 class StatusUpdateService
-  def initialize(reference:, status:)
+  def initialize(reference:, status:, user: nil)
     @reference = reference
     @status = status
+    @user = user
   end
 
   def self.call(*args)
@@ -9,7 +10,10 @@ class StatusUpdateService
   end
 
   def call
-    delivery_attempt.update!(status: status.underscore)
+    delivery_attempt.update!(
+      status: status.underscore,
+      signon_user_uid: user&.uid,
+    )
 
     if delivery_attempt.permanent_failure? && subscriber
       UnsubscribeService.subscriber!(subscriber)
@@ -23,7 +27,7 @@ class StatusUpdateService
 
 private
 
-  attr_reader :reference, :status
+  attr_reader :reference, :status, :user
 
   def delivery_attempt
     @delivery_attempt ||= DeliveryAttempt.find_by!(reference: reference)

--- a/db/migrate/20180116163006_store_signon_user_ids.rb
+++ b/db/migrate/20180116163006_store_signon_user_ids.rb
@@ -1,0 +1,9 @@
+class StoreSignonUserIds < ActiveRecord::Migration[5.1]
+  def change
+    add_column :content_changes,    :signon_user_uid, :string
+    add_column :subscriber_lists,   :signon_user_uid, :string
+    add_column :subscriptions,      :signon_user_uid, :string
+    add_column :subscribers,        :signon_user_uid, :string
+    add_column :delivery_attempts,  :signon_user_uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20180118085957) do
     t.datetime "updated_at", null: false
     t.datetime "processed_at"
     t.integer "priority", default: 0
+    t.string "signon_user_uid"
   end
 
   create_table "delivery_attempts", force: :cascade do |t|
@@ -42,6 +43,7 @@ ActiveRecord::Schema.define(version: 20180118085957) do
     t.string "reference", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "signon_user_uid"
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"
   end
@@ -82,6 +84,7 @@ ActiveRecord::Schema.define(version: 20180118085957) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.integer "subscriber_count"
+    t.string "signon_user_uid"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true
@@ -93,6 +96,7 @@ ActiveRecord::Schema.define(version: 20180118085957) do
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "signon_user_uid"
     t.index ["address"], name: "index_subscribers_on_address", unique: true
   end
 
@@ -113,7 +117,11 @@ ActiveRecord::Schema.define(version: 20180118085957) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
+<<<<<<< HEAD
     t.integer "frequency", default: 0, null: false
+=======
+    t.string "signon_user_uid"
+>>>>>>> Add signon_user_uid fields to table
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,11 +117,8 @@ ActiveRecord::Schema.define(version: 20180118085957) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
-<<<<<<< HEAD
-    t.integer "frequency", default: 0, null: false
-=======
     t.string "signon_user_uid"
->>>>>>> Add signon_user_uid fields to table
+    t.integer "frequency", default: 0, null: false
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe "Receiving a status update", type: :request do
     end
 
     context "when a user does not have 'status_updates' permission" do
-      before do
-        login_as(create(:user, permissions: %w[signin status_updates]))
-      end
+      let(:user) { create(:user, permissions: %w[signin status_updates]) }
+      before { login_as(user) }
 
       it "calls the status update service" do
         expect(StatusUpdateService).to receive(:call).with(
           reference: "ref-123",
           status: "delivered",
+          user: user,
         )
 
         post "/status-updates", params: params

--- a/spec/units/services/notification_handler_service_spec.rb
+++ b/spec/units/services/notification_handler_service_spec.rb
@@ -40,28 +40,8 @@ RSpec.describe NotificationHandlerService do
 
   describe ".call" do
     it "creates a ContentChange" do
-      notification_params = {
-        content_id: params[:content_id],
-        title: params[:title],
-        change_note: params[:change_note],
-        description: params[:description],
-        base_path: params[:base_path],
-        links: params[:links],
-        tags: params[:tags],
-        public_updated_at: Time.parse(params[:public_updated_at]),
-        email_document_supertype: params[:email_document_supertype],
-        government_document_supertype: params[:government_document_supertype],
-        govuk_request_id: params[:govuk_request_id],
-        document_type: params[:document_type],
-        publishing_app: params[:publishing_app],
-        priority: :low,
-      }
-
-      expect(ContentChange).to receive(:create!)
-        .with(notification_params)
-        .and_return(double(id: 1, **notification_params))
-
-      described_class.call(params: params)
+      expect { described_class.call(params: params) }
+        .to change { ContentChange.count }.by(1)
     end
 
     it "enqueues the content change to be processed by the subscription content worker" do


### PR DESCRIPTION
Trello: https://trello.com/c/HqLhaWvN/476-for-models-that-are-created-as-a-result-of-a-request-in-email-alert-api-store-the-user-id-so-we-know-which-user-created-things

or auditing purposes this will store the user id of the user that has
performed an action which has altered the state of the application.

Since we have authentication we have the ability to know who has
performed an action, but this was previously not stored. Storing this
should help if we want to work out analytics based on a user service.

For the most part though this data should be pretty dull with mostly the
same accounts using the API.