### PR TITLE
Digest deduplication

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -31,7 +31,7 @@ private
     <<~RESULT
       ##{result.subscriber_list_title}
 
-      #{presented_content_changes(result.content_changes)}
+      #{deduplicate_and_present(result.content_changes)}
       ---
 
       #{unsubscribe_link(result)}
@@ -44,6 +44,16 @@ private
     else
       "GOV.UK Weekly Update"
     end
+  end
+
+  def deduplicate_and_present(content_changes)
+    presented_content_changes(
+      deduplicated_content_changes(content_changes)
+    )
+  end
+
+  def deduplicated_content_changes(content_changes)
+    ContentChangeDeduplicatorService.call(content_changes)
   end
 
   def presented_content_changes(content_changes)

--- a/app/services/content_change_deduplicator_service.rb
+++ b/app/services/content_change_deduplicator_service.rb
@@ -1,0 +1,18 @@
+class ContentChangeDeduplicatorService
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  def call(content_changes)
+    reverse_by_public_updated_at(content_changes)
+      .uniq(&:content_id)
+  end
+
+private
+
+  def reverse_by_public_updated_at(content_changes)
+    content_changes.sort do |cc_a, cc_b|
+      cc_b.public_updated_at <=> cc_a.public_updated_at
+    end
+  end
+end

--- a/spec/units/services/content_change_deduplicator_service_spec.rb
+++ b/spec/units/services/content_change_deduplicator_service_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ContentChangeDeduplicatorService do
+  it "removes duplicates preserving only the latest" do
+    content_changes = [
+      build(
+        :content_change, id: 1,
+        public_updated_at: 10.day.ago,
+        content_id: "8e1fef7b-cd23-4dd2-84d0-61955203db61"
+      ),
+      latest_content_change = build(
+        :content_change,
+        public_updated_at: 1.days.ago,
+        content_id: "8e1fef7b-cd23-4dd2-84d0-61955203db61"
+      ),
+      build(
+        :content_change,
+        public_updated_at: 5.days.ago,
+        content_id: "8e1fef7b-cd23-4dd2-84d0-61955203db61"
+      ),
+      other_content_change = build(
+        :content_change,
+        public_updated_at: 1.hour.ago,
+        content_id: "7575702c-0494-4791-a1af-150a40fa37f7"
+      )
+    ]
+
+    expect(described_class.call(content_changes)).to eq(
+      [other_content_change, latest_content_change]
+    )
+  end
+end


### PR DESCRIPTION
Remove duplicates within a `SubscriberList` group in digest emails.

[Trello](https://trello.com/c/t1tltKn6/535-build-digestbuilder-worker)