### PR TITLE
Manually call GC.start

### DIFF
--- a/app/workers/daily_digest_initiator_worker.rb
+++ b/app/workers/daily_digest_initiator_worker.rb
@@ -1,5 +1,9 @@
 class DailyDigestInitiatorWorker < DigestInitiatorWorker
   def perform
+    GC.start
+
     DigestInitiatorService.call(range: Frequency::DAILY)
+
+    GC.start
   end
 end

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -4,6 +4,8 @@ class DigestEmailGenerationWorker
   sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)
+    GC.start
+
     @digest_run_subscriber = DigestRunSubscriber.includes(:subscriber, :digest_run).find(digest_run_subscriber_id)
     @subscriber = digest_run_subscriber.subscriber
     @digest_run = digest_run_subscriber.digest_run
@@ -18,6 +20,8 @@ class DigestEmailGenerationWorker
 
       digest_run.check_and_mark_complete!
     end
+
+    GC.start
   end
 
 private

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -4,7 +4,7 @@ class DigestEmailGenerationWorker
   sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)
-    @digest_run_subscriber = DigestRunSubscriber.find(digest_run_subscriber_id)
+    @digest_run_subscriber = DigestRunSubscriber.includes(:subscriber, :digest_run).find(digest_run_subscriber_id)
     @subscriber = digest_run_subscriber.subscriber
     @digest_run = digest_run_subscriber.digest_run
 

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -7,6 +7,8 @@ class ImmediateEmailGenerationWorker
 
   def perform
     ensure_only_running_once do
+      GC.start
+
       subscription_contents.find_in_batches do |group|
         to_queue = []
 
@@ -27,6 +29,8 @@ class ImmediateEmailGenerationWorker
 
         queue_delivery_request_workers(to_queue)
       end
+
+      GC.start
     end
   end
 

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -2,10 +2,14 @@ class SubscriptionContentWorker
   include Sidekiq::Worker
 
   def perform(content_change_id)
+    GC.start
+
     content_change = ContentChange.find(content_change_id)
     queue_delivery_to_subscribers(content_change)
     queue_delivery_to_courtesy_subscribers(content_change)
     content_change.mark_processed!
+
+    GC.start
   end
 
 private

--- a/app/workers/weekly_digest_initiator_worker.rb
+++ b/app/workers/weekly_digest_initiator_worker.rb
@@ -1,5 +1,9 @@
 class WeeklyDigestInitiatorWorker < DigestInitiatorWorker
   def perform
+    GC.start
+
     DigestInitiatorService.call(range: Frequency::WEEKLY)
+
+    GC.start
   end
 end

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -88,6 +88,8 @@ RSpec.describe DigestEmailGenerationWorker do
         subscriber_id: subscriber.id
       )
 
+      allow(DigestRunSubscriber).to receive(:includes).and_return(DigestRunSubscriber)
+
       allow(DigestRunSubscriber).to receive(:find)
         .with(1)
         .and_return(digest_run_subscriber)


### PR DESCRIPTION
This is definitely a code smell, but it seems to have made a difference in staging so it would be good to see how this fares in production. If it doesn't make a difference, we can always revert.

Also made a slight change to avoid keeping an email around in the worker.

[Trello Card](https://trello.com/c/HTzGEXG7/569-investigate-increased-memory-usage-for-email-alert-api)