### PR TITLE
Avoid initialising delivery attempts when fetching emails

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,3 +1,5 @@
 class Email < ApplicationRecord
+  has_many :delivery_attempts
+
   validates :address, :subject, :body, presence: true
 end

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -44,7 +44,7 @@ private
   end
 
   def email
-    @email ||= DeliveryAttempt.find_by!(reference: reference).email
+    @email ||= Email.joins(:delivery_attempts).find_by(delivery_attempts: { reference: reference })
   end
 
   def subscriber


### PR DESCRIPTION
We can use a join on this query to avoid unnecessary initialisation of the delivery attempt class.