### PR TITLE
Stop swallowing any ContentChange errors

### DIFF
--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -9,14 +9,10 @@ class NotificationHandlerService
   end
 
   def call
-    begin
-      content_change = ContentChange.create!(content_change_params)
-      MetricsService.content_change_created
-      MatchedContentChangeGenerationService.call(content_change: content_change)
-      SubscriptionContentWorker.perform_async(content_change.id)
-    rescue StandardError => ex
-      Raven.capture_exception(ex, tags: { version: 2 })
-    end
+    content_change = ContentChange.create!(content_change_params)
+    MetricsService.content_change_created
+    MatchedContentChangeGenerationService.call(content_change: content_change)
+    SubscriptionContentWorker.perform_async(content_change.id)
   end
 
   private_class_method :new

--- a/spec/services/notification_handler_service_spec.rb
+++ b/spec/services/notification_handler_service_spec.rb
@@ -61,17 +61,13 @@ RSpec.describe NotificationHandlerService do
       described_class.call(params: params)
     end
 
-    it "reports ContentChange errors to Sentry and swallows them" do
+    it "Raises errors if the ContentChange is invalid" do
       allow(ContentChange).to receive(:create!).and_raise(
         ActiveRecord::RecordInvalid
       )
-      expect(Raven).to receive(:capture_exception).with(
-        instance_of(ActiveRecord::RecordInvalid),
-        tags: { version: 2 }
-      )
 
       expect { described_class.call(params: params) }
-        .not_to raise_error
+        .to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/KFP3fDo9/659-stop-swallowing-content-change-failures

Initially we had this as catching and reporting errors to sentry to not
disturb the flow of traffic to GovDelivery. Now as we get closer to
launch we want to return approriately if there are problems as we will
soon be no longer sending stuff through to GovDelivery.