### PR TITLE
Subscription Source

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -14,7 +14,9 @@ class SubscriptionsController < ApplicationController
     subscription.deleted_at = nil
     subscription.frequency = frequency
     subscription.signon_user_uid = current_user.uid
+    subscription.source = subscription.new_record? ? :user_signed_up : :frequency_changed
     subscription.save!
+
     render json: { id: subscription.id }, status: status
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,6 +5,7 @@ class Subscription < ApplicationRecord
   has_many :subscription_contents
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
+  enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2 }
 
   before_validation :set_uuid
 

--- a/db/migrate/20180228144454_add_source_to_subscriptions.rb
+++ b/db/migrate/20180228144454_add_source_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddSourceToSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriptions, :source, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180228132051) do
+ActiveRecord::Schema.define(version: 20180228144454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20180228132051) do
     t.integer "frequency", default: 0, null: false
     t.string "signon_user_uid"
     t.datetime "deleted_at"
+    t.integer "source", default: 0, null: false
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"

--- a/lib/import_govdelivery_csv.rb
+++ b/lib/import_govdelivery_csv.rb
@@ -131,12 +131,12 @@ private
           frequency: frequency
         ).exists?
 
-        [subscriber.id, subscribable.id, frequency, SecureRandom.uuid]
+        [subscriber.id, subscribable.id, frequency, SecureRandom.uuid, :imported]
       end
 
     records = records.compact
 
-    columns = %w(subscriber_id subscriber_list_id frequency uuid)
+    columns = %w(subscriber_id subscriber_list_id frequency uuid source)
 
     puts "Importing records..."
 

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe "Creating a subscription", type: :request do
         expect(response.status).to eq(201)
       end
 
+      it "sets the source to a user signup" do
+        params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id)
+        post "/subscriptions", params: params, headers: JSON_HEADERS
+
+        expect(Subscription.first.user_signed_up?).to be true
+      end
+
       context "with a frequency setting" do
         it "returns a 201 and sets the frequency" do
           params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id, frequency: "daily")
@@ -22,6 +29,7 @@ RSpec.describe "Creating a subscription", type: :request do
           expect(response.status).to eq(201)
 
           expect(Subscription.first.daily?).to be_truthy
+          expect(Subscription.first.user_signed_up?).to be true
         end
 
         context "with an existing subscription" do
@@ -37,6 +45,7 @@ RSpec.describe "Creating a subscription", type: :request do
             expect(response.status).to eq(200)
 
             expect(Subscription.first.weekly?).to be_truthy
+            expect(Subscription.first.frequency_changed?).to be true
           end
         end
 

--- a/spec/lib/import_govdelivery_csv_spec.rb
+++ b/spec/lib/import_govdelivery_csv_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe ImportGovdeliveryCsv do
     expect(find_subscription("foo@example.com", "Second").frequency).to eq(Frequency::IMMEDIATELY)
   end
 
+  it "sets the source on the subscriptions" do
+    described_class.call("spec/lib/csv_fixture.csv", "spec/lib/csv_digest_fixture.csv")
+
+    expect(Subscription.where(source: :user_signed_up).count).to eq(0)
+    expect(Subscription.where(source: :imported).count).to eq(3)
+  end
+
   context "when the subscriber list is travel advice" do
     let!(:first_subscribable) do
       create(:subscriber_list, :travel_advice, gov_delivery_id: "UKGOVUK_111", title: "First")


### PR DESCRIPTION
This PR adds a new field on subscriptions to store the source of it. One of either `user_signed_up`, `frequency_changed` or `imported`.

[Trello Card](https://trello.com/c/RRhaDynE/635-append-only-subscription)