### PR TITLE
Return distinct subscribers from query

### DIFF
--- a/app/queries/digest_run_subscriber_query.rb
+++ b/app/queries/digest_run_subscriber_query.rb
@@ -5,5 +5,6 @@ class DigestRunSubscriberQuery
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
       .where("subscriptions.frequency": digest_run.range)
+      .distinct
   end
 end


### PR DESCRIPTION
The `DigestRunSubscriberQuery` returns all subscribers that have matching content within a digest run range. This query was returning the same subscriber multiple times if they were subscribed to more than one `Subscribable` that matched content. This was causing the subscriber
to receive multiple digests instead of just one.

This commit adds a `.distinct` to the query which removes the duplicates.