### PR TITLE
Add anti-spam and survey to templates

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -24,10 +24,14 @@ private
   attr_reader :subscriber, :digest_run, :results
 
   def body
-    results.map { |result| presented_result(result) }.join("\n&nbsp;\n\n")
+    presented_results.concat("\n").concat(spam_prevention_survey_links)
   end
 
-  def presented_result(result)
+  def presented_results
+    results.map { |result| presented_segment(result) }.join("\n&nbsp;\n\n")
+  end
+
+  def presented_segment(result)
     <<~RESULT
       ##{result.subscriber_list_title}
 
@@ -36,6 +40,15 @@ private
 
       #{unsubscribe_link(result)}
     RESULT
+  end
+
+  def spam_prevention_survey_links
+    <<~BODY
+      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+
+      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
+    BODY
   end
 
   def subject

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -46,6 +46,7 @@ private
     <<~BODY
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -32,7 +32,7 @@ private
   end
 
   def subject(content_change)
-    "GOV.UK update - #{content_change.title}"
+    "GOV.UK update – #{content_change.title}"
   end
 
   def body(content_change, subscriptions)
@@ -42,8 +42,12 @@ private
       <<~BODY
         #{presented_content_change(content_change)}
         ---
+        You’re getting this email because you subscribed to #{subscriptions.first.subscriber_list.title} updates on GOV.UK.
 
         #{presented_unsubscribe_links(subscriptions)}
+
+
+        ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
       BODY
     end
   end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -46,6 +46,7 @@ private
 
         #{presented_unsubscribe_links(subscriptions)}
 
+        &nbsp;
 
         ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
       BODY

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe DigestEmailBuilder do
         ---
 
         unsubscribe_link_2
+
+        You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+
+        ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
       BODY
     )
   end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe DigestEmailBuilder do
 
         You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
+        &nbsp;
 
         ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
       BODY

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ImmediateEmailBuilder do
       subscription_one,
       build(
         :subscription,
-        uuid: "69ca6fce-34f5-4ebd-943c-83bd1b2e70fb",
+        id: "69ca6fce-34f5-4ebd-943c-83bd1b2e70fb",
         subscriber: subscriber,
         subscriber_list: build(:subscriber_list, title: "Second Subscription")
       ),

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe ImmediateEmailBuilder do
 
             unsubscribe_link
 
+            &nbsp;
 
             ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
           BODY

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ImmediateEmailBuilder do
     end
 
     it "sets the subject" do
-      expect(email.subject).to eq("GOV.UK update - Title")
+      expect(email.subject).to eq("GOV.UK update – Title")
     end
 
     it "sets the body and unsubscribe links" do
@@ -103,8 +103,12 @@ RSpec.describe ImmediateEmailBuilder do
             presented_content_change
 
             ---
+            You’re getting this email because you subscribed to #{subscriptions.first.subscriber_list.title} updates on GOV.UK.
 
             unsubscribe_link
+
+
+            ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
           BODY
         )
       end

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -89,6 +90,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -277,6 +279,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -306,6 +309,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+
+      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+
+      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -81,6 +86,11 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+
+      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+
+      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -264,6 +274,11 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+
+      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+
+      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -288,6 +303,11 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+
+      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+
+      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
   scenario "weekly digest run" do

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sending an email", type: :request do
     body = email_data.dig(:personalisation, :body)
 
     expect(address).to eq("test@test.com")
-    expect(subject).to eq("GOV.UK update - Title")
+    expect(subject).to eq("GOV.UK update – Title")
 
     expect(body).to include("Description")
     expect(body).to include("gov.uk/base-path")


### PR DESCRIPTION
Add "anti-spam" line and survey link to the immediate and digest email templates.
[Survey link Trello](https://trello.com/c/wa7ksgMD/653-add-basic-smartsurvey-link-into-email-footer)
[Spam line Trello](https://trello.com/c/SerqVQ2Y/643-add-anti-spam-footer-text)