### PR TITLE
Use STDIN.gets instead of gets in rake task

### DIFF
--- a/lib/fake_data.rb
+++ b/lib/fake_data.rb
@@ -13,7 +13,7 @@ class FakeData
     if has_test_subscribers?
       puts "There is already test data in the system. Run rake fake_data:delete first."
       puts "Continue anyway? Press enter or CTRL+C to cancel."
-      gets
+      STDIN.gets
     end
 
     fake_subscriptions_data.each do |subscription_stat|


### PR DESCRIPTION
This is because rake overwrites $stdin and otherwise we see this error: `Errno::ENOENT: No such file or directory @ rb_sysopen`

More info: https://stackoverflow.com/a/40643667