### PR TITLE
Add more email address validation

### DIFF
--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,6 +1,6 @@
 class Subscriber < ApplicationRecord
   with_options allow_nil: true do
-    validates :address, format: { with: /@/, message: "is not an email address" }
+    validates_with EmailAddressValidator, fields: [:address]
     validates_uniqueness_of :address, case_sensitive: false
   end
 

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,0 +1,44 @@
+class EmailAddressValidator < ActiveModel::Validator
+  def validate(record)
+    email_address = record.address
+    unless email_address.nil? || valid_email_address?(email_address)
+      record.errors.add(:address, 'is not an email address')
+    end
+  end
+
+private
+
+  def valid_email_address?(email_address)
+    contains_one_at_sign?(email_address) &&
+      contains_a_valid_domain?(email_address) &&
+      is_a_single_email_address?(email_address) &&
+      does_not_contain_newline_characters?(email_address)
+  end
+
+  def contains_one_at_sign?(email_address)
+    email_address.scan('@').length == 1
+  end
+
+  def contains_a_valid_domain?(email_address)
+    domain = email_address.split('@')[1]
+    return false if domain.nil?
+    domain_contains_at_least_one_dot?(domain) ||
+      domain_is_an_ip_address?(domain)
+  end
+
+  def is_a_single_email_address?(email_address)
+    email_address.scan(',').empty?
+  end
+
+  def does_not_contain_newline_characters?(email_address)
+    email_address !~ /\n/
+  end
+
+  def domain_contains_at_least_one_dot?(domain)
+    !domain.scan('.').empty?
+  end
+
+  def domain_is_an_ip_address?(domain)
+    domain.start_with?('[') && domain.end_with?(']')
+  end
+end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -47,6 +47,24 @@ RSpec.describe Subscriber, type: :model do
       expect(subject).to be_invalid
     end
 
+    it "is invalid for an email address which doesn't have a . in the domain" do
+      subject.address = "me@localhost"
+
+      expect(subject).to be_invalid
+    end
+
+    it "is invalid for an email address which contains a newline" do
+      subject.address = "foo@bar.com\nfoo@baz.com"
+
+      expect(subject).to be_invalid
+    end
+
+    it "is invalid for multiple email addresses" do
+      subject.address = "foo@bar.com,foo@baz.com"
+
+      expect(subject).to be_invalid
+    end
+
     it "is invalid if an email address is already taken" do
       create(:subscriber, address: "foo@bar.com")
 


### PR DESCRIPTION
This commit adds more validation for email addresses. They must have:
* Exactly one “@“ sign
* At least one “.” in the domain or an IP address in “[]”
* No commas

Trello: https://trello.com/c/dywIBaJ5/639-add-more-validation-on-email-addresses