### PR TITLE
Configure additional mock permissions required

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -4,4 +4,5 @@ GDS::SSO.config do |config|
   config.oauth_secret = ENV.fetch('OAUTH_SECRET', "secret")
   config.oauth_root_url = Plek.find("signon")
   config.cache = Rails.cache
+  config.additional_mock_permissions_required = ["internal_app"]
 end


### PR DESCRIPTION
For the development vm, GDS-SSO relies on the Dummy Api User's
credentials. The Dummy Api User is created automatically by GDS-SSO
MockBearerToken and by default is given the "signin" permission. Email
Alert Api, however, requires the "internal_app" permission.

Luckily, a handy configuration key for GDS-SSO allows us to specify the
additional permission we needr.