### PR TITLE
Configure email delivery priorities for digest and immediate emails

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -3,7 +3,7 @@ class ContentChange < ApplicationRecord
 
   has_many :matched_content_changes
 
-  enum priority: { low: 0, high: 1 }
+  enum priority: { normal: 0, high: 1 }
 
   def mark_processed!
     update!(processed_at: Time.now)

--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -37,7 +37,7 @@ private
       govuk_request_id: params[:govuk_request_id],
       document_type: params[:document_type],
       publishing_app: params[:publishing_app],
-      priority: params.fetch(:priority, "low").to_sym,
+      priority: params.fetch(:priority, "normal").to_sym,
       signon_user_uid: user&.uid,
     }
   end

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -13,6 +13,10 @@ class DeliveryRequestWorker
     end
   end
 
+  def self.queue_for_digest
+    :delivery_digest
+  end
+
   sidekiq_options retry: 3, queue: queue_for_immediate(:normal)
 
   sidekiq_retry_in do |count|
@@ -34,6 +38,10 @@ class DeliveryRequestWorker
   def self.perform_async_for_immediate(*args, priority: :normal)
     queue = queue_for_immediate(priority)
     set(queue: queue).perform_async(*args, queue)
+  end
+
+  def self.perform_async_for_digest(*args)
+    set(queue: queue_for_digest).perform_async(*args, queue_for_digest)
   end
 
   def check_rate_limit!

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -13,10 +13,6 @@ class DeliveryRequestWorker
     end
   end
 
-  def self.queue_for_digest
-    :delivery_digest
-  end
-
   sidekiq_options retry: 3, queue: queue_for_immediate(:normal)
 
   sidekiq_retry_in do |count|
@@ -36,14 +32,10 @@ class DeliveryRequestWorker
   end
 
   def self.perform_async_for_immediate(*args, priority: :normal)
-    perform_async_in_queue(*args, queue_for_immediate(priority))
+    perform_async_in_queue(*args, queue: queue_for_immediate(priority))
   end
 
-  def self.perform_async_for_digest(*args)
-    perform_async_in_queue(*args, queue_for_digest)
-  end
-
-  def self.perform_async_in_queue(*args, queue)
+  def self.perform_async_in_queue(*args, queue:)
     set(queue: queue).perform_async(*args, queue)
   end
 

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -6,14 +6,14 @@ class DeliveryRequestWorker
   def self.queue_for_priority(priority)
     if priority == :high
       :delivery_immediate_high
-    elsif priority == :low
+    elsif priority == :normal
       :delivery_immediate
     else
-      raise ArgumentError, "priority should be :high or :low"
+      raise ArgumentError, "priority should be :high or :normal"
     end
   end
 
-  sidekiq_options retry: 3, queue: queue_for_priority(:low)
+  sidekiq_options retry: 3, queue: queue_for_priority(:normal)
 
   sidekiq_retry_in do |count|
     10 * (count + 1) # 10, 20, 30, 40 ish

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -3,7 +3,7 @@ class DeliveryRequestWorker
 
   attr_reader :email, :queue
 
-  def self.queue_for_priority(priority)
+  def self.queue_for_immediate(priority)
     if priority == :high
       :delivery_immediate_high
     elsif priority == :normal
@@ -13,7 +13,7 @@ class DeliveryRequestWorker
     end
   end
 
-  sidekiq_options retry: 3, queue: queue_for_priority(:normal)
+  sidekiq_options retry: 3, queue: queue_for_immediate(:normal)
 
   sidekiq_retry_in do |count|
     10 * (count + 1) # 10, 20, 30, 40 ish
@@ -31,8 +31,8 @@ class DeliveryRequestWorker
     DeliveryRequestService.call(email: @email)
   end
 
-  def self.perform_async_with_priority(*args, priority:)
-    queue = queue_for_priority(priority)
+  def self.perform_async_for_immediate(*args, priority: :normal)
+    queue = queue_for_immediate(priority)
     set(queue: queue).perform_async(*args, queue)
   end
 

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -3,17 +3,7 @@ class DeliveryRequestWorker
 
   attr_reader :email, :queue
 
-  def self.queue_for_immediate(priority)
-    if priority == :high
-      :delivery_immediate_high
-    elsif priority == :normal
-      :delivery_immediate
-    else
-      raise ArgumentError, "priority should be :high or :normal"
-    end
-  end
-
-  sidekiq_options retry: 3, queue: queue_for_immediate(:normal)
+  sidekiq_options retry: 3
 
   sidekiq_retry_in do |count|
     10 * (count + 1) # 10, 20, 30, 40 ish
@@ -29,10 +19,6 @@ class DeliveryRequestWorker
     check_rate_limit!
     increment_rate_limiter
     DeliveryRequestService.call(email: @email)
-  end
-
-  def self.perform_async_for_immediate(*args, priority: :normal)
-    perform_async_in_queue(*args, queue: queue_for_immediate(priority))
   end
 
   def self.perform_async_in_queue(*args, queue:)

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -5,9 +5,9 @@ class DeliveryRequestWorker
 
   def self.queue_for_priority(priority)
     if priority == :high
-      :high_delivery
+      :delivery_immediate_high
     elsif priority == :low
-      :low_delivery
+      :delivery_immediate
     else
       raise ArgumentError, "priority should be :high or :low"
     end

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -36,12 +36,15 @@ class DeliveryRequestWorker
   end
 
   def self.perform_async_for_immediate(*args, priority: :normal)
-    queue = queue_for_immediate(priority)
-    set(queue: queue).perform_async(*args, queue)
+    perform_async_in_queue(*args, queue_for_immediate(priority))
   end
 
   def self.perform_async_for_digest(*args)
-    set(queue: queue_for_digest).perform_async(*args, queue_for_digest)
+    perform_async_in_queue(*args, queue_for_digest)
+  end
+
+  def self.perform_async_in_queue(*args, queue)
+    set(queue: queue).perform_async(*args, queue)
   end
 
   def check_rate_limit!

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -7,7 +7,7 @@ class DigestEmailGenerationWorker
 
     generate_email_and_subscription_contents
 
-    DeliveryRequestWorker.perform_async_for_immediate(email.id, priority: :normal)
+    DeliveryRequestWorker.perform_async_for_digest(email.id)
   end
 
 private

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -7,7 +7,7 @@ class DigestEmailGenerationWorker
 
     generate_email_and_subscription_contents
 
-    DeliveryRequestWorker.perform_async_for_digest(email.id)
+    DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_digest)
   end
 
 private

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -7,7 +7,7 @@ class DigestEmailGenerationWorker
 
     generate_email_and_subscription_contents
 
-    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :normal)
+    DeliveryRequestWorker.perform_async_for_immediate(email.id, priority: :normal)
   end
 
 private

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -7,7 +7,7 @@ class DigestEmailGenerationWorker
 
     generate_email_and_subscription_contents
 
-    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :low)
+    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :normal)
   end
 
 private

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -38,9 +38,19 @@ private
 
   def queue_delivery_request_workers(queue)
     queue.each do |email_id, priority|
-      DeliveryRequestWorker.perform_async_for_immediate(
-        email_id, priority: priority
+      DeliveryRequestWorker.perform_async_in_queue(
+        email_id, queue: queue_for_priority(priority)
       )
+    end
+  end
+
+  def queue_for_priority(priority)
+    if priority == :high
+      :delivery_immediate_high
+    elsif priority == :normal
+      :delivery_immediate
+    else
+      raise ArgumentError, "priority should be :high or :normal"
     end
   end
 

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -38,7 +38,7 @@ private
 
   def queue_delivery_request_workers(queue)
     queue.each do |email_id, priority|
-      DeliveryRequestWorker.perform_async_with_priority(
+      DeliveryRequestWorker.perform_async_for_immediate(
         email_id, priority: priority
       )
     end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -40,7 +40,7 @@ private
           { subscriber: subscriber, content_change: content_change }
         ]).ids.first
 
-        DeliveryRequestWorker.perform_async_with_priority(
+        DeliveryRequestWorker.perform_async_for_immediate(
           email_id, priority: content_change.priority.to_sym,
         )
       rescue StandardError => ex

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -40,8 +40,8 @@ private
           { subscriber: subscriber, content_change: content_change }
         ]).ids.first
 
-        DeliveryRequestWorker.perform_async_for_immediate(
-          email_id, priority: content_change.priority.to_sym,
+        DeliveryRequestWorker.perform_async_in_queue(
+          email_id, queue: :delivery_immediate,
         )
       rescue StandardError => ex
         Raven.capture_exception(ex, tags: { version: 2 })

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,8 +3,9 @@
 :concurrency: 30
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - [delivery_immediate_high, 3]
-  - [delivery_immediate, 2]
+  - [delivery_immediate_high, 4]
+  - [delivery_immediate, 3]
+  - [delivery_digest, 2]
   - [default, 1]
 :schedule:
   immediate_email_generation:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,8 +3,8 @@
 :concurrency: 30
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - [high_delivery, 3]
-  - [low_delivery, 2]
+  - [delivery_immediate_high, 3]
+  - [delivery_immediate, 2]
   - [default, 1]
 :schedule:
   immediate_email_generation:

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -10,12 +10,12 @@ namespace :deliver do
   desc "Send a test email to a subscriber by id"
   task :to_subscriber, [:id] => :environment do |_t, args|
     email = test_email(Subscriber.find(args[:id]).address)
-    DeliveryRequestWorker.perform_async_for_immediate(email.id)
+    DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
   end
 
   desc "Send a test email to an email address"
   task :to_test_email, [:test_email_address] => :environment do |_t, args|
     email = test_email(args[:test_email_address])
-    DeliveryRequestWorker.perform_async_for_immediate(email.id)
+    DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
   end
 end

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -10,12 +10,12 @@ namespace :deliver do
   desc "Send a test email to a subscriber by id"
   task :to_subscriber, [:id] => :environment do |_t, args|
     email = test_email(Subscriber.find(args[:id]).address)
-    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :low)
+    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :normal)
   end
 
   desc "Send a test email to an email address"
   task :to_test_email, [:test_email_address] => :environment do |_t, args|
     email = test_email(args[:test_email_address])
-    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :low)
+    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :normal)
   end
 end

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -10,12 +10,12 @@ namespace :deliver do
   desc "Send a test email to a subscriber by id"
   task :to_subscriber, [:id] => :environment do |_t, args|
     email = test_email(Subscriber.find(args[:id]).address)
-    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :normal)
+    DeliveryRequestWorker.perform_async_for_immediate(email.id)
   end
 
   desc "Send a test email to an email address"
   task :to_test_email, [:test_email_address] => :environment do |_t, args|
     email = test_email(args[:test_email_address])
-    DeliveryRequestWorker.perform_async_with_priority(email.id, priority: :normal)
+    DeliveryRequestWorker.perform_async_for_immediate(email.id)
   end
 end

--- a/spec/units/workers/delivery_request_worker_spec.rb
+++ b/spec/units/workers/delivery_request_worker_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe DeliveryRequestWorker do
       )
     end
 
-    context "with a low priority" do
-      let(:priority) { :low }
+    context "with a normal priority" do
+      let(:priority) { :normal }
 
-      it "adds a worker to the low priority queue" do
+      it "adds a worker to the normal priority queue" do
         expect(Sidekiq::Queues["delivery_immediate"].size).to eq(1)
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe DeliveryRequestWorker do
     end
 
     context "with a low priority" do
-      let(:priority) { :low }
+      let(:priority) { :normal }
 
       it "schedules a job for 30 seconds from now" do
         queued_job = Sidekiq::Queues["delivery_immediate"].first

--- a/spec/units/workers/delivery_request_worker_spec.rb
+++ b/spec/units/workers/delivery_request_worker_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe DeliveryRequestWorker do
     end
   end
 
-  describe ".perform_async_with_priority" do
+  describe ".perform_async_for_immediate" do
     let(:email) { double(id: 0) }
     let(:priority) { nil }
 
     before do
       Sidekiq::Testing.fake!
-      described_class.perform_async_with_priority(
+      described_class.perform_async_for_immediate(
         email.id, priority: priority
       )
     end

--- a/spec/units/workers/delivery_request_worker_spec.rb
+++ b/spec/units/workers/delivery_request_worker_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DeliveryRequestWorker do
       let(:priority) { :low }
 
       it "adds a worker to the low priority queue" do
-        expect(Sidekiq::Queues["low_delivery"].size).to eq(1)
+        expect(Sidekiq::Queues["delivery_immediate"].size).to eq(1)
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe DeliveryRequestWorker do
       let(:priority) { :high }
 
       it "adds a worker to the high priority queue" do
-        expect(Sidekiq::Queues["high_delivery"].size).to eq(1)
+        expect(Sidekiq::Queues["delivery_immediate_high"].size).to eq(1)
       end
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe DeliveryRequestWorker do
       let(:priority) { :low }
 
       it "schedules a job for 30 seconds from now" do
-        queued_job = Sidekiq::Queues["low_delivery"].first
+        queued_job = Sidekiq::Queues["delivery_immediate"].first
         expected_time = (@frozen_time + 30.seconds).to_i
         expect(queued_job["at"].to_i).to eq(expected_time)
       end
@@ -83,7 +83,7 @@ RSpec.describe DeliveryRequestWorker do
       let(:priority) { :high }
 
       it "schedules a job for 30 seconds from now" do
-        queued_job = Sidekiq::Queues["high_delivery"].first
+        queued_job = Sidekiq::Queues["delivery_immediate_high"].first
         expected_time = (@frozen_time + 30.seconds).to_i
         expect(queued_job["at"].to_i).to eq(expected_time)
       end

--- a/spec/units/workers/delivery_request_worker_spec.rb
+++ b/spec/units/workers/delivery_request_worker_spec.rb
@@ -68,6 +68,32 @@ RSpec.describe DeliveryRequestWorker do
     end
   end
 
+  describe ".perform_async_in_queue" do
+    let(:email) { double(id: 0) }
+
+    before do
+      Sidekiq::Testing.fake! do
+        described_class.perform_async_in_queue(email.id, queue)
+      end
+    end
+
+    context "with a delivery digest queue" do
+      let(:queue) { "delivery_digest" }
+
+      it "adds a worker to the correct queue" do
+        expect(Sidekiq::Queues["delivery_digest"].size).to eq(1)
+      end
+    end
+
+    context "with a delivery immediate queue" do
+      let(:queue) { "delivery_immediate" }
+
+      it "adds a worker to the correct queue" do
+        expect(Sidekiq::Queues["delivery_immediate"].size).to eq(1)
+      end
+    end
+  end
+
   describe "rate_limiter" do
     describe "rate_limit_threshold" do
       before do

--- a/spec/units/workers/delivery_request_worker_spec.rb
+++ b/spec/units/workers/delivery_request_worker_spec.rb
@@ -55,6 +55,19 @@ RSpec.describe DeliveryRequestWorker do
     end
   end
 
+  describe ".perform_async_for_digest" do
+    let(:email) { double(id: 0) }
+
+    before do
+      Sidekiq::Testing.fake!
+      described_class.perform_async_for_digest(email.id)
+    end
+
+    it "adds a worker to the digest queue" do
+      expect(Sidekiq::Queues["delivery_digest"].size).to eq(1)
+    end
+  end
+
   describe "rate_limiter" do
     describe "rate_limit_threshold" do
       before do

--- a/spec/units/workers/delivery_request_worker_spec.rb
+++ b/spec/units/workers/delivery_request_worker_spec.rb
@@ -55,25 +55,12 @@ RSpec.describe DeliveryRequestWorker do
     end
   end
 
-  describe ".perform_async_for_digest" do
-    let(:email) { double(id: 0) }
-
-    before do
-      Sidekiq::Testing.fake!
-      described_class.perform_async_for_digest(email.id)
-    end
-
-    it "adds a worker to the digest queue" do
-      expect(Sidekiq::Queues["delivery_digest"].size).to eq(1)
-    end
-  end
-
   describe ".perform_async_in_queue" do
     let(:email) { double(id: 0) }
 
     before do
       Sidekiq::Testing.fake! do
-        described_class.perform_async_in_queue(email.id, queue)
+        described_class.perform_async_in_queue(email.id, queue: queue)
       end
     end
 

--- a/spec/units/workers/delivery_request_worker_spec.rb
+++ b/spec/units/workers/delivery_request_worker_spec.rb
@@ -27,34 +27,6 @@ RSpec.describe DeliveryRequestWorker do
     end
   end
 
-  describe ".perform_async_for_immediate" do
-    let(:email) { double(id: 0) }
-    let(:priority) { nil }
-
-    before do
-      Sidekiq::Testing.fake!
-      described_class.perform_async_for_immediate(
-        email.id, priority: priority
-      )
-    end
-
-    context "with a normal priority" do
-      let(:priority) { :normal }
-
-      it "adds a worker to the normal priority queue" do
-        expect(Sidekiq::Queues["delivery_immediate"].size).to eq(1)
-      end
-    end
-
-    context "with a high priority" do
-      let(:priority) { :high }
-
-      it "adds a worker to the high priority queue" do
-        expect(Sidekiq::Queues["delivery_immediate_high"].size).to eq(1)
-      end
-    end
-  end
-
   describe ".perform_async_in_queue" do
     let(:email) { double(id: 0) }
 

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DigestEmailGenerationWorker do
   it "enqueues delivery" do
     #TODO priority needs sorting out
     expect(DeliveryRequestWorker).to receive(:perform_async_with_priority)
-      .with(instance_of(Integer), priority: :low)
+      .with(instance_of(Integer), priority: :normal)
 
     subject.perform(subscriber_id: 1, digest_run_id: 10)
   end

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe DigestEmailGenerationWorker do
   end
 
   it "enqueues delivery" do
-    expect(DeliveryRequestWorker).to receive(:perform_async_for_digest)
-      .with(instance_of(Integer))
+    expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+      .with(instance_of(Integer), queue: :delivery_digest)
 
     subject.perform(subscriber_id: 1, digest_run_id: 10)
   end

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -49,9 +49,8 @@ RSpec.describe DigestEmailGenerationWorker do
   end
 
   it "enqueues delivery" do
-    #TODO priority needs sorting out
-    expect(DeliveryRequestWorker).to receive(:perform_async_for_immediate)
-      .with(instance_of(Integer), priority: :normal)
+    expect(DeliveryRequestWorker).to receive(:perform_async_for_digest)
+      .with(instance_of(Integer))
 
     subject.perform(subscriber_id: 1, digest_run_id: 10)
   end

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DigestEmailGenerationWorker do
 
   it "enqueues delivery" do
     #TODO priority needs sorting out
-    expect(DeliveryRequestWorker).to receive(:perform_async_with_priority)
+    expect(DeliveryRequestWorker).to receive(:perform_async_for_immediate)
       .with(instance_of(Integer), priority: :normal)
 
     subject.perform(subscriber_id: 1, digest_run_id: 10)

--- a/spec/units/workers/immediate_email_generation_worker_spec.rb
+++ b/spec/units/workers/immediate_email_generation_worker_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe ImmediateEmailGenerationWorker do
         perform_with_fake_sidekiq
         expect(DeliveryRequestWorker.jobs.size).to eq(1)
       end
+
+      context "with a high priority content change" do
+        before do
+          subscription_content.content_change.update(priority: "high")
+        end
+
+        it "should queue a delivery email job with a high priority" do
+          expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+            .with(an_instance_of(Integer), queue: :delivery_immediate_high)
+
+          perform_with_fake_sidekiq
+        end
+      end
     end
   end
 end

--- a/spec/units/workers/subscription_content_worker_spec.rb
+++ b/spec/units/workers/subscription_content_worker_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe SubscriptionContentWorker do
 
     it "enqueues the email to send to the courtesy subscription group" do
       expect(DeliveryRequestWorker)
-        .to receive(:perform_async_with_priority)
+        .to receive(:perform_async_for_immediate)
         .with(kind_of(Integer), priority: :normal)
 
       subject.perform(content_change.id)

--- a/spec/units/workers/subscription_content_worker_spec.rb
+++ b/spec/units/workers/subscription_content_worker_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SubscriptionContentWorker do
     it "enqueues the email to send to the courtesy subscription group" do
       expect(DeliveryRequestWorker)
         .to receive(:perform_async_with_priority)
-        .with(kind_of(Integer), priority: :low)
+        .with(kind_of(Integer), priority: :normal)
 
       subject.perform(content_change.id)
     end

--- a/spec/units/workers/subscription_content_worker_spec.rb
+++ b/spec/units/workers/subscription_content_worker_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe SubscriptionContentWorker do
 
     it "enqueues the email to send to the courtesy subscription group" do
       expect(DeliveryRequestWorker)
-        .to receive(:perform_async_for_immediate)
-        .with(kind_of(Integer), priority: :normal)
+        .to receive(:perform_async_in_queue)
+        .with(kind_of(Integer), queue: :delivery_immediate)
 
       subject.perform(content_change.id)
     end


### PR DESCRIPTION
This PR introduces a new Sidekiq queue dedicated to digest emails and updated the `DeliveryRequestWorker` to support sending immediate emails with a normal or high priority, or sending digest emails all with the same priority.

Both kinds of immediate emails will be sent out with a higher priority than digest emails.

Following on from this, the next part will be to update Travel Advice Publisher and Specialist Publisher to set the content changes as high priority.

[Trello Card](https://trello.com/c/mHXNdskh/550-setup-delivery-priorities)