### PR TITLE
Improve healthcheck performance

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -7,8 +7,7 @@ class DeliveryAttempt < ApplicationRecord
   enum provider: { pseudo: 0, notify: 1 }
 
   def self.latest_per_email
-    inner = group(:email_id).select("email_id AS id, MAX(updated_at) AS max")
-    joins("JOIN (#{inner.to_sql}) x ON email_id = x.id and updated_at = x.max")
+    from("(SELECT DISTINCT ON (email_id) * FROM delivery_attempts ORDER BY email_id, updated_at DESC) AS delivery_attempts")
   end
 
   def failure?

--- a/app/models/healthcheck/status_update_healthcheck.rb
+++ b/app/models/healthcheck/status_update_healthcheck.rb
@@ -22,7 +22,7 @@ class Healthcheck
       from = NOTIFY_DELAY
       to = from + 48
 
-      (from..to).step(3).with_object({}) do |n, hash|
+      (from..to).step(6).with_object({}) do |n, hash|
         hash[:"older_than_#{n}_hours"] = sending_after(n.hours.ago).count
       end
     end

--- a/app/models/healthcheck/technical_failure_healthcheck.rb
+++ b/app/models/healthcheck/technical_failure_healthcheck.rb
@@ -17,7 +17,7 @@ class Healthcheck
     end
 
     def details
-      1.upto(24).each_with_object({}) do |n, hash|
+      [1, 6, 12, 24].each_with_object({}) do |n, hash|
         hash[:"last_#{n}_hours"] = failures_since(n.hours.ago).count
       end
     end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe "Healthcheck", type: :request do
       queue_size:        { status: "ok", queues: a_kind_of(Hash) },
       redis:             { status: "ok" },
       retry_size:        { status: "ok", retry_size: 0 },
-      status_update:     hash_including(status: "ok", older_than_75_hours: 0),
-      technical_failure: hash_including(status: "ok", last_3_hours: 0),
+      status_update:     hash_including(status: "ok", older_than_78_hours: 0),
+      technical_failure: hash_including(status: "ok", last_6_hours: 0),
     )
   end
 end

--- a/spec/models/healthcheck/status_update_healthcheck_spec.rb
+++ b/spec/models/healthcheck/status_update_healthcheck_spec.rb
@@ -57,15 +57,15 @@ RSpec.describe Healthcheck::StatusUpdateHealthcheck do
   describe "#details" do
     before do
       3.times { create_delivery_attempt(:sending, 73.hours.ago) }
-      5.times { create_delivery_attempt(:sending, 76.hours.ago) }
+      5.times { create_delivery_attempt(:sending, 79.hours.ago) }
     end
 
     it "counts how many attempts are sending over 3-hour slices" do
       details = subject.details
 
       expect(details.fetch(:older_than_72_hours)).to eq(8)
-      expect(details.fetch(:older_than_75_hours)).to eq(5)
-      expect(details.fetch(:older_than_78_hours)).to eq(0)
+      expect(details.fetch(:older_than_78_hours)).to eq(5)
+      expect(details.fetch(:older_than_84_hours)).to eq(0)
     end
   end
 end

--- a/spec/models/healthcheck/technical_failure_healthcheck_spec.rb
+++ b/spec/models/healthcheck/technical_failure_healthcheck_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Healthcheck::TechnicalFailureHealthcheck do
       details = subject.details
 
       expect(details.fetch(:last_1_hours)).to eq(3)
-      expect(details.fetch(:last_2_hours)).to eq(8)
-      expect(details.fetch(:last_3_hours)).to eq(8)
+      expect(details.fetch(:last_6_hours)).to eq(8)
+      expect(details.fetch(:last_12_hours)).to eq(8)
     end
   end
 end


### PR DESCRIPTION
This PR reduces the amount of detail we provide in the healthcheck endpoint and reworks a SQL query for performance.

[Trello Card](https://trello.com/c/da9A8mBX/590-investigate-performance-of-email-alert-api-healthcheck)