### PR TITLE
Ignore duplicate content changes

### DIFF
--- a/spec/integration/notifications_spec.rb
+++ b/spec/integration/notifications_spec.rb
@@ -2,20 +2,22 @@ RSpec.describe "Receiving a notification", type: :request do
   context "with authentication and authorisation" do
     describe "#create" do
       let(:body) {
-        <<-BODY.strip_heredoc
+        <<~BODY
           <div>
             <div>Travel advice</div>
           </div>
         BODY
       }
+
       let(:expected_body) {
-        <<-BODY.strip_heredoc
+        <<~BODY
           <div>
             <div>Travel advice</div>
           </div>
           <span data-govuk-request-id="12345-67890"></span>
         BODY
       }
+
       let(:notification_params) {
         {
           subject: "This is a subject",

--- a/spec/integration/notifications_spec.rb
+++ b/spec/integration/notifications_spec.rb
@@ -24,9 +24,13 @@ RSpec.describe "Receiving a notification", type: :request do
           body: body,
           tags: {
             topics: ["oil-and-gas/licensing"]
-          }
+          },
+          public_updated_at: "2018-02-07 10:00:00",
+          base_path: "/government/test/document",
+          content_id: "21b21a21-0534-46ce-bb70-c996a4edd492",
         }
       }
+
       let(:expected_notification_params) {
         notification_params
           .merge(links: {})
@@ -73,6 +77,32 @@ RSpec.describe "Receiving a notification", type: :request do
         )
 
         post "/notifications", params: notification_params.merge(format: :json)
+      end
+
+      context "when a duplicate content change exists" do
+        before do
+          create(
+            :content_change,
+            public_updated_at: "2018-02-07 10:00:00",
+            base_path: "/government/test/document",
+            content_id: "21b21a21-0534-46ce-bb70-c996a4edd492"
+          )
+        end
+
+        it "returns a 409" do
+          post "/notifications", params: notification_params.merge(format: :json)
+          expect(response.status).to eq(409)
+        end
+
+        it "doesn't queue a NotificationWorker job" do
+          expect(NotificationWorker).not_to receive(:perform_async)
+          post "/notifications", params: notification_params.merge(format: :json)
+        end
+
+        it "doesn't call NotificationHandlerService" do
+          expect(NotificationHandlerService).not_to receive(:call)
+          post "/notifications", params: notification_params.merge(format: :json)
+        end
       end
     end
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -54,7 +54,7 @@ module FeatureHelpers
   def create_content_change(overrides = {})
     params = {
       base_path: "/base-path",
-      content_id: "00000000-0000-0000-0000-000000000000",
+      content_id: SecureRandom.uuid,
       change_note: "Change note",
       description: "Description",
       document_type: "document_type",


### PR DESCRIPTION
In the event that `notifications#create` times out the client apps may retry the request despite it having already made it through.

This PR returns a conflict if there is already a `ContentChange` stored with the same `base_path`, `content_id` and `public_updated_at`. Assuming we agree these are a reasonable indicator of duplicate-ish-ness we should add this as a validation on `ContentChange` and a DB constraint but while we need to also prevent Govdelivery calls this is easier to handle in the controller for now. 

We'll also need to clean up the data before adding a DB constraint as there are already duplicates in there.