### PR TITLE
Reorganise Sidekiq queues

### DIFF
--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -1,6 +1,8 @@
 class DigestEmailGenerationWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :email_generation_digest
+
   def perform(digest_run_subscriber_id)
     @digest_run_subscriber = DigestRunSubscriber.find(digest_run_subscriber_id)
     @subscriber = digest_run_subscriber.subscriber

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -1,6 +1,8 @@
 class ImmediateEmailGenerationWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :email_generation_immediate
+
   LOCK_NAME = "immediate_email_generation_worker".freeze
 
   def perform

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -1,6 +1,8 @@
 class NotificationWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :govdelivery
+
   def perform(notification_params)
     notification_params = notification_params.with_indifferent_access
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,9 +7,9 @@
   - [delivery_immediate_high, 6]
   - [delivery_immediate, 5]
   - [email_generation_immediate, 4]
-  - [delivery_digest, 3]
-  - [email_generation_digest, 2]
-  - [default, 1]
+  - [default, 3]
+  - [delivery_digest, 2]
+  - [email_generation_digest, 1]
 :schedule:
   immediate_email_generation:
     every: '5s'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,6 +3,7 @@
 :concurrency: 30
 :logfile: ./log/sidekiq.json.log
 :queues:
+  - govdelivery
   - [delivery_immediate_high, 4]
   - [delivery_immediate, 3]
   - [delivery_digest, 2]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,8 +4,9 @@
 :logfile: ./log/sidekiq.json.log
 :queues:
   - govdelivery
-  - [delivery_immediate_high, 4]
-  - [delivery_immediate, 3]
+  - [delivery_immediate_high, 5]
+  - [delivery_immediate, 4]
+  - [email_generation_immediate, 3]
   - [delivery_digest, 2]
   - [default, 1]
 :schedule:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,10 +4,11 @@
 :logfile: ./log/sidekiq.json.log
 :queues:
   - govdelivery
-  - [delivery_immediate_high, 5]
-  - [delivery_immediate, 4]
-  - [email_generation_immediate, 3]
-  - [delivery_digest, 2]
+  - [delivery_immediate_high, 6]
+  - [delivery_immediate, 5]
+  - [email_generation_immediate, 4]
+  - [delivery_digest, 3]
+  - [email_generation_digest, 2]
   - [default, 1]
 :schedule:
   immediate_email_generation:

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -1,116 +1,128 @@
 require 'rails_helper'
 
 RSpec.describe DigestEmailGenerationWorker do
-  let(:subscriber) { create(:subscriber, id: 1) }
-  let!(:subscription_one) {
-    create(:subscription, id: 1, subscriber_id: subscriber.id)
-  }
-  let!(:subscription_two) {
-    create(:subscription, id: 2, subscriber_id: subscriber.id)
-  }
-  let!(:digest_run) { create(:digest_run, id: 10) }
+  describe ".perform_async" do
+    before do
+      described_class.perform_async
+    end
 
-  let(:subscription_content_change_query_results) {
-    [
-      double(
-        subscription_id: 1,
-        subscription_uuid: "ABC1",
-        subscriber_list_title: "Test title 1",
-        content_changes: [
-          create(:content_change, public_updated_at: "1/1/2016 10:00"),
-        ],
-      ),
-      double(
-        subscription_id: 2,
-        subscription_uuid: "ABC2",
-        subscriber_list_title: "Test title 2",
-        content_changes: [
-          create(:content_change, public_updated_at: "4/1/2016 10:00"),
-        ],
-      ),
-    ]
-  }
-
-  before do
-    allow(SubscriptionContentChangeQuery).to receive(:call).and_return(
-      subscription_content_change_query_results
-    )
+    it "gets put on the email_generation_digest queue" do
+      expect(Sidekiq::Queues["email_generation_digest"].size).to eq(1)
+    end
   end
 
-  it "accepts digest_run_subscriber_id" do
-    create(:digest_run_subscriber, id: 1)
+  describe ".perform" do
+    let(:subscriber) { create(:subscriber, id: 1) }
+    let!(:subscription_one) {
+      create(:subscription, id: 1, subscriber_id: subscriber.id)
+    }
+    let!(:subscription_two) {
+      create(:subscription, id: 2, subscriber_id: subscriber.id)
+    }
+    let!(:digest_run) { create(:digest_run, id: 10) }
 
-    expect {
+    let(:subscription_content_change_query_results) {
+      [
+        double(
+          subscription_id: 1,
+          subscription_uuid: "ABC1",
+          subscriber_list_title: "Test title 1",
+          content_changes: [
+            create(:content_change, public_updated_at: "1/1/2016 10:00"),
+          ],
+        ),
+        double(
+          subscription_id: 2,
+          subscription_uuid: "ABC2",
+          subscriber_list_title: "Test title 2",
+          content_changes: [
+            create(:content_change, public_updated_at: "4/1/2016 10:00"),
+          ],
+        ),
+      ]
+    }
+
+    before do
+      allow(SubscriptionContentChangeQuery).to receive(:call).and_return(
+        subscription_content_change_query_results
+      )
+    end
+
+    it "accepts digest_run_subscriber_id" do
+      create(:digest_run_subscriber, id: 1)
+
+      expect {
+        subject.perform(1)
+      }.not_to raise_error
+    end
+
+    it "creates an email" do
+      create(:digest_run_subscriber, id: 1)
+
+      expect { subject.perform(1) }
+        .to change { Email.count }.by(1)
+    end
+
+    it "enqueues delivery" do
+      expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+        .with(instance_of(Integer), queue: :delivery_digest)
+
+      create(:digest_run_subscriber, id: 1)
+
       subject.perform(1)
-    }.not_to raise_error
-  end
+    end
 
-  it "creates an email" do
-    create(:digest_run_subscriber, id: 1)
+    it "records a metric for the delivery attempt" do
+      expect(MetricsService).to receive(:digest_email_generation)
+        .with("daily")
 
-    expect { subject.perform(1) }
-      .to change { Email.count }.by(1)
-  end
+      create(:digest_run_subscriber, id: 1)
 
-  it "enqueues delivery" do
-    expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-      .with(instance_of(Integer), queue: :delivery_digest)
-
-    create(:digest_run_subscriber, id: 1)
-
-    subject.perform(1)
-  end
-
-  it "records a metric for the delivery attempt" do
-    expect(MetricsService).to receive(:digest_email_generation)
-      .with("daily")
-
-    create(:digest_run_subscriber, id: 1)
-
-    subject.perform(1)
-  end
-
-  it "marks the DigestRunSubscriber completed" do
-    digest_run_subscriber = create(
-      :digest_run_subscriber,
-      id: 1,
-      subscriber_id: subscriber.id
-    )
-
-    allow(DigestRunSubscriber).to receive(:find)
-      .with(1)
-      .and_return(digest_run_subscriber)
-
-    expect(digest_run_subscriber).to receive(:mark_complete!)
-
-    subject.perform(1)
-  end
-
-  it "creates a SubscriptionContent" do
-    create(
-      :digest_run_subscriber,
-      id: 1,
-      subscriber_id: subscriber.id
-    )
-
-    subject.perform(1)
-
-    subscription_content = SubscriptionContent.last
-    expect(subscription_content.digest_run_subscriber_id).to eq(1)
-  end
-
-  it "marks the digest run complete" do
-    create(:digest_run_subscriber, id: 1)
-    expect_any_instance_of(DigestRun).to receive(:mark_complete!)
-    subject.perform(1)
-  end
-
-  context "when there are incomplete DigestRunSubscribers left" do
-    it "doesn't mark the digest run complete" do
-      create(:digest_run_subscriber, id: 1, digest_run_id: digest_run.id)
-      create(:digest_run_subscriber, digest_run_id: digest_run.id)
-      expect_any_instance_of(DigestRun).not_to receive(:mark_complete!)
       subject.perform(1)
+    end
+
+    it "marks the DigestRunSubscriber completed" do
+      digest_run_subscriber = create(
+        :digest_run_subscriber,
+        id: 1,
+        subscriber_id: subscriber.id
+      )
+
+      allow(DigestRunSubscriber).to receive(:find)
+        .with(1)
+        .and_return(digest_run_subscriber)
+
+      expect(digest_run_subscriber).to receive(:mark_complete!)
+
+      subject.perform(1)
+    end
+
+    it "creates a SubscriptionContent" do
+      create(
+        :digest_run_subscriber,
+        id: 1,
+        subscriber_id: subscriber.id
+      )
+
+      subject.perform(1)
+
+      subscription_content = SubscriptionContent.last
+      expect(subscription_content.digest_run_subscriber_id).to eq(1)
+    end
+
+    it "marks the digest run complete" do
+      create(:digest_run_subscriber, id: 1)
+      expect_any_instance_of(DigestRun).to receive(:mark_complete!)
+      subject.perform(1)
+    end
+
+    context "when there are incomplete DigestRunSubscribers left" do
+      it "doesn't mark the digest run complete" do
+        create(:digest_run_subscriber, id: 1, digest_run_id: digest_run.id)
+        create(:digest_run_subscriber, digest_run_id: digest_run.id)
+        expect_any_instance_of(DigestRun).not_to receive(:mark_complete!)
+        subject.perform(1)
+      end
     end
   end
 end

--- a/spec/workers/immediate_email_generation_worker_spec.rb
+++ b/spec/workers/immediate_email_generation_worker_spec.rb
@@ -1,5 +1,15 @@
 RSpec.describe ImmediateEmailGenerationWorker do
-  describe ".call" do
+  describe ".perform_async" do
+    before do
+      described_class.perform_async
+    end
+
+    it "gets put on the email_generation_immediate queue" do
+      expect(Sidekiq::Queues["email_generation_immediate"].size).to eq(1)
+    end
+  end
+
+  describe ".perform" do
     def perform_with_fake_sidekiq
       Sidekiq::Testing.fake! do
         DeliveryRequestWorker.jobs.clear

--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -1,19 +1,29 @@
 RSpec.describe NotificationWorker do
+  let(:notification_params) do
+    {
+      subject: "Test subject",
+      body: "Test body copy",
+      content_id: "111111-aaaaaa",
+      public_updated_at: "2017-02-21T14:58:45+00:00",
+      govuk_request_id: 'AAAAAA',
+    }
+  end
+
+  describe "#perform_async" do
+    before do
+      NotificationWorker.perform_async(notification_params)
+    end
+
+    it "gets put on the govdelivery queue" do
+      expect(Sidekiq::Queues["govdelivery"].size).to eq(1)
+    end
+  end
+
   describe "#perform" do
     before do
       @gov_delivery = double(:gov_delivery, send_bulletin: nil)
       allow(Services).to receive(:gov_delivery).and_return(@gov_delivery)
       allow(Rails.logger).to receive(:info)
-    end
-
-    let(:notification_params) do
-      {
-        subject: "Test subject",
-        body: "Test body copy",
-        content_id: "111111-aaaaaa",
-        public_updated_at: "2017-02-21T14:58:45+00:00",
-        govuk_request_id: 'AAAAAA',
-      }
     end
 
     def make_it_perform


### PR DESCRIPTION
This reconfigures the Sidekiq queues to ensure that all GovDelivery workers are first run before any other kind of worker. Then we prioritise immediate emails (both the delivery and the generation) above digest emails which are given the lowest priority (below the `default` queue).

The queue could probably still do with some tweaking in the future, but this should help relieve some of the issues we're seeing at the moment.

[Trello Card](https://trello.com/c/oc1zoHR2/588-split-immediate-and-digest-email-generation-into-separate-queues)