### PR TITLE
Add DigestSubscriberQuery

### DIFF
--- a/app/queries/digest_subscriber_query.rb
+++ b/app/queries/digest_subscriber_query.rb
@@ -1,0 +1,9 @@
+class DigestSubscriberQuery
+  def self.call(digest_run:)
+    Subscriber
+      .joins(subscriptions: { subscriber_list: { matched_content_changes: :content_change } })
+      .where("content_changes.created_at >= ?", digest_run.starts_at)
+      .where("content_changes.created_at < ?", digest_run.ends_at)
+      .where("subscriptions.frequency": digest_run.range)
+  end
+end

--- a/spec/units/queries/digest_subscriber_query_spec.rb
+++ b/spec/units/queries/digest_subscriber_query_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe DigestSubscriberQuery do
+  let(:ends_at) { Time.parse("2017-01-02 08:00") }
+  let(:digest_run) { create(:digest_run, date: ends_at, range: :daily) }
+  let(:starts_at) { digest_run.starts_at }
+
+  describe ".call" do
+    subject(:subscribers) { described_class.call(digest_run: digest_run) }
+
+    let(:subscriber_list) { create(:subscriber_list) }
+
+    def create_and_match_content_change(created_at: starts_at)
+      content_change = create(
+        :content_change,
+        created_at: created_at,
+      )
+      create(
+        :matched_content_change,
+        content_change: content_change,
+        subscriber_list: subscriber_list,
+      )
+    end
+
+    context "with one subscription" do
+      let!(:subscription) do
+        create(:subscription, subscriber_list: subscriber_list, frequency: :daily)
+      end
+
+      context "with a matched content change" do
+        before do
+          create_and_match_content_change
+        end
+
+        it "returns the subscriber" do
+          expect(subscribers.count).to eq(1)
+        end
+      end
+
+      context "with a matched content change that's out of date" do
+        before do
+          create_and_match_content_change(created_at: ends_at)
+        end
+
+        it "returns no subscribers" do
+          expect(subscribers.count).to eq(0)
+        end
+      end
+
+      context "with no matched content changes" do
+        before do
+          create(:content_change)
+        end
+
+        it "returns no subscribers" do
+          expect(subscribers.count).to eq(0)
+        end
+      end
+    end
+
+    context "with a weekly subscription" do
+      let!(:subscription) do
+        create(:subscription, subscriber_list: subscriber_list, frequency: :weekly)
+      end
+
+      context "with a matched content change" do
+        before do
+          create_and_match_content_change
+        end
+
+        it "returns no subscribers" do
+          expect(subscribers.count).to eq(0)
+        end
+      end
+    end
+
+    context "with two subscriptions" do
+      let!(:subscription_1) do
+        create(:subscription, subscriber_list: subscriber_list, frequency: :daily)
+      end
+
+      let!(:subscription_2) do
+        create(:subscription, subscriber_list: subscriber_list, frequency: :daily)
+      end
+
+      before do
+        create_and_match_content_change
+      end
+
+      it "returns the subscribers" do
+        expect(subscribers.count).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is used to work out which `Subscriber`s are due to get a digest email from a particular `DigestRun`.

[Trello Card](https://trello.com/c/VQYJdiVr/547-implement-digest-architecture)