### PR TITLE
Connect DigestInitiatorService

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -15,6 +15,10 @@ class DigestRun < ApplicationRecord
     update_attributes!(completed_at: Time.now)
   end
 
+  def check_and_mark_complete!
+    mark_complete! unless has_incomplete_subscribers?
+  end
+
 private
 
   def starts_at=(value)
@@ -48,5 +52,9 @@ private
 
   def digest_range_hour
     ENV.fetch("DIGEST_RANGE_HOUR", 8).to_i
+  end
+
+  def has_incomplete_subscribers?
+    digest_run_subscribers.incomplete_for_run(id).exists?
   end
 end

--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -11,6 +11,10 @@ class DigestRun < ApplicationRecord
   DAILY = "daily".freeze
   WEEKLY = "weekly".freeze
 
+  def mark_complete!
+    update_attributes!(completed_at: Time.now)
+  end
+
 private
 
   def starts_at=(value)

--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -3,6 +3,9 @@ class DigestRun < ApplicationRecord
   before_validation :set_range_dates, on: :create
   validate :ends_at_is_in_the_past
 
+  has_many :digest_run_subscribers, dependent: :destroy
+  has_many :subscribers, through: :digest_run_subscribers
+
   enum range: { daily: 0, weekly: 1 }
 
   DAILY = "daily".freeze

--- a/app/models/digest_run_subscriber.rb
+++ b/app/models/digest_run_subscriber.rb
@@ -1,0 +1,9 @@
+class DigestRunSubscriber < ApplicationRecord
+  validates :digest_run_id, :subscriber_id, presence: true
+  belongs_to :digest_run
+  belongs_to :subscriber
+
+  def mark_complete!
+    update_attributes!(completed_at: Time.now)
+  end
+end

--- a/app/models/digest_run_subscriber.rb
+++ b/app/models/digest_run_subscriber.rb
@@ -3,6 +3,8 @@ class DigestRunSubscriber < ApplicationRecord
   belongs_to :digest_run
   belongs_to :subscriber
 
+  scope :incomplete_for_run, ->(digest_run_id) { where(digest_run_id: digest_run_id).where(completed_at: nil) }
+
   def mark_complete!
     update_attributes!(completed_at: Time.now)
   end

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -6,6 +6,8 @@ class Subscriber < ApplicationRecord
 
   has_many :subscriptions, dependent: :destroy
   has_many :subscriber_lists, through: :subscriptions
+  has_many :digest_run_subscribers, dependent: :destroy
+  has_many :digest_runs, through: :digest_run_subscribers
 
   def nullify_address!
     update!(address: nil)

--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -8,36 +8,52 @@ class DigestInitiatorService
   end
 
   def call
-    digest_run = nil
+    digest_run = create_digest_run
+    return if digest_run.nil?
 
+    subscribers = DigestRunSubscriberQuery.call(digest_run: digest_run)
+
+    digest_run_subscriber_params = build_digest_run_subscriber_params(
+      digest_run,
+      subscribers
+    )
+
+    digest_run_subscriber_ids = import_digest_run_subscribers(
+      digest_run_subscriber_params
+    )
+
+    enqueue_jobs(digest_run_subscriber_ids)
+  end
+
+private
+
+  attr_reader :range
+
+  def create_digest_run
     run_with_advisory_lock do
       digest_run = DigestRun.find_or_initialize_by(
         date: Date.current, range: range
       )
       return if digest_run.persisted?
       digest_run.save!
+      digest_run
     end
+  end
 
-    #TODO think about this being retried
-    #
-    subscribers = DigestRunSubscriberQuery.call(digest_run: digest_run)
-
-    digest_run_subscriber_params = subscribers.map do |subscriber|
+  def build_digest_run_subscriber_params(digest_run, subscribers)
+    subscribers.map do |subscriber|
       {
         subscriber_id: subscriber.id,
         digest_run_id: digest_run.id
       }
     end
+  end
 
-    import_result = DigestRunSubscriber.import!(digest_run_subscriber_params)
-    import_result.ids.each do |digest_run_subscriber_id|
+  def enqueue_jobs(digest_run_subscriber_ids)
+    Array(digest_run_subscriber_ids).each do |digest_run_subscriber_id|
       DigestEmailGenerationWorker.perform_async(digest_run_subscriber_id)
     end
   end
-
-private
-
-  attr_reader :range
 
   def run_with_advisory_lock
     DigestRun.with_advisory_lock(lock_name, timeout_seconds: 0) do
@@ -47,5 +63,9 @@ private
 
   def lock_name
     "#{range}_digest_initiator"
+  end
+
+  def import_digest_run_subscribers(params)
+    DigestRunSubscriber.import!(params).ids
   end
 end

--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -29,7 +29,10 @@ class DigestInitiatorService
       }
     end
 
-    DigestRunSubscriber.import!(digest_run_subscriber_params)
+    import_result = DigestRunSubscriber.import!(digest_run_subscriber_params)
+    import_result.ids.each do |digest_run_subscriber_id|
+      DigestEmailGenerationWorker.perform_async(digest_run_subscriber_id)
+    end
   end
 
 private

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -2,8 +2,7 @@ class DigestEmailGenerationWorker
   include Sidekiq::Worker
 
   def perform(digest_run_subscriber_id)
-    digest_run_subscriber = DigestRunSubscriber.find(digest_run_subscriber_id)
-
+    @digest_run_subscriber = DigestRunSubscriber.find(digest_run_subscriber_id)
     @subscriber = digest_run_subscriber.subscriber
     @digest_run = digest_run_subscriber.digest_run
 
@@ -17,7 +16,7 @@ class DigestEmailGenerationWorker
 
 private
 
-  attr_reader :subscriber, :digest_run, :email, :results
+  attr_reader :digest_run, :digest_run_subscriber, :email, :results, :subscriber
 
   def generate_email_and_subscription_contents
     @email = create_email
@@ -34,6 +33,7 @@ private
           email_id: email.id,
           subscription_id: result.subscription_id,
           content_change_id: content_change.id,
+          digest_run_subscriber_id: digest_run_subscriber.id,
         }
       end
     end

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -1,9 +1,11 @@
 class DigestEmailGenerationWorker
   include Sidekiq::Worker
 
-  def perform(subscriber_id:, digest_run_id:)
-    @subscriber = Subscriber.find(subscriber_id)
-    @digest_run = DigestRun.find(digest_run_id)
+  def perform(digest_run_subscriber_id)
+    digest_run_subscriber = DigestRunSubscriber.find(digest_run_subscriber_id)
+
+    @subscriber = digest_run_subscriber.subscriber
+    @digest_run = digest_run_subscriber.digest_run
 
     generate_email_and_subscription_contents
 

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -13,7 +13,7 @@ class DigestEmailGenerationWorker
 
     DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_digest)
 
-    update_digest_run
+    digest_run.check_and_mark_complete!
   end
 
 private
@@ -54,9 +54,5 @@ private
       subscriber: subscriber,
       digest_run: digest_run
     )
-  end
-
-  def update_digest_run
-    digest_run.mark_complete! unless DigestRunSubscriber.incomplete_for_run(digest_run.id).exists?
   end
 end

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -12,6 +12,8 @@ class DigestEmailGenerationWorker
     end
 
     DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_digest)
+
+    update_digest_run
   end
 
 private
@@ -52,5 +54,9 @@ private
       subscriber: subscriber,
       digest_run: digest_run
     )
+  end
+
+  def update_digest_run
+    digest_run.mark_complete! unless DigestRunSubscriber.incomplete_for_run(digest_run.id).exists?
   end
 end

--- a/db/migrate/20180126144040_create_digest_run_subscribers.rb
+++ b/db/migrate/20180126144040_create_digest_run_subscribers.rb
@@ -1,0 +1,13 @@
+class CreateDigestRunSubscribers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :digest_run_subscribers do |t|
+      t.integer :digest_run_id, null: false
+      t.integer :subscriber_id, null: false
+      t.datetime :completed_at
+      t.timestamps
+    end
+
+    add_foreign_key :digest_run_subscribers, :digest_runs, on_delete: :cascade
+    add_foreign_key :digest_run_subscribers, :subscribers, on_delete: :cascade
+  end
+end

--- a/db/migrate/20180129081557_add_digest_run_subscriber_id_to_subscription_contents.rb
+++ b/db/migrate/20180129081557_add_digest_run_subscriber_id_to_subscription_contents.rb
@@ -1,0 +1,6 @@
+class AddDigestRunSubscriberIdToSubscriptionContents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscription_contents, :digest_run_subscriber_id, :integer
+    add_foreign_key :subscription_contents, :digest_run_subscribers, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180126144040) do
+ActiveRecord::Schema.define(version: 20180129081557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,6 +134,7 @@ ActiveRecord::Schema.define(version: 20180126144040) do
     t.bigint "email_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "digest_run_subscriber_id"
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"
@@ -170,6 +171,7 @@ ActiveRecord::Schema.define(version: 20180126144040) do
   add_foreign_key "matched_content_changes", "content_changes"
   add_foreign_key "matched_content_changes", "subscriber_lists"
   add_foreign_key "subscription_contents", "content_changes"
+  add_foreign_key "subscription_contents", "digest_run_subscribers", on_delete: :cascade
   add_foreign_key "subscription_contents", "emails", on_delete: :nullify
   add_foreign_key "subscription_contents", "subscriptions", on_delete: :nullify
   add_foreign_key "subscriptions", "subscriber_lists"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123093411) do
+ActiveRecord::Schema.define(version: 20180126144040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,14 @@ ActiveRecord::Schema.define(version: 20180123093411) do
     t.string "signon_user_uid"
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"
+  end
+
+  create_table "digest_run_subscribers", force: :cascade do |t|
+    t.integer "digest_run_id", null: false
+    t.integer "subscriber_id", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "digest_runs", force: :cascade do |t|
@@ -137,8 +145,8 @@ ActiveRecord::Schema.define(version: 20180123093411) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
-    t.integer "frequency", default: 0, null: false
     t.string "signon_user_uid"
+    t.integer "frequency", default: 0, null: false
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"
@@ -157,6 +165,8 @@ ActiveRecord::Schema.define(version: 20180123093411) do
   end
 
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
+  add_foreign_key "digest_run_subscribers", "digest_runs", on_delete: :cascade
+  add_foreign_key "digest_run_subscribers", "subscribers", on_delete: :cascade
   add_foreign_key "matched_content_changes", "content_changes"
   add_foreign_key "matched_content_changes", "subscriber_lists"
   add_foreign_key "subscription_contents", "content_changes"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,6 +33,11 @@ FactoryBot.define do
     end
   end
 
+  factory :digest_run_subscriber do
+    digest_run
+    subscriber
+  end
+
   factory :email do
     address "test@example.com"
     subject "subject"

--- a/spec/units/models/digest_run_spec.rb
+++ b/spec/units/models/digest_run_spec.rb
@@ -124,4 +124,30 @@ RSpec.describe DigestRun do
       end
     end
   end
+
+  describe ".check_and_mark_complete?" do
+    let(:subject) { create(:digest_run) }
+
+    context "incomplete digest_run_subscribers" do
+      before do
+        create(:digest_run_subscriber, digest_run_id: subject.id)
+      end
+
+      it "marks the digest run complete" do
+        subject.check_and_mark_complete!
+        expect(subject.completed_at).to be_nil
+      end
+    end
+
+    context "no incomplete digest_run_subscribers" do
+      before do
+        create(:digest_run_subscriber, digest_run_id: subject.id, completed_at: Time.now)
+      end
+    end
+
+    it "marks the digest run complete" do
+      subject.check_and_mark_complete!
+      expect(subject.completed_at).not_to be_nil
+    end
+  end
 end

--- a/spec/units/models/digest_run_spec.rb
+++ b/spec/units/models/digest_run_spec.rb
@@ -113,4 +113,15 @@ RSpec.describe DigestRun do
       end
     end
   end
+
+  describe "#mark_complete!" do
+    it "sets completed_at to Time.now" do
+      Timecop.freeze do
+        digest_run = create(:digest_run)
+        digest_run.mark_complete!
+        digest_run.reload
+        expect(digest_run.completed_at.change(nsec: 0)).to eq(Time.now.change(nsec: 0))
+      end
+    end
+  end
 end

--- a/spec/units/models/digest_run_subscriber_spec.rb
+++ b/spec/units/models/digest_run_subscriber_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe DigestRunSubscriber do
+  subject { build(:digest_run_subscriber) }
+
+  describe "mark_complete!" do
+    it "sets completed_at to Time.now" do
+      Timecop.freeze do
+        subject.mark_complete!
+        expect(subject.completed_at).to eq(Time.now)
+      end
+    end
+  end
+end

--- a/spec/units/models/digest_run_subscriber_spec.rb
+++ b/spec/units/models/digest_run_subscriber_spec.rb
@@ -11,4 +11,39 @@ RSpec.describe DigestRunSubscriber do
       end
     end
   end
+
+  describe "incomplete_for_run" do
+    it "returns records with the supplied digest_run_id that have completed_at nil" do
+      create(:digest_run, id: 1)
+      digest_run_subscriber = create(
+        :digest_run_subscriber,
+        digest_run_id: 1,
+        completed_at: nil
+      )
+
+      expect(described_class.incomplete_for_run(1).first).to eq(digest_run_subscriber)
+    end
+
+    it "doesn't return completed_records" do
+      create(:digest_run, id: 1)
+      create(
+        :digest_run_subscriber,
+        digest_run_id: 1,
+        completed_at: Time.now
+      )
+
+      expect(described_class.incomplete_for_run(1).count).to eq(0)
+    end
+
+    it "doesn't return records from other runs" do
+      create(:digest_run, id: 2)
+      create(
+        :digest_run_subscriber,
+        digest_run_id: 2,
+        completed_at: nil
+      )
+
+      expect(described_class.incomplete_for_run(1).count).to eq(0)
+    end
+  end
 end

--- a/spec/units/services/digest_initiator_service_spec.rb
+++ b/spec/units/services/digest_initiator_service_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe DigestInitiatorService do
           end
         end
       end
+
+      it "creates a DigestRunSubscriber for each subscriber" do
+        subscribers = [ create(:subscriber, id: 1), create(:subscriber, id: 2) ]
+
+        allow(DigestRunSubscriberQuery).to receive(:call).and_return(subscribers)
+        described_class.call(range: range)
+
+        expect(DigestRunSubscriber.all.map(&:subscriber_id)).to match([1,2])
+      end
     end
 
     context "weekly" do

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -60,4 +60,15 @@ RSpec.describe DigestEmailGenerationWorker do
 
     subject.perform(1)
   end
+
+  it "marks the DigestRunSubscriber completed" do
+    digest_run_subscriber = create(:digest_run_subscriber, id: 1)
+    allow(DigestRunSubscriber).to receive(:find)
+      .with(1)
+      .and_return(digest_run_subscriber)
+
+    expect(digest_run_subscriber).to receive(:mark_complete!)
+
+    subject.perform(1)
+  end
 end

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -89,4 +89,19 @@ RSpec.describe DigestEmailGenerationWorker do
     subscription_content = SubscriptionContent.last
     expect(subscription_content.digest_run_subscriber_id).to eq(1)
   end
+
+  it "marks the digest run complete" do
+    create(:digest_run_subscriber, id: 1)
+    expect_any_instance_of(DigestRun).to receive(:mark_complete!)
+    subject.perform(1)
+  end
+
+  context "when there are incomplete DigestRunSubscribers left" do
+    it "doesn't mark the digest run complete" do
+      create(:digest_run_subscriber, id: 1, digest_run_id: digest_run.id)
+      create(:digest_run_subscriber, digest_run_id: digest_run.id)
+      expect_any_instance_of(DigestRun).not_to receive(:mark_complete!)
+      subject.perform(1)
+    end
+  end
 end

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -37,14 +37,18 @@ RSpec.describe DigestEmailGenerationWorker do
     )
   end
 
-  it "accepts a subscriber_id and a digest_run_id" do
+  it "accepts digest_run_subscriber_id" do
+    create(:digest_run_subscriber, id: 1)
+
     expect {
-      subject.perform(subscriber_id: 1, digest_run_id: 10)
+      subject.perform(1)
     }.not_to raise_error
   end
 
   it "creates an email" do
-    expect { subject.perform(subscriber_id: 1, digest_run_id: 10) }
+    create(:digest_run_subscriber, id: 1)
+
+    expect { subject.perform(1) }
       .to change { Email.count }.by(1)
   end
 
@@ -52,6 +56,8 @@ RSpec.describe DigestEmailGenerationWorker do
     expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
       .with(instance_of(Integer), queue: :delivery_digest)
 
-    subject.perform(subscriber_id: 1, digest_run_id: 10)
+    create(:digest_run_subscriber, id: 1)
+
+    subject.perform(1)
   end
 end

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -62,7 +62,12 @@ RSpec.describe DigestEmailGenerationWorker do
   end
 
   it "marks the DigestRunSubscriber completed" do
-    digest_run_subscriber = create(:digest_run_subscriber, id: 1)
+    digest_run_subscriber = create(
+      :digest_run_subscriber,
+      id: 1,
+      subscriber_id: subscriber.id
+    )
+
     allow(DigestRunSubscriber).to receive(:find)
       .with(1)
       .and_return(digest_run_subscriber)
@@ -70,5 +75,18 @@ RSpec.describe DigestEmailGenerationWorker do
     expect(digest_run_subscriber).to receive(:mark_complete!)
 
     subject.perform(1)
+  end
+
+  it "creates a SubscriptionContent" do
+    create(
+      :digest_run_subscriber,
+      id: 1,
+      subscriber_id: subscriber.id
+    )
+
+    subject.perform(1)
+
+    subscription_content = SubscriptionContent.last
+    expect(subscription_content.digest_run_subscriber_id).to eq(1)
   end
 end


### PR DESCRIPTION
This PR hooks up the `DigestInitiatorService` to all of the other elements of the digest creation flow as per https://github.com/alphagov/email-alert-api/blob/master/doc/digests.png

[Trello](https://trello.com/c/VQYJdiVr/547-implement-digest-architecture)