### PR TITLE
Add email comms to footer

### DIFF
--- a/app/services/gov_delivery/templates/default_footer.html
+++ b/app/services/gov_delivery/templates/default_footer.html
@@ -2,6 +2,8 @@
 <!--[if mso]>
   <table role="presentation"><tr><td width="700">
 <![endif]-->
+<span style="font-family: Helvetica, Arial, sans-serif; font-size: 15px;"><strong>These emails are changing at the start of March.</strong></span>
+<span style="font-family: Helvetica, Arial, sans-serif; font-size: 15px;">The emails you get from GOV.UK are going to change. They&rsquo;ll come from a different address and have a different subject line. If you don't see emails after then, check your spam folder, and add gov.uk.email@notifications.service.gov.uk to your safe senders list.</span>
 <table role="presentation" style="width: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
   <tr bgcolor="#0B0C0C" style="background: #0B0C0C;">
     <td style="padding: 16px 20px;">


### PR DESCRIPTION
Add short message telling users that emails from GOV.UK will be different from March.
Comes from https://trello.com/c/PoTUON4Z/617-publish-comms-for-publishers-and-users