### PR TITLE
Specify foreign key on_delete as per our archive policy

### DIFF
--- a/db/migrate/20180302090139_remove_incorrect_foreign_keys.rb
+++ b/db/migrate/20180302090139_remove_incorrect_foreign_keys.rb
@@ -1,0 +1,12 @@
+class RemoveIncorrectForeignKeys < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :matched_content_changes, :content_changes
+    remove_foreign_key :matched_content_changes, :subscriber_lists
+
+    remove_foreign_key :subscription_contents, :emails
+    remove_foreign_key :subscription_contents, :subscriptions
+
+    remove_foreign_key :subscriptions, :subscriber_lists
+    remove_foreign_key :subscriptions, :subscribers
+  end
+end

--- a/db/migrate/20180302090154_add_foreign_key_on_deletes.rb
+++ b/db/migrate/20180302090154_add_foreign_key_on_deletes.rb
@@ -1,0 +1,14 @@
+class AddForeignKeyOnDeletes < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_foreign_key :matched_content_changes, :content_changes, on_delete: :cascade
+    add_foreign_key :matched_content_changes, :subscriber_lists, on_delete: :cascade
+
+    add_foreign_key :subscription_contents, :emails, on_delete: :cascade
+    add_foreign_key :subscription_contents, :subscriptions, on_delete: :restrict
+
+    add_foreign_key :subscriptions, :subscriber_lists, on_delete: :restrict
+    add_foreign_key :subscriptions, :subscribers, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180301132513) do
+ActiveRecord::Schema.define(version: 20180302090154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,12 +174,12 @@ ActiveRecord::Schema.define(version: 20180301132513) do
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "digest_runs", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "subscribers", on_delete: :cascade
-  add_foreign_key "matched_content_changes", "content_changes", on_delete: :restrict
-  add_foreign_key "matched_content_changes", "subscriber_lists"
+  add_foreign_key "matched_content_changes", "content_changes", on_delete: :cascade
+  add_foreign_key "matched_content_changes", "subscriber_lists", on_delete: :cascade
   add_foreign_key "subscription_contents", "content_changes", on_delete: :restrict
   add_foreign_key "subscription_contents", "digest_run_subscribers", on_delete: :cascade
-  add_foreign_key "subscription_contents", "emails", on_delete: :nullify
-  add_foreign_key "subscription_contents", "subscriptions", on_delete: :nullify
-  add_foreign_key "subscriptions", "subscriber_lists"
-  add_foreign_key "subscriptions", "subscribers", on_delete: :cascade
+  add_foreign_key "subscription_contents", "emails", on_delete: :cascade
+  add_foreign_key "subscription_contents", "subscriptions", on_delete: :restrict
+  add_foreign_key "subscriptions", "subscriber_lists", on_delete: :restrict
+  add_foreign_key "subscriptions", "subscribers", on_delete: :restrict
 end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Subscriber, type: :model do
     end
   end
 
-  context "with a subscriber list" do
+  context "with a subscription" do
     subject { create(:subscriber) }
 
     before { create(:subscription, subscriber: subject) }
@@ -123,9 +123,8 @@ RSpec.describe Subscriber, type: :model do
       expect(subject.subscriber_lists.size).to eq(1)
     end
 
-    it "can be deleted and won't delete the subscriber list" do
-      expect { subject.destroy }.not_to raise_error
-      expect(SubscriberList.all.size).to eq(1)
+    it "cannot be deleted" do
+      expect { subject.destroy }.to raise_error(ActiveRecord::InvalidForeignKey)
     end
   end
 


### PR DESCRIPTION
This should better match the expectations following the archive policy, hopefully there shouldn't be any surprises here.

This also adds in the foreign key change that used to be in #474.

[Trello Card](https://trello.com/c/RRhaDynE/635-append-only-subscription)