### PR TITLE
Strip markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'govuk_app_config', '~> 1.2'
 gem 'nokogiri', '~> 1.8'
 gem 'notifications-ruby-client', '~> 2.6'
 gem 'plek', '~> 2.1'
+gem 'redcarpet', '~> 3.4'
 
 gem 'govuk_sidekiq', '~> 3.0'
 gem 'ratelimit', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redcarpet (3.4.0)
     redis (4.0.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
@@ -341,6 +342,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.1)
   ratelimit (~> 1.0)
+  redcarpet (~> 3.4)
   rspec-rails (= 3.7.2)
   ruby-prof (~> 0.17)
   sidekiq-scheduler (~> 2.2)

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -1,3 +1,5 @@
+require 'redcarpet/render_strip'
+
 class ContentChangePresenter
   EMAIL_DATE_FORMAT = "%I:%M %P on %-d %B %Y".freeze
 
@@ -13,7 +15,7 @@ class ContentChangePresenter
     <<~BODY
       [#{title}](#{content_url})
 
-      #{change_note}: #{description}
+      #{strip_markdown(change_note)}: #{strip_markdown(description)}
 
       Updated at #{public_updated_at}
     BODY
@@ -33,5 +35,13 @@ private
 
   def public_updated_at
     content_change.public_updated_at.strftime(EMAIL_DATE_FORMAT)
+  end
+
+  def strip_markdown(string)
+    markdown_stripper.render(string).gsub(/$\n/, "")
+  end
+
+  def markdown_stripper
+    @markdown_stripper ||= Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
   end
 end

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -23,5 +23,29 @@ RSpec.describe ContentChangePresenter do
 
       expect(described_class.call(content_change)).to eq(expected)
     end
+
+    context "when content change contains markdown" do
+      let(:content_change) {
+        build(
+          :content_change, title: "Change title",
+          base_path: "/government/test-slug",
+          change_note:  "#Test change note **markdown** [test](https://gov.uk)",
+          description: "more _markdown_",
+          public_updated_at: Time.parse("10:00 1/1/2018")
+        )
+      }
+
+      it "strips markdown" do
+        expected = <<~CONTENT_CHANGE
+          [Change title](http://www.dev.gov.uk/government/test-slug)
+
+          Test change note markdown test (https://gov.uk): more markdown
+
+          Updated at 10:00 am on 1 January 2018
+        CONTENT_CHANGE
+
+        expect(described_class.call(content_change)).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
We don't want to allow markdown through to Notify from publishing app change notes or descriptions. This PR utilises the redcarpet gem to strip markdown within the content change presenter.

The gem seems to add a `\n` at the end of its output which I've also stripped here.

[Trello](https://trello.com/c/fHzSedir/567-strip-markdown-from-incoming-content)