### PR TITLE
Custom Travel Advice and Medical Safety Alerts

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -8,4 +8,12 @@ class ContentChange < ApplicationRecord
   def mark_processed!
     update!(processed_at: Time.now)
   end
+
+  def is_travel_advice?
+    links.include?(:countries)
+  end
+
+  def is_medical_safety_alert?
+    tags.fetch(:format, []).include?("medical_safety_alert")
+  end
 end

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -12,21 +12,12 @@ class ContentChangePresenter
   end
 
   def call
-    if include_description?
-      <<~BODY
-        #{title_markdown}
-
-        #{description_markdown}
-
-        #{change_note_markdown}
-      BODY
-    else
-      <<~BODY
-        #{title_markdown}
-
-        #{change_note_markdown}
-      BODY
-    end
+    [
+      title_markdown,
+      include_description? ? description_markdown : nil,
+      change_note_markdown,
+      include_mhra_line? ? mhra_line_markdown : nil,
+    ].compact.join("\n\n") + "\n"
   end
 
   private_class_method :new
@@ -67,5 +58,13 @@ private
 
   def include_description?
     !content_change.is_travel_advice?
+  end
+
+  def include_mhra_line?
+    content_change.is_medical_safety_alert?
+  end
+
+  def mhra_line_markdown
+    "Do not reply to this email. To contact MHRA, email [email.support@mhra.gov.uk](mailto:email.support@mhra.gov.uk)"
   end
 end

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -12,13 +12,21 @@ class ContentChangePresenter
   end
 
   def call
-    <<~BODY
-      [#{title}](#{content_url})
+    if include_description?
+      <<~BODY
+        #{title_markdown}
 
-      #{strip_markdown(description)}
+        #{description_markdown}
 
-      #{public_updated_at}: #{strip_markdown(change_note)}
-    BODY
+        #{change_note_markdown}
+      BODY
+    else
+      <<~BODY
+        #{title_markdown}
+
+        #{change_note_markdown}
+      BODY
+    end
   end
 
   private_class_method :new
@@ -43,5 +51,21 @@ private
 
   def markdown_stripper
     @markdown_stripper ||= Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+  end
+
+  def title_markdown
+    "[#{title}](#{content_url})"
+  end
+
+  def description_markdown
+    strip_markdown(description)
+  end
+
+  def change_note_markdown
+    "#{public_updated_at}: #{strip_markdown(change_note)}"
+  end
+
+  def include_description?
+    !content_change.is_travel_advice?
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,6 +13,14 @@ FactoryBot.define do
     sequence(:govuk_request_id) { |i| "request-id-#{i}" }
     document_type "document type"
     publishing_app "publishing app"
+
+    trait :travel_advice do
+      links countries: [SecureRandom.uuid]
+    end
+
+    trait :medical_safety_alert do
+      tags format: ["medical_safety_alert"], alert_type: %w(devices drugs field-safety-notices company-led-drugs)
+    end
   end
 
   factory :delivery_attempt do

--- a/spec/models/content_change_spec.rb
+++ b/spec/models/content_change_spec.rb
@@ -1,7 +1,34 @@
 RSpec.describe ContentChange do
-  describe "#mark_processed!" do
-    subject { create(:content_change) }
+  subject { create(:content_change) }
 
+  shared_examples "not travel advice" do
+    it "is not recognised as travel advice" do
+      expect(subject.is_travel_advice?).to be false
+    end
+  end
+
+  shared_examples "travel advice" do
+    it "is recognised as travel advice" do
+      expect(subject.is_travel_advice?).to be true
+    end
+  end
+
+  shared_examples "not medical safety alert" do
+    it "is not recognised as medical safety alert" do
+      expect(subject.is_medical_safety_alert?).to be false
+    end
+  end
+
+  shared_examples "medical safety alert" do
+    it "is recognised as medical safety alert" do
+      expect(subject.is_medical_safety_alert?).to be true
+    end
+  end
+
+  it_behaves_like "not travel advice"
+  it_behaves_like "not medical safety alert"
+
+  describe "#mark_processed!" do
     it "sets processed_at" do
       Timecop.freeze do
         expect { subject.mark_processed! }
@@ -10,5 +37,19 @@ RSpec.describe ContentChange do
           .to(Time.now)
       end
     end
+  end
+
+  context "with a travel advice" do
+    subject { create(:content_change, :travel_advice) }
+
+    it_behaves_like "travel advice"
+    it_behaves_like "not medical safety alert"
+  end
+
+  context "with a medical safety alert" do
+    subject { create(:content_change, :medical_safety_alert) }
+
+    it_behaves_like "not travel advice"
+    it_behaves_like "medical safety alert"
   end
 end

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe ContentChangePresenter do
       expect(described_class.call(content_change)).to eq(expected)
     end
 
+    context "when the content change is travel advice" do
+      let(:content_change) { create(:content_change, :travel_advice, public_updated_at: Time.parse("10:00 1/1/2018")) }
+
+      it "doesn't include the description" do
+        expected = <<~CONTENT_CHANGE
+          [title](http://www.dev.gov.uk/government/base_path)
+
+          10:00am, 1 January 2018: change note
+        CONTENT_CHANGE
+
+        expect(described_class.call(content_change)).to eq(expected)
+      end
+    end
+
     context "when content change contains markdown" do
       let(:content_change) {
         build(

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe ContentChangePresenter do
       end
     end
 
+    context "when the content change is medical safety alert" do
+      let(:content_change) { create(:content_change, :medical_safety_alert, public_updated_at: Time.parse("10:00 1/1/2018")) }
+
+      it "includes the MHRA line" do
+        expected = <<~CONTENT_CHANGE
+          [title](http://www.dev.gov.uk/government/base_path)
+
+          description
+
+          10:00am, 1 January 2018: change note
+
+          Do not reply to this email. To contact MHRA, email [email.support@mhra.gov.uk](mailto:email.support@mhra.gov.uk)
+        CONTENT_CHANGE
+
+        expect(described_class.call(content_change)).to eq(expected)
+      end
+    end
+
     context "when content change contains markdown" do
       let(:content_change) {
         build(


### PR DESCRIPTION
This PR introduces custom emails for travel advice and medical safety alerts.

For travel advice emails, the description doesn't get shown. For medical safety alerts, we include a line about contacting MHRA directly.

[Travel Advice Trello Card](https://trello.com/c/2MgWX34y/642-change-what-we-put-in-travel-advice-updates) [Medical Safety Alert Trello Card](https://trello.com/c/f9gAAlay/627-add-an-extra-blurb-for-medical-device-alert-emails)