### PR TITLE
Use URI.join in PublicUrlService

### DIFF
--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -1,7 +1,7 @@
 module PublicUrlService
   class << self
     def content_url(base_path:)
-      "#{website_root}#{base_path}"
+      URI.join(website_root, base_path).to_s
     end
 
     # This url is for the page mid-way through the signup journey where the user


### PR DESCRIPTION
This seems a more semantically correct way of creating a URL string from a host and a base path and also handles situations where either the trailing or preceding slash is missing from either side.