### PR TITLE
Add presence validation on content change

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -1,6 +1,10 @@
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
 
+  validates_presence_of :content_id, :title, :base_path, :change_note, :description,
+    :public_updated_at, :email_document_supertype, :government_document_supertype,
+    :govuk_request_id, :document_type, :publishing_app
+
   has_many :matched_content_changes
 
   enum priority: { normal: 0, high: 1 }


### PR DESCRIPTION
This should prevent errors about NOT NULL validation appearing in Sentry since the validation will be caught earlier.