### PR TITLE
Add very primitive sanity check to govdelivery import

### DIFF
--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -16,6 +16,7 @@ class ImportGovdeliveryCsv
     check_encoding_is_windows_1252
     get_user_confirmation
 
+    sanity_check_csv
     import_subscribers
     import_subscriptions
   end
@@ -25,6 +26,15 @@ private
   attr_reader :subscriptions_csv_path, :digests_csv_path, :fake_import, :failed_topics
 
   DEFAULT_DIGEST_FREQUENCY = Frequency::IMMEDIATELY
+
+  def sanity_check_csv
+    err = []
+    subscription_csv_headers = CSV.open(subscriptions_csv_path, 'r').first
+    digests_csv_headers = CSV.open(digests_csv_path, 'r').first
+    err << "Your subscription csv is incorrect." unless subscription_csv_headers.map(&:downcase).include?("topic_code")
+    err << "Your digest csv is incorrect." unless digests_csv_headers.map(&:downcase).include?("digest_for")
+    raise err.join(' ') unless err.empty?
+  end
 
   def address_from_row(row)
     address = row.fetch("DESTINATION")

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -12,6 +12,23 @@ RSpec.describe ImportGovdeliveryCsv do
     create(:subscriber_list, gov_delivery_id: "UKGOVUK_222", title: "Second")
   end
 
+  context "with the wrong csvs" do
+    it "raises an error if subscription csv does not include 'topic_code'" do
+      expect { described_class.call("spec/lib/csv_digest_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
+        .to raise_error(RuntimeError, "Your subscription csv is incorrect.")
+    end
+
+    it "raises an error if the digest csv does not include 'digest_for'" do
+      expect { described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_fixture.csv") }
+        .to raise_error(RuntimeError, "Your digest csv is incorrect.")
+    end
+
+    it "raises an error if the digest csv does not include 'digest_for' and the subscription csv does not include 'topic_code'" do
+      expect { described_class.call("spec/lib/csv_digest_fixture.csv", "spec/lib/csv_fixture.csv") }
+        .to raise_error(RuntimeError, "Your subscription csv is incorrect. Your digest csv is incorrect.")
+    end
+  end
+
   it "creates subscribers and subscriptions" do
     expect { described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv") }
       .to change(Subscriber, :count).by(2)


### PR DESCRIPTION
A very primitive test against our govdelivery csv to make sure we pass
them in the correct order.