### PR TITLE
Store digest run subscribers count

### DIFF
--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -26,6 +26,8 @@ class DigestInitiatorService
 
         enqueue_jobs(digest_run_subscriber_ids)
       end
+
+      digest_run.update(subscriber_count: subscriber_ids.count)
     end
   end
 

--- a/db/migrate/20180222142356_add_subscriber_count_to_digest_run.rb
+++ b/db/migrate/20180222142356_add_subscriber_count_to_digest_run.rb
@@ -1,0 +1,5 @@
+class AddSubscriberCountToDigestRun < ActiveRecord::Migration[5.1]
+  def change
+    add_column :digest_runs, :subscriber_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180220125651) do
+ActiveRecord::Schema.define(version: 20180222142356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 20180220125651) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "subscriber_count"
   end
 
   create_table "emails", force: :cascade do |t|

--- a/spec/services/digest_initiator_service_spec.rb
+++ b/spec/services/digest_initiator_service_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe DigestInitiatorService do
             described_class.call(range: range)
           end
         end
+
+        it "sets the digest_run_subscriber_count" do
+          described_class.call(range: range)
+          expect(DigestRun.last.subscriber_count).to eq(2)
+        end
       end
 
       it "records a metric for the delivery attempt" do


### PR DESCRIPTION
This stores the count of all the digest run subscribers created for a particular digest run as we our archive policy will be to delete old digest run subscribers over time and these keeps a useful statistic around.