### PR TITLE
Increase subscriber list title length limit

### DIFF
--- a/db/migrate/20180305091124_increase_subscriber_list_title_length_limit.rb
+++ b/db/migrate/20180305091124_increase_subscriber_list_title_length_limit.rb
@@ -1,0 +1,5 @@
+class IncreaseSubscriberListTitleLengthLimit < ActiveRecord::Migration[5.1]
+  def up
+    change_column :subscriber_lists, :title, :string, limit: 1000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180302090154) do
+ActiveRecord::Schema.define(version: 20180305091124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,7 +117,7 @@ ActiveRecord::Schema.define(version: 20180302090154) do
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
-    t.string "title", limit: 255, null: false
+    t.string "title", limit: 1000, null: false
     t.string "gov_delivery_id", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"


### PR DESCRIPTION
We saw a few errors in Sentry about strings not fiting within the fields on the subscriber list table.