### PR TITLE
Add daily digest feature spec

### DIFF
--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -104,6 +104,9 @@ RSpec.describe "creating and delivering digests", type: :request do
     subscriber_one_address = "test-one@example.com"
     subscriber_two_address = "test-two@example.com"
 
+    #subscriber that shouldn't receive a digest
+    non_digest_subscriber_address = "test-three@example.com"
+
     subscribe_to_subscribable(
       subscribable_one_id,
       address: subscriber_one_address,
@@ -120,6 +123,12 @@ RSpec.describe "creating and delivering digests", type: :request do
       subscribable_one_id,
       address: subscriber_two_address,
       frequency: Frequency::DAILY
+    )
+
+    subscribe_to_subscribable(
+      subscribable_one_id,
+      address: non_digest_subscriber_address,
+      frequency: Frequency::IMMEDIATELY
     )
 
     #publish two items to each list

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+RSpec.describe "creating and delivering digests", type: :request do
+  before do
+    Timecop.freeze "2017-01-02 10:00"
+
+    allow_any_instance_of(DeliveryRequestService)
+      .to receive(:provider_name).and_return("notify")
+  end
+
+  after do
+    Timecop.return
+  end
+
+  scenario "daily digest run" do
+    login_with_internal_app
+
+    #create two subscriber lists with different links
+    list_one_topic_id = "0eb5d0f0-d384-4f27-9da8-3f9e9b22a820"
+    list_two_topic_id = "a915e039-070b-4633-813d-187af61cad7a"
+
+    stub_govdelivery("TEST123")
+    subscribable_one_id = create_subscribable(title: "Subscriber list one", links: {
+      topics: [list_one_topic_id]
+    })
+
+    stub_govdelivery("TEST456")
+    subscribable_two_id = create_subscribable(title: "Subscriber list two", links: {
+      topics: [list_two_topic_id]
+    })
+
+    #create two daily subscribers, one subscribed to daily digests for both
+    #subscribables and the other for daily for subscribable_one only
+    subscriber_one_address = "test-one@example.com"
+    subscriber_two_address = "test-two@example.com"
+
+    subscribe_to_subscribable(
+      subscribable_one_id,
+      address: subscriber_one_address,
+      frequency: Frequency::DAILY
+    )
+
+    subscribe_to_subscribable(
+      subscribable_two_id,
+      address: subscriber_one_address,
+      frequency: Frequency::DAILY
+    )
+
+    subscribe_to_subscribable(
+      subscribable_one_id,
+      address: subscriber_two_address,
+      frequency: Frequency::DAILY
+    )
+
+    #publish two items to each list
+    Timecop.freeze "2017-01-01 10:00" do
+      create_content_change(
+        title: "Title one",
+        content_id: SecureRandom.uuid,
+        description: "Description one",
+        change_note: "Change note one",
+        public_updated_at: "2017-01-01 10:00:00",
+        links: {
+          topics: [list_one_topic_id]
+        }
+      )
+    end
+
+    Timecop.freeze "2017-01-01 09:00" do
+      create_content_change(
+        title: "Title two",
+        content_id: SecureRandom.uuid,
+        description: "Description two",
+        change_note: "Change note two",
+        public_updated_at: "2017-01-01 09:00:00",
+        links: {
+          topics: [list_one_topic_id]
+        }
+      )
+    end
+
+    Timecop.freeze "2017-01-01 09:00:00" do
+      create_content_change(
+        title: "Title three",
+        content_id: SecureRandom.uuid,
+        description: "Description three",
+        change_note: "Change note three",
+        public_updated_at: "2017-01-01 09:00:00",
+        links: {
+          topics: [list_two_topic_id]
+        }
+      )
+    end
+
+    Timecop.freeze "2017-01-01 09:30:00" do
+      create_content_change(
+        title: "Title four",
+        content_id: SecureRandom.uuid,
+        description: "Description four",
+        change_note: "Change note four",
+        public_updated_at: "2017-01-01 09:30:00",
+        links: {
+          topics: [list_two_topic_id]
+        }
+      )
+    end
+
+    #TODO retrieve this via the API when we have an endpoint
+    subscriptions = Subscription.all
+
+    expected_subscriber_one_body = <<~BODY
+      #Subscriber list one
+
+      [Title one](http://www.dev.gov.uk/base-path)
+
+      Change note one: Description one
+
+      Updated at 10:00 am on 1 January 2017
+
+      ---
+
+      [Title two](http://www.dev.gov.uk/base-path)
+
+      Change note two: Description two
+
+      Updated at 09:00 am on 1 January 2017
+
+      ---
+
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscriptions[0].uuid}?title=Subscriber%20list%20one)
+
+      &nbsp;
+
+      #Subscriber list two
+
+      [Title four](http://www.dev.gov.uk/base-path)
+
+      Change note four: Description four
+
+      Updated at 09:30 am on 1 January 2017
+
+      ---
+
+      [Title three](http://www.dev.gov.uk/base-path)
+
+      Change note three: Description three
+
+      Updated at 09:00 am on 1 January 2017
+
+      ---
+
+      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscriptions[1].uuid}?title=Subscriber%20list%20two)
+    BODY
+
+    expected_subscriber_two_body = <<~BODY
+      #Subscriber list one
+
+      [Title one](http://www.dev.gov.uk/base-path)
+
+      Change note one: Description one
+
+      Updated at 10:00 am on 1 January 2017
+
+      ---
+
+      [Title two](http://www.dev.gov.uk/base-path)
+
+      Change note two: Description two
+
+      Updated at 09:00 am on 1 January 2017
+
+      ---
+
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscriptions[2].uuid}?title=Subscriber%20list%20one)
+    BODY
+
+    first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
+      .with(body: hash_including(email_address: "test-one@example.com"))
+      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK Daily Update")))
+      .with(body: hash_including(personalisation: hash_including("body" => expected_subscriber_one_body)))
+      .to_return(body: {}.to_json)
+
+    second_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
+      .with(body: hash_including(email_address: "test-two@example.com"))
+      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK Daily Update")))
+      .with(body: hash_including(personalisation: hash_including("body" => expected_subscriber_two_body)))
+      .to_return(body: {}.to_json)
+
+    DailyDigestInitiatorWorker.new.perform
+    Sidekiq::Worker.drain_all
+
+    expect(first_digest_stub).to have_been_requested
+    expect(second_digest_stub).to have_been_requested
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -34,8 +34,13 @@ module FeatureHelpers
     expect(response.status).to eq(expected_status)
   end
 
-  def subscribe_to_subscribable(subscribable_id, expected_status: 201)
-    params = { subscribable_id: subscribable_id, address: "test@test.com" }
+  def subscribe_to_subscribable(subscribable_id, expected_status: 201,
+    address: "test@test.com", frequency: "immediately")
+    params = {
+      subscribable_id: subscribable_id,
+      address: address,
+      frequency: frequency
+    }
     post "/subscriptions", params: params.to_json, headers: JSON_HEADERS
     expect(response.status).to eq(expected_status)
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -27,6 +27,7 @@ module FeatureHelpers
   def lookup_subscribable(gov_delivery_id, expected_status: 200)
     get "/subscribables/#{gov_delivery_id}"
     expect(response.status).to eq(expected_status)
+    data.dig(:subscribable, :id)
   end
 
   def lookup_subscriber_list(params, expected_status: 200)


### PR DESCRIPTION
This PR adds a high level feature spec for the daily digest functionality.

I've intentionally left it 'long and procedural' as I think it reads better as a spec without jumping between method definitions where possible. Obviously, open to debate.

I've also had to dip into the DB at one point to retrieve the subscriptions to allow checking of unsubscribe links as we don't currently have an endpoint for that.  We should be adding one soon so I've left it as a TODO.

That does throw up whether this test is going into too much detail at this level. We could just check the right number of emails are sent to the right people here and go into more detail of the email content in an integration test. Happy to take that approach if we prefer it but I think this approach exercises a lot of the system, still runs quickly and gives a nice readable 'narrative' of what is supposed to happen.

Once we've agreed on this I'll add a weekly version in a subsequent PR.

[Trello](https://trello.com/c/b6ZxunyQ/589-create-high-level-test-that-creates-and-delivers-digests)