### PR TITLE
Add ability to ignore notify email addresses for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ and it will create a new subscription between the email address and the
 subscriber list. It will respond with a `201 Created` if it's a new
 subscription or a `200 OK` if the subscription already exists.
 
+### Using test email addresses for signup
+
+Using any email address that ends with '@notifications.service.gov.uk'
+will not create a subscriber or a subscription, however will return a `201 Created`.
+
 ### healthcheck API
 
 A queue health check endpoint is available at /healthcheck

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe "Creating a subscription", type: :request do
             expect(Subscription.first.weekly?).to be_truthy
           end
         end
+
+        context "with a notify email address" do
+          it "returns a 201 but doesn't create a subscriber or subscription" do
+            params = JSON.dump(address: "simulate-delivered@notifications.service.gov.uk", subscribable_id: subscribable.id, frequency: "daily")
+            expect { post "/subscriptions", params: params, headers: JSON_HEADERS }.to_not change(Subscriber, :count)
+
+            expect(response.status).to eq(201)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Ignores notify email addresses containing '@notifications.service.gov.uk',
meaning no subsriber will be created but a successful sign up message will still
appear.