### PR TITLE
DigestRun bases range from supplied date

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -10,6 +10,14 @@ class DigestRun < ApplicationRecord
 
 private
 
+  def starts_at=(value)
+    super
+  end
+
+  def ends_at=(value)
+    super
+  end
+
   def set_range_dates
     self.starts_at = configured_starts_at
     self.ends_at = configured_ends_at
@@ -20,15 +28,15 @@ private
   end
 
   def configured_starts_at
-    Time.parse("#{digest_range_hour}:00", starts_at_date)
+    Time.parse("#{digest_range_hour}:00", starts_at_time)
   end
 
   def configured_ends_at
-    Time.parse("#{digest_range_hour}:00", Time.now)
+    Time.parse("#{digest_range_hour}:00", date.to_time)
   end
 
-  def starts_at_date
-    daily? ? 1.day.ago : 1.week.ago
+  def starts_at_time
+    (daily? ? date - 1.day : date - 1.week).to_time
   end
 
   def digest_range_hour

--- a/spec/units/models/digest_run_spec.rb
+++ b/spec/units/models/digest_run_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DigestRun do
     context "with no environment vars set" do
       context "daily" do
         it "sets starts_at to 8am on date - 1.day" do
-          date = Date.current
+          date = 2.days.ago
           instance = described_class.create(date: date, range: "daily")
 
           expect(instance.starts_at).to eq(
@@ -22,7 +22,7 @@ RSpec.describe DigestRun do
         end
 
         it "sets ends_at to 8am on date" do
-          date = Date.current
+          date = 1.day.ago
           instance = described_class.create(date: date, range: "daily")
 
           expect(instance.ends_at).to eq(
@@ -33,7 +33,7 @@ RSpec.describe DigestRun do
 
       context "weekly" do
         it "sets starts_at to 8am on date - 1.week" do
-          date = Date.current
+          date = 1.day.ago
           instance = described_class.create(date: date, range: "weekly")
 
           expect(instance.starts_at).to eq(
@@ -65,7 +65,7 @@ RSpec.describe DigestRun do
 
       context "daily" do
         it "sets starts_at to the configured hour on date - 1.day" do
-          date = Date.current
+          date = 1.week.ago
           instance = described_class.create(date: date, range: "daily")
 
           expect(instance.starts_at).to eq(
@@ -74,7 +74,7 @@ RSpec.describe DigestRun do
         end
 
         it "sets ends_at to the configured hour on date" do
-          date = Date.current
+          date = 1.day.ago
           instance = described_class.create(date: date, range: "daily")
 
           expect(instance.ends_at).to eq(
@@ -94,7 +94,7 @@ RSpec.describe DigestRun do
         end
 
         it "sets ends_at to the configured hour on date" do
-          date = Date.current
+          date = 4.days.ago
           instance = described_class.create(date: date, range: "weekly")
 
           expect(instance.ends_at).to eq(


### PR DESCRIPTION
The `DigestRun` class was creating the date range based on `Time.now`. It should use the date it is provided but tests weren't failing as they all set date to Date.current.

This PR updates the tests to use a range of dates and fixes the implementation.

Also makes starts_at and ends_at private to avoid them being set explicitly.