### PR TITLE
Disallow any kind of whitespace in email addresses

### DIFF
--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -12,7 +12,7 @@ private
     contains_one_at_sign?(email_address) &&
       contains_a_valid_domain?(email_address) &&
       is_a_single_email_address?(email_address) &&
-      does_not_contain_newline_characters?(email_address)
+      does_not_contain_whitespace?(email_address)
   end
 
   def contains_one_at_sign?(email_address)
@@ -30,8 +30,8 @@ private
     email_address.scan(',').empty?
   end
 
-  def does_not_contain_newline_characters?(email_address)
-    email_address !~ /\n/
+  def does_not_contain_whitespace?(email_address)
+    email_address !~ /\s/
   end
 
   def domain_contains_at_least_one_dot?(domain)

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe Subscriber, type: :model do
       expect(subject).to be_invalid
     end
 
+    it "is invalid for an email address which contains a space" do
+      subject.address = "foo @ bar.com"
+
+      expect(subject).to be_invalid
+    end
+
     it "is invalid for multiple email addresses" do
       subject.address = "foo@bar.com,foo@baz.com"
 


### PR DESCRIPTION
This prevents us from allowing emails with spaces in as well as newline characters.