### PR TITLE
Remove old UUID fields

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -7,19 +7,11 @@ class Subscription < ApplicationRecord
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
   enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2 }
 
-  before_validation :set_uuid
-
   validates :subscriber, uniqueness: { scope: :subscriber_list }
 
   scope :not_deleted, -> { where(ended_at: nil) }
 
   def destroy
     update_attributes!(ended_at: Time.now)
-  end
-
-private
-
-  def set_uuid
-    self.uuid ||= SecureRandom.uuid
   end
 end

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -61,7 +61,6 @@ private
       email: email,
       status: :sending,
       provider: provider_name,
-      reference: reference,
     )
   end
 

--- a/db/migrate/20180301130127_remove_old_uuid_fields.rb
+++ b/db/migrate/20180301130127_remove_old_uuid_fields.rb
@@ -1,0 +1,6 @@
+class RemoveOldUuidFields < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :delivery_attempts, :reference
+    remove_column :subscriptions, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,14 +40,12 @@ ActiveRecord::Schema.define(version: 20180301132513) do
   create_table "delivery_attempts", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.integer "status", null: false
     t.integer "provider", null: false
-    t.uuid "reference", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
     t.uuid "email_id", null: false
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"
-    t.index ["reference"], name: "index_delivery_attempts_on_reference", unique: true
   end
 
   create_table "digest_run_subscribers", force: :cascade do |t|
@@ -152,7 +150,6 @@ ActiveRecord::Schema.define(version: 20180301132513) do
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "uuid", null: false
     t.integer "frequency", default: 0, null: false
     t.string "signon_user_uid"
     t.datetime "deleted_at"
@@ -161,7 +158,6 @@ ActiveRecord::Schema.define(version: 20180301132513) do
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"
-    t.index ["uuid"], name: "index_subscriptions_on_uuid", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -131,12 +131,12 @@ private
           frequency: frequency
         ).exists?
 
-        [subscriber.id, subscribable.id, frequency, SecureRandom.uuid, :imported]
+        [subscriber.id, subscribable.id, frequency, :imported]
       end
 
     records = records.compact
 
-    columns = %w(subscriber_id subscriber_list_id frequency uuid source)
+    columns = %w(subscriber_id subscriber_list_id frequency source)
 
     puts "Importing records..."
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,7 +19,6 @@ FactoryBot.define do
     email
     status :sending
     provider :notify
-    reference { SecureRandom.uuid }
   end
 
   factory :digest_run do

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -1,9 +1,6 @@
 RSpec.describe "Receiving a status update", type: :request do
-  let(:reference) { "b6589b2b-8f8e-457b-9ddf-237b62438ad1" }
-
-  let!(:delivery_attempt) do
-    create(:delivery_attempt, id: reference, status: "sending")
-  end
+  let(:delivery_attempt) { create(:delivery_attempt, status: "sending") }
+  let(:reference) { delivery_attempt.id }
 
   let(:permissions) { %w[signin status_updates] }
   let(:user) { create(:user, permissions: permissions) }


### PR DESCRIPTION
This removes the old UUID fields on delivery attempts and subscriptions as we can now just use their IDs.

Depends on #463.

[Trello Card](https://trello.com/c/B8db764N/637-switch-some-of-our-primary-keys-from-id-to-uuid)