### PR TITLE
Disable digest generation

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,9 +11,3 @@
   immediate_email_generation:
     every: '5s'
     class: ImmediateEmailGenerationWorker
-  daily_digest_initiator:
-    cron: '30 8 * * *' # every day at 8:30am
-    class: DailyDigestInitiatorWorker
-  weekly_digest_initiator:
-    cron: '30 8 * * 6' # every Saturday at 8:30am
-    class: WeeklyDigestInitiatorWorker


### PR DESCRIPTION
This is a temporary commit that removes the scheduling config for daily and weekly digests. We are experiencing some issues with capacity for these and don't want them to run over the weekend while we diagnose and fix the issues.

[Trello](https://trello.com/c/cct1i3Vp/587-disable-digest-emails)