### PR TITLE
Speed up status update handling

### DIFF
--- a/db/migrate/20180212121358_add_unique_index_on_reference.rb
+++ b/db/migrate/20180212121358_add_unique_index_on_reference.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexOnReference < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :delivery_attempts, :reference, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180205165003) do
+ActiveRecord::Schema.define(version: 20180212121358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20180205165003) do
     t.string "signon_user_uid"
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"
+    t.index ["reference"], name: "index_delivery_attempts_on_reference", unique: true
   end
 
   create_table "digest_run_subscribers", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     email
     status :sending
     provider :notify
-    reference "reference"
+    reference { SecureRandom.uuid }
   end
 
   factory :digest_run do

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe StatusUpdateService do
     let(:status) { "unknown" }
 
     it "raises an error" do
-      expect { status_update }.to raise_error(ArgumentError)
+      expect { status_update }.to raise_error(ActiveRecord::StatementInvalid)
     end
   end
 end


### PR DESCRIPTION
Currently a normal status update will require two queries, one lookup and one update. Instead we can rework this so that only special status updates (permenant failures, ones that happen a lot less often) require the lookup and update query separately.

Also we've added an index on the `reference` field on delivery attempts since we'll be using them a lot in the status updates.