### PR TITLE
Add table counts to truncate task

### DIFF
--- a/lib/tasks/truncate_tables_for_live_deploy.rake
+++ b/lib/tasks/truncate_tables_for_live_deploy.rake
@@ -2,5 +2,10 @@ namespace :deploy do
   desc "Truncate tables for live deploy. This will truncate emails, delivery_attempts, subscription_contents, subscribers, subscriptions, digest_runs, digest_run_subscriptions, content_changes and matched_content_changes"
   task truncate_tables: :environment do
     ActiveRecord::Base.connection.execute("TRUNCATE emails, subscribers, content_changes, digest_runs RESTART IDENTITY CASCADE;")
+
+    puts "** Sanity check row counts ** "
+    [Email, DeliveryAttempt, SubscriptionContent, Subscriber, Subscription, DigestRun, DigestRunSubscriber, ContentChange, MatchedContentChange].each do |table|
+      puts "#{table}: #{table.count}"
+    end
   end
 end


### PR DESCRIPTION
After truncating our tables, `puts` the table count for each table we
expect to have been truncated.