### PR TITLE
Only one unsubscribe link

### DIFF
--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -37,31 +37,34 @@ private
                    subscription_content_change.fetch(:subscriber)
                  end
 
-    [subscriber.address, subject(content_change), body(subscriber, content_change)]
+    [subscriber.address, subject(content_change), body(content_change, subscription)]
   end
 
   def subject(content_change)
     "GOV.UK Update - #{content_change.title}"
   end
 
-  def body(subscriber, content_change)
-    <<~BODY
-      #{presented_content_change(content_change)}
-      ---
+  def body(content_change, subscription)
+    if subscription
+      <<~BODY
+        #{presented_content_change(content_change)}
+        ---
 
-      #{unsubscribe_links(subscriber)}
-    BODY
+        #{presented_unsubscribe_link(subscription)}
+      BODY
+    else
+      presented_content_change(content_change)
+    end
   end
 
   def presented_content_change(content_change)
     ContentChangePresenter.call(content_change)
   end
 
-  def unsubscribe_links(subscriber)
-    links = subscriber.subscriptions.map do |subscription|
-      UnsubscribeLinkPresenter.call(uuid: subscription.uuid, title: subscription.subscriber_list.title)
-    end
-
-    links.join("\n\n")
+  def presented_unsubscribe_link(subscription)
+    UnsubscribeLinkPresenter.call(
+      uuid: subscription.uuid,
+      title: subscription.subscriber_list.title,
+    )
   end
 end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -1,6 +1,6 @@
 class ImmediateEmailBuilder
-  def initialize(subscriber_content_changes)
-    @subscriber_content_changes = subscriber_content_changes
+  def initialize(subscription_content_changes)
+    @subscription_content_changes = subscription_content_changes
   end
 
   def self.call(*args)
@@ -15,11 +15,11 @@ class ImmediateEmailBuilder
 
 private
 
-  attr_reader :subscriber_content_changes
+  attr_reader :subscription_content_changes
 
   def records
-    subscriber_content_changes.map do |subscriber_content_change|
-      single_email_record(subscriber_content_change)
+    subscription_content_changes.map do |subscription_content_change|
+      single_email_record(subscription_content_change)
     end
   end
 
@@ -27,9 +27,15 @@ private
     %i(address subject body)
   end
 
-  def single_email_record(subscriber_content_change)
-    subscriber = subscriber_content_change.fetch(:subscriber)
-    content_change = subscriber_content_change.fetch(:content_change)
+  def single_email_record(subscription_content_change)
+    content_change = subscription_content_change.fetch(:content_change)
+    subscription = subscription_content_change[:subscription]
+
+    subscriber = if subscription
+                   subscription.subscriber
+                 else
+                   subscription_content_change.fetch(:subscriber)
+                 end
 
     [subscriber.address, subject(content_change), body(subscriber, content_change)]
   end

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -65,13 +65,13 @@ private
   end
 
   def import_emails(subscription_contents)
-    subscriber_content_changes = subscription_contents.map do |subscription_content|
+    subscription_content_changes = subscription_contents.map do |subscription_content|
       {
-        subscriber: subscription_content.subscription.subscriber,
+        subscription: subscription_content.subscription,
         content_change: subscription_content.content_change,
       }
     end
 
-    ImmediateEmailBuilder.call(subscriber_content_changes)
+    ImmediateEmailBuilder.call(subscription_content_changes)
   end
 end

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -1,10 +1,21 @@
 RSpec.describe ImmediateEmailBuilder do
-  let(:subscriber) { double(:subscriber, subscriptions: subscriptions, address: "test@example.com") }
+  let(:subscriber) { build(:subscriber, address: "test@example.com") }
 
   let(:subscriptions) do
     [
-      double(uuid: "1234", subscriber_list: double(title: "First Subscription")),
-      double(uuid: "5678", subscriber_list: double(title: "Second Subscription")),
+      build(
+        :subscription,
+        uuid: "bef9b608-05ba-46ce-abb7-8567f4180a25",
+        subscriber: subscriber,
+        subscriber_list: build(:subscriber_list, title: "First Subscription")
+      ),
+
+      build(
+        :subscription,
+        uuid: "69ca6fce-34f5-4ebd-943c-83bd1b2e70fb",
+        subscriber: subscriber,
+        subscriber_list: build(:subscriber_list, title: "Second Subscription")
+      ),
     ]
   end
 


### PR DESCRIPTION
Currently immediate emails include an unsubscribe link for everything the subscriber is subscribed too. This can lead to very large and confusing looking emails, it makes more sense to only show the unsubscribe link of the subscription that caused the email to be sent.

Due to the courtesy emails, we have to let `ImmediateEmailBuilder` support being given either a `subscription ` or a `subscriber`.