### PR TITLE
Deduplicate immediate emails

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,6 +2,8 @@ class Subscription < ApplicationRecord
   belongs_to :subscriber
   belongs_to :subscriber_list
 
+  has_many :subscription_contents
+
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
 
   before_validation :set_uuid

--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -1,0 +1,17 @@
+class SubscribersForImmediateEmailQuery
+  def self.call
+    Subscriber
+      .where(
+        unprocessed_subscription_contents_exist_for_subscribers
+       )
+       .where.not(address: nil)
+  end
+
+  def self.unprocessed_subscription_contents_exist_for_subscribers
+    SubscriptionContent
+      .joins(:subscription)
+      .where(email_id: nil)
+      .where("subscriptions.subscriber_id = subscribers.id")
+      .exists
+  end
+end

--- a/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
+++ b/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
@@ -1,0 +1,44 @@
+class UnprocessedSubscriptionContentsBySubscriberQuery
+  attr_reader :subscriber_ids
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(subscriber_ids)
+    @subscriber_ids = subscriber_ids
+  end
+
+  def call
+    from_query = <<-SQL
+      (
+        select subscription_contents.*, subscriptions.subscriber_id AS subscriber_id
+        from subscription_contents
+        join subscriptions on subscription_contents.subscription_id = subscriptions.id
+      ) as subscription_contents
+    SQL
+
+    subscription_contents = SubscriptionContent
+      .from(from_query)
+      .includes(:subscription)
+      .where(email_id: nil)
+
+    transform_results(subscription_contents)
+  end
+
+  private_class_method :new
+
+private
+
+  def transform_results(subscription_contents)
+    subscription_contents.each_with_object({}) do |subscription_content, results|
+      current_value = results[subscription_content.subscriber_id] || {}
+      subscription_contents_for_content_change = Array(current_value[subscription_content.content_change_id])
+      subscription_contents_for_content_change << subscription_content
+
+      results[subscription_content.subscriber_id] = current_value.merge(
+        subscription_content.content_change_id => subscription_contents_for_content_change
+      )
+    end
+  end
+end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -41,7 +41,7 @@ private
     Subscriber.where(address: addresses).find_each do |subscriber|
       begin
         email_id = ImmediateEmailBuilder.call([
-          { subscriber: subscriber, content_change: content_change }
+          { address: subscriber.address, subscriptions: [], content_change: content_change }
         ]).ids.first
 
         DeliveryRequestWorker.perform_async_in_queue(

--- a/spec/queries/subscribers_for_immediate_email_query_spec.rb
+++ b/spec/queries/subscribers_for_immediate_email_query_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe SubscribersForImmediateEmailQuery do
+  it "returns Subscriber objects that have an email-less SubscriptionContent" do
+    create(:subscription_content, email: nil)
+    expect(described_class.call.count).to eq(1)
+  end
+
+  it "does not return Subscriber objects with email_id != nil" do
+    create(:subscription_content, email: build(:email))
+    expect(described_class.call.count).to eq(0)
+  end
+
+  it "does not return Subscriber for subscribers with nil addresses" do
+    create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, address: nil)))
+    expect(described_class.call.count).to eq(0)
+  end
+
+  it "returns one record per subscriber" do
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber = create(:subscriber)))
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber))
+
+    create(:subscription_content, email: create(:email), subscription: create(:subscription, subscriber: subscriber))
+
+    content_change = ContentChange.last
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
+
+    expect(described_class.call.count).to eq(1)
+  end
+end

--- a/spec/queries/unprocessed_subscription_contents_by_subscriber_query_spec.rb
+++ b/spec/queries/unprocessed_subscription_contents_by_subscriber_query_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe UnprocessedSubscriptionContentsBySubscriberQuery do
+  let(:subscriber_one) { create(:subscriber) }
+  let(:subscriber_two) { create(:subscriber) }
+  let(:content_change_one) { create(:content_change) }
+  let(:content_change_two) { create(:content_change) }
+
+  before do
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_one), content_change: content_change_one)
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_one), content_change: content_change_one)
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_one), content_change: content_change_two)
+  end
+
+  subject { described_class.call(Subscriber.pluck(:id)) }
+
+  it "returns a hash keyed by subscriber_id" do
+    expect(subject.keys).to eq(Subscriber.pluck(:id))
+  end
+
+  it "creates a hash keyed by content_change_id per subscriber key" do
+    expect(subject[subscriber_one.id].keys).to eq(ContentChange.pluck(:id))
+  end
+
+  it "creates an array of subscription contents at each content change key" do
+    expect(subject[subscriber_one.id][content_change_one.id])
+      .to eq(SubscriptionContent.where(content_change: content_change_one))
+  end
+end

--- a/spec/workers/immediate_email_generation_worker_spec.rb
+++ b/spec/workers/immediate_email_generation_worker_spec.rb
@@ -17,6 +17,31 @@ RSpec.describe ImmediateEmailGenerationWorker do
       end
     end
 
+    context "with subscribers that have duplicate subscription contents" do
+      it "deduplicates when creating the emails" do
+        subscriber_one = create(:subscriber)
+        subscription_one = create(:subscription, subscriber: subscriber_one)
+        subscription_two = create(:subscription, subscriber: subscriber_one)
+        content_change = create(:content_change)
+
+        create(
+          :subscription_content,
+          subscription: subscription_one,
+          content_change: content_change
+        )
+
+        create(
+          :subscription_content,
+          subscription: subscription_two,
+          content_change: content_change
+        )
+
+        described_class.new.perform
+
+        expect(Email.count).to eq(1)
+      end
+    end
+
     context "with many subscription contents" do
       before do
         50.times do

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe SubscriptionContentWorker do
     it "creates an email for the courtesy email group" do
       expect(ImmediateEmailBuilder)
         .to receive(:call)
-        .with([hash_including(subscriber: subscriber)])
+        .with([hash_including(address: subscriber.address)])
         .and_return(double(ids: [0]))
 
       subject.perform(content_change.id)


### PR DESCRIPTION
Where a subscriber is subscribed to multiple lists that match a content change we are currently sending them multiple emails.

e.g

```
subscriber subscribes to "All publications"
same subscriber subscribes to "Publications from DfE"

DfE publishes a publication

subscriber receives two emails
```

~~We were using a query that returned `SubscriptionContent` objects that have nil email_id and then in a batch operation, creating `Email` objects for each and then building a SQL string from the returned email ids that updates the `SubscriptionContent` records in another single command.~~

~~This commit changes this to use a query that returns `Subscribers` and create one `Email` per `ContentChange` per subscriber. There is some complication as we then need to update all of the 
`SubscriptionContent` records with a single `Email#id`. This complexity seems unavoidable on account of us having to batch the processes to achieve the performance we need.~~

UPDATE: 17:15 19/2/2018 Totally reworked this based on discussions. 

We were using a query that returned `SubscriptionContent` objects that
have nil email_id and then in a batch operation, create `Email` objects
for each and then build a SQL from the returned email ids that updates
the `SubscriptionContent`records in another single command.

This commit changes this to use a query that returns `Subscribers` that
require an email and a separate query to return `SubscriptionContent`
grouped by `ContentChange`. These queries have been separated to avoid
loading all `Subscription` per `Subscriber` when trying to eager load
them. We then create one `Email` per `ContentChange`. There is some
further complication as we then need to update all of the `SubscriptionContent`
records with a single `Email#id`. This complexity seems unavoidable on account
of us having to batch the processes to achieve the performance we need.

To reduce the memory that is consumed during the process (hopefully, not tested yet but the existing implementation is struggling for RAM) this commit also introduces caching of the `ContentChange` objects. Previously we loaded a `ContentChange` on each `SubscriptionContent` when in reality
we are probably only dealing with a small number of them (or probably one).

This significantly changes the immediate email generation process so we'll need to load test again before merging.

[Trello](https://trello.com/c/bAiuj8JZ/601-de-duplicate-immediate-emails)

