### PR TITLE
Add some digest related stats

### DIFF
--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -11,18 +11,20 @@ class DigestInitiatorService
     digest_run = create_digest_run
     return if digest_run.nil?
 
-    subscribers = DigestRunSubscriberQuery.call(digest_run: digest_run)
+    MetricsService.digest_initiator_service(range) do
+      subscribers = DigestRunSubscriberQuery.call(digest_run: digest_run)
 
-    digest_run_subscriber_params = build_digest_run_subscriber_params(
-      digest_run,
-      subscribers
-    )
+      digest_run_subscriber_params = build_digest_run_subscriber_params(
+        digest_run,
+        subscribers
+      )
 
-    digest_run_subscriber_ids = import_digest_run_subscribers(
-      digest_run_subscriber_params
-    )
+      digest_run_subscriber_ids = import_digest_run_subscribers(
+        digest_run_subscriber_params
+      )
 
-    enqueue_jobs(digest_run_subscriber_ids)
+      enqueue_jobs(digest_run_subscriber_ids)
+    end
   end
 
 private

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -24,6 +24,14 @@ class MetricsService
       time("#{provider_name}.email_send_request.timing", &block)
     end
 
+    def digest_email_generation(range, &block)
+      time("digest_email_generation.#{range}.timing", &block)
+    end
+
+    def digest_initiator_service(range, &block)
+      time("digest_initiator_service.#{range}.timing", &block)
+    end
+
     def first_delivery_attempt(email, time)
       return if DeliveryAttempt.exists?(email: email)
       store_time_to_send_email(email, time)

--- a/spec/units/services/digest_initiator_service_spec.rb
+++ b/spec/units/services/digest_initiator_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe DigestInitiatorService do
 
         it "creates a DigestRunSubscriber for each subscriber" do
           Timecop.freeze(Time.parse("08:30")) do
-            described_class.call(range: DigestRun::DAILY)
+            described_class.call(range: range)
             expect(DigestRunSubscriber.all.map(&:subscriber_id)).to match([1, 2])
           end
         end
@@ -64,9 +64,16 @@ RSpec.describe DigestInitiatorService do
               .to receive(:perform_async)
               .exactly(2).times
 
-            described_class.call(range: DigestRun::DAILY)
+            described_class.call(range: range)
           end
         end
+      end
+
+      it "records a metric for the delivery attempt" do
+        expect(MetricsService).to receive(:digest_initiator_service)
+          .with("daily")
+
+        described_class.call(range: range)
       end
     end
 

--- a/spec/units/workers/digest_email_generation_worker_spec.rb
+++ b/spec/units/workers/digest_email_generation_worker_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe DigestEmailGenerationWorker do
     subject.perform(1)
   end
 
+  it "records a metric for the delivery attempt" do
+    expect(MetricsService).to receive(:digest_email_generation)
+      .with("daily")
+
+    create(:digest_run_subscriber, id: 1)
+
+    subject.perform(1)
+  end
+
   it "marks the DigestRunSubscriber completed" do
     digest_run_subscriber = create(
       :digest_run_subscriber,


### PR DESCRIPTION
This PR introduces two new stats, how long it takes for the digest initiation to finish and how long it takes for the generation of digest emails. The stats are stored separate for daily and weekly digests.

[Trello Card](https://trello.com/c/gEBmF1yT/552-store-and-represent-digest-statistics-on-dashboard)