### PR TITLE
Revert "Disable digest generation"

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,3 +14,9 @@
   immediate_email_generation:
     every: '5s'
     class: ImmediateEmailGenerationWorker
+  daily_digest_initiator:
+    cron: '30 8 * * *' # every day at 8:30am
+    class: DailyDigestInitiatorWorker
+  weekly_digest_initiator:
+    cron: '30 8 * * 6' # every Saturday at 8:30am
+    class: WeeklyDigestInitiatorWorker


### PR DESCRIPTION
Reverts alphagov/email-alert-api#397

After we've made a few changes to how the system works, I believe we've solved the problems we were seeing.