### PR TITLE
Append-only Subscriptions

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -12,9 +12,12 @@ class SubscriptionsController < ApplicationController
     status = subscription.new_record? ? :created : :ok
 
     subscription.ended_at = nil
+    subscription.ended_reason = nil
+
     subscription.frequency = frequency
     subscription.signon_user_uid = current_user.uid
     subscription.source = subscription.new_record? ? :user_signed_up : :frequency_changed
+
     subscription.save!
 
     render json: { id: subscription.id }, status: status

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,24 +2,29 @@ class SubscriptionsController < ApplicationController
   def create
     return render json: { id: 0 }, status: :created if smoke_test_address?
 
-    subscription = Subscription.find_or_initialize_by(
-      subscriber: subscriber,
-      subscriber_list: subscribable,
-    )
+    existing_subscription = nil
+    subscription = nil
 
-    subscriber.activate! if subscriber.deactivated?
+    Subscription.transaction do
+      existing_subscription = Subscription.active.lock.find_by(
+        subscriber: subscriber,
+        subscriber_list: subscribable,
+      )
 
-    status = subscription.new_record? ? :created : :ok
+      existing_subscription.end(reason: :frequency_changed) if existing_subscription
 
-    subscription.ended_at = nil
-    subscription.ended_reason = nil
+      subscriber.activate! if subscriber.deactivated?
 
-    subscription.frequency = frequency
-    subscription.signon_user_uid = current_user.uid
-    subscription.source = subscription.new_record? ? :user_signed_up : :frequency_changed
+      subscription = Subscription.create!(
+        subscriber: subscriber,
+        subscriber_list: subscribable,
+        frequency: frequency,
+        signon_user_uid: current_user.uid,
+        source: existing_subscription ? :frequency_changed : :user_signed_up
+      )
+    end
 
-    subscription.save!
-
+    status = existing_subscription ? :ok : :created
     render json: { id: subscription.id }, status: status
   end
 
@@ -44,7 +49,7 @@ private
   end
 
   def subscribable
-    SubscriberList.find(subscription_params.require(:subscribable_id))
+    @subscribable ||= SubscriberList.find(subscription_params.require(:subscribable_id))
   end
 
   def frequency

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -1,6 +1,6 @@
 class UnsubscribeController < ApplicationController
   def unsubscribe
-    UnsubscribeService.subscription!(subscription)
+    UnsubscribeService.subscription!(subscription, :unsubscribed)
   end
 
 private

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -6,7 +6,7 @@ class UnsubscribeController < ApplicationController
 private
 
   def subscription
-    Subscription.not_deleted.find(id)
+    Subscription.active.find(id)
   end
 
   def id

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -6,7 +6,7 @@ class Subscriber < ApplicationRecord
 
   validate :not_nullified_and_activated
 
-  has_many :subscriptions, -> { not_deleted }
+  has_many :subscriptions, -> { active }
   has_many :subscriber_lists, through: :subscriptions
   has_many :digest_run_subscribers, dependent: :destroy
   has_many :digest_runs, through: :digest_run_subscribers

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,6 +6,7 @@ class Subscription < ApplicationRecord
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
   enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2 }, _prefix: true
+  enum ended_reason: { unsubscribed: 0, non_existant_email: 1, frequency_change: 2 }, _prefix: :ended
 
   validates :subscriber, uniqueness: { scope: :subscriber_list }
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -9,7 +9,7 @@ class Subscription < ApplicationRecord
 
   validates :subscriber, uniqueness: { scope: :subscriber_list }
 
-  scope :not_deleted, -> { where(ended_at: nil) }
+  scope :active, -> { where(ended_at: nil) }
 
   def destroy
     update_attributes!(ended_at: Time.now)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,7 +5,7 @@ class Subscription < ApplicationRecord
   has_many :subscription_contents
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
-  enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2 }
+  enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2 }, _prefix: true
 
   validates :subscriber, uniqueness: { scope: :subscriber_list }
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,9 +6,9 @@ class Subscription < ApplicationRecord
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
   enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2 }, _prefix: true
-  enum ended_reason: { unsubscribed: 0, non_existant_email: 1, frequency_change: 2 }, _prefix: :ended
+  enum ended_reason: { unsubscribed: 0, non_existant_email: 1, frequency_changed: 2 }, _prefix: :ended
 
-  validates :subscriber, uniqueness: { scope: :subscriber_list }
+  validates_uniqueness_of :subscriber, scope: :subscriber_list, conditions: -> { active }
 
   scope :active, -> { where(ended_at: nil) }
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,7 +12,20 @@ class Subscription < ApplicationRecord
 
   scope :active, -> { where(ended_at: nil) }
 
-  def destroy
-    update_attributes!(ended_at: Time.now)
+  def active?
+    ended_at.nil?
+  end
+
+  def ended?
+    ended_at.present?
+  end
+
+  def end(reason:, datetime: nil)
+    raise "Already ended." if ended?
+
+    update!(
+      ended_reason: reason,
+      ended_at: datetime || Time.now,
+    )
   end
 end

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -27,7 +27,7 @@ class StatusUpdateService
     end
 
     if delivery_attempt.permanent_failure? && subscriber
-      UnsubscribeService.subscriber!(subscriber)
+      UnsubscribeService.subscriber!(subscriber, :non_existant_email)
     elsif delivery_attempt.temporary_failure?
       DeliveryRequestWorker.perform_in(15.minutes, email.id, :default)
     end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -1,20 +1,22 @@
 module UnsubscribeService
   class << self
-    def subscriber!(subscriber)
-      unsubscribe!(subscriber, subscriber.subscriptions)
+    def subscriber!(subscriber, reason)
+      unsubscribe!(subscriber, subscriber.subscriptions, reason)
     end
 
-    def subscription!(subscription)
-      unsubscribe!(subscription.subscriber, [subscription])
+    def subscription!(subscription, reason)
+      unsubscribe!(subscription.subscriber, [subscription], reason)
     end
 
   private
 
-    def unsubscribe!(subscriber, subscriptions)
+    def unsubscribe!(subscriber, subscriptions, reason)
       ActiveRecord::Base.transaction do
         nullify_references_to_subscriptions!(subscriptions)
 
-        subscriptions.each(&:destroy)
+        subscriptions.each do |subscription|
+          subscription.end(reason: reason)
+        end
 
         if no_other_subscriptions?(subscriber, subscriptions)
           subscriber.deactivate!

--- a/db/migrate/20180301141036_remove_deleted_at_from_subscription.rb
+++ b/db/migrate/20180301141036_remove_deleted_at_from_subscription.rb
@@ -1,0 +1,5 @@
+class RemoveDeletedAtFromSubscription < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :subscriptions, :deleted_at, :datetime
+  end
+end

--- a/db/migrate/20180301141950_add_ended_reason_to_subscriptions.rb
+++ b/db/migrate/20180301141950_add_ended_reason_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddEndedReasonToSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriptions, :ended_reason, :integer
+  end
+end

--- a/db/migrate/20180301151800_remove_unique_index_on_subscriptions.rb
+++ b/db/migrate/20180301151800_remove_unique_index_on_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexOnSubscriptions < ActiveRecord::Migration[5.1]
+  def up
+    remove_index :subscriptions, %w(subscriber_id subscriber_list_id)
+  end
+end

--- a/db/migrate/20180301153539_add_unique_index_on_active_subscriptions.rb
+++ b/db/migrate/20180301153539_add_unique_index_on_active_subscriptions.rb
@@ -1,0 +1,10 @@
+class AddUniqueIndexOnActiveSubscriptions < ActiveRecord::Migration[5.1]
+  disable_ddl_transactions!
+
+  def up
+    add_index :subscriptions,
+      %w(subscriber_id subscriber_list_id),
+      unique: true,
+      where: "(ended_at IS NULL)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 20180302090154) do
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
     t.integer "ended_reason"
-    t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
+    t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true, where: "(ended_at IS NULL)"
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,7 +152,6 @@ ActiveRecord::Schema.define(version: 20180302090154) do
     t.datetime "updated_at", null: false
     t.integer "frequency", default: 0, null: false
     t.string "signon_user_uid"
-    t.datetime "deleted_at"
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20180302090154) do
     t.string "signon_user_uid"
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
+    t.integer "ended_reason"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -97,6 +97,11 @@ FactoryBot.define do
     trait :weekly do
       frequency Frequency::WEEKLY
     end
+
+    trait :ended do
+      ended_at { Time.now }
+      ended_reason :unsubscribed
+    end
   end
 
   factory :subscription_content do

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Creating a subscription", type: :request do
         params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id)
         post "/subscriptions", params: params, headers: JSON_HEADERS
 
-        expect(Subscription.first.user_signed_up?).to be true
+        expect(Subscription.first.source_user_signed_up?).to be true
       end
 
       context "with a frequency setting" do
@@ -29,7 +29,7 @@ RSpec.describe "Creating a subscription", type: :request do
           expect(response.status).to eq(201)
 
           expect(Subscription.first.daily?).to be_truthy
-          expect(Subscription.first.user_signed_up?).to be true
+          expect(Subscription.first.source_user_signed_up?).to be true
         end
 
         context "with an existing subscription" do
@@ -45,7 +45,7 @@ RSpec.describe "Creating a subscription", type: :request do
             expect(response.status).to eq(200)
 
             expect(Subscription.first.weekly?).to be_truthy
-            expect(Subscription.first.frequency_changed?).to be true
+            expect(Subscription.first.source_frequency_changed?).to be true
           end
         end
 

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -44,8 +44,16 @@ RSpec.describe "Creating a subscription", type: :request do
 
             expect(response.status).to eq(200)
 
-            expect(Subscription.first.weekly?).to be_truthy
-            expect(Subscription.first.source_frequency_changed?).to be true
+            old_subscription = Subscription.order(:created_at).first
+            expect(old_subscription.weekly?).to be false
+            expect(old_subscription.ended?).to be true
+            expect(old_subscription.ended_frequency_changed?).to be true
+
+            new_subscription = Subscription.order(:created_at).last
+            expect(new_subscription.weekly?).to be true
+            expect(new_subscription.source_frequency_changed?).to be true
+
+            expect(Subscription.active.count).to eq(1)
           end
         end
 

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -43,11 +43,13 @@ RSpec.describe "Subscriptions", type: :request do
       end
 
       context "with a deleted subscription" do
-        let!(:subscription) { create(:subscription, subscriber_list: subscribable, subscriber: subscriber, ended_at: 1.day.ago) }
+        let!(:subscription) { create(:subscription, :ended, subscriber_list: subscribable, subscriber: subscriber) }
 
         it "undeletes the subscription" do
           create_subscription
-          expect(Subscription.find(subscription.id).ended_at).to be_nil
+
+          expect(subscription.reload.active?).to be true
+          expect(subscription.reload.ended?).to be false
         end
       end
     end

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -28,28 +28,33 @@ RSpec.describe "Subscriptions", type: :request do
         post "/subscriptions", params: { subscribable_id: subscribable.id, address: subscriber.address }
       end
 
-      it "doesn't create a new subscription" do
-        expect { create_subscription }.not_to change(Subscription, :count)
+      it "creates a new subscription" do
+        expect { create_subscription }.to change(Subscription, :count)
       end
 
-      it "returns status code 201" do
+      it "returns status code 200" do
         create_subscription
         expect(response.status).to eq(200)
       end
 
-      it "returns the ID of the existing subscription" do
+      it "returns the ID of the new subscription" do
         create_subscription
-        expect(data[:id]).to eq(subscription.id)
+        expect(data[:id]).to_not eq(subscription.id)
       end
 
-      context "with a deleted subscription" do
+      it "marks the existing subscription as ended" do
+        create_subscription
+        expect(subscription.reload.ended?).to be true
+      end
+
+      context "with an ended subscription" do
         let!(:subscription) { create(:subscription, :ended, subscriber_list: subscribable, subscriber: subscriber) }
 
-        it "undeletes the subscription" do
+        it "leaves the subscription as ended" do
           create_subscription
 
-          expect(subscription.reload.active?).to be true
-          expect(subscription.reload.ended?).to be false
+          expect(subscription.reload.active?).to be false
+          expect(subscription.reload.ended?).to be true
         end
       end
     end

--- a/spec/integration/unsubscribe_spec.rb
+++ b/spec/integration/unsubscribe_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Unsubscribing", type: :request do
         end
 
         it "deletes the subscription" do
-          expect(Subscription.not_deleted.count).to eq(0)
+          expect(Subscription.active.count).to eq(0)
         end
 
         it "responds with a 200 status" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -25,17 +25,17 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe "destroy" do
+  describe "end" do
     subject { create(:subscription) }
 
     it "doesn't delete the record" do
-      subject.destroy
+      subject.end(reason: :unsubscribed)
       expect(described_class.find(subject.id)).to eq(subject)
     end
 
     it "sets ended_at to Time.now" do
       Timecop.freeze do
-        subject.destroy
+        subject.end(reason: :unsubscribed)
         expect(subject.ended_at).to eq(Time.now)
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe Subscription, type: :model do
     end
 
     it "doesn't return subscriptions with ended_at" do
-      create(:subscription, ended_at: Time.now)
+      create(:subscription, :ended)
       expect(Subscription.active.count).to eq(0)
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,19 +1,23 @@
 RSpec.describe Subscription, type: :model do
   describe "validations" do
-    subject { build(:subscription) }
+    subject { create(:subscription) }
 
     it "is valid for the default factory" do
       expect(subject).to be_valid
     end
 
+    it "has no ended reason" do
+      expect(subject.ended_reason).to be_nil
+    end
+
     it "must be unique between subscriber and subscriber lists" do
-      create(
+      new_subscription = build(
         :subscription,
         subscriber: subject.subscriber,
         subscriber_list: subject.subscriber_list
       )
 
-      expect(subject).to be_invalid
+      expect(new_subscription).to be_invalid
     end
 
     it "is an immediate email" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -37,15 +37,15 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe ".not_deleted" do
+  describe ".active" do
     it "returns subscriptions with ended_at nil" do
       create(:subscription)
-      expect(Subscription.not_deleted.count).to eq(1)
+      expect(Subscription.active.count).to eq(1)
     end
 
     it "doesn't return subscriptions with ended_at" do
       create(:subscription, ended_at: Time.now)
-      expect(Subscription.not_deleted.count).to eq(0)
+      expect(Subscription.active.count).to eq(0)
     end
   end
 end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe UnsubscribeService do
 
     it "removes the subscription" do
       subject.subscription!(subscription)
-      expect(Subscription.not_deleted.find_by(id: subscription.id)).to be_nil
+      expect(Subscription.active.find_by(id: subscription.id)).to be_nil
     end
 
     it "does not remove the subscription if the email address update fails" do

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe UnsubscribeService do
     let!(:subscriber) { create(:subscriber, address: "foo@bar.com") }
 
     it "deactivates the subscriber" do
-      expect { subject.subscriber!(subscriber) }
+      expect { subject.subscriber!(subscriber, :unsubscribed) }
         .to change { subscriber.reload.deactivated? }
         .from(false)
         .to(true)
@@ -15,7 +15,7 @@ RSpec.describe UnsubscribeService do
       end
 
       it "removes them" do
-        expect { subject.subscriber!(subscriber) }
+        expect { subject.subscriber!(subscriber, :unsubscribed) }
           .to change(subscriber.subscriptions, :count)
           .from(3)
           .to(0)
@@ -25,7 +25,7 @@ RSpec.describe UnsubscribeService do
         allow_any_instance_of(Subscriber).
           to receive(:valid?).and_raise("failed")
 
-        expect { subject.subscriber!(subscriber) }
+        expect { subject.subscriber!(subscriber, :unsubscribed) }
           .to raise_error("failed")
           .and change(subscriber.subscriptions, :count)
           .by(0)
@@ -38,7 +38,7 @@ RSpec.describe UnsubscribeService do
     let(:subscriber) { subscription.subscriber }
 
     it "removes the subscription" do
-      subject.subscription!(subscription)
+      subject.subscription!(subscription, :unsubscribed)
       expect(Subscription.active.find_by(id: subscription.id)).to be_nil
     end
 
@@ -46,7 +46,7 @@ RSpec.describe UnsubscribeService do
       allow_any_instance_of(Subscriber).
         to receive(:valid?).and_raise("failed")
 
-      expect { subject.subscriber!(subscriber) }
+      expect { subject.subscriber!(subscriber, :unsubscribed) }
         .to raise_error("failed")
         .and change(subscriber.subscriptions, :count)
         .by(0)
@@ -54,7 +54,7 @@ RSpec.describe UnsubscribeService do
 
     context "when it is the only remaining subscription for the subscriber" do
       it "deactivates the subscriber" do
-        expect { subject.subscription!(subscription) }
+        expect { subject.subscription!(subscription, :unsubscribed) }
           .to change { subscriber.reload.deactivated? }
           .from(false)
           .to(true)
@@ -69,7 +69,7 @@ RSpec.describe UnsubscribeService do
       it "does not nullify the email address of the subscriber" do
         subscriber = subscription.subscriber
 
-        subject.subscription!(subscription)
+        subject.subscription!(subscription, :unsubscribed)
         expect(subscriber.reload.address).not_to be_nil
       end
     end
@@ -80,7 +80,7 @@ RSpec.describe UnsubscribeService do
       end
 
       it "nullifies the subscription on the subscription_content" do
-        expect { subject.subscription!(subscription) }
+        expect { subject.subscription!(subscription, :unsubscribed) }
           .to change { subscription_content.reload.subscription }
           .from(subscription)
           .to(nil)


### PR DESCRIPTION
This PR makes it such that the subscriptions table will be append only, meaning that we have a record of what users used to be subscribed to.

This introduces a new `ended_reason` field to store why the subscription was ended, and a subscription is considered ended if both the `ended_reason` and `ended_at` fields are present. There is validation to make sure they are either both set or neither are set.

The `Subscription.active` scope can be used to look for currently active subscriptions.

[Trello Card](https://trello.com/c/RRhaDynE/635-append-only-subscription)