### PR TITLE
Fix call to disable_ddl_transaction!

### DIFF
--- a/db/migrate/20180301153539_add_unique_index_on_active_subscriptions.rb
+++ b/db/migrate/20180301153539_add_unique_index_on_active_subscriptions.rb
@@ -1,5 +1,5 @@
 class AddUniqueIndexOnActiveSubscriptions < ActiveRecord::Migration[5.1]
-  disable_ddl_transactions!
+  disable_ddl_transaction!
 
   def up
     add_index :subscriptions,


### PR DESCRIPTION
Somehow this gained an extra 's' at the end, but the migrations won't run without fixing this.