### PR TITLE
Case insensitive email addresses

### DIFF
--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,7 +1,7 @@
 class Subscriber < ApplicationRecord
   with_options allow_nil: true do
     validates :address, format: { with: /@/, message: "is not an email address" }
-    validates :address, uniqueness: true
+    validates_uniqueness_of :address, case_sensitive: false
   end
 
   has_many :subscriptions, -> { not_deleted }

--- a/db/migrate/20180215144634_add_case_insensitive_index_on_emails.rb
+++ b/db/migrate/20180215144634_add_case_insensitive_index_on_emails.rb
@@ -1,0 +1,6 @@
+class AddCaseInsensitiveIndexOnEmails < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :subscribers, :address, unique: true
+    add_index :subscribers, 'LOWER(address)', name: 'index_subscribers_on_lower_address', unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180212121358) do
+ActiveRecord::Schema.define(version: 20180215144634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,7 +126,7 @@ ActiveRecord::Schema.define(version: 20180212121358) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
-    t.index ["address"], name: "index_subscribers_on_address", unique: true
+    t.index "lower((address)::text)", name: "index_subscribers_on_lower_address", unique: true
   end
 
   create_table "subscription_contents", force: :cascade do |t|

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe Subscriber, type: :model do
 
       subject.address = "foo@bar.com"
       expect(subject).to be_invalid
+
+      expect {
+        subject.save!(validate: false)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "is invalid if an email address is already taken but with a different case" do
+      create(:subscriber, address: "FOO@BAR.com")
+
+      subject.address = "foo@bar.com"
+      expect(subject).to be_invalid
+
+      expect {
+        subject.save!(validate: false)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it "is valid to have more than one nil email address" do


### PR DESCRIPTION
This ensures that email addresses on subscribers ignore the case when considering uniqueness.

[Trello Card](https://trello.com/c/k8ruPLll/620-have-a-unique-case-insensitive-index-on-user-addresses-for-email)