### PR TITLE
Import digest data from GovDelivery

### DIFF
--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -23,6 +23,8 @@ class ImportGovdeliveryCsv
     build_report
   end
 
+private
+
   def import_row(row)
     subscriber = find_or_create_subscriber(row)
     subscribable = find_subscribable(row)

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -5,11 +5,11 @@ class ImportGovdeliveryCsv
     new(*args).import
   end
 
-  attr_accessor :csv_path, :output_io
+  attr_reader :csv_path, :output_io
 
   def initialize(csv_path, output_io = nil)
-    self.csv_path = csv_path
-    self.output_io = output_io
+    @csv_path = csv_path
+    @output_io = output_io
   end
 
   def import

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -5,10 +5,11 @@ class ImportGovdeliveryCsv
     new(*args).import
   end
 
-  attr_reader :csv_path, :output_io
+  attr_reader :csv_path, :digest_csv_path, :output_io
 
-  def initialize(csv_path, output_io = nil)
+  def initialize(csv_path, digest_csv_path, output_io = nil)
     @csv_path = csv_path
+    @digest_csv_path = digest_csv_path
     @output_io = output_io
   end
 

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -7,7 +7,7 @@ class ImportGovdeliveryCsv
 
   attr_reader :csv_path, :digest_csv_path, :output_io
 
-  def initialize(csv_path, digest_csv_path, output_io = nil)
+  def initialize(csv_path, digest_csv_path, output_io: nil)
     @csv_path = csv_path
     @digest_csv_path = digest_csv_path
     @output_io = output_io

--- a/spec/lib/csv_digest_fixture.csv
+++ b/spec/lib/csv_digest_fixture.csv
@@ -1,0 +1,3 @@
+"DESTINATION","SUBSCRIBER_TYPE","DIGEST_FOR"
+"foo@example.com","EmailSubscriber",0
+"bar@example.com","EmailSubscriber",1

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe ImportGovdeliveryCsv do
     expect(Subscription.third.subscriber_list.title).to eq("Second")
   end
 
+  it "sets the frequencies on the subscriptions" do
+    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+
+    expect(Subscription.first.frequency).to eq(Frequency::IMMEDIATELY)
+    expect(Subscription.second.frequency).to eq(Frequency::DAILY)
+    expect(Subscription.third.frequency).to eq(Frequency::IMMEDIATELY)
+  end
+
   it "is idempotent" do
     described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -110,4 +110,14 @@ RSpec.describe ImportGovdeliveryCsv do
         .to raise_error(/should be WINDOWS-1252/)
     end
   end
+
+  context "when doing a fake import" do
+    it "sets the addresses to AWS success addresses" do
+      described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", fake_import: true)
+
+      expect(Subscription.first.subscriber.address).to eq("success+767e74eab7081c41e0b83630511139d130249666@simulator.amazonses.com")
+      expect(Subscription.second.subscriber.address).to eq("success+1ac2c5ab67ab3279b2de1d2bed879b2a63e59ee7@simulator.amazonses.com")
+      expect(Subscription.third.subscriber.address).to eq("success+767e74eab7081c41e0b83630511139d130249666@simulator.amazonses.com")
+    end
+  end
 end

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ImportGovdeliveryCsv do
     before { second_subscribable.update!(title: "Something else") }
 
     it "logs output to the io object" do
-      described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", io)
+      described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", output_io: io)
       expect(io.string).to eq("..F")
     end
   end

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -8,20 +8,20 @@ RSpec.describe ImportGovdeliveryCsv do
   end
 
   it "creates subscribers and subscriptions" do
-    expect { described_class.import("spec/lib/csv_fixture.csv") }
+    expect { described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
       .to change(Subscriber, :count).by(2)
       .and change(Subscription, :count).by(3)
   end
 
   it "sets the subscriber address from the csv" do
-    described_class.import("spec/lib/csv_fixture.csv")
+    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(Subscriber.first.address).to eq("foo@example.com")
     expect(Subscriber.second.address).to eq("bar@example.com")
   end
 
   it "associates the subscriptions with the subscribers" do
-    described_class.import("spec/lib/csv_fixture.csv")
+    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(Subscription.first.subscriber.address).to eq("foo@example.com")
     expect(Subscription.second.subscriber.address).to eq("bar@example.com")
@@ -29,7 +29,7 @@ RSpec.describe ImportGovdeliveryCsv do
   end
 
   it "associates the subscriptions with the subscribables" do
-    described_class.import("spec/lib/csv_fixture.csv")
+    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(Subscription.first.subscriber_list.title).to eq("First")
     expect(Subscription.second.subscriber_list.title).to eq("First")
@@ -37,15 +37,15 @@ RSpec.describe ImportGovdeliveryCsv do
   end
 
   it "is idempotent" do
-    described_class.import("spec/lib/csv_fixture.csv")
+    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
-    expect { described_class.import("spec/lib/csv_fixture.csv") }
+    expect { described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
       .to change(Subscriber, :count).by(0)
       .and change(Subscription, :count).by(0)
   end
 
   it "returns a report of imported rows" do
-    report = described_class.import("spec/lib/csv_fixture.csv")
+    report = described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(report).to eq(
       success_count: 3,
@@ -58,12 +58,12 @@ RSpec.describe ImportGovdeliveryCsv do
     before { second_subscribable.update!(title: "Something else") }
 
     it "does not import a subscription for that subscribable" do
-      expect { described_class.import("spec/lib/csv_fixture.csv") }
+      expect { described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
         .to change(Subscription, :count).by(2)
     end
 
     it "includes the failed rows in the report" do
-      report = described_class.import("spec/lib/csv_fixture.csv")
+      report = described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
       expect(report).to eq(
         success_count: 2,
@@ -91,14 +91,14 @@ RSpec.describe ImportGovdeliveryCsv do
     before { second_subscribable.update!(title: "Something else") }
 
     it "logs output to the io object" do
-      described_class.import("spec/lib/csv_fixture.csv", io)
+      described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", io)
       expect(io.string).to eq("..F")
     end
   end
 
   context "when the file has the wrong encoding" do
     it "raises an error" do
-      expect { described_class.import("spec/lib/csv_fixture_broken.csv") }
+      expect { described_class.import("spec/lib/csv_fixture_broken.csv", "spec/lib/csv_digest_fixture.csv") }
         .to raise_error(/should be WINDOWS-1252/)
     end
   end


### PR DESCRIPTION
This enables us to also import the digest data from the GovDelivery export CSVs.

I've also updated this to include a `fake_import: true` argument which will convert the email addresses of the subscribers into AWS success email addresses using a SHA1 hash of the original address. This allows us to import the data for a test run while preventing real emails from being sent out.

[Trello Card](https://trello.com/c/R2QWnANZ/594-replace-fake-data-with-anonymised-real-data-for-load-testing)