### PR TITLE
Add rake task to truncate tables for switch to Notify

### DIFF
--- a/lib/tasks/truncate_tables_for_live_deploy.rake
+++ b/lib/tasks/truncate_tables_for_live_deploy.rake
@@ -1,0 +1,6 @@
+namespace :deploy do
+  desc "Truncate tables for live deploy. This will truncate emails, delivery_attempts, subscription_contents, subscribers, subscriptions, digest_runs, digest_run_subscriptions, content_changes and matched_content_changes"
+  task truncate_tables: :environment do
+    ActiveRecord::Base.connection.execute("TRUNCATE emails, subscribers, content_changes, digest_runs RESTART IDENTITY CASCADE;")
+  end
+end


### PR DESCRIPTION
When we switch the service to use Notify, we want to truncate our test data from our new tables.
Add a rake task to make this easy.