### PR TITLE
Further improve healthcheck performance

### DIFF
--- a/app/models/healthcheck/status_update_healthcheck.rb
+++ b/app/models/healthcheck/status_update_healthcheck.rb
@@ -20,9 +20,9 @@ class Healthcheck
 
     def details
       from = NOTIFY_DELAY
-      to = from + 48
+      to = from + 36
 
-      (from..to).step(6).with_object({}) do |n, hash|
+      (from..to).step(12).with_object({}) do |n, hash|
         hash[:"older_than_#{n}_hours"] = sending_after(n.hours.ago).count
       end
     end

--- a/app/models/healthcheck/technical_failure_healthcheck.rb
+++ b/app/models/healthcheck/technical_failure_healthcheck.rb
@@ -7,9 +7,9 @@ class Healthcheck
     def status
       return :ok unless expect_status_update_callbacks?
 
-      if failures_since(1.hour.ago).exists?
+      if failures_since(1.hour).exists?
         :critical
-      elsif failures_since(1.day.ago).exists?
+      elsif failures_since(24.hours).exists?
         :warning
       else
         :ok
@@ -18,17 +18,20 @@ class Healthcheck
 
     def details
       [1, 12, 24].each_with_object({}) do |n, hash|
-        hash[:"last_#{n}_hours"] = failures_since(n.hours.ago).count
+        hash[:"last_#{n}_hours"] = failures_since(n.hours).count
       end
     end
 
   private
 
-    def failures_since(datetime)
-      DeliveryAttempt
-        .latest_per_email
-        .where(status: :technical_failure)
-        .where("updated_at > ?", datetime)
+    def failures_since(hours)
+      @failures_since_cache ||= {}
+      @failures_since_cache[hours] ||= begin
+        DeliveryAttempt
+          .latest_per_email
+          .where(status: :technical_failure)
+          .where("updated_at > ?", hours.ago)
+      end
     end
 
     def expect_status_update_callbacks?

--- a/app/models/healthcheck/technical_failure_healthcheck.rb
+++ b/app/models/healthcheck/technical_failure_healthcheck.rb
@@ -17,7 +17,7 @@ class Healthcheck
     end
 
     def details
-      [1, 6, 12, 24].each_with_object({}) do |n, hash|
+      [1, 12, 24].each_with_object({}) do |n, hash|
         hash[:"last_#{n}_hours"] = failures_since(n.hours.ago).count
       end
     end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe "Healthcheck", type: :request do
       queue_size:        { status: "ok", queues: a_kind_of(Hash) },
       redis:             { status: "ok" },
       retry_size:        { status: "ok", retry_size: 0 },
-      status_update:     hash_including(status: "ok", older_than_78_hours: 0),
-      technical_failure: hash_including(status: "ok", last_6_hours: 0),
+      status_update:     hash_including(status: "ok", older_than_96_hours: 0),
+      technical_failure: hash_including(status: "ok", last_12_hours: 0),
     )
   end
 end

--- a/spec/models/healthcheck/status_update_healthcheck_spec.rb
+++ b/spec/models/healthcheck/status_update_healthcheck_spec.rb
@@ -57,15 +57,15 @@ RSpec.describe Healthcheck::StatusUpdateHealthcheck do
   describe "#details" do
     before do
       3.times { create_delivery_attempt(:sending, 73.hours.ago) }
-      5.times { create_delivery_attempt(:sending, 79.hours.ago) }
+      5.times { create_delivery_attempt(:sending, 85.hours.ago) }
     end
 
     it "counts how many attempts are sending over 3-hour slices" do
       details = subject.details
 
       expect(details.fetch(:older_than_72_hours)).to eq(8)
-      expect(details.fetch(:older_than_78_hours)).to eq(5)
-      expect(details.fetch(:older_than_84_hours)).to eq(0)
+      expect(details.fetch(:older_than_84_hours)).to eq(5)
+      expect(details.fetch(:older_than_96_hours)).to eq(0)
     end
   end
 end

--- a/spec/models/healthcheck/technical_failure_healthcheck_spec.rb
+++ b/spec/models/healthcheck/technical_failure_healthcheck_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Healthcheck::TechnicalFailureHealthcheck do
       details = subject.details
 
       expect(details.fetch(:last_1_hours)).to eq(3)
-      expect(details.fetch(:last_6_hours)).to eq(8)
       expect(details.fetch(:last_12_hours)).to eq(8)
+      expect(details.fetch(:last_24_hours)).to eq(8)
     end
   end
 end


### PR DESCRIPTION
This improves the performance of the healthcheck endpoint by further reducing the amount of detail provided and caching the results of some queries. Unfortunately #406 was good enough for integration, but did not work for staging which has more data.

[Trello Card](https://trello.com/c/da9A8mBX/590-investigate-performance-of-email-alert-api-healthcheck)