### PR TITLE
Soft delete subscriptions

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -7,6 +7,7 @@ class SubscriptionsController < ApplicationController
 
     status = subscription.new_record? ? :created : :ok
 
+    subscription.deleted_at = nil
     subscription.frequency = frequency
     subscription.signon_user_uid = current_user.uid
     subscription.save!

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -6,7 +6,7 @@ class UnsubscribeController < ApplicationController
 private
 
   def subscription
-    Subscription.find_by!(uuid: uuid)
+    Subscription.not_deleted.find_by!(uuid: uuid)
   end
 
   def uuid

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -4,7 +4,7 @@ class Subscriber < ApplicationRecord
     validates :address, uniqueness: true
   end
 
-  has_many :subscriptions, dependent: :destroy
+  has_many :subscriptions, -> { not_deleted }
   has_many :subscriber_lists, through: :subscriptions
   has_many :digest_run_subscribers, dependent: :destroy
   has_many :digest_runs, through: :digest_run_subscribers

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,6 +8,12 @@ class Subscription < ApplicationRecord
 
   validates :subscriber, uniqueness: { scope: :subscriber_list }
 
+  scope :not_deleted, -> { where(deleted_at: nil) }
+
+  def destroy
+    update_attributes!(deleted_at: Time.now)
+  end
+
 private
 
   def set_uuid

--- a/db/migrate/20180205165003_add_deleted_at_to_subscriptions.rb
+++ b/db/migrate/20180205165003_add_deleted_at_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriptions, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180129081557) do
+ActiveRecord::Schema.define(version: 20180205165003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,7 @@ ActiveRecord::Schema.define(version: 20180129081557) do
     t.uuid "uuid", null: false
     t.string "signon_user_uid"
     t.integer "frequency", default: 0, null: false
+    t.datetime "deleted_at"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -41,7 +41,17 @@ RSpec.describe "Subscriptions", type: :request do
         create_subscription
         expect(data[:id]).to eq(subscription.id)
       end
+
+      context "with a deleted subscription" do
+        let!(:subscription) { create(:subscription, subscriber_list: subscribable, subscriber: subscriber, deleted_at: 1.day.ago) }
+
+        it "undeletes the subscription" do
+          create_subscription
+          expect(Subscription.find(subscription.id).deleted_at).to be_nil
+        end
+      end
     end
+
 
     context "without an existing subscription" do
       context "with a subscribable" do

--- a/spec/integration/unsubscribe_spec.rb
+++ b/spec/integration/unsubscribe_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Unsubscribing", type: :request do
         end
 
         it "deletes the subscription" do
-          expect(Subscription.count).to eq(0)
+          expect(Subscription.not_deleted.count).to eq(0)
         end
 
         it "responds with a 200 status" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -39,4 +39,32 @@ RSpec.describe Subscription, type: :model do
       expect(subject.uuid).to eq(uuid)
     end
   end
+
+  describe "destroy" do
+    subject { create(:subscription) }
+
+    it "doesn't delete the record" do
+      subject.destroy
+      expect(described_class.find(subject.id)).to eq(subject)
+    end
+
+    it "sets deleted_at to Time.now" do
+      Timecop.freeze do
+        subject.destroy
+        expect(subject.deleted_at).to eq(Time.now)
+      end
+    end
+  end
+
+  describe ".not_deleted" do
+    it "returns subscriptions with deleted_at nil" do
+      create(:subscription)
+      expect(Subscription.not_deleted.count).to eq(1)
+    end
+
+    it "doesn't return subscriptions with deleted_at" do
+      create(:subscription, deleted_at: Time.now)
+      expect(Subscription.not_deleted.count).to eq(0)
+    end
+  end
 end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe UnsubscribeService do
 
     it "removes the subscription" do
       subject.subscription!(subscription)
-      expect(subscription).not_to be_persisted
+      expect(Subscription.not_deleted.find_by(id: subscription.id)).to be_nil
     end
 
     it "does not remove the subscription if the email address update fails" do


### PR DESCRIPTION
We currently 'hard' delete subscription records when a user unsubscribes to comply with our data retention policy. 

During the forthcoming migration between providers we don't want to do this as we will lose data should we need to rollback.

This PR implements 'soft deletion' on `Subscription` to preserve the data. Once we have successfully completed the migration we can remove the records and revert this PR.

[Trello](https://trello.com/c/aslPwUf1/566-temporarily-change-unsubscribes-to-soft-delete-only)