### PR TITLE
Marking an email as completed (finished sending)

### DIFF
--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -1,6 +1,14 @@
 class StatusUpdatesController < ApplicationController
   wrap_parameters false
 
+  rescue_from StatusUpdateService::DeliveryAttemptStatusConflictError do |e|
+    render json: { error: e.message }, status: :conflict
+  end
+
+  rescue_from StatusUpdateService::DeliveryAttemptInvalidStatusError do |e|
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   def create
     StatusUpdateService.call(
       reference: params.require(:reference),

--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -3,6 +3,8 @@ class DeliveryAttempt < ApplicationRecord
 
   validates :email, :status, :provider, presence: true
 
+  FINAL_STATUSES = %i[delivered permanent_failure].freeze
+
   enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4 }
   enum provider: { pseudo: 0, notify: 1 }
 
@@ -16,5 +18,13 @@ class DeliveryAttempt < ApplicationRecord
 
   def should_remove_subscriber?
     permanent_failure?
+  end
+
+  def has_final_status?
+    self.class.final_status?(status)
+  end
+
+  def self.final_status?(status)
+    FINAL_STATUSES.include?(status.to_sym)
   end
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -2,4 +2,11 @@ class Email < ApplicationRecord
   has_many :delivery_attempts
 
   validates :address, :subject, :body, presence: true
+
+  # Mark an email to indicate the process of sending it is complete
+  def finish_sending(delivery_attempt)
+    raise ArgumentError, "DeliveryAttempt for different email" if delivery_attempt.email_id != id
+    # @FIXME We should use a timestamp from the provider if possible
+    update!(finished_sending_at: delivery_attempt.updated_at)
+  end
 end

--- a/app/providers/notify_provider.rb
+++ b/app/providers/notify_provider.rb
@@ -23,9 +23,11 @@ class NotifyProvider
     )
 
     MetricsService.sent_to_notify_successfully
-  rescue Notifications::Client::RequestError => e
+    :sending
+  rescue StandardError => e
     MetricsService.failed_to_send_to_notify
-    raise ProviderError, e
+    GovukError.notify(e, tags: { provider: "notify" })
+    :technical_failure
   end
 
 private

--- a/app/providers/pseudo_provider.rb
+++ b/app/providers/pseudo_provider.rb
@@ -14,6 +14,7 @@ class PseudoProvider
     INFO
 
     MetricsService.sent_to_pseudo_successfully
+    :delivered
   end
 
   private_class_method :new

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -33,7 +33,11 @@ class DeliveryRequestService
         reference: reference,
       )
 
-      delivery_attempt.update!(status: status) if status != :sending
+      ActiveRecord::Base.transaction do
+        delivery_attempt.update!(status: status) if status != :sending
+
+        email.finish_sending(delivery_attempt) if delivery_attempt.has_final_status?
+      end
     end
   end
 

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -16,6 +16,8 @@ class StatusUpdateService
         status: status.underscore,
         signon_user_uid: user&.uid,
       )
+
+      email.finish_sending(delivery_attempt) if delivery_attempt.has_final_status?
     rescue ArgumentError
       # This is because Rails doesn't currently do validations for enums
       # see: https://github.com/rails/rails/issues/13971

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -7,7 +7,7 @@ class StatusUpdateService
   end
 
   def self.call(*args)
-    new(*args).call
+    DeliveryAttempt.transaction { new(*args).call }
   end
 
   def call
@@ -53,6 +53,7 @@ private
     attempt = DeliveryAttempt
                 .includes(:email)
                 .joins(:email)
+                .lock
                 .find_by!(reference: reference)
 
     if !attempt.sending?

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,3 @@ end
 
 require_relative '../lib/email_alert_api/config'
 EmailAlertAPI.config = EmailAlertAPI::Config.new(Rails.env)
-
-class ProviderError < StandardError; end;

--- a/db/migrate/20180226101223_add_finished_sending_at_to_emails.rb
+++ b/db/migrate/20180226101223_add_finished_sending_at_to_emails.rb
@@ -1,0 +1,5 @@
+class AddFinishedSendingAtToEmails < ActiveRecord::Migration[5.1]
+  def change
+    add_column :emails, :finished_sending_at, :datetime
+  end
+end

--- a/db/migrate/20180226101630_index_finished_sending_at_on_emails.rb
+++ b/db/migrate/20180226101630_index_finished_sending_at_on_emails.rb
@@ -1,0 +1,7 @@
+class IndexFinishedSendingAtOnEmails < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :emails, :finished_sending_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,6 +75,8 @@ ActiveRecord::Schema.define(version: 20180228132051) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
+    t.datetime "finished_sending_at"
+    t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     allow_any_instance_of(DeliveryRequestService)
       .to receive(:provider_name).and_return("notify")
+
+    stub_notify
   end
 
   after do

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Receiving a status update", type: :request do
       end
     end
 
-    context "when a user does not have 'status_updates' permission" do
+    context "when a user does have 'status_updates' permission" do
       let(:user) { create(:user, permissions: %w[signin status_updates]) }
       before { login_as(user) }
 

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -5,13 +5,39 @@ RSpec.describe "Receiving a status update", type: :request do
     create(:delivery_attempt, reference: reference, status: "sending")
   end
 
+  let(:permissions) { %w[signin status_updates] }
+  let(:user) { create(:user, permissions: permissions) }
+  before { login_as(user) }
+
   describe "#create" do
     let(:params) { { reference: reference, status: "delivered" } }
+    let(:permissions) { %w[signin status_updates] }
+
+    it "calls the status update service" do
+      expect(StatusUpdateService).to receive(:call).with(
+        reference: reference,
+        status: "delivered",
+        user: user,
+      )
+
+      post "/status-updates", params: params
+    end
+
+    it "renders 204 no content" do
+      post "/status-updates", params: params
+
+      expect(response.status).to eq(204)
+      expect(response.body).to eq("")
+    end
+
+    it "updates the delivery attempt" do
+      expect { post "/status-updates", params: params }
+        .to change { delivery_attempt.reload.status }
+        .to eq("delivered")
+    end
 
     context "when a user does not have 'status_updates' permission" do
-      before do
-        login_as(create(:user, permissions: %w[signin]))
-      end
+      let(:permissions) { %w[signin] }
 
       it "renders 403" do
         post "/status-updates", params: params
@@ -20,31 +46,21 @@ RSpec.describe "Receiving a status update", type: :request do
       end
     end
 
-    context "when a user does have 'status_updates' permission" do
-      let(:user) { create(:user, permissions: %w[signin status_updates]) }
-      before { login_as(user) }
+    context "when a status attempt arrives for an already handled delivery attempt" do
+      before { delivery_attempt.update!(status: "delivered") }
 
-      it "calls the status update service" do
-        expect(StatusUpdateService).to receive(:call).with(
-          reference: reference,
-          status: "delivered",
-          user: user,
-        )
-
-        post "/status-updates", params: params
-      end
-
-      it "renders 204 no content" do
+      it "renders 409" do
         post "/status-updates", params: params
 
-        expect(response.status).to eq(204)
-        expect(response.body).to eq("")
+        expect(response.status).to eq(409)
       end
+    end
 
-      it "updates the delivery attempt" do
-        expect { post "/status-updates", params: params }
-          .to change { delivery_attempt.reload.status }
-          .to eq("delivered")
+    context "when a status attempt arrives with an unknown status" do
+      it "renders 422" do
+        post "/status-updates", params: params.merge(status: "unknown")
+
+        expect(response.status).to eq(422)
       end
     end
   end

--- a/spec/models/delivery_attempt_spec.rb
+++ b/spec/models/delivery_attempt_spec.rb
@@ -38,4 +38,31 @@ RSpec.describe DeliveryAttempt, type: :model do
       expect(subject.should_report_failure?).to be_truthy
     end
   end
+
+  describe ".final_status?" do
+    subject { described_class.final_status?(status) }
+    context "when given a final status" do
+      let(:status) { :delivered }
+      it { is_expected.to be true }
+    end
+
+    context "when given a non final status" do
+      let(:status) { :sending }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe ".has_final_status?" do
+    subject { build(:delivery_attempt, status: status).has_final_status? }
+
+    context "when it has a final status" do
+      let(:status) { "delivered" }
+      it { is_expected.to be true }
+    end
+
+    context "when it has a non final status" do
+      let(:status) { "sending" }
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -10,4 +10,30 @@ RSpec.describe Email do
       expect(subject.errors[:body]).not_to be_empty
     end
   end
+
+  describe "#finish_sending" do
+    context "when delivery attempt is for same email" do
+      let(:email) { create(:email) }
+      let(:delivery_attempt) { create(:delivery_attempt, email: email) }
+
+      it "sets the finished_sending_at field" do
+        Timecop.freeze do
+          expect { email.finish_sending(delivery_attempt) }
+            .to change { email.finished_sending_at }
+            .from(nil)
+            .to(Time.now)
+        end
+      end
+    end
+
+    context "when delivery_attempt is for a different email" do
+      let(:email) { create(:email) }
+      let(:delivery_attempt) { build(:delivery_attempt) }
+
+      it "raises an error" do
+        expect { email.finish_sending(delivery_attempt) }
+          .to raise_error(ArgumentError)
+      end
+    end
+  end
 end

--- a/spec/providers/notify_provider_spec.rb
+++ b/spec/providers/notify_provider_spec.rb
@@ -1,25 +1,57 @@
 RSpec.describe NotifyProvider do
-  let(:template_id) { EmailAlertAPI.config.notify.fetch(:template_id) }
-
-  it "calls the Notifications client" do
-    allow(Notifications::Client).to receive(:new).and_return(client = double)
-
-    expect(client).to receive(:send_email)
-      .with(
-        email_address: "email@address.com",
-        template_id: template_id,
+  describe ".call" do
+    let(:template_id) { EmailAlertAPI.config.notify.fetch(:template_id) }
+    let(:arguments) do
+      {
+        address: "email@address.com",
+        subject: "subject",
+        body: "body",
         reference: "ref-123",
-        personalisation: {
-          subject: "subject",
-          body: "body",
-        },
-      )
+      }
+    end
 
-    described_class.call(
-      address: "email@address.com",
-      subject: "subject",
-      body: "body",
-      reference: "ref-123",
-    )
+    it "calls the Notifications client" do
+      client = instance_double("Notifications::Client")
+      allow(Notifications::Client).to receive(:new).and_return(client)
+
+      expect(client).to receive(:send_email)
+        .with(
+          email_address: "email@address.com",
+          template_id: template_id,
+          reference: "ref-123",
+          personalisation: {
+            subject: "subject",
+            body: "body",
+          },
+        )
+
+      described_class.call(arguments)
+    end
+
+    context "when it sends successfully" do
+      before { stub_request(:post, /fake-notify/).to_return(body: {}.to_json) }
+
+      it "returns a status of sending" do
+        return_value = described_class.call(arguments)
+        expect(return_value).to be(:sending)
+      end
+    end
+
+    context "when an error occurs" do
+      before do
+        allow_any_instance_of(Notifications::Client).to receive(:send_email)
+          .and_raise("Sending Failed")
+      end
+
+      it "returns a status of technical_failure" do
+        return_value = described_class.call(arguments)
+        expect(return_value).to be(:technical_failure)
+      end
+
+      it "notifies GovukError" do
+        expect(GovukError).to receive(:notify)
+        described_class.call(arguments)
+      end
+    end
   end
 end

--- a/spec/providers/pseudo_provider_spec.rb
+++ b/spec/providers/pseudo_provider_spec.rb
@@ -1,19 +1,31 @@
 RSpec.describe PseudoProvider do
-  it "logs to a file" do
-    allow(Logger).to receive(:new).and_return(logger = double)
+  describe ".call" do
+    it "logs to a file" do
+      allow(Logger).to receive(:new).and_return(logger = double)
 
-    expect(logger).to receive(:info).with(->(string) {
-      expect(string).to include("Sending email to email@address.com")
-      expect(string).to include("Subject: subject")
-      expect(string).to include("Body: body")
-      expect(string).to include("Reference: ref-123")
-    })
+      expect(logger).to receive(:info).with(->(string) {
+        expect(string).to include("Sending email to email@address.com")
+        expect(string).to include("Subject: subject")
+        expect(string).to include("Body: body")
+        expect(string).to include("Reference: ref-123")
+      })
 
-    described_class.call(
-      address: "email@address.com",
-      subject: "subject",
-      body: "body",
-      reference: "ref-123",
-    )
+      described_class.call(
+        address: "email@address.com",
+        subject: "subject",
+        body: "body",
+        reference: "ref-123",
+      )
+    end
+
+    it "returns a status of delivered" do
+      return_value = described_class.call(
+        address: "email@address.com",
+        subject: "subject",
+        body: "body",
+        reference: "ref-123",
+      )
+      expect(return_value).to be(:delivered)
+    end
   end
 end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -102,11 +102,22 @@ RSpec.describe DeliveryRequestService do
       expect(DeliveryAttempt.last.email).to eq(email)
     end
 
-    it "sets the delivery attempt's status to provider response" do
-      allow(subject.provider).to receive(:call).and_return(:delivered)
-      subject.call(email: email)
-      expect(DeliveryAttempt.last).to be_delivered
+    context "when the delivery attempt returns a final status" do
+      before { allow(subject.provider).to receive(:call).and_return(:delivered) }
+
+      it "sets the delivery attempt's status to provider response" do
+        subject.call(email: email)
+        expect(DeliveryAttempt.last).to be_delivered
+      end
+
+      it "marks the email as being finished sending" do
+        expect { subject.call(email: email) }
+          .to change { email.finished_sending_at }
+          .from(nil)
+          .to(an_instance_of(ActiveSupport::TimeWithZone))
+      end
     end
+
 
     it "sets the delivery attempt's provider to the name of the provider" do
       subject.call(email: email)

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -56,7 +56,19 @@ RSpec.describe StatusUpdateService do
     let(:status) { "unknown" }
 
     it "raises an error" do
-      expect { status_update }.to raise_error(ActiveRecord::StatementInvalid)
+      expect { status_update }
+        .to raise_error(StatusUpdateService::DeliveryAttemptInvalidStatusError)
+    end
+  end
+
+  context "when the delivery attempt already has a non waiting status" do
+    before do
+      delivery_attempt.update!(status: "delivered")
+    end
+
+    it "raises an error" do
+      expect { status_update }
+        .to raise_error(StatusUpdateService::DeliveryAttemptStatusConflictError)
     end
   end
 end

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe StatusUpdateService do
 
     it "does not update the emails finished_sending_at timestamp" do
       expect { status_update }
-        .to_not change { delivery_attempt.reload.email.finished_sending_at }
+        .to_not(change { delivery_attempt.reload.email.finished_sending_at })
     end
   end
 

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe StatusUpdateService do
       .to("delivered")
   end
 
+  it "updates the emails finished_sending_at timestamp" do
+    expect { status_update }
+      .to change { delivery_attempt.reload.email.finished_sending_at }
+      .from(nil)
+      .to(an_instance_of(ActiveSupport::TimeWithZone))
+  end
+
   context "with a temporary failure" do
     let(:status) { "temporary-failure" }
 
@@ -28,6 +35,11 @@ RSpec.describe StatusUpdateService do
         .with(15.minutes, delivery_attempt.email.id, :default)
 
       status_update
+    end
+
+    it "does not update the emails finished_sending_at timestamp" do
+      expect { status_update }
+        .to_not change { delivery_attempt.reload.email.finished_sending_at }
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/R14kXWU9/633-set-up-rudimentary-email-archive-system

This introduces a new field to email (finished_sending_at) which is used as a means to determine that the sending process for an Email has finished and then can be used as a means to determine which emails are archivable or not (the alternative to this is a rather grim query that pulls in latest delivery attempts for an email on a join.

I'm not particularly attached to the name `finished_sending_at` so suggestions for a better one are welcome. It seemed clearer than using terminology like "completed_at"

Along the way this also takes on a few issues: 

- Pseudo delivery attempts were being left as marked as sending forever as they won't have a status update
- There was the ability to get a status update for same delivery attempt twice which could cause incorrect data. 
- Fixes some concealed exceptions as part of feature testing.