### PR TITLE
Fix logging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_app_config (1.3.1)
+    govuk_app_config (1.3.2)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,2 @@
-require "govuk_app_config"
+require "govuk_app_config/govuk_unicorn"
 GovukUnicorn.configure(self)


### PR DESCRIPTION
This updates to govuk_app_config 1.3.2 which resolves the issues we have
with logs not making it to the correct file and instead being sent to
STDOUT.