### PR TITLE
Update email presentation

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -40,9 +40,9 @@ private
 
   def subject
     if digest_run.daily?
-      "GOV.UK Daily Update"
+      "GOV.UK: your daily update"
     else
-      "GOV.UK Weekly Update"
+      "GOV.UK: your weekly update"
     end
   end
 

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -41,7 +41,7 @@ private
   end
 
   def subject(content_change)
-    "GOV.UK Update - #{content_change.title}"
+    "GOV.UK update - #{content_change.title}"
   end
 
   def body(content_change, subscription)

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -1,7 +1,7 @@
 require 'redcarpet/render_strip'
 
 class ContentChangePresenter
-  EMAIL_DATE_FORMAT = "%I:%M %P on %-d %B %Y".freeze
+  EMAIL_DATE_FORMAT = "%l:%M%P, %-d %B %Y".freeze
 
   def initialize(content_change)
     @content_change = content_change

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -15,9 +15,9 @@ class ContentChangePresenter
     <<~BODY
       [#{title}](#{content_url})
 
-      #{strip_markdown(change_note)}: #{strip_markdown(description)}
+      #{strip_markdown(description)}
 
-      Updated at #{public_updated_at}
+      #{public_updated_at}: #{strip_markdown(change_note)}
     BODY
   end
 

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -111,14 +111,14 @@ RSpec.describe DigestEmailBuilder do
 
   context "daily" do
     it "sets the subject" do
-      expect(email.subject).to eq("GOV.UK Daily Update")
+      expect(email.subject).to eq("GOV.UK: your daily update")
     end
   end
 
   context "weekly" do
     let(:digest_run) { double(daily?: false) }
     it "sets the subject" do
-      expect(email.subject).to eq("GOV.UK Weekly Update")
+      expect(email.subject).to eq("GOV.UK: your weekly update")
     end
   end
 end

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ImmediateEmailBuilder do
     end
 
     it "sets the subject" do
-      expect(email.subject).to eq("GOV.UK Update - Title")
+      expect(email.subject).to eq("GOV.UK update - Title")
     end
 
     it "sets the body and unsubscribe links" do

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -18,17 +18,17 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Title one](http://www.dev.gov.uk/base-path)
 
-      Change note one: Description one
+      Description one
 
-      Updated at 10:00 am on 1 January 2017
+      10:00 am on 1 January 2017: Change note one
 
       ---
 
       [Title two](http://www.dev.gov.uk/base-path)
 
-      Change note two: Description two
+      Description two
 
-      Updated at 09:00 am on 1 January 2017
+      09:00 am on 1 January 2017: Change note two
 
       ---
 
@@ -40,17 +40,17 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Title four](http://www.dev.gov.uk/base-path)
 
-      Change note four: Description four
+      Description four
 
-      Updated at 09:30 am on 1 January 2017
+      09:30 am on 1 January 2017: Change note four
 
       ---
 
       [Title three](http://www.dev.gov.uk/base-path)
 
-      Change note three: Description three
+      Description three
 
-      Updated at 09:00 am on 1 January 2017
+      09:00 am on 1 January 2017: Change note three
 
       ---
 
@@ -64,17 +64,17 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Title one](http://www.dev.gov.uk/base-path)
 
-      Change note one: Description one
+      Description one
 
-      Updated at 10:00 am on 1 January 2017
+      10:00 am on 1 January 2017: Change note one
 
       ---
 
       [Title two](http://www.dev.gov.uk/base-path)
 
-      Change note two: Description two
+      Description two
 
-      Updated at 09:00 am on 1 January 2017
+      09:00 am on 1 January 2017: Change note two
 
       ---
 
@@ -224,17 +224,17 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Title one](http://www.dev.gov.uk/base-path)
 
-      Change note one: Description one
+      Description one
 
-      Updated at 10:00 am on 28 December 2016
+      10:00 am on 28 December 2016: Change note one
 
       ---
 
       [Title two](http://www.dev.gov.uk/base-path)
 
-      Change note two: Description two
+      Description two
 
-      Updated at 09:00 am on 27 December 2016
+      09:00 am on 27 December 2016: Change note two
 
       ---
 
@@ -246,17 +246,17 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Title four](http://www.dev.gov.uk/base-path)
 
-      Change note four: Description four
+      Description four
 
-      Updated at 09:30 am on 1 January 2017
+      09:30 am on 1 January 2017: Change note four
 
       ---
 
       [Title three](http://www.dev.gov.uk/base-path)
 
-      Change note three: Description three
+      Description three
 
-      Updated at 09:00 am on 30 December 2016
+      09:00 am on 30 December 2016: Change note three
 
       ---
 
@@ -270,17 +270,17 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Title one](http://www.dev.gov.uk/base-path)
 
-      Change note one: Description one
+      Description one
 
-      Updated at 10:00 am on 28 December 2016
+      10:00 am on 28 December 2016: Change note one
 
       ---
 
       [Title two](http://www.dev.gov.uk/base-path)
 
-      Change note two: Description two
+      Description two
 
-      Updated at 09:00 am on 27 December 2016
+      09:00 am on 27 December 2016: Change note two
 
       ---
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK Daily Update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your daily update")))
       .with(
         body: hash_including(
           personalisation: hash_including(
@@ -201,7 +201,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     second_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-two@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK Daily Update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your daily update")))
       .with(
         body: hash_including(
           personalisation: hash_including(
@@ -393,7 +393,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK Weekly Update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your weekly update")))
       .with(
         body: hash_including(
           personalisation: hash_including(
@@ -405,7 +405,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     second_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-two@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK Weekly Update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your weekly update")))
       .with(
         body: hash_including(
           personalisation: hash_including(

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description one
 
-      10:00 am on 1 January 2017: Change note one
+      10:00am, 1 January 2017: Change note one
 
       ---
 
@@ -28,7 +28,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description two
 
-      09:00 am on 1 January 2017: Change note two
+       9:00am, 1 January 2017: Change note two
 
       ---
 
@@ -42,7 +42,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description four
 
-      09:30 am on 1 January 2017: Change note four
+       9:30am, 1 January 2017: Change note four
 
       ---
 
@@ -50,7 +50,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description three
 
-      09:00 am on 1 January 2017: Change note three
+       9:00am, 1 January 2017: Change note three
 
       ---
 
@@ -66,7 +66,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description one
 
-      10:00 am on 1 January 2017: Change note one
+      10:00am, 1 January 2017: Change note one
 
       ---
 
@@ -74,7 +74,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description two
 
-      09:00 am on 1 January 2017: Change note two
+       9:00am, 1 January 2017: Change note two
 
       ---
 
@@ -226,7 +226,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description one
 
-      10:00 am on 28 December 2016: Change note one
+      10:00am, 28 December 2016: Change note one
 
       ---
 
@@ -234,7 +234,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description two
 
-      09:00 am on 27 December 2016: Change note two
+       9:00am, 27 December 2016: Change note two
 
       ---
 
@@ -248,7 +248,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description four
 
-      09:30 am on 1 January 2017: Change note four
+       9:30am, 1 January 2017: Change note four
 
       ---
 
@@ -256,7 +256,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description three
 
-      09:00 am on 30 December 2016: Change note three
+       9:00am, 30 December 2016: Change note three
 
       ---
 
@@ -272,7 +272,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description one
 
-      10:00 am on 28 December 2016: Change note one
+      10:00am, 28 December 2016: Change note one
 
       ---
 
@@ -280,7 +280,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       Description two
 
-      09:00 am on 27 December 2016: Change note two
+       9:00am, 27 December 2016: Change note two
 
       ---
 

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe "Sending an email", type: :request do
     expect(address).to eq("test@test.com")
     expect(subject).to eq("GOV.UK Update - Title")
 
-    expect(body).to include("Change note: Description")
+    expect(body).to include("Description")
     expect(body).to include("gov.uk/base-path")
-    expect(body).to include("Updated at 12:00 am on 1 January 2017")
+    expect(body).to include("12:00 am on 1 January 2017: Change note")
 
     expect(body).to include("Unsubscribe from [Example]")
     expect(body).to include("gov.uk/email/unsubscribe/")

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sending an email", type: :request do
     body = email_data.dig(:personalisation, :body)
 
     expect(address).to eq("test@test.com")
-    expect(subject).to eq("GOV.UK Update - Title")
+    expect(subject).to eq("GOV.UK update - Title")
 
     expect(body).to include("Description")
     expect(body).to include("gov.uk/base-path")

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Sending an email", type: :request do
 
     expect(body).to include("Description")
     expect(body).to include("gov.uk/base-path")
-    expect(body).to include("12:00 am on 1 January 2017: Change note")
+    expect(body).to include("12:00am, 1 January 2017: Change note")
 
     expect(body).to include("Unsubscribe from [Example]")
     expect(body).to include("gov.uk/email/unsubscribe/")

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe ContentChangePresenter do
       expected = <<~CONTENT_CHANGE
         [Change title](http://www.dev.gov.uk/government/test-slug)
 
-        Test change note: Test description
+        Test description
 
-        Updated at 10:00 am on 1 January 2018
+        10:00 am on 1 January 2018: Test change note
       CONTENT_CHANGE
 
       expect(described_class.call(content_change)).to eq(expected)
@@ -39,9 +39,9 @@ RSpec.describe ContentChangePresenter do
         expected = <<~CONTENT_CHANGE
           [Change title](http://www.dev.gov.uk/government/test-slug)
 
-          Test change note markdown test (https://gov.uk): more markdown
+          more markdown
 
-          Updated at 10:00 am on 1 January 2018
+          10:00 am on 1 January 2018: Test change note markdown test (https://gov.uk)
         CONTENT_CHANGE
 
         expect(described_class.call(content_change)).to eq(expected)

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ContentChangePresenter do
 
         Test description
 
-        10:00 am on 1 January 2018: Test change note
+        10:00am, 1 January 2018: Test change note
       CONTENT_CHANGE
 
       expect(described_class.call(content_change)).to eq(expected)
@@ -41,7 +41,7 @@ RSpec.describe ContentChangePresenter do
 
           more markdown
 
-          10:00 am on 1 January 2018: Test change note markdown test (https://gov.uk)
+          10:00am, 1 January 2018: Test change note markdown test (https://gov.uk)
         CONTENT_CHANGE
 
         expect(described_class.call(content_change)).to eq(expected)


### PR DESCRIPTION
These small changes bring the immediate and digest emails more into line 
with the examples we've got mocked up in Notify. 
Comes from: https://trello.com/c/aTBCNJTb/604-iterate-the-templated-content-sent-in-emails