### PR TITLE
Remove email_generation_service rake task

### DIFF
--- a/lib/tasks/process.rake
+++ b/lib/tasks/process.rake
@@ -1,6 +1,0 @@
-namespace :process do
-  desc "Run the email generation service"
-  task :email_generation_service, [] => :environment do
-    EmailGenerationService.call
-  end
-end


### PR DESCRIPTION
The `EmailGenerationService` no longer exists so this task wouldn't work. We could modify the task to instead call the worker that replaced it, but it feels like this rake task was forgotten and built when we thought this would be a long running jenkins task.

We can bring this back if we feel like we do need it.