### PR TITLE
Remove status-updates healthcheck

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -33,7 +33,6 @@ private
       QueueSizeHealthcheck.new,
       RedisHealthcheck.new,
       RetrySizeHealthcheck.new,
-      StatusUpdateHealthcheck.new,
       TechnicalFailureHealthcheck.new,
     ]
   end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe "Healthcheck", type: :request do
       queue_size:        { status: "ok", queues: a_kind_of(Hash) },
       redis:             { status: "ok" },
       retry_size:        { status: "ok", retry_size: 0 },
-      status_update:     hash_including(status: "ok", pending: 0),
       technical_failure: hash_including(status: "ok", failing: 0),
     )
   end


### PR DESCRIPTION
Status updates are currently unhealthily disabled so this PR removes the health check for them.

This will be reverted in a few days when they are reinstated.