### PR TITLE
Enable environment variable for override whitelist

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -8,13 +8,13 @@ class DeliveryRequestService
     new.call(*args)
   end
 
-  attr_accessor :provider_name, :provider, :subject_prefix, :overrider
+  attr_reader :provider_name, :provider, :subject_prefix, :overrider
 
   def initialize(config: EmailAlertAPI.config.email_service)
-    self.provider_name = config.fetch(:provider).downcase
-    self.provider = PROVIDERS.fetch(provider_name)
-    self.subject_prefix = config.fetch(:email_subject_prefix)
-    self.overrider = EmailAddressOverrider.new(config)
+    @provider_name = config.fetch(:provider).downcase
+    @provider = PROVIDERS.fetch(provider_name)
+    @subject_prefix = config.fetch(:email_subject_prefix)
+    @overrider = EmailAddressOverrider.new(config)
   end
 
   def call(email:)
@@ -22,7 +22,7 @@ class DeliveryRequestService
 
     subject = "#{subject_prefix}#{email.subject}"
     reference = generate_reference(email)
-    address = overrider.address(email, subject, reference)
+    address = determine_address(email, reference)
 
     MetricsService.email_send_request(provider_name) do
       provider.call(
@@ -54,24 +54,25 @@ private
     "delivery-attempt-for-email-#{email.id}-sent-to-notify-at-#{timestamp}"
   end
 
+  def determine_address(email, reference)
+    overrider.destination_address(email.address).tap do |address|
+      next if address == email.address
+      Rails.logger.info(<<-INFO.strip_heredoc)
+        Overriding email address #{email.address} to #{address}
+        For email with reference: #{reference}
+      INFO
+    end
+  end
+
   class EmailAddressOverrider
-    attr_accessor :email_address_override
+    attr_reader :override_address
 
     def initialize(config)
-      self.email_address_override = config[:email_address_override]
+      @override_address = config[:email_address_override]
     end
 
-    def address(email, subject, reference)
-      return email.address unless email_address_override
-
-      Rails.logger.info(<<-INFO.strip_heredoc)
-        Sending email to #{email.address} (overridden to #{email_address_override})
-        Subject: #{subject}
-        Reference: #{reference}
-        Body: #{email.body}
-      INFO
-
-      email_address_override
+    def destination_address(address)
+      override_address || address
     end
   end
 end

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -65,14 +65,17 @@ private
   end
 
   class EmailAddressOverrider
-    attr_reader :override_address
+    attr_reader :override_address, :whitelist_addresses
 
     def initialize(config)
       @override_address = config[:email_address_override]
+      @whitelist_addresses = Array(config[:email_address_override_whitelist])
     end
 
     def destination_address(address)
-      override_address || address
+      return address unless override_address
+
+      whitelist_addresses.include?(address) ? address : override_address
     end
   end
 end

--- a/config/email_service.yml
+++ b/config/email_service.yml
@@ -3,20 +3,24 @@
 <% email_subject_prefix = "#{env.upcase} - " if env %>
 <% expect_status_update_callbacks = !env %>
 
-development:
+default: &default
   provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "PSEUDO" %>
   email_subject_prefix: <%= email_subject_prefix %>
   email_address_override: <%= ENV["EMAIL_ADDRESS_OVERRIDE"] %>
+  email_address_override_whitelist:
+    <% whitelist = ENV.fetch("EMAIL_ADDRESS_OVERRIDE_WHITELIST", "").split(",").map(&:strip) %>
+    <% whitelist.each do |email| %>
+      - <%= email %>
+    <% end %>
+
+development:
+  <<: *default
   expect_status_update_callbacks: false
 
 test:
-  provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "PSEUDO" %>
-  email_subject_prefix: <%= email_subject_prefix %>
-  email_address_override: <%= ENV["EMAIL_ADDRESS_OVERRIDE"] %>
+  <<: *default
   expect_status_update_callbacks: true
 
 production:
-  provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "NOTIFY" %>
-  email_subject_prefix: <%= email_subject_prefix %>
-  email_address_override: <%= ENV["EMAIL_ADDRESS_OVERRIDE"] %>
+  <<: *default
   expect_status_update_callbacks: <%= expect_status_update_callbacks %>

--- a/doc/transition-from-govdelivery-to-notify.md
+++ b/doc/transition-from-govdelivery-to-notify.md
@@ -23,3 +23,33 @@ When this environment variable set the redirect location that is returned
 as part of a subscriber list JSON serialization. Once this is returning
 frontend apps will redirect users to the Email Alert Frontend signup which
 does not use govdelivery.
+
+### `EMAIL_ADDRESS_OVERRIDE`
+
+By setting this environment variable all emails sent will have their address
+overridden by the specified value. This can be useful in test environments
+when you want to test that the email service sends but not send to any users.
+
+Based on [Notify docs][notify-docs] we can use
+`simulate-delivered@notifications.service.gov.uk` as a means to send fake
+emails to Notify. Based on [Amazon SES][ses-docs] we can use
+`success@simulator.amazonses.com` to send emails through to SES (the underlying
+service Notify uses at the time of writing.
+
+The intention is to transition to using an override here while we are in the
+process of experimenting with importing real data.
+
+[notify-docs]: https://www.notifications.service.gov.uk/integration-testing
+[ses-docs]: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mailbox-simulator.html
+
+### `EMAIL_ADDRESS_OVERRIDE_WHITELIST`
+
+This environment variable takes a comma separated list of email addresses which
+can be used to send emails to a whitelist of recipients despite the above
+described whitelist existing.
+
+This can be used to send emails to a select group of testers while the rest of
+the emails are sent to a smoke test address. The intention is to use this in
+the build up to launch so we can be testing real emails internally until the
+switchover.
+

--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -26,7 +26,9 @@ module EmailAlertAPI
   private
 
     def environment_config(path:)
-      YAML.safe_load(ERB.new(File.read(path)).result).fetch(@environment)
+      YAML.safe_load(
+        ERB.new(File.read(path)).result, [], [], true
+      ).fetch(@environment)
     end
 
     def gov_delivery_config_path

--- a/spec/integration/sending_email_to_a_recipient_spec.rb
+++ b/spec/integration/sending_email_to_a_recipient_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe "Sending an email to a recipient" do
+  let(:email) { create(:email, address: original_address) }
+  let(:original_address) { "original@example.com" }
+  let(:environment) do
+    {
+      EMAIL_SERVICE_PROVIDER: "notify",
+      EMAIL_ADDRESS_OVERRIDE: email_address_override,
+      EMAIL_ADDRESS_OVERRIDE_WHITELIST: email_address_override_whitelist,
+    }
+  end
+  let(:email_address_override) { nil }
+  let(:email_address_override_whitelist) { nil }
+
+  def expect_notify_request_for(email_address:)
+    request = a_request(:post, /fake-notify/)
+        .with(body: hash_including(email_address: email_address))
+    expect(request).to have_been_made
+  end
+
+  before { stub_request(:post, /fake-notify/).to_return(body: {}.to_json) }
+
+  around do |example|
+    config = EmailAlertAPI.config
+    ClimateControl.modify(environment) do
+      EmailAlertAPI.config = EmailAlertAPI::Config.new(Rails.env)
+      example.run
+    end
+    EmailAlertAPI.config = config
+  end
+
+  context "when an override is not set" do
+    it "sends an email to the original address" do
+      DeliveryRequestService.call(email: email)
+      expect_notify_request_for(email_address: original_address)
+    end
+  end
+
+  context "when override is set" do
+    let(:email_address_override) { "override@example.com" }
+
+    it "sends an email to the override address" do
+      DeliveryRequestService.call(email: email)
+      expect_notify_request_for(email_address: "override@example.com")
+    end
+  end
+
+  context "when override is set with an override whitelist" do
+    let(:email_address_override) { "override@example.com" }
+    let(:email_address_override_whitelist) do
+      "whitelist-1@example.com, whitelist-2@example.com, whitelist-3@example.com"
+    end
+    let(:original_address) { "whitelist-1@example.com" }
+
+    it "sends to the whitelist address" do
+      DeliveryRequestService.call(email: email)
+      expect_notify_request_for(email_address: "whitelist-1@example.com")
+    end
+  end
+end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -157,22 +157,63 @@ RSpec.describe DeliveryRequestService do
 
   describe described_class::EmailAddressOverrider do
     let(:config) { EmailAlertAPI.config.email_service }
-    subject { described_class.new(config) }
 
     describe "#destination_address" do
+      subject(:destination_address) do
+        described_class.new(config).destination_address(address)
+      end
+
       context "when an override address is set" do
         let(:config) { { email_address_override: "overriden@example.com" } }
+        let(:address) { "original@example.com" }
 
         it "returns the overridden address" do
-          result = subject.destination_address("original@example.com")
-          expect(result).to eq("overriden@example.com")
+          expect(destination_address).to eq("overriden@example.com")
         end
       end
 
       context "when an override address is not set" do
+        let(:address) { "original@example.com" }
+
         it "returns the original address" do
-          result = subject.destination_address("original@example.com")
-          expect(result).to eq("original@example.com")
+          expect(destination_address).to eq("original@example.com")
+        end
+      end
+
+      context "when an override address is set and whitelist addresses are set" do
+        let(:config) do
+          {
+            email_address_override: "overriden@example.com",
+            email_address_override_whitelist: ["whitelist@example.com"],
+          }
+        end
+
+        context "when the argument is a whitelist address" do
+          let(:address) { "whitelist@example.com" }
+
+          it "returns the whitelisted address" do
+            expect(destination_address).to eq("whitelist@example.com")
+          end
+        end
+
+        context "when the argument is not a whitelist address" do
+          let(:address) { "original@example.com" }
+
+          it "returns the overriden address" do
+            expect(destination_address).to eq("overriden@example.com")
+          end
+        end
+      end
+
+      context "when an override address is not set and whitelist addresses are set" do
+        let(:config) do
+          { email_address_override_whitelist: ["whitelist@example.com"] }
+        end
+
+        let(:address) { "original@example.com" }
+
+        it "returns the original address" do
+          expect(destination_address).to eq("original@example.com")
         end
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/CDYgpQDY/565-add-flags-to-enable-migration-from-govdelivery-to-notify

This sets up an additional environment variable so that we can have a few email addresses that receive emails despite the rest of them going to a specific address.

For example:
If we have these env vars
```
EMAIL_ADDRESS_OVERRIDE=simulate-delivered@notifications.service.gov.uk
EMAIL_ADDRESS_OVERRIDE_WHITELIST=name@gov.uk,other-name@gov.uk
```

Then emails to name@gov.uk which will make it through to a user but an email to say name@me.com will go to simulate-delivered@notifications.service.gov.uk