### PR TITLE
Add frequency to subscriptions

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -1,7 +1,7 @@
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
 
-  enum priority: %i(low high)
+  enum priority: { low: 0, high: 1 }
 
   def mark_processed!
     update!(processed_at: Time.now)

--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -3,8 +3,8 @@ class DeliveryAttempt < ApplicationRecord
 
   validates :email, :status, :provider, presence: true
 
-  enum status: %i(sending delivered permanent_failure temporary_failure technical_failure)
-  enum provider: %i(pseudo notify)
+  enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4 }
+  enum provider: { pseudo: 0, notify: 1 }
 
   def self.latest_per_email
     inner = group(:email_id).select("email_id AS id, MAX(updated_at) AS max")

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,6 +2,8 @@ class Subscription < ApplicationRecord
   belongs_to :subscriber
   belongs_to :subscriber_list
 
+  enum frequency: %i(immediately daily weekly)
+
   before_validation :set_uuid
 
   validates :subscriber, uniqueness: { scope: :subscriber_list }

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,7 +2,7 @@ class Subscription < ApplicationRecord
   belongs_to :subscriber
   belongs_to :subscriber_list
 
-  enum frequency: %i(immediately daily weekly)
+  enum frequency: { immediately: 0, daily: 1, weekly: 2 }
 
   before_validation :set_uuid
 

--- a/db/migrate/20180118085957_add_frequency_to_subscriptions.rb
+++ b/db/migrate/20180118085957_add_frequency_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddFrequencyToSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriptions, :frequency, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219104253) do
+ActiveRecord::Schema.define(version: 20180118085957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20171219104253) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
+    t.integer "frequency", default: 0, null: false
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"

--- a/spec/units/models/subscription_spec.rb
+++ b/spec/units/models/subscription_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Subscription, type: :model do
 
       expect(subject).to be_invalid
     end
+
+    it "is an immediate email" do
+      expect(subject.immediately?).to be_truthy
+    end
   end
 
   describe "callbacks" do


### PR DESCRIPTION
This will be used to set whether a subscription is a daily or weekly digest, or if the emails should be sent immediately.

[Trello Card](https://trello.com/c/xNqETkOc/349-add-type-information-to-subscription)