### PR TITLE
Add ended_at field to subscriptions

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -11,7 +11,7 @@ class SubscriptionsController < ApplicationController
 
     status = subscription.new_record? ? :created : :ok
 
-    subscription.deleted_at = nil
+    subscription.ended_at = nil
     subscription.frequency = frequency
     subscription.signon_user_uid = current_user.uid
     subscription.source = subscription.new_record? ? :user_signed_up : :frequency_changed

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -11,10 +11,10 @@ class Subscription < ApplicationRecord
 
   validates :subscriber, uniqueness: { scope: :subscriber_list }
 
-  scope :not_deleted, -> { where(deleted_at: nil) }
+  scope :not_deleted, -> { where(ended_at: nil) }
 
   def destroy
-    update_attributes!(deleted_at: Time.now)
+    update_attributes!(ended_at: Time.now)
   end
 
 private

--- a/db/migrate/20180301132513_add_subscription_ended_at.rb
+++ b/db/migrate/20180301132513_add_subscription_ended_at.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionEndedAt < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriptions, :ended_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180228144454) do
+ActiveRecord::Schema.define(version: 20180301132513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,6 +157,7 @@ ActiveRecord::Schema.define(version: 20180228144454) do
     t.string "signon_user_uid"
     t.datetime "deleted_at"
     t.integer "source", default: 0, null: false
+    t.datetime "ended_at"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -43,15 +43,14 @@ RSpec.describe "Subscriptions", type: :request do
       end
 
       context "with a deleted subscription" do
-        let!(:subscription) { create(:subscription, subscriber_list: subscribable, subscriber: subscriber, deleted_at: 1.day.ago) }
+        let!(:subscription) { create(:subscription, subscriber_list: subscribable, subscriber: subscriber, ended_at: 1.day.ago) }
 
         it "undeletes the subscription" do
           create_subscription
-          expect(Subscription.find(subscription.id).deleted_at).to be_nil
+          expect(Subscription.find(subscription.id).ended_at).to be_nil
         end
       end
     end
-
 
     context "without an existing subscription" do
       context "with a subscribable" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -29,22 +29,22 @@ RSpec.describe Subscription, type: :model do
       expect(described_class.find(subject.id)).to eq(subject)
     end
 
-    it "sets deleted_at to Time.now" do
+    it "sets ended_at to Time.now" do
       Timecop.freeze do
         subject.destroy
-        expect(subject.deleted_at).to eq(Time.now)
+        expect(subject.ended_at).to eq(Time.now)
       end
     end
   end
 
   describe ".not_deleted" do
-    it "returns subscriptions with deleted_at nil" do
+    it "returns subscriptions with ended_at nil" do
       create(:subscription)
       expect(Subscription.not_deleted.count).to eq(1)
     end
 
-    it "doesn't return subscriptions with deleted_at" do
-      create(:subscription, deleted_at: Time.now)
+    it "doesn't return subscriptions with ended_at" do
+      create(:subscription, ended_at: Time.now)
       expect(Subscription.not_deleted.count).to eq(0)
     end
   end


### PR DESCRIPTION
This replaces the existing `deleted_at` field but doesn't delete that field yet as old code will still be using that field.

[Trello Card](https://trello.com/c/RRhaDynE/635-append-only-subscription)