### PR TITLE
Force travel and medical advice to be immediate

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -38,6 +38,14 @@ class SubscriberList < ApplicationRecord
     super(options)
   end
 
+  def is_travel_advice?
+    self[:links].include?("countries")
+  end
+
+  def is_medical_safety_alert?
+    self[:tags].fetch("format", []).include?("medical_safety_alert")
+  end
+
 private
 
   def tag_values_are_valid

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -88,6 +88,14 @@ private
     nil
   end
 
+  def frequency_for_subscription(subscribable, subscriber)
+    if subscribable.is_travel_advice? || subscribable.is_medical_safety_alert?
+      Frequency::IMMEDIATELY
+    else
+      digest_frequencies.fetch(subscriber.address, Frequency::DAILY)
+    end
+  end
+
   def import_subscriptions
     puts "Loading new subscriptions from file..."
 
@@ -101,7 +109,7 @@ private
 
         next unless subscribable
 
-        frequency = digest_frequencies.fetch(subscriber.address, Frequency::DAILY)
+        frequency = frequency_for_subscription(subscribable, subscriber)
 
         next if Subscription.where(
           subscriber_id: subscriber.id,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -63,6 +63,14 @@ FactoryBot.define do
     sequence(:gov_delivery_id) { |n| "UKGOVUK_#{n}" }
     tags(topics: ["motoring/road_rage"])
     created_at { 1.year.ago }
+
+    trait :travel_advice do
+      links countries: [SecureRandom.uuid]
+    end
+
+    trait :medical_safety_alert do
+      tags format: ["medical_safety_alert"], alert_type: %w(devices drugs field-safety-notices company-led-drugs)
+    end
   end
 
   factory :subscription do

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -49,6 +49,30 @@ RSpec.describe ImportGovdeliveryCsv do
     expect(Subscription.third.frequency).to eq(Frequency::IMMEDIATELY)
   end
 
+  context "when the subscriber list is travel advice" do
+    let!(:first_subscribable) do
+      create(:subscriber_list, :travel_advice, gov_delivery_id: "UKGOVUK_111", title: "First")
+    end
+
+    it "sets the frequency to immediate" do
+      described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+
+      expect(Subscription.second.frequency).to eq(Frequency::IMMEDIATELY)
+    end
+  end
+
+  context "when the subscriber list is a medical safety alery" do
+    let!(:first_subscribable) do
+      create(:subscriber_list, :medical_safety_alert, gov_delivery_id: "UKGOVUK_111", title: "First")
+    end
+
+    it "sets the frequency to immediate" do
+      described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+
+      expect(Subscription.second.frequency).to eq(Frequency::IMMEDIATELY)
+    end
+  end
+
   it "is idempotent" do
     described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe SubscriberList, type: :model do
       expect(subject).to be_invalid
       expect(subject.errors[:links]).to include("All link values must be sent as Arrays")
     end
+
+    it "is not recognised as travel advice" do
+      expect(subject.is_travel_advice?).to be false
+    end
+
+    it "is not recognised as medical safety alert" do
+      expect(subject.is_medical_safety_alert?).to be false
+    end
   end
 
   context "with a subscription" do
@@ -84,6 +92,22 @@ RSpec.describe SubscriberList, type: :model do
       expect {
         subject.destroy
       }.to raise_error(ActiveRecord::InvalidForeignKey)
+    end
+  end
+
+  context "with a travel advice subscriber list" do
+    subject { build(:subscriber_list, :travel_advice) }
+
+    it "is recognised as travel advice" do
+      expect(subject.is_travel_advice?).to be true
+    end
+  end
+
+  context "with a medical safety alert subscriber list" do
+    subject { build(:subscriber_list, :medical_safety_alert) }
+
+    it "is recognised as a medical safety alert" do
+      expect(subject.is_medical_safety_alert?).to be true
     end
   end
 


### PR DESCRIPTION
This ensures that the import will set travel advice and medial safety alert subscriptions to immediate.

```
irb(main):015:0> SubscriberList.all.select(&:is_travel_advice?).count
=> 227
irb(main):016:0> SubscriberList.all.select(&:is_medical_safety_alert?).count
=> 15
```

[Trello Card](https://trello.com/c/GC1zfLbb/602-force-travel-alert-and-drug-device-alert-emails-to-always-be-immediate-for-data-import)