### PR TITLE
Various delivery request improvements

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -18,8 +18,6 @@ class DeliveryRequestService
   end
 
   def call(email:)
-    raise ArgumentError, "email cannot be nil" if email.nil?
-
     subject = "#{subject_prefix}#{email.subject}"
     reference = SecureRandom.uuid
     address = determine_address(email, reference)

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -62,17 +62,22 @@ private
   end
 
   class EmailAddressOverrider
-    attr_reader :override_address, :whitelist_addresses
+    attr_reader :override_address, :whitelist_addresses, :whitelist_only
 
     def initialize(config)
       @override_address = config[:email_address_override]
       @whitelist_addresses = Array(config[:email_address_override_whitelist])
+      @whitelist_only = config[:email_address_override_whitelist_only]
     end
 
     def destination_address(address)
       return address unless override_address
 
-      whitelist_addresses.include?(address) ? address : override_address
+      if whitelist_addresses.include?(address)
+        address
+      else
+        whitelist_only ? nil : override_address
+      end
     end
   end
 end

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -21,7 +21,7 @@ class DeliveryRequestService
     raise ArgumentError, "email cannot be nil" if email.nil?
 
     subject = "#{subject_prefix}#{email.subject}"
-    reference = generate_reference(email)
+    reference = SecureRandom.uuid
     address = determine_address(email, reference)
 
     MetricsService.email_send_request(provider_name) do
@@ -48,11 +48,6 @@ class DeliveryRequestService
   end
 
 private
-
-  def generate_reference(email)
-    timestamp = Time.now.to_s(:iso8601)
-    "delivery-attempt-for-email-#{email.id}-sent-to-notify-at-#{timestamp}"
-  end
 
   def determine_address(email, reference)
     overrider.destination_address(email.address).tap do |address|

--- a/config/email_service.yml
+++ b/config/email_service.yml
@@ -1,10 +1,10 @@
 <% app_domain = ENV.fetch("GOVUK_APP_DOMAIN", "") %>
 <% env = %w(integration staging).detect { |s| app_domain.include?(s) } %>
-<% email_subject_prefix = "#{env.upcase} - " if env %>
+<% email_subject_prefix = env ? "#{env.upcase} - " : "" %>
 
 default: &default
   provider: <%= ENV["EMAIL_SERVICE_PROVIDER"] || "PSEUDO" %>
-  email_subject_prefix: <%= email_subject_prefix %>
+  email_subject_prefix: '<%= email_subject_prefix %>'
   email_address_override: <%= ENV["EMAIL_ADDRESS_OVERRIDE"] %>
   email_address_override_whitelist:
     <% whitelist = ENV.fetch("EMAIL_ADDRESS_OVERRIDE_WHITELIST", "").split(",").map(&:strip) %>

--- a/config/email_service.yml
+++ b/config/email_service.yml
@@ -11,6 +11,7 @@ default: &default
     <% whitelist.each do |email| %>
       - <%= email %>
     <% end %>
+  email_address_override_whitelist_only: <%= ENV.include?("EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY") %>
   expect_status_update_callbacks: true
 
 development:

--- a/db/migrate/20180220125651_make_delivery_attempt_reference_uuid.rb
+++ b/db/migrate/20180220125651_make_delivery_attempt_reference_uuid.rb
@@ -1,0 +1,13 @@
+class MakeDeliveryAttemptReferenceUuid < ActiveRecord::Migration[5.1]
+  def up
+    DeliveryAttempt.find_each do |delivery_attempt|
+      delivery_attempt.update(reference: SecureRandom.uuid)
+    end
+
+    change_column :delivery_attempts, :reference, 'UUID USING reference::uuid'
+  end
+
+  def down
+    change_column :delivery_attempts, :reference, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215144634) do
+ActiveRecord::Schema.define(version: 20180220125651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20180215144634) do
     t.bigint "email_id", null: false
     t.integer "status", null: false
     t.integer "provider", null: false
-    t.string "reference", null: false
+    t.uuid "reference", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe "Receiving a status update", type: :request do
+  let(:reference) { "b6589b2b-8f8e-457b-9ddf-237b62438ad1" }
+
   let!(:delivery_attempt) do
-    create(:delivery_attempt, reference: "ref-123", status: "sending")
+    create(:delivery_attempt, reference: reference, status: "sending")
   end
 
   describe "#create" do
-    let(:params) { { reference: "ref-123", status: "delivered" } }
+    let(:params) { { reference: reference, status: "delivered" } }
 
     context "when a user does not have 'status_updates' permission" do
       before do
@@ -24,7 +26,7 @@ RSpec.describe "Receiving a status update", type: :request do
 
       it "calls the status update service" do
         expect(StatusUpdateService).to receive(:call).with(
-          reference: "ref-123",
+          reference: reference,
           status: "delivered",
           user: user,
         )

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe DeliveryRequestService do
   end
 
   describe "#subject_prefix" do
-    it "defaults to nil" do
-      expect(subject.subject_prefix).to eq(nil)
+    it "defaults to be an empty string" do
+      expect(subject.subject_prefix).to eq("")
     end
 
     it "can be configured" do

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -87,16 +87,6 @@ RSpec.describe DeliveryRequestService do
       subject.call(email: email)
     end
 
-    it "sets the reference to something that might make debugging easier" do
-      expected = "delivery-attempt-for-email-#{email.id}-sent-to-notify-at-2017-01-01T00:00:00+00:00"
-
-      expect(subject.provider).to receive(:call).with(->(params) {
-        expect(params.fetch(:reference)).to eq(expected)
-      })
-
-      subject.call(email: email)
-    end
-
     it "creates a delivery attempt" do
       expect { subject.call(email: email) }
         .to change(DeliveryAttempt, :count).by(1)

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -195,6 +195,32 @@ RSpec.describe DeliveryRequestService do
         end
       end
 
+      context "when an override address is set and whitelist addresses are set and only whitelist emails should be sent" do
+        let(:config) do
+          {
+            email_address_override: "overriden@example.com",
+            email_address_override_whitelist: ["whitelist@example.com"],
+            email_address_override_whitelist_only: true,
+          }
+        end
+
+        context "when the argument is a whitelist address" do
+          let(:address) { "whitelist@example.com" }
+
+          it "returns the whitelisted address" do
+            expect(destination_address).to eq("whitelist@example.com")
+          end
+        end
+
+        context "when the argument is not a whitelist address" do
+          let(:address) { "original@example.com" }
+
+          it "returns a nil address" do
+            expect(destination_address).to be_nil
+          end
+        end
+      end
+
       context "when an override address is not set and whitelist addresses are set" do
         let(:config) do
           { email_address_override_whitelist: ["whitelist@example.com"] }

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe StatusUpdateService do
   let!(:delivery_attempt) do
-    create(:delivery_attempt, reference: "ref-123", status: "sending")
+    create(:delivery_attempt, reference: "b6589b2b-8f8e-457b-9ddf-237b62438ad1", status: "sending")
   end
 
-  let(:reference) { "ref-123" }
+  let(:reference) { "b6589b2b-8f8e-457b-9ddf-237b62438ad1" }
   let(:status) { "delivered" }
 
   subject(:status_update) { described_class.call(reference: reference, status: status) }


### PR DESCRIPTION
This PR introduces a number of improvements to the delivery request service and delivery attempts.

Firstly, this makes the delivery attempt reference a UUID and stores it like that in the database. This should enable an ever so slightly performance improvement, and reduced disk storage size.

Secondly, this enables an option that allows only emails with an address in the whitelist to be sent, while all others are ignored. This allows us to reduce the number of emails being sent out in staging and integration.

[Trello Card](https://trello.com/c/Q7xZvdUN/630-only-send-emails-to-the-whitelist)