### PR TITLE
Stop using old UUID fields

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -66,7 +66,7 @@ private
 
   def unsubscribe_link(result)
     UnsubscribeLinkPresenter.call(
-      uuid: result.subscription_uuid,
+      id: result.subscription_id,
       title: result.subscriber_list_title
     )
   end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -55,7 +55,7 @@ private
   def presented_unsubscribe_links(subscriptions)
     links_array = subscriptions.map do |subscription|
       UnsubscribeLinkPresenter.call(
-        uuid: subscription.uuid,
+        id: subscription.id,
         title: subscription.subscriber_list.title,
       )
     end

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -6,10 +6,10 @@ class UnsubscribeController < ApplicationController
 private
 
   def subscription
-    Subscription.not_deleted.find_by!(uuid: uuid)
+    Subscription.not_deleted.find_by!(id: id)
   end
 
-  def uuid
-    params.fetch(:uuid)
+  def id
+    params.fetch(:id)
   end
 end

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -6,7 +6,7 @@ class UnsubscribeController < ApplicationController
 private
 
   def subscription
-    Subscription.not_deleted.find_by!(id: id)
+    Subscription.not_deleted.find(id)
   end
 
   def id

--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -1,6 +1,6 @@
 class UnsubscribeLinkPresenter
-  def initialize(uuid:, title:)
-    @uuid = uuid
+  def initialize(id:, title:)
+    @id = id
     @title = title
   end
 
@@ -16,11 +16,11 @@ class UnsubscribeLinkPresenter
 
 private
 
-  attr_reader :uuid, :title
+  attr_reader :id, :title
 
   def url
     escaped_title = ERB::Util.url_encode(title)
-    base_path = "/email/unsubscribe/#{uuid}?title=#{escaped_title}"
+    base_path = "/email/unsubscribe/#{id}?title=#{escaped_title}"
     PublicUrlService.url_for(base_path: base_path)
   end
 end

--- a/app/queries/subscription_content_change_query.rb
+++ b/app/queries/subscription_content_change_query.rb
@@ -18,13 +18,12 @@ private
 
   attr_reader :subscriber, :digest_run
 
-  Result = Struct.new(:subscription_id, :subscription_uuid, :subscriber_list_title, :content_changes)
+  Result = Struct.new(:subscription_id, :subscriber_list_title, :content_changes)
 
   def present
-    grouped_content_changes.map do |(subscription_id, subscription_uuid, subscriber_list_title), content_changes|
+    grouped_content_changes.map do |(subscription_id, subscriber_list_title), content_changes|
       Result.new(
         subscription_id,
-        subscription_uuid,
         subscriber_list_title,
         content_changes,
       )
@@ -33,13 +32,13 @@ private
 
   def grouped_content_changes
     content_changes.group_by do |record|
-      [record["subscription_id"], record["subscription_uuid"], record["subscriber_list_title"]]
+      [record["subscription_id"], record["subscriber_list_title"]]
     end
   end
 
   def content_changes
     ContentChange
-      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriptions.uuid AS subscription_uuid")
+      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title")
       .joins(matched_content_changes: { subscriber_list: { subscriptions: :subscriber } })
       .where(subscribers: { id: subscriber.id })
       .where("content_changes.created_at >= ?", digest_run.starts_at)

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -19,8 +19,8 @@ class DeliveryRequestService
 
   def call(email:)
     reference = SecureRandom.uuid
-    address = determine_address(email, reference)
 
+    address = determine_address(email, reference)
     return if address.nil?
 
     delivery_attempt = create_delivery_attempt(email, reference)
@@ -57,6 +57,7 @@ private
     MetricsService.first_delivery_attempt(email, Time.now.utc)
 
     DeliveryAttempt.create!(
+      id: reference,
       email: email,
       status: :sending,
       provider: provider_name,

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -54,7 +54,7 @@ private
                 .includes(:email)
                 .joins(:email)
                 .lock
-                .find_by!(id: reference)
+                .find(reference)
 
     if !attempt.sending?
       raise DeliveryAttemptStatusConflictError, "Status update already received"

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -54,7 +54,7 @@ private
                 .includes(:email)
                 .joins(:email)
                 .lock
-                .find_by!(reference: reference)
+                .find_by!(id: reference)
 
     if !attempt.sending?
       raise DeliveryAttemptStatusConflictError, "Status update already received"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,6 @@ Rails.application.routes.draw do
 
     get "/healthcheck", to: "healthcheck#check"
 
-    post "/unsubscribe/:uuid", to: "unsubscribe#unsubscribe"
+    post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
   end
 end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe DigestEmailBuilder do
   let(:subscription_content_change_results) {
     [
       double(
-        subscription_id: 1,
-        subscription_uuid: "ABC1",
+        subscription_id: "ABC1",
         subscriber_list_title: "Test title 1",
         content_changes: [
           build(:content_change, public_updated_at: "1/1/2016 10:00"),
@@ -15,8 +14,7 @@ RSpec.describe DigestEmailBuilder do
         ],
       ),
       double(
-        subscription_id: 2,
-        subscription_uuid: "ABC2",
+        subscription_id: "ABC2",
         subscriber_list_title: "Test title 2",
         content_changes: [
           build(:content_change, public_updated_at: "4/1/2016 10:00"),
@@ -45,12 +43,12 @@ RSpec.describe DigestEmailBuilder do
 
   it "adds an entry to body for each content change" do
     expect(UnsubscribeLinkPresenter).to receive(:call).with(
-      uuid: "ABC1",
+      id: "ABC1",
       title: "Test title 1"
     ).and_return("unsubscribe_link_1")
 
     expect(UnsubscribeLinkPresenter).to receive(:call).with(
-      uuid: "ABC2",
+      id: "ABC2",
       title: "Test title 2"
     ).and_return("unsubscribe_link_2")
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ImmediateEmailBuilder do
   let(:subscription_one) {
     build(
       :subscription,
-      uuid: "bef9b608-05ba-46ce-abb7-8567f4180a25",
+      id: "bef9b608-05ba-46ce-abb7-8567f4180a25",
       subscriber: subscriber,
       subscriber_list: build(:subscriber_list, title: "First Subscription")
     )
@@ -91,7 +91,7 @@ RSpec.describe ImmediateEmailBuilder do
 
       it "sets the body and unsubscribe links" do
         expect(UnsubscribeLinkPresenter).to receive(:call).with(
-          uuid: "bef9b608-05ba-46ce-abb7-8567f4180a25",
+          id: "bef9b608-05ba-46ce-abb7-8567f4180a25",
           title: "First Subscription"
         ).and_return("unsubscribe_link")
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
   end
 
   factory :delivery_attempt do
+    id { SecureRandom.uuid }
     email
     status :sending
     provider :notify

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,7 +16,6 @@ FactoryBot.define do
   end
 
   factory :delivery_attempt do
-    id { SecureRandom.uuid }
     email
     status :sending
     provider :notify

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.uuid}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
 
       &nbsp;
 
@@ -56,7 +56,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.uuid}?title=Subscriber%20list%20two)
+      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
     BODY
   end
 
@@ -80,7 +80,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.uuid}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
     BODY
   end
 
@@ -168,6 +168,7 @@ RSpec.describe "creating and delivering digests", type: :request do
         change_note: "Change note three",
         public_updated_at: "2017-01-01 09:00:00",
         links: {
+
           topics: [list_two_topic_id]
         }
       )
@@ -240,7 +241,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.uuid}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
 
       &nbsp;
 
@@ -262,7 +263,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.uuid}?title=Subscriber%20list%20two)
+      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
     BODY
   end
 
@@ -286,7 +287,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.uuid}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
     BODY
   end
   scenario "weekly digest run" do

--- a/spec/features/permanent_failure_spec.rb
+++ b/spec/features/permanent_failure_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Failing to deliver an email via Notify (permanent failure)", typ
     3.times { create_content_change }
     expect_an_email_was_not_sent
 
-    uuid = extract_unsubscribe_uuid(email_data)
-    unsubscribe_from_subscribable(uuid, expected_status: 404)
+    id = extract_unsubscribe_id(email_data)
+    unsubscribe_from_subscribable(id, expected_status: 404)
   end
 end

--- a/spec/features/unsubscribing_spec.rb
+++ b/spec/features/unsubscribing_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe "Unsubscribing from a subscribable", type: :request do
     create_content_change
     email_data = expect_an_email_was_sent
 
-    uuid = extract_unsubscribe_uuid(email_data)
-    unsubscribe_from_subscribable(uuid, expected_status: 204)
+    id = extract_unsubscribe_id(email_data)
+    unsubscribe_from_subscribable(id, expected_status: 204)
 
     clear_any_requests_that_have_been_recorded!
 
     create_content_change
     expect_an_email_was_not_sent
 
-    unsubscribe_from_subscribable(uuid, expected_status: 404)
+    unsubscribe_from_subscribable(id, expected_status: 404)
     unsubscribe_from_subscribable("missing", expected_status: 404)
   end
 end

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Receiving a status update", type: :request do
   let(:reference) { "b6589b2b-8f8e-457b-9ddf-237b62438ad1" }
 
   let!(:delivery_attempt) do
-    create(:delivery_attempt, reference: reference, status: "sending")
+    create(:delivery_attempt, id: reference, status: "sending")
   end
 
   let(:permissions) { %w[signin status_updates] }

--- a/spec/integration/unsubscribe_spec.rb
+++ b/spec/integration/unsubscribe_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Unsubscribing", type: :request do
         let(:subscription) { create(:subscription) }
 
         before do
-          post "/unsubscribe/#{subscription.uuid}"
+          post "/unsubscribe/#{subscription.id}"
         end
 
         it "deletes the subscription" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -21,25 +21,6 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe "callbacks" do
-    subject { build(:subscription) }
-
-    it "sets a uuid before validation" do
-      expect(subject.uuid).to be_nil
-
-      expect(subject).to be_valid
-      expect(subject.uuid).not_to be_nil
-    end
-
-    it "preserves the same uuid" do
-      subject.valid?
-      uuid = subject.uuid
-
-      subject.valid?
-      expect(subject.uuid).to eq(uuid)
-    end
-  end
-
   describe "destroy" do
     subject { create(:subscription) }
 

--- a/spec/presenters/unsubscribe_link_presenter_spec.rb
+++ b/spec/presenters/unsubscribe_link_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UnsubscribeLinkPresenter do
   describe ".call" do
     it "returns a presented unsubscribe link" do
       expected = "Unsubscribe from [Test title](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
-      expect(described_class.call(uuid: "abc123", title: "Test title")).to eq(expected)
+      expect(described_class.call(id: "abc123", title: "Test title")).to eq(expected)
     end
   end
 end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -118,7 +118,6 @@ RSpec.describe DeliveryRequestService do
       end
     end
 
-
     it "sets the delivery attempt's provider to the name of the provider" do
       subject.call(email: email)
       expect(DeliveryAttempt.last.provider).to eq("pseudo")
@@ -133,7 +132,7 @@ RSpec.describe DeliveryRequestService do
       subject.call(email: email)
 
       expect(reference).to be_present
-      expect(DeliveryAttempt.last.reference).to eq(reference)
+      expect(DeliveryAttempt.last.id).to eq(reference)
     end
 
     it "records a metric for the delivery attempt" do

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe StatusUpdateService do
+  let(:reference) { "b6589b2b-8f8e-457b-9ddf-237b62438ad1" }
+
   let!(:delivery_attempt) do
-    create(:delivery_attempt, reference: "b6589b2b-8f8e-457b-9ddf-237b62438ad1", status: "sending")
+    create(:delivery_attempt, id: reference, status: "sending")
   end
 
-  let(:reference) { "b6589b2b-8f8e-457b-9ddf-237b62438ad1" }
   let(:status) { "delivered" }
 
   subject(:status_update) { described_class.call(reference: reference, status: status) }

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -87,7 +87,7 @@ module FeatureHelpers
     expect(a_request(:post, /fake-notify/)).not_to have_been_made
   end
 
-  def extract_unsubscribe_uuid(email_data)
+  def extract_unsubscribe_id(email_data)
     body = email_data.dig(:personalisation, :body)
     body[%r{/unsubscribe/(.*)\?}, 1]
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -46,8 +46,8 @@ module FeatureHelpers
     expect(response.status).to eq(expected_status)
   end
 
-  def unsubscribe_from_subscribable(uuid, expected_status: 204)
-    post "/unsubscribe/#{uuid}"
+  def unsubscribe_from_subscribable(id, expected_status: 204)
+    post "/unsubscribe/#{id}"
     expect(response.status).to eq(expected_status)
   end
 

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe DigestEmailGenerationWorker do
       [
         double(
           subscription_id: subscription_one.id,
-          subscription_uuid: subscription_one.uuid,
           subscriber_list_title: "Test title 1",
           content_changes: [
             create(:content_change, public_updated_at: "1/1/2016 10:00"),
@@ -35,7 +34,6 @@ RSpec.describe DigestEmailGenerationWorker do
         ),
         double(
           subscription_id: subscription_two.id,
-          subscription_uuid: subscription_two.uuid,
           subscriber_list_title: "Test title 2",
           content_changes: [
             create(:content_change, public_updated_at: "4/1/2016 10:00"),


### PR DESCRIPTION
This stops using the custom UUID fields on delivery attempts and subscriptions and instead uses their IDs as they are now UUIDs.

Depends on #461.

[Trello Card](https://trello.com/c/B8db764N/637-switch-some-of-our-primary-keys-from-id-to-uuid)