### PR TITLE
Add digest schedulers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'govuk_app_config', '~> 1.2'
 gem 'nokogiri', '~> 1.8'
 gem 'notifications-ruby-client', '~> 2.6'
 gem 'plek', '~> 2.0'
+gem 'whenever', require: false
 
 gem 'govuk_sidekiq', '~> 3.0'
 gem 'ratelimit', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     ast (2.3.0)
     builder (3.2.3)
     byebug (9.1.0)
+    chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -314,6 +315,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
     with_advisory_lock (3.2.0)
       activerecord (>= 3.2)
 
@@ -344,6 +347,7 @@ DEPENDENCIES
   sidekiq-scheduler (~> 2.1)
   timecop
   webmock
+  whenever
   with_advisory_lock (~> 3.2)
 
 BUNDLED WITH

--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -1,0 +1,37 @@
+class DigestRun < ApplicationRecord
+  validates :starts_at, :ends_at, :date, :range, presence: true
+  before_validation :set_range_dates, on: :create
+  validate :ends_at_is_in_the_past
+
+  enum range: { daily: 0, weekly: 1 }
+
+  DAILY = "daily".freeze
+  WEEKLY = "weekly".freeze
+
+private
+
+  def set_range_dates
+    self.starts_at = configured_starts_at
+    self.ends_at = configured_ends_at
+  end
+
+  def ends_at_is_in_the_past
+    errors.add(:ends_at, "must be in the past") if ends_at >= Time.now
+  end
+
+  def configured_starts_at
+    Time.parse("#{digest_range_hour}:00", starts_at_date)
+  end
+
+  def configured_ends_at
+    Time.parse("#{digest_range_hour}:00", Time.now)
+  end
+
+  def starts_at_date
+    daily? ? 1.day.ago : 1.week.ago
+  end
+
+  def digest_range_hour
+    ENV.fetch("DIGEST_RANGE_HOUR", 8).to_i
+  end
+end

--- a/app/services/daily_digest_scheduler_service.rb
+++ b/app/services/daily_digest_scheduler_service.rb
@@ -1,27 +1,5 @@
 class DailyDigestSchedulerService
+  include DigestSchedulerService
   LOCK_NAME = "daily_digest_scheduler".freeze
-
-  def self.call(*args)
-    new.call(*args)
-  end
-
-  def call
-    run_with_advisory_lock do
-      digest_run = DigestRun.find_or_initialize_by(
-        date: Date.current, range: DigestRun::DAILY
-      )
-      return if digest_run.persisted?
-      digest_run.save!
-    end
-
-    #enqueue the digest creation workers TBC
-  end
-
-private
-
-  def run_with_advisory_lock
-    DigestRun.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
-      yield
-    end
-  end
+  RANGE = DigestRun::DAILY.freeze
 end

--- a/app/services/daily_digest_scheduler_service.rb
+++ b/app/services/daily_digest_scheduler_service.rb
@@ -1,0 +1,27 @@
+class DailyDigestSchedulerService
+  LOCK_NAME = "daily_digest_scheduler".freeze
+
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  def call
+    run_with_advisory_lock do
+      digest_run = DigestRun.find_or_initialize_by(
+        date: Date.current, range: DigestRun::DAILY
+      )
+      return if digest_run.persisted?
+      digest_run.save!
+    end
+
+    #enqueue the digest creation workers TBC
+  end
+
+private
+
+  def run_with_advisory_lock
+    DigestRun.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
+      yield
+    end
+  end
+end

--- a/app/services/digest_scheduler_service.rb
+++ b/app/services/digest_scheduler_service.rb
@@ -1,0 +1,29 @@
+module DigestSchedulerService
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def call(*args)
+      new.call(*args)
+    end
+  end
+
+  def call
+    run_with_advisory_lock do
+      digest_run = DigestRun.find_or_initialize_by(
+        date: Date.current, range: self.class::RANGE
+      )
+      return if digest_run.persisted?
+      digest_run.save!
+    end
+
+    #enqueue the digest creation workers TBC
+  end
+
+private
+
+  def run_with_advisory_lock
+    DigestRun.with_advisory_lock(self.class::LOCK_NAME, timeout_seconds: 0) do
+      yield
+    end
+  end
+end

--- a/app/services/weekly_digest_scheduler_service.rb
+++ b/app/services/weekly_digest_scheduler_service.rb
@@ -1,0 +1,5 @@
+class WeeklyDigestSchedulerService
+  include DigestSchedulerService
+  LOCK_NAME = "weekly_digest_scheduler".freeze
+  RANGE = DigestRun::WEEKLY.freeze
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+every 1.day, at: "8:30 am" do
+  runner "DailyDigestSchedulerService.call"
+end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,4 +21,8 @@ every 1.day, at: "8:30 am" do
   runner "DailyDigestSchedulerService.call"
 end
 
+every :saturday, at: "8:30 am" do
+  runner "WeeklyDigestSchedulerService.call"
+end
+
 # Learn more: http://github.com/javan/whenever

--- a/db/migrate/20180118134516_create_digest_runs.rb
+++ b/db/migrate/20180118134516_create_digest_runs.rb
@@ -1,0 +1,12 @@
+class CreateDigestRuns < ActiveRecord::Migration[5.1]
+  def change
+    create_table :digest_runs do |t|
+      t.date :date, null: false
+      t.datetime :starts_at, null: false
+      t.datetime :ends_at, null: false
+      t.integer :range, null: false
+      t.datetime :completed_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180118085957) do
+ActiveRecord::Schema.define(version: 20180118134516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,16 @@ ActiveRecord::Schema.define(version: 20180118085957) do
     t.datetime "updated_at", null: false
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"
+  end
+
+  create_table "digest_runs", force: :cascade do |t|
+    t.date "date", null: false
+    t.datetime "starts_at", null: false
+    t.datetime "ends_at", null: false
+    t.integer "range", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "emails", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,30 +1,4 @@
 FactoryBot.define do
-  factory :subscriber_list do
-    sequence(:title) { |n| "title #{n}" }
-    sequence(:gov_delivery_id) { |n| "UKGOVUK_#{n}" }
-    tags(topics: ["motoring/road_rage"])
-    created_at { 1.year.ago }
-  end
-
-  factory :notification_log do
-    sequence(:govuk_request_id) { |i| "request-id-#{i}" }
-    sequence(:content_id) { |i| "content-id-#{i}" }
-    public_updated_at Time.now.to_s
-    links {}
-    tags {}
-    document_type "announcement"
-    gov_delivery_ids %w(TOPIC_123 TOPIC_456)
-  end
-
-  factory :subscriber do
-    sequence(:address) { |i| "test-#{i}@example.com" }
-  end
-
-  factory :subscription do
-    subscriber
-    subscriber_list
-  end
-
   factory :content_change do
     content_id { SecureRandom.uuid }
     title "title"
@@ -41,9 +15,11 @@ FactoryBot.define do
     publishing_app "publishing app"
   end
 
-  factory :subscription_content do
-    subscription
-    content_change
+  factory :delivery_attempt do
+    email
+    status :sending
+    provider :notify
+    reference "reference"
   end
 
   factory :email do
@@ -52,11 +28,35 @@ FactoryBot.define do
     body "body"
   end
 
-  factory :delivery_attempt do
-    email
-    status :sending
-    provider :notify
-    reference "reference"
+  factory :notification_log do
+    sequence(:govuk_request_id) { |i| "request-id-#{i}" }
+    sequence(:content_id) { |i| "content-id-#{i}" }
+    public_updated_at Time.now.to_s
+    links {}
+    tags {}
+    document_type "announcement"
+    gov_delivery_ids %w(TOPIC_123 TOPIC_456)
+  end
+
+  factory :subscriber do
+    sequence(:address) { |i| "test-#{i}@example.com" }
+  end
+
+  factory :subscriber_list do
+    sequence(:title) { |n| "title #{n}" }
+    sequence(:gov_delivery_id) { |n| "UKGOVUK_#{n}" }
+    tags(topics: ["motoring/road_rage"])
+    created_at { 1.year.ago }
+  end
+
+  factory :subscription do
+    subscriber
+    subscriber_list
+  end
+
+  factory :subscription_content do
+    subscription
+    content_change
   end
 
   factory :user

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,6 +22,17 @@ FactoryBot.define do
     reference "reference"
   end
 
+  factory :digest_run do
+    date { Date.current }
+    range DigestRun::DAILY
+
+    trait :daily
+
+    trait :weekly do
+      range DigestRun::WEEKLY
+    end
+  end
+
   factory :email do
     address "test@example.com"
     subject "subject"

--- a/spec/units/models/digest_run_spec.rb
+++ b/spec/units/models/digest_run_spec.rb
@@ -1,0 +1,116 @@
+require "rails_helper"
+
+RSpec.describe DigestRun do
+  context "with valid parameters" do
+    it "can be created" do
+      expect {
+        described_class.create(
+          attributes_for(:digest_run)
+        )
+      }.to change { DigestRun.count }.from(0).to(1)
+    end
+
+    context "with no environment vars set" do
+      context "daily" do
+        it "sets starts_at to 8am on date - 1.day" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "daily")
+
+          expect(instance.starts_at).to eq(
+            Time.parse("08:00", (date - 1.day).to_time)
+          )
+        end
+
+        it "sets ends_at to 8am on date" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "daily")
+
+          expect(instance.ends_at).to eq(
+            Time.parse("08:00", date.to_time)
+          )
+        end
+      end
+
+      context "weekly" do
+        it "sets starts_at to 8am on date - 1.week" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "weekly")
+
+          expect(instance.starts_at).to eq(
+            Time.parse("08:00", (date - 1.week).to_time)
+          )
+        end
+
+        it "sets ends_at to 8am on date" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "weekly")
+
+          expect(instance.ends_at).to eq(
+            Time.parse("08:00", date.to_time)
+          )
+        end
+      end
+    end
+
+    context "configured with an env var" do
+      before do
+        ENV["DIGEST_RANGE_HOUR"] = "10"
+        Timecop.freeze("10:30", Time.now)
+      end
+
+      after do
+        ENV["DIGEST_RANGE_HOUR"] = nil
+        Timecop.return
+      end
+
+      context "daily" do
+        it "sets starts_at to the configured hour on date - 1.day" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "daily")
+
+          expect(instance.starts_at).to eq(
+            Time.parse("10:00", (date - 1.day).to_time)
+          )
+        end
+
+        it "sets ends_at to the configured hour on date" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "daily")
+
+          expect(instance.ends_at).to eq(
+            Time.parse("10:00", date.to_time)
+          )
+        end
+      end
+
+      context "weekly" do
+        it "sets starts_at to the configured hour on date - 1.week" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "weekly")
+
+          expect(instance.starts_at).to eq(
+            Time.parse("10:00", (date - 1.week).to_time)
+          )
+        end
+
+        it "sets ends_at to the configured hour on date" do
+          date = Date.current
+          instance = described_class.create(date: date, range: "weekly")
+
+          expect(instance.ends_at).to eq(
+            Time.parse("10:00", date.to_time)
+          )
+        end
+      end
+    end
+
+    describe "validations" do
+      it "fails if the calculated ends_at is in the future" do
+        Timecop.freeze(Time.parse("07:00", Time.now)) do
+          instance = described_class.create(date: Date.current, range: "daily")
+          expect(instance.errors[:ends_at]).to eq(["must be in the past"])
+        end
+      end
+    end
+  end
+end

--- a/spec/units/services/daily_digest_scheduler_service_spec.rb
+++ b/spec/units/services/daily_digest_scheduler_service_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe DailyDigestSchedulerService do
+  describe "call" do
+    after do
+      ENV["DIGEST_RANGE_HOUR"] = nil
+    end
+
+    context "when there is no daily DigestRun for the date" do
+      it "creates one" do
+        Timecop.freeze(Time.parse("08:30")) do
+          expect { described_class.call }
+            .to change { DigestRun.daily.count }.from(0).to(1)
+        end
+      end
+    end
+
+    context "when a DigestRun already exists" do
+      it "doesn't create another one" do
+        Timecop.freeze(Time.parse("08:30")) do
+          create(:digest_run, :daily, date: Date.current)
+
+          described_class.call
+
+          expect(DigestRun.count).to eq(1)
+        end
+      end
+    end
+
+    context "when the service is called multiple times" do
+      it "only creates one DigestRun" do
+        Timecop.freeze(Time.parse("08:30")) do
+          described_class.call
+          described_class.call
+          described_class.call
+          described_class.call
+
+          expect(DigestRun.count).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/units/services/weekly_digest_scheduler_service_spec.rb
+++ b/spec/units/services/weekly_digest_scheduler_service_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe WeeklyDigestSchedulerService do
+  describe "call" do
+    context "when there is no daily DigestRun for the date" do
+      it "creates one" do
+        Timecop.freeze(Time.parse("08:30")) do
+          expect { described_class.call }
+            .to change { DigestRun.weekly.count }.from(0).to(1)
+        end
+      end
+    end
+
+    context "when a DigestRun already exists" do
+      it "doesn't create another one" do
+        Timecop.freeze(Time.parse("08:30")) do
+          create(:digest_run, :weekly, date: Date.current)
+
+          described_class.call
+
+          expect(DigestRun.count).to eq(1)
+        end
+      end
+    end
+
+    context "when the service is called multiple times" do
+      it "only creates one DigestRun" do
+        Timecop.freeze(Time.parse("08:30")) do
+          described_class.call
+          described_class.call
+          described_class.call
+          described_class.call
+
+          expect(DigestRun.count).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of the implementation of digest emails within email-alert-api we need a way of scheduling and scoping their creation. This PR adds a `DailyDigestSchedulerService` which when called creates a `DigestRange` object. This object models the time scope of the digest ie the span within which notifications should be generated for any matching content changes.

To reduce complexity in deployment the service has been implemented to allow multiple calls without initiated duplicate runs of digest emails. This allows it to be called from all host machines so we can schedule it simply with cron.

This class will be expanded in future PRs to enqueue jobs to create the digest emails.

Marked WIP as I'm adding the weekly version and wanted to get some early feedback and not block the next bit but if we're happy with this it can be merged and I'll update in a separate PR.

[Trello](https://trello.com/c/WPFnHqCJ/533-create-digest-schedulers)