### PR TITLE
Email archiving tasks

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,6 +1,10 @@
 class Email < ApplicationRecord
   has_many :delivery_attempts
 
+  scope :archivable, lambda {
+    where(archived_at: nil).where.not(finished_sending_at: nil)
+  }
+
   validates :address, :subject, :body, presence: true
 
   # Mark an email to indicate the process of sending it is complete

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -5,6 +5,10 @@ class Email < ApplicationRecord
     where(archived_at: nil).where.not(finished_sending_at: nil)
   }
 
+  scope :deleteable, lambda {
+    where.not(archived_at: nil).where("finished_sending_at < ?", 14.days.ago)
+  }
+
   validates :address, :subject, :body, presence: true
 
   # Mark an email to indicate the process of sending it is complete

--- a/app/models/email_archive.rb
+++ b/app/models/email_archive.rb
@@ -1,0 +1,1 @@
+class EmailArchive < ApplicationRecord; end

--- a/app/models/subscription_content.rb
+++ b/app/models/subscription_content.rb
@@ -1,6 +1,7 @@
 class SubscriptionContent < ApplicationRecord
   belongs_to :subscription
   belongs_to :content_change
+  belongs_to :digest_run_subscriber, optional: true
   belongs_to :email, optional: true
 
   scope :immediate, -> { where(digest_run_subscriber_id: nil) }

--- a/app/queries/email_archive_query.rb
+++ b/app/queries/email_archive_query.rb
@@ -1,0 +1,68 @@
+class EmailArchiveQuery
+  def self.call
+    new.call
+  end
+
+  def call
+    Email.archivable.select(fields)
+  end
+
+  private_class_method :new
+
+private
+
+  def fields
+    [
+      :id,
+      :subject,
+      :finished_sending_at,
+      :created_at,
+      subscriber_ids,
+      subscription_ids,
+      content_change_ids,
+      digest_run_ids,
+      sent,
+    ]
+  end
+
+  def subscriber_ids
+    query = Subscription
+      .joins(:subscription_contents)
+      .where("subscription_contents.email_id = emails.id")
+      .distinct
+      .select(:subscriber_id)
+    "ARRAY(#{query.to_sql}) AS subscriber_ids"
+  end
+
+  def subscription_ids
+    query = SubscriptionContent
+      .where("email_id = emails.id")
+      .distinct
+      .select(:subscription_id)
+    "ARRAY(#{query.to_sql}) AS subscription_ids"
+  end
+
+  def content_change_ids
+    query = SubscriptionContent
+      .where("email_id = emails.id")
+      .distinct
+      .select(:content_change_id)
+    "ARRAY(#{query.to_sql}) AS content_change_ids"
+  end
+
+  def digest_run_ids
+    query = SubscriptionContent
+      .joins(:digest_run_subscriber)
+      .where("email_id = emails.id")
+      .distinct
+      .select("digest_run_subscribers.digest_run_id")
+    "ARRAY(#{query.to_sql}) AS digest_run_ids"
+  end
+
+  def sent
+    query = DeliveryAttempt
+      .where(status: :delivered)
+      .where("email_id = emails.id")
+    "EXISTS(#{query.to_sql}) AS sent"
+  end
+end

--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -1,0 +1,71 @@
+class EmailArchiveWorker
+  include Sidekiq::Worker
+
+  LOCK_NAME = "email_archive_worker".freeze
+
+  def perform
+    Email.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
+      EmailArchiveQuery.call.in_batches do |batch|
+        Email.transaction { archive_batch(batch) }
+      end
+    end
+  end
+
+private
+
+  def archive_batch(batch)
+    archived_at = Time.zone.now
+
+    import_batch(batch, archived_at)
+    Email.where(id: batch.pluck(:id)).update_all(archived_at: archived_at)
+  end
+
+  def import_batch(batch, archived_at)
+    to_import = batch.as_json.map { |e| build_email_archive(e, archived_at) }
+    columns = to_import.first.keys.map(&:to_s)
+    values = to_import.map(&:values)
+    EmailArchive.import!(columns, values)
+  end
+
+  def build_email_archive(email_data, archived_at)
+    content_change = build_content_change(email_data)
+
+    {
+      archived_at: archived_at,
+      content_change: content_change,
+      created_at: email_data.fetch("created_at"),
+      finished_sending_at: email_data.fetch("finished_sending_at"),
+      id: email_data.fetch("id"),
+      sent: email_data.fetch("sent"),
+      subject: email_data.fetch("subject"),
+      subscriber_id: build_subscriber_id(email_data),
+    }
+  end
+
+  def build_content_change(email_data)
+    return if email_data.fetch("content_change_ids").empty?
+
+    if email_data.fetch("digest_run_ids").count > 1
+      error = "Email with id: #{email_data['id']} is associated with "\
+        "multiple digest runs: #{email_data['digest_run_ids'].join(', ')}"
+      GovukError.notify(error)
+    end
+
+    {
+      content_change_ids: email_data.fetch("content_change_ids"),
+      digest_run_id: email_data.fetch("digest_run_ids").first,
+      subscription_ids: email_data.fetch("subscription_ids"),
+    }
+  end
+
+  def build_subscriber_id(email_data)
+    if email_data.fetch("subscriber_ids").count > 1
+      error = "Email with id: #{email_data['id']} is associated with "\
+        "multiple subscribers: #{email_data['subscribers'].join(', ')}"
+      GovukError.notify(error)
+    end
+
+    email_data.fetch("subscriber_ids").first
+  end
+
+end

--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -26,7 +26,7 @@ private
     to_import = batch.as_json.map { |e| build_email_archive(e, archived_at) }
     columns = to_import.first.keys.map(&:to_s)
     values = to_import.map(&:values)
-    EmailArchive.import!(columns, values)
+    EmailArchive.import(columns, values, validate: false)
   end
 
   def build_email_archive(email_data, archived_at)

--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -1,6 +1,8 @@
 class EmailArchiveWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :cleanup
+
   LOCK_NAME = "email_archive_worker".freeze
 
   def perform

--- a/app/workers/email_deletion_worker.rb
+++ b/app/workers/email_deletion_worker.rb
@@ -7,7 +7,19 @@ class EmailDeletionWorker
 
   def perform
     Email.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
-      Email.deleteable.in_batches { |b| b.delete_all }
+      start_time = Time.zone.now
+      deleted_count = Email.deleteable.in_batches.inject(0) do |memo, batch|
+        memo + batch.delete_all
+      end
+      log_complete(deleted_count, start_time, Time.zone.now)
     end
+  end
+
+private
+
+  def log_complete(deleted, start_time, end_time)
+    seconds = (end_time - start_time).round(2)
+    message = "Deleted #{deleted} emails in #{seconds} seconds"
+    logger.info(message)
   end
 end

--- a/app/workers/email_deletion_worker.rb
+++ b/app/workers/email_deletion_worker.rb
@@ -1,0 +1,13 @@
+class EmailDeletionWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :cleanup
+
+  LOCK_NAME = "email_deletion_worker".freeze
+
+  def perform
+    Email.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
+      Email.deleteable.in_batches { |b| b.delete_all }
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,3 +27,6 @@
   email_archiver:
     every: '1h'
     class: EmailArchiveWorker
+  email_deleter:
+    every: '1h'
+    class: EmailDeletionWorker

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -24,3 +24,6 @@
   nullify_deactivated_subscribers:
     every: '1h'
     class: NullifyDeactivatedSubscribersWorker
+  email_archiver:
+    every: '1h'
+    class: EmailArchiveWorker

--- a/db/migrate/20180228112734_create_email_archive.rb
+++ b/db/migrate/20180228112734_create_email_archive.rb
@@ -1,0 +1,13 @@
+class CreateEmailArchive < ActiveRecord::Migration[5.1]
+  def change
+    create_table :email_archives, id: :uuid, default: "uuid_generate_v4()" do |t|
+      t.string "subject", null: false
+      t.bigint "subscriber_id"
+      t.json "content_change"
+      t.boolean "sent", null: false
+      t.datetime "created_at", null: false
+      t.datetime "archived_at", null: false
+      t.datetime "finished_sending_at", null: false
+    end
+  end
+end

--- a/db/migrate/20180228122502_add_archived_at_to_emails.rb
+++ b/db/migrate/20180228122502_add_archived_at_to_emails.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToEmails < ActiveRecord::Migration[5.1]
+  def change
+    add_column :emails, :archived_at, :datetime
+  end
+end

--- a/db/migrate/20180228122604_index_archived_at_on_emails.rb
+++ b/db/migrate/20180228122604_index_archived_at_on_emails.rb
@@ -1,0 +1,7 @@
+class IndexArchivedAtOnEmails < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :emails, :archived_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 20180302090154) do
     t.datetime "updated_at", null: false
     t.string "address", null: false
     t.datetime "finished_sending_at"
+    t.datetime "archived_at"
+    t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,6 +67,16 @@ ActiveRecord::Schema.define(version: 20180302090154) do
     t.integer "subscriber_count"
   end
 
+  create_table "email_archives", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string "subject", null: false
+    t.bigint "subscriber_id"
+    t.json "content_change"
+    t.boolean "sent", null: false
+    t.datetime "created_at", null: false
+    t.datetime "archived_at", null: false
+    t.datetime "finished_sending_at", null: false
+  end
+
   create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "subject", null: false
     t.text "body", null: false
@@ -150,8 +160,8 @@ ActiveRecord::Schema.define(version: 20180302090154) do
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "frequency", default: 0, null: false
     t.string "signon_user_uid"
+    t.integer "frequency", default: 0, null: false
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
     t.integer "ended_reason"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,6 +50,11 @@ FactoryBot.define do
       finished_sending_at { 2.days.ago }
       archived_at { 1.day.ago }
     end
+
+    factory :deleteable_email do
+      finished_sending_at { 15.days.ago }
+      archived_at { 14.days.ago }
+    end
   end
 
   factory :notification_log do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -37,10 +37,19 @@ FactoryBot.define do
     subscriber
   end
 
-  factory :email do
+  factory :email, aliases: [:unarchivable_email] do
     address "test@example.com"
     subject "subject"
     body "body"
+
+    factory :archivable_email do
+      finished_sending_at { 2.days.ago }
+    end
+
+    factory :archived_email do
+      finished_sending_at { 2.days.ago }
+      archived_at { 1.day.ago }
+    end
   end
 
   factory :notification_log do
@@ -107,6 +116,10 @@ FactoryBot.define do
   factory :subscription_content do
     subscription
     content_change
+
+    trait :with_archivable_email do
+      association :email, factory: :archivable_email
+    end
   end
 
   factory :matched_content_change do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
   end
 
   factory :digest_run do
-    date { Date.current }
+    date { 1.day.ago }
     range Frequency::DAILY
 
     trait :daily

--- a/spec/queries/email_archive_query_spec.rb
+++ b/spec/queries/email_archive_query_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EmailArchiveQuery do
     let(:now) { Time.zone.now }
 
     context "when there are archivable emails" do
-      before { create(:email, finished_sending_at: now) }
+      before { create(:archivable_email) }
 
       it "has items" do
         expect(scope.to_a.size).to be_positive
@@ -12,7 +12,7 @@ RSpec.describe EmailArchiveQuery do
     end
 
     context "when there are no archivable emails" do
-      before { create(:email, archived_at: now) }
+      before { create(:archived_email) }
 
       it "doesn't have items" do
         expect(scope.to_a.size).to be_zero
@@ -20,7 +20,7 @@ RSpec.describe EmailArchiveQuery do
     end
 
     context "when an email is associated with content changes" do
-      let!(:email) { create(:email, finished_sending_at: now) }
+      let!(:email) { create(:archivable_email) }
       let!(:subscriber) { create(:subscriber) }
       let!(:subscription_contents) do
         [
@@ -49,7 +49,7 @@ RSpec.describe EmailArchiveQuery do
     end
 
     context "when an email is not associated with content changes" do
-      before { create(:email, finished_sending_at: now) }
+      before { create(:archivable_email) }
 
       it "has empty subscriber_ids, subscription_ids and content_change_ids" do
         first = scope.first
@@ -60,7 +60,7 @@ RSpec.describe EmailArchiveQuery do
     end
 
     context "when an email is associated with digest runs" do
-      let!(:email) { create(:email, finished_sending_at: now) }
+      let!(:email) { create(:archivable_email) }
       let!(:digest_run_subscriber) { create(:digest_run_subscriber) }
       let!(:subscription_contents) do
         [
@@ -80,7 +80,7 @@ RSpec.describe EmailArchiveQuery do
     end
 
     context "when an email is not associated with digest runs" do
-      before { create(:email, finished_sending_at: now) }
+      before { create(:archivable_email) }
 
       it "has no digest run ids" do
         expect(scope.first.digest_run_ids).to be_empty
@@ -92,7 +92,7 @@ RSpec.describe EmailArchiveQuery do
         create(
           :delivery_attempt,
           status: "delivered",
-          email: create(:email, finished_sending_at: now),
+          email: create(:archivable_email),
         )
       end
 
@@ -106,7 +106,7 @@ RSpec.describe EmailArchiveQuery do
         create(
           :delivery_attempt,
           status: "technical_failure",
-          email: create(:email, finished_sending_at: now),
+          email: create(:archivable_email),
         )
       end
 

--- a/spec/queries/email_archive_query_spec.rb
+++ b/spec/queries/email_archive_query_spec.rb
@@ -1,0 +1,118 @@
+RSpec.describe EmailArchiveQuery do
+  describe ".call" do
+    subject(:scope) { described_class.call }
+    let(:now) { Time.zone.now }
+
+    context "when there are archivable emails" do
+      before { create(:email, finished_sending_at: now) }
+
+      it "has items" do
+        expect(scope.to_a.size).to be_positive
+      end
+    end
+
+    context "when there are no archivable emails" do
+      before { create(:email, archived_at: now) }
+
+      it "doesn't have items" do
+        expect(scope.to_a.size).to be_zero
+      end
+    end
+
+    context "when an email is associated with content changes" do
+      let!(:email) { create(:email, finished_sending_at: now) }
+      let!(:subscriber) { create(:subscriber) }
+      let!(:subscription_contents) do
+        [
+          create(
+            :subscription_content,
+            email: email,
+            subscription: create(:subscription, subscriber: subscriber),
+          ),
+          create(
+            :subscription_content,
+            email: email,
+            subscription: create(:subscription, subscriber: subscriber),
+          ),
+        ]
+      end
+
+      it "has subscriber_ids, subscription_ids and content_change_ids" do
+        first = scope.first
+        subscription_ids = subscription_contents.map(&:subscription_id)
+        content_change_ids = subscription_contents.map(&:content_change_id)
+
+        expect(first.subscriber_ids).to match_array(subscriber.id)
+        expect(first.subscription_ids).to match_array(subscription_ids)
+        expect(first.content_change_ids).to match_array(content_change_ids)
+      end
+    end
+
+    context "when an email is not associated with content changes" do
+      before { create(:email, finished_sending_at: now) }
+
+      it "has empty subscriber_ids, subscription_ids and content_change_ids" do
+        first = scope.first
+        expect(first.subscriber_ids).to be_empty
+        expect(first.subscription_ids).to be_empty
+        expect(first.content_change_ids).to be_empty
+      end
+    end
+
+    context "when an email is associated with digest runs" do
+      let!(:email) { create(:email, finished_sending_at: now) }
+      let!(:digest_run_subscriber) { create(:digest_run_subscriber) }
+      let!(:subscription_contents) do
+        [
+          create(
+            :subscription_content,
+            email: email,
+            digest_run_subscriber: digest_run_subscriber,
+          )
+        ]
+      end
+
+      it "has digest_run_ids" do
+        first = scope.first
+        digest_run_ids = [digest_run_subscriber.digest_run_id]
+        expect(first.digest_run_ids).to match_array(digest_run_ids)
+      end
+    end
+
+    context "when an email is not associated with digest runs" do
+      before { create(:email, finished_sending_at: now) }
+
+      it "has no digest run ids" do
+        expect(scope.first.digest_run_ids).to be_empty
+      end
+    end
+
+    context "when an email is sent" do
+      before do
+        create(
+          :delivery_attempt,
+          status: "delivered",
+          email: create(:email, finished_sending_at: now),
+        )
+      end
+
+      it "is available in the result" do
+        expect(scope.first.sent).to be true
+      end
+    end
+
+    context "when an email is not sent" do
+      before do
+        create(
+          :delivery_attempt,
+          status: "technical_failure",
+          email: create(:email, finished_sending_at: now),
+        )
+      end
+
+      it "is available in the result" do
+        expect(scope.first.sent).to be false
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,7 @@ WebMock.disable_net_connect!(allow_localhost: true)
 
 Sidekiq::Testing.inline!
 Sidekiq::Worker.clear_all
+Sidekiq::Logging.logger = nil
 
 JSON_HEADERS = {
   "CONTENT_TYPE" => "application/json",

--- a/spec/workers/email_archive_worker_spec.rb
+++ b/spec/workers/email_archive_worker_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe EmailArchiveWorker do
+  describe "#perform" do
+    def perform
+      described_class.new.perform
+    end
+
+    context "when there are no emails to archive" do
+      before do
+        create(:unarchivable_email)
+        create(:archived_email)
+      end
+      it "doesn't change the number of EmailArchive records" do
+        expect { perform }.not_to(change { EmailArchive.count })
+      end
+    end
+
+    context "when there are emails to archive" do
+      let!(:emails) { 3.times.map { create(:archivable_email) } }
+
+      it "adds EmailArchive records" do
+        expect { perform }.to change { EmailArchive.count }.by(3)
+      end
+
+      it "adds an archived_at field to emails" do
+        expect { perform }
+          .to change { emails.map { |e| e.reload.archived_at }.uniq }
+          .from([nil])
+          .to(match_array([an_instance_of(ActiveSupport::TimeWithZone)]))
+      end
+
+      it "sets approriate EmailArchive fields" do
+        perform
+        email = emails.last.reload
+        email_archive = EmailArchive.find(email.id)
+
+        expect(email_archive.created_at).to eq email.created_at
+        expect(email_archive.subject).to eq email.subject
+        expect(email_archive.finished_sending_at).to eq email.finished_sending_at
+        expect(email_archive.archived_at).to eq email.archived_at
+      end
+    end
+
+    context "when an email is not associated with content changes" do
+      let!(:email) { create(:archivable_email) }
+
+      it "has a nil content change field" do
+        perform
+        expect(EmailArchive.find(email.id).content_change).to be nil
+      end
+    end
+
+    context "when an email is associated with content changes" do
+      let!(:subscription_content) do
+        create(:subscription_content, :with_archivable_email)
+      end
+      let(:email) { subscription_content.email }
+      let(:subscription) { subscription_content.subscription }
+
+      it "has content change details" do
+        perform
+        email_archive = EmailArchive.find(email.id)
+        expect(email_archive.subscriber_id).to eq subscription.subscriber_id
+        expect(email_archive.content_change).to match(
+          hash_including(
+            "content_change_ids" => [subscription_content.content_change_id],
+            "digest_run_id" => nil,
+            "subscription_ids" => [subscription_content.subscription_id],
+          )
+        )
+      end
+    end
+
+    context "when an email is associated with a digest" do
+      let(:subscriber) { create(:subscriber) }
+      let(:digest_run_subscriber) do
+        create(:digest_run_subscriber, subscriber: subscriber)
+      end
+
+      let!(:subscription_content) do
+        create(
+          :subscription_content,
+          :with_archivable_email,
+          subscription: create(:subscription, subscriber: subscriber),
+          digest_run_subscriber: digest_run_subscriber,
+        )
+      end
+      let(:email) { subscription_content.email }
+
+      it "has digest id" do
+        perform
+        email_archive = EmailArchive.find(email.id)
+        expect(email_archive.content_change).to match(
+          hash_including(
+            "digest_run_id" => digest_run_subscriber.digest_run_id
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/workers/email_deletion_worker_spec.rb
+++ b/spec/workers/email_deletion_worker_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe EmailDeletionWorker do
+  describe "#perform" do
+    def perform
+      described_class.new.perform
+    end
+
+    context "when there are no emails to delete" do
+      before do
+        create(:unarchivable_email)
+        create(:archivable_email)
+        create(:archived_email)
+      end
+      it "doesn't change the number of Email records" do
+        expect { perform }.not_to(change { Email.count })
+      end
+    end
+
+    context "when there are emails to delete" do
+      let!(:emails) { 3.times.map { create(:deleteable_email) } }
+
+      it "deletes the Email records" do
+        expect { perform }.to change { Email.count }.by(-3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/R14kXWU9/633-set-up-rudimentary-email-archive-system

This sets up the appropriate extra data fields for email archiving as per [data retention strategy](https://github.com/alphagov/email-alert-api/blob/68fb5c40863114a18655c12db01c87e60eb5dc77/doc/arch/adr-003-data-retention.md) and the worker classes to perform the tasks.

I've set them to run every hour and I imagine they'll be pretty fast. My maths has them averaging at about 30,000 emails an hour and running locally (for a dataset of 30,000) I get:

```
irb(main):009:0> 30_000.times { FactoryBot.create(:subscription_content, :with_archivable_email) }
=> 30000
irb(main):011:0> { archivable_emails: Email.archivable.count, deleteable_emails: Email.deleteable.count, subscription_contents: SubscriptionContent.count, email_archives: EmailArchive.count }
=> {:archivable_emails=>30000, :deleteable_emails=>0, :subscription_contents=>30000, :email_archives=>0}
irb(main):012:0> EmailArchiveWorker.new.perform
{"@timestamp":"2018-03-01T16:41:58Z","@fields":{"pid":24478,"tid":"TID-gndlb4qq0","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Archived 30000 emails in 12.77 seconds"}
=> true
irb(main):013:0> { archivable_emails: Email.archivable.count, deleteable_emails: Email.deleteable.count, subscription_contents: SubscriptionContent.count, email_archives: EmailArchive.count }
=> {:archivable_emails=>0, :deleteable_emails=>0, :subscription_contents=>30000, :email_archives=>30000}
irb(main):014:0> Email.update_all(finished_sending_at: 15.days.ago)
=> 30000
irb(main):015:0> { archivable_emails: Email.archivable.count, deleteable_emails: Email.deleteable.count, subscription_contents: SubscriptionContent.count, email_archives: EmailArchive.count }
=> {:archivable_emails=>0, :deleteable_emails=>30000, :subscription_contents=>30000, :email_archives=>30000}
irb(main):016:0> EmailDeletionWorker.new.perform
{"@timestamp":"2018-03-01T16:42:40Z","@fields":{"pid":24478,"tid":"TID-gndlb4qq0","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Deleted 30000 emails in 7.18 seconds"}
=> true
irb(main):017:0> { archivable_emails: Email.archivable.count, deleteable_emails: Email.deleteable.count, subscription_contents: SubscriptionContent.count, email_archives: EmailArchive.count }
=> {:archivable_emails=>0, :deleteable_emails=>0, :subscription_contents=>30000, :email_archives=>30000}
irb(main):018:0> Email.count
=> 0
```

It is set to wait 14 days before deleting emails. Until we've upped the postgres disk space this might be a little optimistic, but hopefully that will be resolved soon - but we may still need to adjust this.