### PR TITLE
Increase connection pool from 30 to 35

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 30
+  pool: 35
   # Necessary to allow creating a db with different encodings.
   # See http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html for details
   template: template0


### PR DESCRIPTION
We're currently seeing a few ActiveRecord::ConnectionTimeoutError in Sentry which means we're hitting the limits of our connection pool.

It's currently set to 30 and we have 30 concurrent workers, which means that when all the workers are accessing the database, no web requests can access the database and vice versa. When processing
digests, the workers can often take longer than 5 seconds to run, which is why we may be seeing the timeout error.

I've decided to add 5 more connections available to the pool which should allow for a small buffer even when all the workers are busy accessing the database.

[Trello Card](https://trello.com/c/r7TYPvl3/572-investigate-activerecordconnectiontimeouterror-for-email-alert-api)