### PR TITLE
Speed up GovDelivery import task

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ tags via the external services.
 * Check that the configuration in `config/database.yml` is right
 * Run `bundle exec rake db:setup` to load the database
 
-
 ### Running the application
 
-`./startup.sh`
+```bash
+$ ./startup.sh
+```
 
 email-alert-api runs on port 3088
 sidekiq-monitoring for email-alert-api uses 3089
@@ -52,6 +53,16 @@ sidekiq-monitoring for email-alert-api uses 3089
 
 * Run `RAILS_ENV=test bundle exec rake db:setup` to load the database
 * Run `bundle exec rspec` to run the tests
+
+### Tasks
+
+#### Import from GovDelivery export
+
+To import the data from a GovDelivery export, you can use a Rake task:
+
+```bash
+$ bundle exec rake import_govdelivery_csv[subscriptions.csv,digests.csv]
+```
 
 ### GovDelivery interaction
 
@@ -127,6 +138,7 @@ subscription or a `200 OK` if the subscription already exists.
 ### healthcheck API
 
 A queue health check endpoint is available at /healthcheck
+
 ```json
 {
   "checks": {
@@ -153,13 +165,13 @@ In the event of a GovDelivery outage the Email Alert API will enqueue failed not
 in the Sidekiq retry queue.
 The retry queue size can be viewed via Sidekiq monitoring or by issuing the following command in a rails console:
 
-```
+```ruby
 Sidekiq::RetrySet.new.size
 ```
 
 To manually retry all jobs in the retry queue:
 
-```
+```ruby
 Sidekiq::RetrySet.new.retry_all
 ```
 

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -93,7 +93,9 @@ private
 
     records = CSV
       .foreach(subscriptions_csv_path, headers: true, encoding: "WINDOWS-1252")
-      .map do |row|
+      .with_index(1).map do |row, i|
+        puts "Processed #{i} records" if (i % 10000).zero?
+
         subscriber = subscriber_for_row(row)
         subscribable = subscribable_for_row(row)
 

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -5,18 +5,18 @@ class ImportGovdeliveryCsv
     new(*args).import
   end
 
-  attr_reader :csv_path, :digest_csv_path, :fake_import
+  attr_reader :subscriptions_csv_path, :digests_csv_path, :fake_import
 
-  def initialize(csv_path, digest_csv_path, fake_import: false)
-    @csv_path = csv_path
-    @digest_csv_path = digest_csv_path
+  def initialize(subscriptions_csv_path, digests_csv_path, fake_import: false)
+    @subscriptions_csv_path = subscriptions_csv_path
+    @digests_csv_path = digests_csv_path
     @fake_import = fake_import
   end
 
   def import
     check_encoding_is_windows_1252
 
-    CSV.foreach(csv_path, headers: true, encoding: "WINDOWS-1252") do |row|
+    CSV.foreach(subscriptions_csv_path, headers: true, encoding: "WINDOWS-1252") do |row|
       with_reporting(row) { import_row(row) }
     end
 
@@ -63,7 +63,7 @@ private
 
   def digest_data
     @digest_data ||= begin
-      CSV.foreach(digest_csv_path, headers: true, encoding: "WINDOWS-1252").each_with_object({}) do |row, hash|
+      CSV.foreach(digests_csv_path, headers: true, encoding: "WINDOWS-1252").each_with_object({}) do |row, hash|
         hash[fetch_address_for_row(row)] = digest_frequency_for_row(row.fetch("DIGEST_FOR"))
       end
     end
@@ -112,7 +112,7 @@ private
   end
 
   def check_encoding_is_windows_1252
-    File.readlines(csv_path).each do |line|
+    File.readlines(subscriptions_csv_path).each do |line|
       if line.include?("Principe") && !line.include?("São Tomé and Principe")
         message = "The CSV has the wrong encoding. It should be WINDOWS-1252."
         message += "\nYou can set the encoding in LibreOffice with:"

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -1,19 +1,17 @@
 require "csv"
 
 class ImportGovdeliveryCsv
-  def self.import(*args)
-    new(*args).import
-  end
-
-  attr_reader :subscriptions_csv_path, :digests_csv_path, :fake_import
-
   def initialize(subscriptions_csv_path, digests_csv_path, fake_import: false)
     @subscriptions_csv_path = subscriptions_csv_path
     @digests_csv_path = digests_csv_path
     @fake_import = fake_import
   end
 
-  def import
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
     check_encoding_is_windows_1252
 
     CSV.foreach(subscriptions_csv_path, headers: true, encoding: "WINDOWS-1252") do |row|
@@ -24,6 +22,8 @@ class ImportGovdeliveryCsv
   end
 
 private
+
+  attr_reader :subscriptions_csv_path, :digests_csv_path, :fake_import
 
   def import_row(row)
     subscriber = find_or_create_subscriber(row)

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -99,7 +99,7 @@ private
 
         next unless subscribable
 
-        frequency = digest_frequencies.fetch(subscriber.address, Frequency::IMMEDIATELY)
+        frequency = digest_frequencies.fetch(subscriber.address, Frequency::DAILY)
 
         next if Subscription.where(
           subscriber_id: subscriber.id,

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -5,13 +5,12 @@ class ImportGovdeliveryCsv
     new(*args).import
   end
 
-  attr_reader :csv_path, :digest_csv_path, :fake_import, :output_io
+  attr_reader :csv_path, :digest_csv_path, :fake_import
 
-  def initialize(csv_path, digest_csv_path, fake_import: false, output_io: nil)
+  def initialize(csv_path, digest_csv_path, fake_import: false)
     @csv_path = csv_path
     @digest_csv_path = digest_csv_path
     @fake_import = fake_import
-    @output_io = output_io
   end
 
   def import
@@ -97,10 +96,8 @@ private
 
     begin
       yield
-      output(".")
       @success_count += 1
     rescue StandardError => error
-      output("F")
       @failed_count += 1
       @failed_rows << [error.message, row.to_h]
     end
@@ -112,10 +109,6 @@ private
       failed_count: @failed_count,
       failed_rows: @failed_rows,
     }
-  end
-
-  def output(message)
-    output_io.print(message) if output_io
   end
 
   def check_encoding_is_windows_1252

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -26,6 +26,8 @@ private
 
   attr_reader :subscriptions_csv_path, :digests_csv_path, :fake_import
 
+  DEFAULT_DIGEST_FREQUENCY = Frequency::IMMEDIATELY
+
   def address_from_row(row)
     address = row.fetch("DESTINATION")
 
@@ -49,7 +51,7 @@ private
   def import_row(row)
     subscriber = subscriber_for_row(row)
     subscribable = subscribable_for_row(row)
-    frequency = digest_frequencies.fetch(subscriber.address)
+    frequency = digest_frequencies.fetch(subscriber.address, DEFAULT_DIGEST_FREQUENCY)
 
     validate_name(subscribable, row)
 

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -13,6 +13,7 @@ class ImportGovdeliveryCsv
 
   def call
     check_encoding_is_windows_1252
+    get_user_confirmation
 
     CSV.foreach(subscriptions_csv_path, headers: true, encoding: "WINDOWS-1252") do |row|
       with_reporting(row) { import_row(row) }
@@ -124,5 +125,22 @@ private
         raise EncodingError, message
       end
     end
+  end
+
+  def get_user_confirmation
+    puts "You are about to import the following data:"
+    puts " > Subscriptions from #{subscriptions_csv_path}"
+    puts " > Digests from #{digests_csv_path}"
+
+    if fake_import
+      puts " > The email addresses will be anonymised."
+    else
+      puts " > This is a real import. The email addresses will NOT be anonymised."
+    end
+
+    puts
+    puts "Continue? (Press Ctrl+C to cancel)"
+
+    $stdin.gets
   end
 end

--- a/lib/tasks/import_govdelivery_csv.rake
+++ b/lib/tasks/import_govdelivery_csv.rake
@@ -1,6 +1,8 @@
-task import_govdelivery_csv: :environment do
-  csv_path = ENV.fetch("CSV_PATH")
-  report = ImportGovdeliveryCsv.import(csv_path)
+task :import_govdelivery_csv, %i(subscriptions_csv_path digests_csv_path) => :environment do |_, args|
+  raise "Missing subscriptions CSV path." if args[:subscriptions_csv_path].nil?
+  raise "Missing digests CSV path." if args[:digests_csv_path].nil?
+
+  report = ImportGovdeliveryCsv.import(args[:subscriptions_csv_path], args[:digests_csv_path])
 
   puts
   puts "Successful rows: #{report.fetch(:success_count)}"

--- a/lib/tasks/import_govdelivery_csv.rake
+++ b/lib/tasks/import_govdelivery_csv.rake
@@ -2,7 +2,7 @@ task :import_govdelivery_csv, %i(subscriptions_csv_path digests_csv_path) => :en
   raise "Missing subscriptions CSV path." if args[:subscriptions_csv_path].nil?
   raise "Missing digests CSV path." if args[:digests_csv_path].nil?
 
-  report = ImportGovdeliveryCsv.import(args[:subscriptions_csv_path], args[:digests_csv_path])
+  report = ImportGovdeliveryCsv.call(args[:subscriptions_csv_path], args[:digests_csv_path])
 
   puts
   puts "Successful rows: #{report.fetch(:success_count)}"

--- a/lib/tasks/import_govdelivery_csv.rake
+++ b/lib/tasks/import_govdelivery_csv.rake
@@ -2,13 +2,5 @@ task :import_govdelivery_csv, %i(subscriptions_csv_path digests_csv_path) => :en
   raise "Missing subscriptions CSV path." if args[:subscriptions_csv_path].nil?
   raise "Missing digests CSV path." if args[:digests_csv_path].nil?
 
-  report = ImportGovdeliveryCsv.call(args[:subscriptions_csv_path], args[:digests_csv_path])
-
-  puts
-  puts "Successful rows: #{report.fetch(:success_count)}"
-  puts "Failed rows: #{report.fetch(:failed_count)}"
-
-  report.fetch(:failed_rows).each do |failure|
-    puts " - #{failure.inspect}"
-  end
+  ImportGovdeliveryCsv.call(args[:subscriptions_csv_path], args[:digests_csv_path])
 end

--- a/lib/tasks/import_govdelivery_csv.rake
+++ b/lib/tasks/import_govdelivery_csv.rake
@@ -1,6 +1,6 @@
 task import_govdelivery_csv: :environment do
   csv_path = ENV.fetch("CSV_PATH")
-  report = ImportGovdeliveryCsv.import(csv_path, $stdout)
+  report = ImportGovdeliveryCsv.import(csv_path)
 
   puts
   puts "Successful rows: #{report.fetch(:success_count)}"

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -8,20 +8,20 @@ RSpec.describe ImportGovdeliveryCsv do
   end
 
   it "creates subscribers and subscriptions" do
-    expect { described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
+    expect { described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
       .to change(Subscriber, :count).by(2)
       .and change(Subscription, :count).by(3)
   end
 
   it "sets the subscriber address from the csv" do
-    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+    described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(Subscriber.first.address).to eq("foo@example.com")
     expect(Subscriber.second.address).to eq("bar@example.com")
   end
 
   it "associates the subscriptions with the subscribers" do
-    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+    described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(Subscription.first.subscriber.address).to eq("foo@example.com")
     expect(Subscription.second.subscriber.address).to eq("bar@example.com")
@@ -29,7 +29,7 @@ RSpec.describe ImportGovdeliveryCsv do
   end
 
   it "associates the subscriptions with the subscribables" do
-    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+    described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(Subscription.first.subscriber_list.title).to eq("First")
     expect(Subscription.second.subscriber_list.title).to eq("First")
@@ -37,7 +37,7 @@ RSpec.describe ImportGovdeliveryCsv do
   end
 
   it "sets the frequencies on the subscriptions" do
-    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+    described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(Subscription.first.frequency).to eq(Frequency::IMMEDIATELY)
     expect(Subscription.second.frequency).to eq(Frequency::DAILY)
@@ -45,15 +45,15 @@ RSpec.describe ImportGovdeliveryCsv do
   end
 
   it "is idempotent" do
-    described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+    described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
-    expect { described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
+    expect { described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
       .to change(Subscriber, :count).by(0)
       .and change(Subscription, :count).by(0)
   end
 
   it "returns a report of imported rows" do
-    report = described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+    report = described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
     expect(report).to eq(
       success_count: 3,
@@ -66,12 +66,12 @@ RSpec.describe ImportGovdeliveryCsv do
     before { second_subscribable.update!(title: "Something else") }
 
     it "does not import a subscription for that subscribable" do
-      expect { described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
+      expect { described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
         .to change(Subscription, :count).by(2)
     end
 
     it "includes the failed rows in the report" do
-      report = described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+      report = described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
       expect(report).to eq(
         success_count: 2,
@@ -95,14 +95,14 @@ RSpec.describe ImportGovdeliveryCsv do
 
   context "when the file has the wrong encoding" do
     it "raises an error" do
-      expect { described_class.import("spec/lib/csv_fixture_broken.csv", "spec/lib/csv_digest_fixture.csv") }
+      expect { described_class.call("spec/lib/csv_fixture_broken.csv", "spec/lib/csv_digest_fixture.csv") }
         .to raise_error(/should be WINDOWS-1252/)
     end
   end
 
   context "when doing a fake import" do
     it "sets the addresses to AWS success addresses" do
-      described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", fake_import: true)
+      described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", fake_import: true)
 
       expect(Subscription.first.subscriber.address).to eq("success+767e74eab7081c41e0b83630511139d130249666@simulator.amazonses.com")
       expect(Subscription.second.subscriber.address).to eq("success+1ac2c5ab67ab3279b2de1d2bed879b2a63e59ee7@simulator.amazonses.com")

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -57,44 +57,12 @@ RSpec.describe ImportGovdeliveryCsv do
       .and change(Subscription, :count).by(0)
   end
 
-  it "returns a report of imported rows" do
-    report = described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
-
-    expect(report).to eq(
-      success_count: 3,
-      failed_count: 0,
-      failed_rows: [],
-    )
-  end
-
   context "when the subscribable name doesn't match the csv" do
     before { second_subscribable.update!(title: "Something else") }
 
-    it "does not import a subscription for that subscribable" do
+    it "should raise an exception" do
       expect { described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
-        .to change(Subscription, :count).by(2)
-    end
-
-    it "includes the failed rows in the report" do
-      report = described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
-
-      expect(report).to eq(
-        success_count: 2,
-        failed_count: 1,
-        failed_rows: [
-          [
-            "Name mismatch: Second != Something else",
-            {
-              "TOPIC_ID" => "67890",
-              "TOPIC_NAME" => "Second",
-              "TOPIC_CODE" => "UKGOVUK_222",
-              "TOPIC_VISIBILITY" => "1",
-              "SUBSCRIBER_ID" => "1111111111",
-              "DESTINATION" => "foo@example.com"
-            },
-          ],
-        ]
-      )
+        .to raise_error(/Name mismatch/)
     end
   end
 

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -93,17 +93,6 @@ RSpec.describe ImportGovdeliveryCsv do
     end
   end
 
-  context "when an io object is provided" do
-    let(:io) { StringIO.new }
-
-    before { second_subscribable.update!(title: "Something else") }
-
-    it "logs output to the io object" do
-      described_class.import("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", output_io: io)
-      expect(io.string).to eq("..F")
-    end
-  end
-
   context "when the file has the wrong encoding" do
     it "raises an error" do
       expect { described_class.import("spec/lib/csv_fixture_broken.csv", "spec/lib/csv_digest_fixture.csv") }

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe ImportGovdeliveryCsv do
+  before do
+    allow($stdin).to receive(:gets).and_return("<enter>")
+    allow($stdout).to receive(:write)
+  end
+
   let!(:first_subscribable) do
     create(:subscriber_list, gov_delivery_id: "UKGOVUK_111", title: "First")
   end

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -57,15 +57,6 @@ RSpec.describe ImportGovdeliveryCsv do
       .and change(Subscription, :count).by(0)
   end
 
-  context "when the subscribable name doesn't match the csv" do
-    before { second_subscribable.update!(title: "Something else") }
-
-    it "should raise an exception" do
-      expect { described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
-        .to raise_error(/Name mismatch/)
-    end
-  end
-
   context "when the file has the wrong encoding" do
     it "raises an error" do
       expect { described_class.call("spec/lib/csv_fixture_broken.csv", "spec/lib/csv_digest_fixture.csv") }


### PR DESCRIPTION
This PR reworks the GovDelivery CSV import task with the intention of speeding it up but has ended up changing how it works. Some of the key changes include:

- Default to daily frequency when the digest data is unavailable (this may be contentious, but there are 100k subscription entries missing in the digest data and some of those include people who are subscribed to hundreds of subscriptions)
- Import the data in bulk (this means it's no longer possible to top up the data later)
- Topics that doesn't exist get ignored (since they won't be receiving emails anyway as the topic doesn't exist in production)

In terms of review, it's probably easier not to consider what's changed, but to consider the final code of the importer.

Running the dry run should help to identify any problems with this process and we can iterate on it in the future.

Importing all of the data onto my dev VM took over 12 hours before, and it took just under an hour after running with this.

[Trello Card](https://trello.com/c/Qe1wUlW8/603-speed-up-data-import)