### PR TITLE
Add space after subscription title for digests

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -29,7 +29,7 @@ private
 
   def presented_result(result)
     <<~RESULT
-      ##{result.subscriber_list_title}
+      ##{result.subscriber_list_title}&nbsp;
 
       #{deduplicate_and_present(result.content_changes)}
       ---

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe DigestEmailBuilder do
 
     expect(email.body).to eq(
       <<~BODY
-        #Test title 1
+        #Test title 1&nbsp;
 
         presented_content_change
 
@@ -87,7 +87,7 @@ RSpec.describe DigestEmailBuilder do
 
         &nbsp;
 
-        #Test title 2
+        #Test title 2&nbsp;
 
         presented_content_change
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def first_expected_daily_email_body(subscription_one, subscription_two)
     <<~BODY
-      #Subscriber list one
+      #Subscriber list one&nbsp;
 
       [Title one](http://www.dev.gov.uk/base-path)
 
@@ -38,7 +38,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       &nbsp;
 
-      #Subscriber list two
+      #Subscriber list two&nbsp;
 
       [Title four](http://www.dev.gov.uk/base-path)
 
@@ -62,7 +62,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def second_expected_daily_email_body(subscription)
     <<~BODY
-      #Subscriber list one
+      #Subscriber list one&nbsp;
 
       [Title one](http://www.dev.gov.uk/base-path)
 
@@ -223,7 +223,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def first_expected_weekly_email_body(subscription_one, subscription_two)
     <<~BODY
-      #Subscriber list one
+      #Subscriber list one&nbsp;
 
       [Title one](http://www.dev.gov.uk/base-path)
 
@@ -245,7 +245,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       &nbsp;
 
-      #Subscriber list two
+      #Subscriber list two&nbsp;
 
       [Title four](http://www.dev.gov.uk/base-path)
 
@@ -269,7 +269,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def second_expected_weekly_email_body(subscription)
     <<~BODY
-      #Subscriber list one
+      #Subscriber list one&nbsp;
 
       [Title one](http://www.dev.gov.uk/base-path)
 


### PR DESCRIPTION
This commit adds a space after each subscription title for digests. This allows certain mobile mail clients that build summaries by appending text to show a space between the title and body text.

Trello: https://trello.com/c/rs9XH4MK/660-add-a-space-at-the-end-of-subscription-titles