### PR TITLE
Remove calls to GC.start

### DIFF
--- a/app/workers/daily_digest_initiator_worker.rb
+++ b/app/workers/daily_digest_initiator_worker.rb
@@ -1,9 +1,5 @@
 class DailyDigestInitiatorWorker < DigestInitiatorWorker
   def perform
-    GC.start
-
     DigestInitiatorService.call(range: Frequency::DAILY)
-
-    GC.start
   end
 end

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -4,8 +4,6 @@ class DigestEmailGenerationWorker
   sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)
-    GC.start
-
     @digest_run_subscriber = DigestRunSubscriber.includes(:subscriber, :digest_run).find(digest_run_subscriber_id)
     @subscriber = digest_run_subscriber.subscriber
     @digest_run = digest_run_subscriber.digest_run
@@ -20,8 +18,6 @@ class DigestEmailGenerationWorker
 
       digest_run.check_and_mark_complete!
     end
-
-    GC.start
   end
 
 private

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -11,8 +11,6 @@ class ImmediateEmailGenerationWorker
     @content_changes = {}
 
     ensure_only_running_once do
-      GC.start
-
       subscribers.find_in_batches do |group|
         to_queue = []
 
@@ -43,8 +41,6 @@ class ImmediateEmailGenerationWorker
 
         queue_delivery_request_workers(to_queue)
       end
-
-      GC.start
     end
   end
 

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -2,14 +2,10 @@ class SubscriptionContentWorker
   include Sidekiq::Worker
 
   def perform(content_change_id)
-    GC.start
-
     content_change = ContentChange.find(content_change_id)
     queue_delivery_to_subscribers(content_change)
     queue_delivery_to_courtesy_subscribers(content_change)
     content_change.mark_processed!
-
-    GC.start
   end
 
 private

--- a/app/workers/weekly_digest_initiator_worker.rb
+++ b/app/workers/weekly_digest_initiator_worker.rb
@@ -1,9 +1,5 @@
 class WeeklyDigestInitiatorWorker < DigestInitiatorWorker
   def perform
-    GC.start
-
     DigestInitiatorService.call(range: Frequency::WEEKLY)
-
-    GC.start
   end
 end


### PR DESCRIPTION
We never felt like this was a good solution to the memory problem and the work done in #429 has helped with the memory usage problem a lot that we shouldn't need this anymore.