### PR TITLE
Add a migration to make various primary keys UUIDs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://email-alert-api:email-alert-api@localhost/email-alert-api_test")
   govuk.buildProject()
 }

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -32,7 +32,7 @@ class ImmediateEmailGenerationWorker
             to_queue << [email_id, content_changes[content_change_id].priority.to_sym]
 
             subscription_contents_in_this_email.each do |subscription_content|
-              values << "(#{subscription_content.id}, #{email_id})"
+              values << "(#{subscription_content.id}, '#{email_id}'::UUID)"
             end
           end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,7 @@ development:
 test:
   <<: *default
   database: email-alert-api_test
+  url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
   <<: *default

--- a/db/migrate/20180223095104_make_various_primary_key_uui_ds.rb
+++ b/db/migrate/20180223095104_make_various_primary_key_uui_ds.rb
@@ -1,0 +1,41 @@
+class MakeVariousPrimaryKeyUuiDs < ActiveRecord::Migration[5.1]
+  def make_id_uuid(table)
+    remove_column table, :id
+    add_column table, :id, :uuid, default: "uuid_generate_v4()", primary_key: true
+  end
+
+  def remove_int_ids(column, from:)
+    from.each do |table|
+      remove_column table, column
+    end
+  end
+
+  def add_uuid_reference(source_table, target_table, index: true, null: false, on_delete: :restrict)
+    add_reference source_table, target_table, type: :uuid, index: index, null: null
+    add_foreign_key source_table.to_s.pluralize.to_sym, target_table.to_s.pluralize.to_sym, on_delete: on_delete
+  end
+
+  def up
+    enable_extension "uuid-ossp"
+
+    execute "TRUNCATE emails, content_changes, subscriptions CASCADE"
+
+    make_id_uuid :delivery_attempts
+
+    remove_int_ids :email_id, from: %w(delivery_attempts subscription_contents)
+    make_id_uuid :emails
+    add_uuid_reference :delivery_attempts, :email, on_delete: :cascade
+    add_uuid_reference :subscription_contents, :email, null: true, on_delete: :nullify
+    add_index :delivery_attempts, %w(email_id updated_at)
+
+    remove_column :subscription_contents, :subscription_id
+    make_id_uuid :subscriptions
+    add_uuid_reference :subscription_contents, :subscription, null: true, on_delete: :nullify
+
+    remove_int_ids :content_change_id, from: %w(subscription_contents matched_content_changes)
+    make_id_uuid :content_changes
+    add_uuid_reference :subscription_contents, :content_change
+    add_uuid_reference :matched_content_changes, :content_change
+    add_index :matched_content_changes, %w(content_change_id subscriber_list_id), unique: true, name: "index_matched_content_changes_content_change_subscriber_list"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222142356) do
+ActiveRecord::Schema.define(version: 20180223095104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
-  create_table "content_changes", force: :cascade do |t|
+  create_table "content_changes", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "content_id", null: false
     t.text "title", null: false
     t.text "base_path", null: false
@@ -36,14 +37,14 @@ ActiveRecord::Schema.define(version: 20180222142356) do
     t.string "signon_user_uid"
   end
 
-  create_table "delivery_attempts", force: :cascade do |t|
-    t.bigint "email_id", null: false
+  create_table "delivery_attempts", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.integer "status", null: false
     t.integer "provider", null: false
     t.uuid "reference", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
+    t.uuid "email_id", null: false
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"
     t.index ["reference"], name: "index_delivery_attempts_on_reference", unique: true
@@ -68,7 +69,7 @@ ActiveRecord::Schema.define(version: 20180222142356) do
     t.integer "subscriber_count"
   end
 
-  create_table "emails", force: :cascade do |t|
+  create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "subject", null: false
     t.text "body", null: false
     t.datetime "created_at", null: false
@@ -77,10 +78,10 @@ ActiveRecord::Schema.define(version: 20180222142356) do
   end
 
   create_table "matched_content_changes", force: :cascade do |t|
-    t.bigint "content_change_id", null: false
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "content_change_id", null: false
     t.index ["content_change_id", "subscriber_list_id"], name: "index_matched_content_changes_content_change_subscriber_list", unique: true
     t.index ["content_change_id"], name: "index_matched_content_changes_on_content_change_id"
     t.index ["subscriber_list_id"], name: "index_matched_content_changes_on_subscriber_list_id"
@@ -131,26 +132,26 @@ ActiveRecord::Schema.define(version: 20180222142356) do
   end
 
   create_table "subscription_contents", force: :cascade do |t|
-    t.bigint "subscription_id"
-    t.bigint "content_change_id", null: false
-    t.bigint "email_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "digest_run_subscriber_id"
+    t.uuid "email_id"
+    t.uuid "subscription_id"
+    t.uuid "content_change_id", null: false
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"
   end
 
-  create_table "subscriptions", force: :cascade do |t|
+  create_table "subscriptions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.bigint "subscriber_id", null: false
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "uuid", null: false
-    t.string "signon_user_uid"
     t.integer "frequency", default: 0, null: false
+    t.string "signon_user_uid"
     t.datetime "deleted_at"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
@@ -172,9 +173,9 @@ ActiveRecord::Schema.define(version: 20180222142356) do
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "digest_runs", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "subscribers", on_delete: :cascade
-  add_foreign_key "matched_content_changes", "content_changes"
+  add_foreign_key "matched_content_changes", "content_changes", on_delete: :restrict
   add_foreign_key "matched_content_changes", "subscriber_lists"
-  add_foreign_key "subscription_contents", "content_changes"
+  add_foreign_key "subscription_contents", "content_changes", on_delete: :restrict
   add_foreign_key "subscription_contents", "digest_run_subscribers", on_delete: :cascade
   add_foreign_key "subscription_contents", "emails", on_delete: :nullify
   add_foreign_key "subscription_contents", "subscriptions", on_delete: :nullify

--- a/spec/integration/anonymise_email_addresses_spec.rb
+++ b/spec/integration/anonymise_email_addresses_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe "Anonymising email addresses" do
 
     execute_sql
 
-    expect(foo_subscriber.reload.address).to eq("anonymous-1@example.com")
-    expect(bar_subscriber.reload.address).to eq("anonymous-2@example.com")
+    expect(foo_email.reload.address).to eq(foo_subscriber.reload.address)
+    expect(foo_email.reload.address).to_not eq(bar_subscriber.reload.address)
 
-    expect(foo_email.reload.address).to eq("anonymous-1@example.com")
-    expect(bar_email.reload.address).to eq("anonymous-2@example.com")
+    expect(bar_email.reload.address).to eq(bar_subscriber.reload.address)
+    expect(bar_subscriber.reload.address).to_not eq(foo_subscriber.reload.address)
   end
 
   it "cleans up after itself" do

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -21,32 +21,29 @@ RSpec.describe ImportGovdeliveryCsv do
   it "sets the subscriber address from the csv" do
     described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
-    expect(Subscriber.first.address).to eq("foo@example.com")
-    expect(Subscriber.second.address).to eq("bar@example.com")
+    expect(Subscriber.pluck(:address)).to match_array(%w(foo@example.com bar@example.com))
   end
 
-  it "associates the subscriptions with the subscribers" do
-    described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
-
-    expect(Subscription.first.subscriber.address).to eq("foo@example.com")
-    expect(Subscription.second.subscriber.address).to eq("bar@example.com")
-    expect(Subscription.third.subscriber.address).to eq("foo@example.com")
+  def find_subscription(address, title)
+    Subscription
+      .joins(:subscriber, :subscriber_list)
+      .find_by(subscribers: { address: address }, subscriber_lists: { title: title })
   end
 
-  it "associates the subscriptions with the subscribables" do
+  it "associates the subscriptions with the subscribers and subscribables" do
     described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
-    expect(Subscription.first.subscriber_list.title).to eq("First")
-    expect(Subscription.second.subscriber_list.title).to eq("First")
-    expect(Subscription.third.subscriber_list.title).to eq("Second")
+    expect(find_subscription("foo@example.com", "First")).to_not be_nil
+    expect(find_subscription("bar@example.com", "First")).to_not be_nil
+    expect(find_subscription("foo@example.com", "Second")).to_not be_nil
   end
 
   it "sets the frequencies on the subscriptions" do
     described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
-    expect(Subscription.first.frequency).to eq(Frequency::IMMEDIATELY)
-    expect(Subscription.second.frequency).to eq(Frequency::DAILY)
-    expect(Subscription.third.frequency).to eq(Frequency::IMMEDIATELY)
+    expect(find_subscription("foo@example.com", "First").frequency).to eq(Frequency::IMMEDIATELY)
+    expect(find_subscription("bar@example.com", "First").frequency).to eq(Frequency::DAILY)
+    expect(find_subscription("foo@example.com", "Second").frequency).to eq(Frequency::IMMEDIATELY)
   end
 
   context "when the subscriber list is travel advice" do
@@ -57,7 +54,7 @@ RSpec.describe ImportGovdeliveryCsv do
     it "sets the frequency to immediate" do
       described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
-      expect(Subscription.second.frequency).to eq(Frequency::IMMEDIATELY)
+      expect(find_subscription("bar@example.com", "First").frequency).to eq(Frequency::IMMEDIATELY)
     end
   end
 
@@ -69,7 +66,7 @@ RSpec.describe ImportGovdeliveryCsv do
     it "sets the frequency to immediate" do
       described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
 
-      expect(Subscription.second.frequency).to eq(Frequency::IMMEDIATELY)
+      expect(find_subscription("bar@example.com", "First").frequency).to eq(Frequency::IMMEDIATELY)
     end
   end
 
@@ -92,9 +89,9 @@ RSpec.describe ImportGovdeliveryCsv do
     it "sets the addresses to AWS success addresses" do
       described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv", fake_import: true)
 
-      expect(Subscription.first.subscriber.address).to eq("success+767e74eab7081c41e0b83630511139d130249666@simulator.amazonses.com")
-      expect(Subscription.second.subscriber.address).to eq("success+1ac2c5ab67ab3279b2de1d2bed879b2a63e59ee7@simulator.amazonses.com")
-      expect(Subscription.third.subscriber.address).to eq("success+767e74eab7081c41e0b83630511139d130249666@simulator.amazonses.com")
+      expect(find_subscription("success+767e74eab7081c41e0b83630511139d130249666@simulator.amazonses.com", "First")).to_not be_nil
+      expect(find_subscription("success+1ac2c5ab67ab3279b2de1d2bed879b2a63e59ee7@simulator.amazonses.com", "First")).to_not be_nil
+      expect(find_subscription("success+767e74eab7081c41e0b83630511139d130249666@simulator.amazonses.com", "Second")).to_not be_nil
     end
   end
 end

--- a/spec/queries/subscription_content_change_query_spec.rb
+++ b/spec/queries/subscription_content_change_query_spec.rb
@@ -92,17 +92,17 @@ RSpec.describe SubscriptionContentChangeQuery do
     end
 
     let!(:subscription_2) do
-      create(:subscription, id: 2, subscriber_list: subscriber_list_2, subscriber: subscriber)
+      create(:subscription, id: "b8c3fd84-5f00-460d-a812-edb628f28c8f", subscriber_list: subscriber_list_2, subscriber: subscriber)
     end
 
     let!(:subscription_1) do
-      create(:subscription, id: 1, subscriber_list: subscriber_list_1, subscriber: subscriber)
+      create(:subscription, id: "b0f887f1-20b1-4386-881d-f909c98c373b", subscriber_list: subscriber_list_1, subscriber: subscriber)
     end
 
     let(:content_change_1) do
       create(
         :content_change,
-        id: 1,
+        id: "d5ee8e1a-72c1-4525-94f0-23d58af8a6c5",
         tags: { topics: ["oil-and-gas/licensing"] },
         created_at: starts_at,
       )
@@ -111,7 +111,7 @@ RSpec.describe SubscriptionContentChangeQuery do
     let(:content_change_2) do
       create(
         :content_change,
-        id: 2,
+        id: "70ac31fa-505e-4060-b7bb-bfa15028cc99",
         tags: { topics: ["oil-and-gas/drilling"] },
         created_at: starts_at,
       )
@@ -132,13 +132,13 @@ RSpec.describe SubscriptionContentChangeQuery do
     end
 
     it "returns correctly ordered" do
-      expect(subject.first.subscription_id).to eq(1)
+      expect(subject.first.subscription_id).to eq("b0f887f1-20b1-4386-881d-f909c98c373b")
       expect(subject.first.subscriber_list_title).to eq("list-1")
-      expect(subject.first.content_changes.first.id).to eq(1)
+      expect(subject.first.content_changes.first.id).to eq("d5ee8e1a-72c1-4525-94f0-23d58af8a6c5")
 
-      expect(subject.second.subscription_id).to eq(2)
+      expect(subject.second.subscription_id).to eq("b8c3fd84-5f00-460d-a812-edb628f28c8f")
       expect(subject.second.subscriber_list_title).to eq("list-2")
-      expect(subject.second.content_changes.first.id).to eq(2)
+      expect(subject.second.content_changes.first.id).to eq("70ac31fa-505e-4060-b7bb-bfa15028cc99")
     end
   end
 end

--- a/spec/queries/unprocessed_subscription_contents_by_subscriber_query_spec.rb
+++ b/spec/queries/unprocessed_subscription_contents_by_subscriber_query_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe UnprocessedSubscriptionContentsBySubscriberQuery do
   subject { described_class.call(Subscriber.pluck(:id)) }
 
   it "returns a hash keyed by subscriber_id" do
-    expect(subject.keys).to eq(Subscriber.pluck(:id))
+    expect(subject.keys).to match_array(Subscriber.pluck(:id))
   end
 
   it "creates a hash keyed by content_change_id per subscriber key" do
-    expect(subject[subscriber_one.id].keys).to eq(ContentChange.pluck(:id))
+    expect(subject[subscriber_one.id].keys).to match_array(ContentChange.pluck(:id))
   end
 
   it "creates an array of subscription contents at each content change key" do
     expect(subject[subscriber_one.id][content_change_one.id])
-      .to eq(SubscriptionContent.where(content_change: content_change_one))
+      .to match_array(SubscriptionContent.where(content_change: content_change_one))
   end
 end

--- a/spec/workers/immediate_email_generation_worker_spec.rb
+++ b/spec/workers/immediate_email_generation_worker_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe ImmediateEmailGenerationWorker do
 
         it "should queue a delivery email job with a high priority" do
           expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-            .with(an_instance_of(Integer), queue: :delivery_immediate_high)
+            .with(an_instance_of(String), queue: :delivery_immediate_high)
 
           perform_with_fake_sidekiq
         end

--- a/spec/workers/immediate_email_generation_worker_spec.rb
+++ b/spec/workers/immediate_email_generation_worker_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe ImmediateEmailGenerationWorker do
   describe ".perform_async" do
     before do
-      described_class.perform_async
+      Sidekiq::Testing.fake! do
+        described_class.perform_async
+      end
     end
 
     it "gets put on the email_generation_immediate queue" do
@@ -52,7 +54,7 @@ RSpec.describe ImmediateEmailGenerationWorker do
       it "should match up with the right emails" do
         perform_with_fake_sidekiq
 
-        SubscriptionContent.all.find_each do |subscription_content|
+        SubscriptionContent.includes(:email, subscription: :subscriber).find_each do |subscription_content|
           expect(subscription_content.email.address)
             .to eq(subscription_content.subscription.subscriber.address)
         end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SubscriptionContentWorker do
     it "enqueues the email to send to the courtesy subscription group" do
       expect(DeliveryRequestWorker)
         .to receive(:perform_async_in_queue)
-        .with(kind_of(Integer), queue: :delivery_immediate)
+        .with(kind_of(String), queue: :delivery_immediate)
 
       subject.perform(content_change.id)
     end


### PR DESCRIPTION
This changes the primary keys on delivery attempts, content changes, emails and subscription contents into UUIDs. This is because UUIDs fit better for these records, especially in terms of archiving the data. We will also replace the reference field on delivery attempts to use this primary key.

Depends on https://github.com/alphagov/govuk-puppet/pull/7289.

[Trello Card](https://trello.com/c/B8db764N/637-switch-some-of-our-primary-keys-from-id-to-uuid)