### PR TITLE
Subscriber Deactivation

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -7,6 +7,8 @@ class SubscriptionsController < ApplicationController
       subscriber_list: subscribable,
     )
 
+    subscriber.activate! if subscriber.deactivated?
+
     status = subscription.new_record? ? :created : :ok
 
     subscription.deleted_at = nil

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -11,10 +11,11 @@ class Subscriber < ApplicationRecord
   has_many :digest_run_subscribers, dependent: :destroy
   has_many :digest_runs, through: :digest_run_subscribers
 
+  scope :nullified, -> { where(address: nil) }
   scope :deactivated, -> { where.not(deactivated_at: nil) }
   scope :activated, -> { where(deactivated_at: nil) }
 
-  def nullify_address!
+  def nullify!
     raise "Already nullified." if address.nil?
     raise "Must be deactivated first." if deactivated_at.nil?
 

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -4,12 +4,41 @@ class Subscriber < ApplicationRecord
     validates_uniqueness_of :address, case_sensitive: false
   end
 
+  validate :not_nullified_and_activated
+
   has_many :subscriptions, -> { not_deleted }
   has_many :subscriber_lists, through: :subscriptions
   has_many :digest_run_subscribers, dependent: :destroy
   has_many :digest_runs, through: :digest_run_subscribers
 
+  scope :deactivated, -> { where.not(deactivated_at: nil) }
+  scope :activated, -> { where(deactivated_at: nil) }
+
   def nullify_address!
+    raise "Already nullified." if address.nil?
+    raise "Must be deactivated first." if deactivated_at.nil?
+
     update!(address: nil)
+  end
+
+  def deactivate!(datetime: nil)
+    raise "Already deactivated." unless deactivated_at.nil?
+
+    update!(deactivated_at: datetime || Time.now)
+  end
+
+  def activate!
+    raise "Cannot activate as the address is nil." if address.nil?
+    raise "Already activated." if deactivated_at.nil?
+
+    update!(deactivated_at: nil)
+  end
+
+private
+
+  def not_nullified_and_activated
+    if address.nil? && deactivated_at.nil?
+      errors.add(:deactivated_at, "should be set to the deactivation date")
+    end
   end
 end

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -14,6 +14,7 @@ class Subscriber < ApplicationRecord
   scope :activated, -> { where(deactivated_at: nil) }
   scope :deactivated, -> { where.not(deactivated_at: nil) }
   scope :nullified, -> { where(address: nil) }
+  scope :not_nullified, -> { where.not(address: nil) }
 
   def activated?
     deactivated_at.nil?

--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -1,10 +1,10 @@
 class SubscribersForImmediateEmailQuery
   def self.call
     Subscriber
+      .activated
       .where(
         unprocessed_subscription_contents_exist_for_subscribers
        )
-       .where.not(address: nil)
   end
 
   def self.unprocessed_subscription_contents_exist_for_subscribers

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -17,7 +17,7 @@ module UnsubscribeService
         subscriptions.each(&:destroy)
 
         if no_other_subscriptions?(subscriber, subscriptions)
-          subscriber.nullify_address!
+          subscriber.nullify!
         end
       end
     end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -17,6 +17,7 @@ module UnsubscribeService
         subscriptions.each(&:destroy)
 
         if no_other_subscriptions?(subscriber, subscriptions)
+          subscriber.deactivate!
           subscriber.nullify!
         end
       end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -18,7 +18,6 @@ module UnsubscribeService
 
         if no_other_subscriptions?(subscriber, subscriptions)
           subscriber.deactivate!
-          subscriber.nullify!
         end
       end
     end

--- a/app/workers/nullify_deactivated_subscribers_worker.rb
+++ b/app/workers/nullify_deactivated_subscribers_worker.rb
@@ -1,0 +1,26 @@
+class NullifyDeactivatedSubscribersWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :cleanup
+
+  def perform
+    run_only_once do
+      subscribers.find_each(&:nullify!)
+    end
+  end
+
+private
+
+  def subscribers
+    Subscriber
+      .deactivated
+      .not_nullified
+      .where("deactivated_at < ?", 28.days.ago)
+  end
+
+  def run_only_once
+    Subscriber.with_advisory_lock("nullify_deactivated_subscribers", timeout_seconds: 0) do
+      yield
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,6 +10,7 @@
   - [default, 3]
   - [delivery_digest, 2]
   - [email_generation_digest, 1]
+  - cleanup
 :schedule:
   immediate_email_generation:
     every: '5s'
@@ -20,3 +21,6 @@
   weekly_digest_initiator:
     cron: '30 8 * * 6' # every Saturday at 8:30am
     class: WeeklyDigestInitiatorWorker
+  nullify_deactivated_subscribers:
+    every: '1h'
+    class: NullifyDeactivatedSubscribersWorker

--- a/db/migrate/20180228132051_add_deactivated_at_to_subscriber.rb
+++ b/db/migrate/20180228132051_add_deactivated_at_to_subscriber.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedAtToSubscriber < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscribers, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180223095104) do
+ActiveRecord::Schema.define(version: 20180228132051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 20180223095104) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
+    t.datetime "deactivated_at"
     t.index "lower((address)::text)", name: "index_subscribers_on_lower_address", unique: true
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,6 +56,17 @@ FactoryBot.define do
 
   factory :subscriber do
     sequence(:address) { |i| "test-#{i}@example.com" }
+
+    trait :activated
+
+    trait :deactivated do
+      deactivated_at { Time.now }
+    end
+
+    trait :nullified do
+      address nil
+      deactivated_at { Time.now }
+    end
   end
 
   factory :subscriber_list do

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe "Creating a subscription", type: :request do
             expect(response.status).to eq(201)
           end
         end
+
+        context "with a deactivated subscriber" do
+          before do
+            create(:subscriber, :deactivated, address: "deactivated@example.com")
+          end
+
+          it "activates the subscriber" do
+            params = JSON.dump(address: "deactivated@example.com", subscribable_id: subscribable.id)
+            post "/subscriptions", params: params, headers: JSON_HEADERS
+
+            expect(Subscriber.first.deactivated?).to be false
+            expect(Subscriber.first.activated?).to be true
+          end
+        end
       end
     end
   end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -123,35 +123,6 @@ RSpec.describe Subscriber, type: :model do
     end
   end
 
-  describe "#nullify!" do
-    subject(:subscriber) { create(:subscriber, :deactivated, address: "foo@bar.com") }
-
-    it "sets the address to nil and saves the record" do
-      expect { subscriber.nullify! }
-        .to change { subscriber.reload.address }
-        .from("foo@bar.com")
-        .to(nil)
-    end
-
-    it "appears in the nullified scope" do
-      subscriber.nullify!
-      expect(Subscriber.nullified.count).to eq(1)
-    end
-
-    it "doesn't appear in the activated scope" do
-      subscriber.nullify!
-      expect(Subscriber.activated.count).to eq(0)
-    end
-
-    context "already nullified" do
-      it "refuses to nullify again" do
-        subscriber.nullify!
-
-        expect { subscriber.nullify! }.to raise_error(/Already nullified/)
-      end
-    end
-  end
-
   describe "#activate!" do
     context "when activated" do
       subject(:subscriber) { create(:subscriber, :activated) }
@@ -171,6 +142,8 @@ RSpec.describe Subscriber, type: :model do
           .to change { subscriber.reload.deactivated_at }
           .from(deactivated_at)
           .to(nil)
+
+        expect(subscriber.reload.activated?).to be true
       end
 
       it "appears in the activated scope" do
@@ -203,6 +176,8 @@ RSpec.describe Subscriber, type: :model do
             .to change { subscriber.reload.deactivated_at }
             .from(nil)
             .to(Time.parse("1/1/2017"))
+
+          expect(subscriber.reload.deactivated?).to be true
         end
       end
 
@@ -222,6 +197,37 @@ RSpec.describe Subscriber, type: :model do
 
       it "refuses to deactivate" do
         expect { subscriber.deactivate! }.to raise_error(/Already deactivated/)
+      end
+    end
+  end
+
+  describe "#nullify!" do
+    subject(:subscriber) { create(:subscriber, :deactivated, address: "foo@bar.com") }
+
+    it "sets the address to nil and saves the record" do
+      expect { subscriber.nullify! }
+        .to change { subscriber.reload.address }
+        .from("foo@bar.com")
+        .to(nil)
+
+      expect(subscriber.reload.nullified?).to be true
+    end
+
+    it "appears in the nullified scope" do
+      subscriber.nullify!
+      expect(Subscriber.nullified.count).to eq(1)
+    end
+
+    it "doesn't appear in the activated scope" do
+      subscriber.nullify!
+      expect(Subscriber.activated.count).to eq(0)
+    end
+
+    context "already nullified" do
+      it "refuses to nullify again" do
+        subscriber.nullify!
+
+        expect { subscriber.nullify! }.to raise_error(/Already nullified/)
       end
     end
   end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Subscriber, type: :model do
       create(:subscriber, :nullified)
 
       subject.deactivate!
-      subject.nullify_address!
+      subject.nullify!
       expect(subject).to be_valid
     end
   end
@@ -123,21 +123,31 @@ RSpec.describe Subscriber, type: :model do
     end
   end
 
-  describe "#nullify_address!" do
+  describe "#nullify!" do
     subject(:subscriber) { create(:subscriber, :deactivated, address: "foo@bar.com") }
 
     it "sets the address to nil and saves the record" do
-      expect { subscriber.nullify_address! }
+      expect { subscriber.nullify! }
         .to change { subscriber.reload.address }
         .from("foo@bar.com")
         .to(nil)
     end
 
+    it "appears in the nullified scope" do
+      subscriber.nullify!
+      expect(Subscriber.nullified.count).to eq(1)
+    end
+
+    it "doesn't appear in the activated scope" do
+      subscriber.nullify!
+      expect(Subscriber.activated.count).to eq(0)
+    end
+
     context "already nullified" do
       it "refuses to nullify again" do
-        subscriber.nullify_address!
+        subscriber.nullify!
 
-        expect { subscriber.nullify_address! }.to raise_error(/Already nullified/)
+        expect { subscriber.nullify! }.to raise_error(/Already nullified/)
       end
     end
   end

--- a/spec/queries/subscribers_for_immediate_email_query_spec.rb
+++ b/spec/queries/subscribers_for_immediate_email_query_spec.rb
@@ -11,8 +11,13 @@ RSpec.describe SubscribersForImmediateEmailQuery do
     expect(described_class.call.count).to eq(0)
   end
 
-  it "does not return Subscriber for subscribers with nil addresses" do
-    create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, address: nil)))
+  it "does not return Subscriber for nullified subscribers" do
+    create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :nullified)))
+    expect(described_class.call.count).to eq(0)
+  end
+
+  it "does not return Subscriber for deactivates subscribers" do
+    create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :deactivated)))
     expect(described_class.call.count).to eq(0)
   end
 

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -34,12 +34,13 @@ RSpec.describe StatusUpdateService do
   context "with a permanent failure" do
     let(:status) { "permanent-failure" }
 
-    it "unsubscribes the subscriber" do
+    it "deactivates the subscriber" do
       create(:subscriber, address: delivery_attempt.email.address)
 
       expect { status_update }
-        .to change { Subscriber.last.address }
-        .to(nil)
+        .to change { Subscriber.last.deactivated? }
+        .from(false)
+        .to(true)
     end
   end
 

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe UnsubscribeService do
   describe ".subscriber!" do
     let!(:subscriber) { create(:subscriber, address: "foo@bar.com") }
 
-    it "nullifies the email address" do
+    it "deactivates the subscriber" do
       expect { subject.subscriber!(subscriber) }
-        .to change { subscriber.reload.address }
-        .from("foo@bar.com")
-        .to(nil)
+        .to change { subscriber.reload.deactivated? }
+        .from(false)
+        .to(true)
     end
 
     context "when the subscriber has subscriptions" do
@@ -53,9 +53,9 @@ RSpec.describe UnsubscribeService do
     end
 
     context "when it is the only remaining subscription for the subscriber" do
-      it "nullifies the email address of the subscriber" do
+      it "deactivates the subscriber" do
         expect { subject.subscription!(subscription) }
-          .to change { subscriber.reload.address.nil? }
+          .to change { subscriber.reload.deactivated? }
           .from(false)
           .to(true)
       end

--- a/spec/workers/immediate_email_generation_worker_spec.rb
+++ b/spec/workers/immediate_email_generation_worker_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ImmediateEmailGenerationWorker do
 
       before do
         create(:subscription_content, email: create(:email))
-        create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, address: nil)))
+        create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :nullified)))
       end
 
       it "should create an email" do

--- a/spec/workers/nullify_deactivated_subscribers_worker_spec.rb
+++ b/spec/workers/nullify_deactivated_subscribers_worker_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe NullifyDeactivatedSubscribersWorker do
+  describe ".perform_async" do
+    before do
+      Sidekiq::Testing.fake! do
+        described_class.perform_async
+      end
+    end
+
+    it "gets added to the cleanup queue" do
+      expect(Sidekiq::Queues["cleanup"].size).to eq(1)
+    end
+  end
+
+  describe ".perform" do
+    context "with some subscribers" do
+      before do
+        create(:subscriber, :nullified)
+
+        create(:subscriber, :deactivated)
+        create(:subscriber, :deactivated, deactivated_at: 27.days.ago)
+        create(:subscriber, :deactivated, address: "nullify@me.com", deactivated_at: 29.days.ago)
+
+        create(:subscriber, :activated)
+      end
+
+      it "nullifies the subscribers that were deactivated more than 28 days ago" do
+        expect { subject.perform }
+          .to change { Subscriber.not_nullified.count }
+          .from(4)
+          .to(3)
+      end
+
+      it "doesn't deactivate any subscribers" do
+        expect { subject.perform }
+          .to_not change { Subscriber.activated.count }
+          .from(1)
+      end
+
+      it "nullifies the right subscriber" do
+        expect { subject.perform }
+          .to change { Subscriber.find_by(address: "nullify@me.com") }
+          .from(anything)
+          .to(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR deactivates subscribers instead of nullifying them when they unsubscribe, and then after 28 days it will nullify them.

It introduces the following states on subscribers with the appropriate validations and methods to change between them:

- **activated**: The subscriber wishes to receive emails.
- **deactivated**: The subscriber has asked to be unsubscribe from everything, they will be deleted 28 days after they unsubscribed.
- **deactivated and nullified (called nullified)**: There once was a subscriber but we now know nothing about them.

[Trello Card](https://trello.com/c/ElK95Sge/634-subscriber-deactivation)