### PR TITLE
 Only send time to send content change metric for immediate emails

### DIFF
--- a/app/models/subscription_content.rb
+++ b/app/models/subscription_content.rb
@@ -2,4 +2,7 @@ class SubscriptionContent < ApplicationRecord
   belongs_to :subscription
   belongs_to :content_change
   belongs_to :email, optional: true
+
+  scope :immediate, -> { where(digest_run_subscriber_id: nil) }
+  scope :digest, -> { where.not(digest_run_subscriber_id: nil) }
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -45,13 +45,11 @@ class MetricsService
     end
 
     def store_time_to_send_content_change(email, time)
-      # We don't want to store this statistic for emails that have more than one
-      # content change associated with them. Since they don't exist yet this
-      # does just a crude check.
-      content_changes = ContentChangesForEmailQuery.call(email).all
-      return unless content_changes.count == 1
+      return if SubscriptionContent.where(email: email).digest.exists?
 
-      content_change = content_changes.first
+      content_change = ContentChangesForEmailQuery.call(email).first
+      return unless content_change
+
       difference = (time - content_change.created_at) * 1000
       namespace = "content_change_created_to_first_delivery_attempt"
       timing(namespace, difference)


### PR DESCRIPTION
It doesn't make sense to send this for digests since the email could potentially be sent days after the content change is created and it doesn't give us any useful information.

[Trello Card](https://trello.com/c/gEBmF1yT/552-store-and-represent-digest-statistics-on-dashboard)