### PR TITLE
Add SubscriptionContentChangeQuery

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -1,7 +1,7 @@
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
 
-  has_many :matched_subscriber_lists, through: :matched_content_changes
+  has_many :matched_content_changes
 
   enum priority: { low: 0, high: 1 }
 

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -10,7 +10,7 @@ class SubscriberList < ApplicationRecord
 
   has_many :subscriptions
   has_many :subscribers, through: :subscriptions
-  has_many :matched_content_changes, through: :matched_content_changes
+  has_many :matched_content_changes
 
   def self.build_from(params:, gov_delivery_id:)
     new(

--- a/app/queries/subscription_content_change_query.rb
+++ b/app/queries/subscription_content_change_query.rb
@@ -1,0 +1,49 @@
+class SubscriptionContentChangeQuery
+  def initialize(subscriber:, digest_run:)
+    @subscriber = subscriber
+    @digest_run = digest_run
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    present
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscriber, :digest_run
+
+  Result = Struct.new(:subscription_id, :subscription_uuid, :subscriber_list_title, :content_changes)
+
+  def present
+    grouped_content_changes.map do |(subscription_id, subscription_uuid, subscriber_list_title), content_changes|
+      Result.new(
+        subscription_id,
+        subscription_uuid,
+        subscriber_list_title,
+        content_changes,
+      )
+    end
+  end
+
+  def grouped_content_changes
+    content_changes.group_by do |record|
+      [record["subscription_id"], record["subscription_uuid"], record["subscriber_list_title"]]
+    end
+  end
+
+  def content_changes
+    ContentChange
+      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriptions.uuid AS subscription_uuid")
+      .joins(matched_content_changes: { subscriber_list: { subscriptions: :subscriber } })
+      .where(subscribers: { id: subscriber.id })
+      .where("content_changes.created_at >= ?", digest_run.starts_at)
+      .where("content_changes.created_at < ?", digest_run.ends_at)
+      .order("subscriber_list_title ASC", "content_changes.title ASC")
+  end
+end

--- a/spec/units/queries/subscription_content_change_query_spec.rb
+++ b/spec/units/queries/subscription_content_change_query_spec.rb
@@ -1,0 +1,144 @@
+RSpec.describe SubscriptionContentChangeQuery do
+  let(:subscriber) do
+    create(:subscriber)
+  end
+
+  let(:ends_at) { Time.parse("2017-01-02 08:00") }
+
+  let(:digest_run) do
+    create(:digest_run, date: ends_at, range: :daily)
+  end
+
+  let(:starts_at) { digest_run.starts_at }
+
+  subject { described_class.call(subscriber: subscriber, digest_run: digest_run) }
+
+  context "with one subscription" do
+    let(:subscriber_list) do
+      create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] })
+    end
+
+    let!(:subscription) do
+      create(:subscription, subscriber_list: subscriber_list, subscriber: subscriber)
+    end
+
+    def create_and_match_content_change(created_at: starts_at, title: nil)
+      content_change = create(
+        :content_change,
+        tags: { topics: ["oil-and-gas/licensing"] },
+        created_at: created_at,
+      )
+      content_change.update!(title: title) if title
+      create(
+        :matched_content_change,
+        content_change: content_change,
+        subscriber_list: subscriber_list,
+      )
+    end
+
+    describe ".call" do
+      context "with a matched content change" do
+        before do
+          create_and_match_content_change
+        end
+
+        it "returns one result" do
+          expect(subject.first.content_changes.count).to eq(1)
+        end
+      end
+
+      context "with two matched content changes" do
+        before do
+          create_and_match_content_change(title: "Z")
+          create_and_match_content_change(title: "A")
+        end
+
+        it "returns two results correctly ordered" do
+          expect(subject.first.content_changes.count).to eq(2)
+          expect(subject.first.content_changes.first.title).to eq("A")
+          expect(subject.first.content_changes.second.title).to eq("Z")
+        end
+      end
+
+      context "with a matched content change that's out of date" do
+        before do
+          create_and_match_content_change(created_at: ends_at)
+        end
+
+        it "returns no results" do
+          expect(subject.count).to eq(0)
+        end
+      end
+
+      context "with no matched content changes" do
+        before do
+          create(:content_change)
+        end
+
+        it "returns no results" do
+          expect(subject.count).to eq(0)
+        end
+      end
+    end
+  end
+
+  context "with two subscriptions" do
+    let(:subscriber_list_1) do
+      create(:subscriber_list, title: "list-1", tags: { topics: ["oil-and-gas/licensing"] })
+    end
+
+    let(:subscriber_list_2) do
+      create(:subscriber_list, title: "list-2", tags: { topics: ["oil-and-gas/drilling"] })
+    end
+
+    let!(:subscription_2) do
+      create(:subscription, id: 2, subscriber_list: subscriber_list_2, subscriber: subscriber)
+    end
+
+    let!(:subscription_1) do
+      create(:subscription, id: 1, subscriber_list: subscriber_list_1, subscriber: subscriber)
+    end
+
+    let(:content_change_1) do
+      create(
+        :content_change,
+        id: 1,
+        tags: { topics: ["oil-and-gas/licensing"] },
+        created_at: starts_at,
+      )
+    end
+
+    let(:content_change_2) do
+      create(
+        :content_change,
+        id: 2,
+        tags: { topics: ["oil-and-gas/drilling"] },
+        created_at: starts_at,
+      )
+    end
+
+    before do
+      create(
+        :matched_content_change,
+        content_change: content_change_1,
+        subscriber_list: subscriber_list_1,
+      )
+
+      create(
+        :matched_content_change,
+        content_change: content_change_2,
+        subscriber_list: subscriber_list_2,
+      )
+    end
+
+    it "returns correctly ordered" do
+      expect(subject.first.subscription_id).to eq(1)
+      expect(subject.first.subscriber_list_title).to eq("list-1")
+      expect(subject.first.content_changes.first.id).to eq(1)
+
+      expect(subject.second.subscription_id).to eq(2)
+      expect(subject.second.subscriber_list_title).to eq("list-2")
+      expect(subject.second.content_changes.first.id).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
The purpose of this class will be to query which content changes
should be associated with a subscriber and a digest run. It will
return the content changes grouped by subscription and subscriber
list.

[Trello Card](https://trello.com/c/NRw0zkGc/534-content-changes-for-subscription)