### PR TITLE
Use import with columns and records

### DIFF
--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -8,7 +8,7 @@ class ImmediateEmailBuilder
   end
 
   def call
-    Email.import!(records)
+    Email.import!(columns, records)
   end
 
   private_class_method :new
@@ -23,15 +23,15 @@ private
     end
   end
 
+  def columns
+    %i(address subject body)
+  end
+
   def single_email_record(subscriber_content_change)
     subscriber = subscriber_content_change.fetch(:subscriber)
     content_change = subscriber_content_change.fetch(:content_change)
 
-    {
-      address: subscriber.address,
-      subject: subject(content_change),
-      body: body(subscriber, content_change)
-    }
+    [subscriber.address, subject(content_change), body(subscriber, content_change)]
   end
 
   def subject(content_change)

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -8,19 +8,21 @@ class MatchedContentChangeGenerationService
   end
 
   def call
-    MatchedContentChange.import!(records)
+    MatchedContentChange.import!(columns, records)
   end
 
 private
 
   attr_reader :content_change
 
+  def columns
+    %i(content_change_id subscriber_list_id)
+  end
+
   def records
+    content_change_id = content_change.id
     subscriber_lists.map do |subscriber_list|
-      {
-        content_change_id: content_change.id,
-        subscriber_list_id: subscriber_list.id,
-      }
+      [content_change_id, subscriber_list.id]
     end
   end
 

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -28,19 +28,24 @@ private
     @email = create_email
 
     SubscriptionContent.import!(
-      formatted_subscription_content_changes
+      formatted_subscription_content_change_columns,
+      formatted_subscription_content_changes,
     )
+  end
+
+  def formatted_subscription_content_change_columns
+    %i(email_id subscription_id content_change_id digest_run_subscriber_id)
   end
 
   def formatted_subscription_content_changes
     subscriber_content_changes.flat_map do |result|
       result.content_changes.map do |content_change|
-        {
-          email_id: email.id,
-          subscription_id: result.subscription_id,
-          content_change_id: content_change.id,
-          digest_run_subscriber_id: digest_run_subscriber.id,
-        }
+        [
+          email.id,
+          result.subscription_id,
+          content_change.id,
+          digest_run_subscriber.id,
+        ]
       end
     end
   end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SubscriptionContentWorker do
     it "creates subscription content for the content change" do
       expect(SubscriptionContent)
         .to receive(:import!)
-        .with([{ content_change_id: content_change.id, subscription_id: subscription.id }])
+        .with(%i(content_change_id subscription_id), [[content_change.id, subscription.id]])
 
       subject.perform(content_change.id)
     end


### PR DESCRIPTION
This is the most performant method of bulk insertion of records and it will use the least memory.

[Trello Card](https://trello.com/c/HTzGEXG7/569-investigate-increased-memory-usage-for-email-alert-api)