### PR TITLE
Import subscriptions in larger chunks

### DIFF
--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -126,7 +126,7 @@ private
 
     puts "Importing records..."
 
-    records.each_slice(50000) do |records_chunk|
+    records.each_slice(150000) do |records_chunk|
       count = Subscription.import!(columns, records_chunk).ids.count
       puts "#{count} subscriptions imported..."
     end


### PR DESCRIPTION
We're seeing that we have enough memory available to increase the size of the chunks we're importing, which should also help to speed up performance of the import.