### PR TITLE
Import the GovDelivery CSV file in chunks

### DIFF
--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -126,9 +126,10 @@ private
 
     puts "Importing records..."
 
-    count = Subscription.import!(columns, records).ids.count
-
-    puts "#{count} subscriptions imported!"
+    records.each_slice(10000) do |records_chunk|
+      count = Subscription.import!(columns, records_chunk).ids.count
+      puts "#{count} subscriptions imported..."
+    end
 
     puts "Unable to match #{failed_topics.count} topics:"
     p failed_topics

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -45,9 +45,9 @@ private
       .map { |row| address_from_row(row) }
       .uniq
 
-    existing_addresses = Subscriber.where(address: addresses).pluck(:address)
-
     puts "Identifying new subscribers..."
+
+    existing_addresses = Subscriber.where(address: addresses).pluck(:address)
 
     new_addresses = addresses - existing_addresses
 

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -126,7 +126,7 @@ private
 
     puts "Importing records..."
 
-    records.each_slice(10000) do |records_chunk|
+    records.each_slice(50000) do |records_chunk|
       count = Subscription.import!(columns, records_chunk).ids.count
       puts "#{count} subscriptions imported..."
     end


### PR DESCRIPTION
This means that importing the records into the database will use less memory as we don't have to allocate one large SQL query and instead can clear the memory of the last one before running the next one.