### PR TITLE
Increase queue latency healthcheck thresholds

### DIFF
--- a/app/models/healthcheck/queue_latency_healthcheck.rb
+++ b/app/models/healthcheck/queue_latency_healthcheck.rb
@@ -39,11 +39,11 @@ class Healthcheck
     end
 
     def critical_size
-      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_CRITICAL", 300).to_i
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_CRITICAL", 15 * 60).to_i
     end
 
     def warning_size
-      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_WARNING", 250).to_i
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_WARNING", 10 * 60).to_i
     end
   end
 end

--- a/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Healthcheck::QueueLatencyHealthcheck do
   end
 
   context "when the warning threshold is reached" do
-    let(:latency) { 275 }
+    let(:latency) { 750 }
     specify { expect(subject.status).to eq(:warning) }
   end
 
   context "when the critical threshold is reached" do
-    let(:latency) { 500 }
+    let(:latency) { 1000 }
     specify { expect(subject.status).to eq(:critical) }
   end
 end


### PR DESCRIPTION
When digests run in the morning it's normal for the queue latency to grow a bit. Due to the way we've prioritised the queues, the digest jobs will always process last which can appear to show the latency as very large when really it's not a problem.