### PR TITLE
Ensure rate limit options are integers

### DIFF
--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -44,13 +44,13 @@ class DeliveryRequestWorker
   end
 
   def rate_limit_threshold
-    per_minute_to_allow_360_per_second = 21600
-    ENV["DELIVERY_REQUEST_THRESHOLD"] || per_minute_to_allow_360_per_second
+    per_minute_to_allow_360_per_second = "21600"
+    ENV.fetch("DELIVERY_REQUEST_THRESHOLD", per_minute_to_allow_360_per_second).to_i
   end
 
   def rate_limit_interval
-    minute_in_seconds = 60
-    ENV["DELIVERY_REQUEST_INTERVAL"] || minute_in_seconds
+    minute_in_seconds = "60"
+    ENV.fetch("DELIVERY_REQUEST_INTERVAL", minute_in_seconds).to_i
   end
 
 private

--- a/spec/workers/delivery_request_worker_spec.rb
+++ b/spec/workers/delivery_request_worker_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe DeliveryRequestWorker do
 
       it "returns ENV['DELIVERY_REQUEST_THRESHOLD'] if set" do
         ENV["DELIVERY_REQUEST_THRESHOLD"] = "10"
-        expect(subject.rate_limit_threshold).to eq("10")
+        expect(subject.rate_limit_threshold).to eq(10)
       end
 
       it "is 21600 by default" do
@@ -76,7 +76,7 @@ RSpec.describe DeliveryRequestWorker do
 
       it "returns ENV['DELIVERY_REQUEST_INTERVAL'] if set" do
         ENV["DELIVERY_REQUEST_INTERVAL"] = "20"
-        expect(subject.rate_limit_interval).to eq("20")
+        expect(subject.rate_limit_interval).to eq(20)
       end
 
       it "is 60 by default" do


### PR DESCRIPTION
We load these from environment variables which will come in as strings so we need to cast them to integers.