### PR TITLE
Support a blank content change description

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -1,6 +1,10 @@
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
 
+  validates_presence_of :content_id, :title, :base_path, :change_note, :description,
+    :public_updated_at, :email_document_supertype, :government_document_supertype,
+    :govuk_request_id, :document_type, :publishing_app
+
   has_many :matched_content_changes
 
   enum priority: { normal: 0, high: 1 }

--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -1,7 +1,7 @@
 class ContentChange < ApplicationRecord
   include SymbolizeJSON
 
-  validates_presence_of :content_id, :title, :base_path, :change_note, :description,
+  validates_presence_of :content_id, :title, :base_path, :change_note,
     :public_updated_at, :email_document_supertype, :government_document_supertype,
     :govuk_request_id, :document_type, :publishing_app
 

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -12,13 +12,11 @@ class ContentChangePresenter
   end
 
   def call
-    <<~BODY
-      [#{title}](#{content_url})
-
-      #{strip_markdown(description)}
-
-      #{public_updated_at}: #{strip_markdown(change_note)}
-    BODY
+    [
+      title_markdown,
+      description_markdown,
+      change_note_markdown,
+    ].compact.join("\n\n") + "\n"
   end
 
   private_class_method :new
@@ -43,5 +41,17 @@ private
 
   def markdown_stripper
     @markdown_stripper ||= Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+  end
+
+  def title_markdown
+    "[#{title}](#{content_url})"
+  end
+
+  def description_markdown
+    strip_markdown(description)
+  end
+
+  def change_note_markdown
+    "#{public_updated_at}: #{strip_markdown(change_note)}"
   end
 end

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -48,6 +48,7 @@ private
   end
 
   def description_markdown
+    return nil if description.blank?
     strip_markdown(description)
   end
 

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -47,5 +47,24 @@ RSpec.describe ContentChangePresenter do
         expect(described_class.call(content_change)).to eq(expected)
       end
     end
+
+    context "when the content change has no description" do
+      let(:content_change) {
+        build(
+          :content_change, description: "",
+          public_updated_at: Time.parse("10:00 1/1/2018")
+        )
+      }
+
+      it "doesn't leave an empty gap" do
+        expected = <<~CONTENT_CHANGE
+          [title](http://www.dev.gov.uk/government/base_path)
+
+          10:00am, 1 January 2018: change note
+        CONTENT_CHANGE
+
+        expect(described_class.call(content_change)).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
This will be used to render travel advice emails without a description as they can be excessively long. We will also update travel advice publisher to stop sending descriptions with content changes.

Replaces #483 with a more generic solution.

[Trello Card](https://trello.com/c/2MgWX34y/642-change-what-we-put-in-travel-advice-updates)