### PR TITLE
Add `Frequency` class

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -8,9 +8,6 @@ class DigestRun < ApplicationRecord
 
   enum range: { daily: 0, weekly: 1 }
 
-  DAILY = "daily".freeze
-  WEEKLY = "weekly".freeze
-
   def mark_complete!
     update_attributes!(completed_at: Time.now)
   end

--- a/app/models/frequency.rb
+++ b/app/models/frequency.rb
@@ -1,0 +1,5 @@
+class Frequency
+  IMMEDIATELY = "immediately".freeze
+  DAILY = "daily".freeze
+  WEEKLY = "weekly".freeze
+end

--- a/app/workers/daily_digest_initiator_worker.rb
+++ b/app/workers/daily_digest_initiator_worker.rb
@@ -1,5 +1,5 @@
 class DailyDigestInitiatorWorker < DigestInitiatorWorker
   def perform
-    DigestInitiatorService.call(range: DigestRun::DAILY)
+    DigestInitiatorService.call(range: Frequency::DAILY)
   end
 end

--- a/app/workers/weekly_digest_initiator_worker.rb
+++ b/app/workers/weekly_digest_initiator_worker.rb
@@ -1,5 +1,5 @@
 class WeeklyDigestInitiatorWorker < DigestInitiatorWorker
   def perform
-    DigestInitiatorService.call(range: DigestRun::WEEKLY)
+    DigestInitiatorService.call(range: Frequency::WEEKLY)
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,12 +24,12 @@ FactoryBot.define do
 
   factory :digest_run do
     date { Date.current }
-    range DigestRun::DAILY
+    range Frequency::DAILY
 
     trait :daily
 
     trait :weekly do
-      range DigestRun::WEEKLY
+      range Frequency::WEEKLY
     end
   end
 
@@ -68,15 +68,16 @@ FactoryBot.define do
   factory :subscription do
     subscriber
     subscriber_list
+    frequency Frequency::IMMEDIATELY
 
     trait :immediately
 
     trait :daily do
-      frequency "daily"
+      frequency Frequency::DAILY
     end
 
     trait :weekly do
-      frequency "weekly"
+      frequency Frequency::WEEKLY
     end
   end
 

--- a/spec/queries/digest_run_subscriber_query_spec.rb
+++ b/spec/queries/digest_run_subscriber_query_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe DigestRunSubscriberQuery do
   let(:ends_at) { Time.parse("2017-01-02 08:00") }
-  let(:digest_run) { create(:digest_run, date: ends_at, range: :daily) }
+  let(:digest_run) { create(:digest_run, :daily, date: ends_at) }
   let(:starts_at) { digest_run.starts_at }
 
   describe ".call" do
@@ -58,7 +58,7 @@ RSpec.describe DigestRunSubscriberQuery do
 
     context "with a weekly subscription" do
       let!(:subscription) do
-        create(:subscription, subscriber_list: subscriber_list, frequency: :weekly)
+        create(:subscription, :weekly, subscriber_list: subscriber_list)
       end
 
       context "with a matched content change" do
@@ -74,11 +74,11 @@ RSpec.describe DigestRunSubscriberQuery do
 
     context "with two subscriptions" do
       let!(:subscription_1) do
-        create(:subscription, subscriber_list: subscriber_list, frequency: :daily)
+        create(:subscription, :daily, subscriber_list: subscriber_list)
       end
 
       let!(:subscription_2) do
-        create(:subscription, subscriber_list: subscriber_list, frequency: :daily)
+        create(:subscription, :daily, subscriber_list: subscriber_list)
       end
 
       before do

--- a/spec/queries/subscription_content_change_query_spec.rb
+++ b/spec/queries/subscription_content_change_query_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SubscriptionContentChangeQuery do
   let(:ends_at) { Time.parse("2017-01-02 08:00") }
 
   let(:digest_run) do
-    create(:digest_run, date: ends_at, range: :daily)
+    create(:digest_run, :daily, date: ends_at)
   end
 
   let(:starts_at) { digest_run.starts_at }

--- a/spec/services/digest_initiator_service_spec.rb
+++ b/spec/services/digest_initiator_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe DigestInitiatorService do
   describe ".call" do
     context "daily" do
-      let(:range) { DigestRun::DAILY }
+      let(:range) { Frequency::DAILY }
 
       after do
         ENV["DIGEST_RANGE_HOUR"] = nil
@@ -78,7 +78,7 @@ RSpec.describe DigestInitiatorService do
     end
 
     context "weekly" do
-      let(:range) { DigestRun::WEEKLY }
+      let(:range) { Frequency::WEEKLY }
 
       context "when there is no daily DigestRun for the date" do
         it "creates one" do

--- a/spec/workers/daily_digest_initiator_worker_spec.rb
+++ b/spec/workers/daily_digest_initiator_worker_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe DailyDigestInitiatorWorker do
   describe ".perform" do
     it "calls the daily digest initiator service" do
       expect(DigestInitiatorService).to receive(:call)
-        .with(range: DigestRun::DAILY)
+        .with(range: Frequency::DAILY)
 
       subject.perform
     end

--- a/spec/workers/weekly_digest_initiator_worker_spec.rb
+++ b/spec/workers/weekly_digest_initiator_worker_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe WeeklyDigestInitiatorWorker do
   describe ".perform" do
     it "calls the weekly digest initiator service" do
       expect(DigestInitiatorService).to receive(:call)
-        .with(range: DigestRun::WEEKLY)
+        .with(range: Frequency::WEEKLY)
 
       subject.perform
     end


### PR DESCRIPTION
Both `DigestRun` and `Subscription` have frequency enums. The string values for these were defined as constants on `DigestRun`. This commit abstracts them out into their own `Frequency` class to reuse everywhere.

Also updates the factories that have frequency traits and updates some specs to use the traits rather than specifying the frequency directly.