### PR TITLE
Fail domains that start with a dot

### DIFF
--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -35,7 +35,7 @@ private
   end
 
   def domain_contains_at_least_one_dot?(domain)
-    !domain.scan('.').empty?
+    !domain.start_with?('.') && !domain.scan('.').empty?
   end
 
   def domain_is_an_ip_address?(domain)

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Subscriber, type: :model do
       expect(subject).to be_invalid
     end
 
+    it "is invalid for an email address which has a domain starting with a ." do
+      subject.address = "me@.invalid"
+
+      expect(subject).to be_invalid
+    end
+
     it "is invalid for an email address which contains a newline" do
       subject.address = "foo@bar.com\nfoo@baz.com"
 


### PR DESCRIPTION
This commit adds extra validation to stop domains that start with a “.” from passing validation.