### PR TITLE
ENV vars for handling transition to notify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'ratelimit', '~> 1.0'
 gem 'sidekiq-scheduler', '~> 2.2'
 
 group :test do
+  gem 'climate_control'
   gem 'equivalent-xml'
   gem 'factory_bot_rails'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     ast (2.4.0)
     builder (3.2.3)
     byebug (9.1.0)
+    climate_control (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -322,6 +323,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import (~> 0.22)
+  climate_control
   equivalent-xml
   factory_bot_rails
   faraday (= 0.12.2)

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -4,6 +4,13 @@ class NotificationWorker
   sidekiq_options queue: :govdelivery
 
   def perform(notification_params)
+    # This is used to disable sending data to govdelivery while the system
+    # transitions from govdelivery to notify.
+    #
+    # Note this does not store any data and details of any jobs that are
+    # disabled will be lost unless we set something up to store them.
+    return if ENV.include?("DISABLE_GOVDELIVERY_EMAILS")
+
     notification_params = notification_params.with_indifferent_access
 
     tags_hash  = Hash(notification_params[:tags])

--- a/doc/transition-from-govdelivery-to-notify.md
+++ b/doc/transition-from-govdelivery-to-notify.md
@@ -1,0 +1,18 @@
+# Transition from Govdelivery to Notify
+
+This document serves as documentation for the transition from Govdelivery to
+Notify as the means to send emails. The intention is that this stores
+information related to the migration and this app close to the codebase.
+It will be safe to remove this once the migration has been completed.
+
+## ENV vars
+
+### `DISABLE_GOVDELIVERY_EMAILS`
+
+By setting a value for this notification changes will no longer be sent to
+govdelivery. This is set within the [app/notifications_worker.rb][worker].
+
+When this is set jobs will still be scheduled to sidekiq but they will all not
+be executed. No data will be saved about jobs aborted.
+
+[worker]: ../app/notifications_worker.rb

--- a/doc/transition-from-govdelivery-to-notify.md
+++ b/doc/transition-from-govdelivery-to-notify.md
@@ -16,3 +16,10 @@ When this is set jobs will still be scheduled to sidekiq but they will all not
 be executed. No data will be saved about jobs aborted.
 
 [worker]: ../app/notifications_worker.rb
+
+### `USE_EMAIL_ALERT_FRONTEND_FOR_EMAIL_COLLECTION`
+
+When this environment variable set the redirect location that is returned
+as part of a subscriber list JSON serialization. Once this is returning
+frontend apps will redirect users to the Email Alert Frontend signup which
+does not use govdelivery.

--- a/spec/workers/notification_worker_spec.rb
+++ b/spec/workers/notification_worker_spec.rb
@@ -308,5 +308,22 @@ RSpec.describe NotificationWorker do
         )
       end
     end
+
+    context "when DISABLE_GOVDELIVERY_EMAILS env var is set" do
+      around do |example|
+        ClimateControl.modify(DISABLE_GOVDELIVERY_EMAILS: "1") do
+          example.run
+        end
+      end
+
+      it "does not send a bulletin" do
+        make_it_perform
+        expect(@gov_delivery).not_to have_received(:send_bulletin)
+      end
+
+      it "does not append a notification log entry" do
+        expect { make_it_perform }.to_not change(NotificationLog, :count)
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/CDYgpQDY/565-add-flags-to-enable-migration-from-govdelivery-to-notify

This adds a new ENV var (`DISABLE_GOVDELIVERY_EMAILS`) and documents an existing one (`USE_EMAIL_ALERT_FRONTEND_FOR_EMAIL_COLLECTION`) which will be used to transition to notify.

Follow up PRs are coming to:
- Set up these env vars in puppet
- Create a means to whitelist some people to receive notify emails during the transition but others don't (so we can have an imported database, but not be emailing them all)