### PR TITLE
Store matched content changes

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -1,6 +1,8 @@
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
 
+  has_many :matched_subscriber_lists, through: :matched_content_changes
+
   enum priority: { low: 0, high: 1 }
 
   def mark_processed!

--- a/app/models/matched_content_change.rb
+++ b/app/models/matched_content_change.rb
@@ -1,0 +1,4 @@
+class MatchedContentChange < ApplicationRecord
+  belongs_to :content_change
+  belongs_to :subscriber_list
+end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -10,6 +10,7 @@ class SubscriberList < ApplicationRecord
 
   has_many :subscriptions
   has_many :subscribers, through: :subscriptions
+  has_many :matched_content_changes, through: :matched_content_changes
 
   def self.build_from(params:, gov_delivery_id:)
     new(

--- a/app/queries/subscription_matcher.rb
+++ b/app/queries/subscription_matcher.rb
@@ -1,17 +1,7 @@
 class SubscriptionMatcher
   def self.call(content_change:)
     Subscription.where(
-      subscriber_list: subscribables_for(content_change: content_change)
+      subscriber_list: MatchedContentChange.where(content_change: content_change).pluck(:subscriber_list_id)
     ).distinct
-  end
-
-  def self.subscribables_for(content_change:)
-    SubscriberListQuery.new(
-      tags: content_change.tags,
-      links: content_change.links,
-      document_type: content_change.document_type,
-      email_document_supertype: content_change.email_document_supertype,
-      government_document_supertype: content_change.government_document_supertype,
-    ).lists
   end
 end

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -1,0 +1,36 @@
+class MatchedContentChangeGenerationService
+  def initialize(content_change:)
+    @content_change = content_change
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    MatchedContentChange.import!(records)
+  end
+
+private
+
+  attr_reader :content_change
+
+  def records
+    subscriber_lists.map do |subscriber_list|
+      {
+        content_change_id: content_change.id,
+        subscriber_list_id: subscriber_list.id,
+      }
+    end
+  end
+
+  def subscriber_lists
+    SubscriberListQuery.new(
+      tags: content_change.tags,
+      links: content_change.links,
+      document_type: content_change.document_type,
+      email_document_supertype: content_change.email_document_supertype,
+      government_document_supertype: content_change.government_document_supertype,
+    ).lists
+  end
+end

--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -13,7 +13,7 @@ class NotificationHandlerService
     begin
       content_change = ContentChange.create!(content_change_params)
       MetricsService.content_change_created
-      store_matched_content_change(content_change)
+      MatchedContentChangeGenerationService.call(content_change: content_change)
       SubscriptionContentWorker.perform_async(content_change.id)
     rescue StandardError => ex
       Raven.capture_exception(ex, tags: { version: 2 })
@@ -21,31 +21,6 @@ class NotificationHandlerService
   end
 
 private
-
-  def store_matched_content_change(content_change)
-    MatchedContentChange.import!(
-      matched_content_change_records_for(content_change: content_change)
-    )
-  end
-
-  def matched_content_change_records_for(content_change:)
-    subscriber_lists_for(content_change: content_change).map do |subscriber_list|
-      {
-        content_change_id: content_change.id,
-        subscriber_list_id: subscriber_list.id,
-      }
-    end
-  end
-
-  def subscriber_lists_for(content_change:)
-    SubscriberListQuery.new(
-      tags: content_change.tags,
-      links: content_change.links,
-      document_type: content_change.document_type,
-      email_document_supertype: content_change.email_document_supertype,
-      government_document_supertype: content_change.government_document_supertype,
-    ).lists
-  end
 
   def content_change_params
     {

--- a/db/migrate/20180123093411_add_matched_content_change.rb
+++ b/db/migrate/20180123093411_add_matched_content_change.rb
@@ -1,0 +1,11 @@
+class AddMatchedContentChange < ActiveRecord::Migration[5.1]
+  def change
+    create_table :matched_content_changes do |t|
+      t.references :content_change, null: false, foreign_key: true
+      t.references :subscriber_list, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :matched_content_changes, %i(content_change_id subscriber_list_id), unique: true, name: "index_matched_content_changes_content_change_subscriber_list"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180118134516) do
+ActiveRecord::Schema.define(version: 20180123093411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,16 @@ ActiveRecord::Schema.define(version: 20180118134516) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
+  end
+
+  create_table "matched_content_changes", force: :cascade do |t|
+    t.bigint "content_change_id", null: false
+    t.bigint "subscriber_list_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_change_id", "subscriber_list_id"], name: "index_matched_content_changes_content_change_subscriber_list", unique: true
+    t.index ["content_change_id"], name: "index_matched_content_changes_on_content_change_id"
+    t.index ["subscriber_list_id"], name: "index_matched_content_changes_on_subscriber_list_id"
   end
 
   create_table "notification_logs", id: :serial, force: :cascade do |t|
@@ -127,8 +137,8 @@ ActiveRecord::Schema.define(version: 20180118134516) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
-    t.string "signon_user_uid"
     t.integer "frequency", default: 0, null: false
+    t.string "signon_user_uid"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"
@@ -147,6 +157,8 @@ ActiveRecord::Schema.define(version: 20180118134516) do
   end
 
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
+  add_foreign_key "matched_content_changes", "content_changes"
+  add_foreign_key "matched_content_changes", "subscriber_lists"
   add_foreign_key "subscription_contents", "content_changes"
   add_foreign_key "subscription_contents", "emails", on_delete: :nullify
   add_foreign_key "subscription_contents", "subscriptions", on_delete: :nullify

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -70,5 +70,10 @@ FactoryBot.define do
     content_change
   end
 
+  factory :matched_content_change do
+    content_change
+    subscriber_list
+  end
+
   factory :user
 end

--- a/spec/units/models/matched_content_change_spec.rb
+++ b/spec/units/models/matched_content_change_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe MatchedContentChange, type: :model do
+  context "validations" do
+    subject { build(:matched_content_change) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/units/queries/subscription_matcher_spec.rb
+++ b/spec/units/queries/subscription_matcher_spec.rb
@@ -3,8 +3,16 @@ RSpec.describe SubscriptionMatcher do
     create(:content_change, tags: { topics: ["oil-and-gas/licensing"] })
   end
 
-  let(:subscribable) do
+  let(:subscriber_list) do
     create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] })
+  end
+
+  before do
+    create(
+      :matched_content_change,
+      content_change: content_change,
+      subscriber_list: subscriber_list,
+    )
   end
 
   subject { described_class.call(content_change: content_change) }
@@ -12,7 +20,7 @@ RSpec.describe SubscriptionMatcher do
   describe ".call" do
     context "with a subscription" do
       before do
-        create(:subscription, subscriber_list: subscribable)
+        create(:subscription, subscriber_list: subscriber_list)
       end
 
       it "returns the subscriptions" do
@@ -22,8 +30,8 @@ RSpec.describe SubscriptionMatcher do
 
     context "with two subscriptions" do
       before do
-        create(:subscription, subscriber_list: subscribable)
-        create(:subscription, subscriber_list: subscribable, subscriber: create(:subscriber, address: "test2@example.com"))
+        create(:subscription, subscriber_list: subscriber_list)
+        create(:subscription, subscriber_list: subscriber_list, subscriber: create(:subscriber, address: "test2@example.com"))
       end
 
       it "returns the subscriptions" do

--- a/spec/units/services/matched_content_change_generation_service_spec.rb
+++ b/spec/units/services/matched_content_change_generation_service_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe MatchedContentChangeGenerationService do
+  let(:content_change) do
+    create(:content_change, tags: { topics: ["oil-and-gas/licensing"] })
+  end
+
+  before do
+    create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] })
+  end
+
+  describe ".call" do
+    it "creates a MatchedContentChange" do
+      expect { described_class.call(content_change: content_change) }
+        .to change { MatchedContentChange.count }.by(1)
+    end
+  end
+end

--- a/spec/units/services/notification_handler_service_spec.rb
+++ b/spec/units/services/notification_handler_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotificationHandlerService do
     }
   }
 
-  let(:subscriber_list) do
+  let!(:subscriber_list) do
     create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] })
   end
 
@@ -44,11 +44,19 @@ RSpec.describe NotificationHandlerService do
         .to change { ContentChange.count }.by(1)
     end
 
+    it "creates a MatchedContentChange" do
+      expect { described_class.call(params: params) }
+        .to change { MatchedContentChange.count }.by(1)
+    end
+
+    let(:content_change) { create(:content_change) }
+
     it "enqueues the content change to be processed by the subscription content worker" do
-      allow(ContentChange).to receive(:create!).and_return(double(id: 1))
+      allow(ContentChange).to receive(:create!).and_return(content_change)
+
       expect(SubscriptionContentWorker)
         .to receive(:perform_async)
-        .with(1)
+        .with(content_change.id)
 
       described_class.call(params: params)
     end

--- a/spec/units/workers/subscription_content_worker_spec.rb
+++ b/spec/units/workers/subscription_content_worker_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SubscriptionContentWorker do
   context "with a subscription" do
     let(:subscriber) { create(:subscriber) }
     let(:subscriber_list) { create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] }) }
+    let!(:matched_content_change) { create(:matched_content_change, subscriber_list: subscriber_list, content_change: content_change) }
     let!(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
 
     context "asynchronously" do


### PR DESCRIPTION
This PR introduces a new table to store content changes match with their subscriber lists when they come straight into the system. This allows the workers down the line to make use of this "cached" data, and enables the creation of a query that matches subscribers with content changes useful for digests.

[Trello Card](https://trello.com/c/NRw0zkGc/534-content-changes-for-subscription)