### PR TITLE
Configure the test database in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://email-alert-api:email-alert-api@localhost/email-alert-api_test")
   govuk.buildProject()
 }

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,7 @@ development:
 test:
   <<: *default
   database: email-alert-api_test
+  url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
   <<: *default


### PR DESCRIPTION
We have to use a special email-alert-api user as it has superuser
access to enable extensions.