### PR TITLE
Add digest generation and sending

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -1,0 +1,63 @@
+class DigestEmailBuilder
+  def initialize(subscriber:, digest_run:, subscription_content_change_results:)
+    @subscriber = subscriber
+    @digest_run = digest_run
+    @results = subscription_content_change_results
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    Email.new(
+      subject: subject,
+      body: body,
+      address: subscriber.address
+    )
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscriber, :digest_run, :results
+
+  def body
+    results.map { |result| presented_result(result) }.join("\n&nbsp;\n\n")
+  end
+
+  def presented_result(result)
+    <<~RESULT
+      ##{result.subscriber_list_title}
+
+      #{presented_content_changes(result.content_changes)}
+      ---
+
+      #{unsubscribe_link(result)}
+    RESULT
+  end
+
+  def subject
+    if digest_run.daily?
+      "GOV.UK Daily Update"
+    else
+      "GOV.UK Weekly Update"
+    end
+  end
+
+  def presented_content_changes(content_changes)
+    changes = content_changes.map do |content_change|
+      ContentChangePresenter.call(content_change)
+    end
+
+    changes.join("\n---\n\n")
+  end
+
+  def unsubscribe_link(result)
+    UnsubscribeLinkPresenter.call(
+      uuid: result.subscription_uuid,
+      title: result.subscriber_list_title
+    )
+  end
+end

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -1,0 +1,37 @@
+class ContentChangePresenter
+  EMAIL_DATE_FORMAT = "%I:%M %P on %-d %B %Y".freeze
+
+  def initialize(content_change)
+    @content_change = content_change
+  end
+
+  def self.call(content_change)
+    new(content_change).call
+  end
+
+  def call
+    <<~BODY
+      [#{title}](#{content_url})
+
+      #{change_note}: #{description}
+
+      Updated at #{public_updated_at}
+    BODY
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :content_change
+
+  delegate :title, :description, :change_note, to: :content_change
+
+  def content_url
+    PublicUrlService.content_url(base_path: content_change.base_path)
+  end
+
+  def public_updated_at
+    content_change.public_updated_at.strftime(EMAIL_DATE_FORMAT)
+  end
+end

--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -1,0 +1,26 @@
+class UnsubscribeLinkPresenter
+  attr_reader :uuid, :title
+
+  def initialize(uuid:, title:)
+    @uuid = uuid
+    @title = title
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    "Unsubscribe from [#{title}](#{url})"
+  end
+
+private
+
+  def url
+    PublicUrlService.url_for(base_path: "/email/unsubscribe/#{uuid}?title=#{escaped_title}")
+  end
+
+  def escaped_title
+    ERB::Util.url_encode(title)
+  end
+end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -4,6 +4,8 @@ module PublicUrlService
       URI.join(website_root, base_path).to_s
     end
 
+    alias_method :url_for, :content_url
+
     # This url is for the page mid-way through the signup journey where the user
     # enters their email address. At present, multiple frontends start the
     # journey, e.g. collections, but eventually all these will be consolidated

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -1,0 +1,61 @@
+class DigestEmailGenerationWorker
+  include Sidekiq::Worker
+
+  attr_reader :subscriber, :digest_run, :email
+
+  def perform(subscriber_id:, digest_run_id:)
+    @subscriber = Subscriber.find(subscriber_id)
+    @digest_run = DigestRun.find(digest_run_id)
+
+    generate_email_and_subscription_contents
+
+    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :low)
+  end
+
+private
+
+  attr_reader :results
+
+  def generate_email_and_subscription_contents
+    @results = subscriber_content_changes
+    @email = build_email
+    persist_email_and_subscription_contents
+  end
+
+  def persist_email_and_subscription_contents
+    Email.transaction do
+      email.save!
+
+      SubscriptionContent.import!(
+        formatted_subscription_content_changes
+      )
+    end
+  end
+
+  def formatted_subscription_content_changes
+    results.flat_map do |result|
+      result.content_changes.map do |content_change|
+        {
+          email_id: email.id,
+          subscription_id: result.subscription_id,
+          content_change_id: content_change.id,
+        }
+      end
+    end
+  end
+
+  def build_email
+    DigestEmailBuilder.call(
+      subscriber: subscriber,
+      digest_run: digest_run,
+      subscription_content_change_results: results,
+    )
+  end
+
+  def subscriber_content_changes
+    SubscriptionContentChangeQuery.call(
+      subscriber: subscriber,
+      digest_run: digest_run
+    )
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -63,6 +63,16 @@ FactoryBot.define do
   factory :subscription do
     subscriber
     subscriber_list
+
+    trait :immediately
+
+    trait :daily do
+      frequency "daily"
+    end
+
+    trait :weekly do
+      frequency "weekly"
+    end
   end
 
   factory :subscription_content do

--- a/spec/units/builders/digest_email_builder_spec.rb
+++ b/spec/units/builders/digest_email_builder_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+RSpec.describe DigestEmailBuilder do
+  let(:digest_run) { double(daily?: true) }
+  let(:subscriber) { build(:subscriber) }
+  let(:subscription_content_change_results) {
+    [
+      double(
+        subscription_id: 1,
+        subscription_uuid: "ABC1",
+        subscriber_list_title: "Test title 1",
+        content_changes: [
+          build(:content_change, public_updated_at: "1/1/2016 10:00"),
+          build(:content_change, public_updated_at: "2/1/2016 11:00"),
+          build(:content_change, public_updated_at: "3/1/2016 12:00"),
+        ],
+      ),
+      double(
+        subscription_id: 2,
+        subscription_uuid: "ABC2",
+        subscriber_list_title: "Test title 2",
+        content_changes: [
+          build(:content_change, public_updated_at: "4/1/2016 10:00"),
+          build(:content_change, public_updated_at: "5/1/2016 11:00"),
+          build(:content_change, public_updated_at: "6/1/2016 12:00"),
+        ],
+      ),
+    ]
+  }
+
+  let(:email) {
+    described_class.call(
+      subscriber: subscriber,
+      digest_run: digest_run,
+      subscription_content_change_results: subscription_content_change_results,
+    )
+  }
+
+  it "returns an Email" do
+    expect(email).to be_a(Email)
+  end
+
+  it "adds an entry to body for each content change" do
+    expect(UnsubscribeLinkPresenter).to receive(:call).with(
+      uuid: "ABC1",
+      title: "Test title 1"
+    ).and_return("unsubscribe_link_1")
+
+    expect(UnsubscribeLinkPresenter).to receive(:call).with(
+      uuid: "ABC2",
+      title: "Test title 2"
+    ).and_return("unsubscribe_link_2")
+
+    expect(ContentChangePresenter).to receive(:call).exactly(6).times
+      .and_return("presented_content_change\n")
+
+    expect(email.body).to eq(
+      <<~BODY
+        #Test title 1
+
+        presented_content_change
+
+        ---
+
+        presented_content_change
+
+        ---
+
+        presented_content_change
+
+        ---
+
+        unsubscribe_link_1
+
+        &nbsp;
+
+        #Test title 2
+
+        presented_content_change
+
+        ---
+
+        presented_content_change
+
+        ---
+
+        presented_content_change
+
+        ---
+
+        unsubscribe_link_2
+      BODY
+    )
+  end
+
+  context "daily" do
+    it "sets the subject" do
+      expect(email.subject).to eq("GOV.UK Daily Update")
+    end
+  end
+
+  context "weekly" do
+    let(:digest_run) { double(daily?: false) }
+    it "sets the subject" do
+      expect(email.subject).to eq("GOV.UK Weekly Update")
+    end
+  end
+end

--- a/spec/units/presenters/content_change_presenter_spec.rb
+++ b/spec/units/presenters/content_change_presenter_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ContentChangePresenter do
+  let(:content_change) {
+    build(
+      :content_change, title: "Change title",
+      base_path: "/government/test-slug",
+      change_note: "Test change note",
+      description: "Test description",
+      public_updated_at: Time.parse("10:00 1/1/2018")
+    )
+  }
+
+  describe ".call" do
+    it "returns a presenter content change" do
+      expected = <<~CONTENT_CHANGE
+        [Change title](http://www.dev.gov.uk/government/test-slug)
+
+        Test change note: Test description
+
+        Updated at 10:00 am on 1 January 2018
+      CONTENT_CHANGE
+
+      expect(described_class.call(content_change)).to eq(expected)
+    end
+  end
+end

--- a/spec/units/presenters/unsubscribe_link_presenter_spec.rb
+++ b/spec/units/presenters/unsubscribe_link_presenter_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe UnsubscribeLinkPresenter do
+  describe ".call" do
+    it "returns a presented unsubscribe link" do
+      expected = "Unsubscribe from [Test title](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
+      expect(described_class.call(uuid: "abc123", title: "Test title")).to eq(expected)
+    end
+  end
+end

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe DigestEmailGenerationWorker do
+  let(:subscriber) { create(:subscriber, id: 1) }
+  let!(:subscription_one) {
+    create(:subscription, id: 1, subscriber_id: subscriber.id)
+  }
+  let!(:subscription_two) {
+    create(:subscription, id: 2, subscriber_id: subscriber.id)
+  }
+  let!(:digest_run) { create(:digest_run, id: 10) }
+
+  let(:subscription_content_change_query_results) {
+    [
+      double(
+        subscription_id: 1,
+        subscription_uuid: "ABC1",
+        subscriber_list_title: "Test title 1",
+        content_changes: [
+          create(:content_change, public_updated_at: "1/1/2016 10:00"),
+        ],
+      ),
+      double(
+        subscription_id: 2,
+        subscription_uuid: "ABC2",
+        subscriber_list_title: "Test title 2",
+        content_changes: [
+          create(:content_change, public_updated_at: "4/1/2016 10:00"),
+        ],
+      ),
+    ]
+  }
+
+  before do
+    allow(SubscriptionContentChangeQuery).to receive(:call).and_return(
+      subscription_content_change_query_results
+    )
+  end
+
+  it "accepts a subscriber_id and a digest_run_id" do
+    expect {
+      subject.perform(subscriber_id: 1, digest_run_id: 10)
+    }.not_to raise_error
+  end
+
+  it "creates an email" do
+    expect { subject.perform(subscriber_id: 1, digest_run_id: 10) }
+      .to change { Email.count }.by(1)
+  end
+
+  it "enqueues delivery" do
+    #TODO priority needs sorting out
+    expect(DeliveryRequestWorker).to receive(:perform_async_with_priority)
+      .with(instance_of(Integer), priority: :low)
+
+    subject.perform(subscriber_id: 1, digest_run_id: 10)
+  end
+
+  it "builds and saves the correct email" do
+    allow(SubscriptionContent).to receive(:import!)
+    allow(DeliveryRequestWorker).to receive(:perform_async_with_priority)
+    expect(DigestEmailBuilder).to receive(:call).with(
+      subscriber: subscriber,
+      digest_run: digest_run,
+      subscription_content_change_results: subscription_content_change_query_results,
+    ).and_return(email = double(id: 100))
+    expect(email).to receive(:save!)
+
+    subject.perform(subscriber_id: 1, digest_run_id: 10)
+  end
+end


### PR DESCRIPTION
This PR adds digest generation functionality that will be initiatiated by the `DigestScheduler`s (soon to be renamed to `Initiator`s)

It also extracts presentation behaviour for `ContentChange` and `UnsubscribeLink` which will be incorporated into immediate email generation in a future PR.

We'll add a feature test for this whole process in another PR once we have implemented `DigestSubscriberQuery` and hooked it up to the initiator.

Paired with @thomasleese 

[Trello](https://trello.com/c/t1tltKn6/535-build-digestbuilder-worker)