### PR TITLE
Accept frequency when creating subscriptions

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,12 +5,10 @@ class SubscriptionsController < ApplicationController
       subscriber_list: subscribable,
     )
 
-    if subscription.new_record?
-      subscription.save!
-      status = :created
-    else
-      status = :ok
-    end
+    status = subscription.new_record? ? :created : :ok
+
+    subscription.frequency = frequency
+    subscription.save!
 
     render json: { id: subscription.id }, status: status
   end
@@ -25,9 +23,13 @@ private
     SubscriberList.find(subscription_params[:subscribable_id])
   end
 
+  def frequency
+    subscription_params.fetch(:frequency, "immediately").to_sym
+  end
+
   def subscription_params
     params.require(:address)
     params.require(:subscribable_id)
-    params.permit(:address, :subscribable_id)
+    params.permit(:address, :subscribable_id, :frequency)
   end
 end

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -13,6 +13,33 @@ RSpec.describe "Creating a subscription", type: :request do
 
         expect(response.status).to eq(201)
       end
+
+      context "with a frequency setting" do
+        it "returns a 201 and sets the frequency" do
+          params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id, frequency: "daily")
+          post "/subscriptions", params: params, headers: JSON_HEADERS
+
+          expect(response.status).to eq(201)
+
+          expect(Subscription.first.daily?).to be_truthy
+        end
+
+        context "with an existing subscription" do
+          it "updates the frequency" do
+            params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id, frequency: "daily")
+            post "/subscriptions", params: params, headers: JSON_HEADERS
+
+            expect(response.status).to eq(201)
+
+            params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id, frequency: "weekly")
+            post "/subscriptions", params: params, headers: JSON_HEADERS
+
+            expect(response.status).to eq(200)
+
+            expect(Subscription.first.weekly?).to be_truthy
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This allows the user to specify if they want this subscription to be a daily or weekly digest, or if they want to receive emails immediately.

Depends on #361.

[Trello Card](https://trello.com/c/8tnYuGjO/531-accept-type-parameters-in-subscriptionscontroller)