### PR TITLE
Content change footnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ and it will respond with the JSON response for the `GET` call above.
 and it will respond with `202 Accepted` (the call is queued to prevent slowness
 in the external notifications API).
 
+The following fields are accepted on this endpoint: `subject`, `from_address_id`, `urgent`, `header`, `footer`,
+`document_type`, `content_id`, `public_updated_at`, `publishing_app`, `email_document_supertype`,
+`government_document_supertype`, `title`, `description`, `change_note`, `base_path`, `priority` and `footnote`.
+
 * `POST /subscriptions` with data:
 
 ```json

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -26,7 +26,7 @@ private
     permitted_params = params.permit!.to_h
     permitted_params.slice(:subject, :from_address_id, :urgent, :header, :footer, :document_type,
       :content_id, :public_updated_at, :publishing_app, :email_document_supertype,
-      :government_document_supertype, :title, :description, :change_note, :base_path, :priority)
+      :government_document_supertype, :title, :description, :change_note, :base_path, :priority, :footnote)
       .merge(tags: permitted_params.fetch(:tags, {}))
       .merge(links: permitted_params.fetch(:links, {}))
       .merge(body: notification_body)

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -16,6 +16,7 @@ class ContentChangePresenter
       title_markdown,
       description_markdown,
       change_note_markdown,
+      footnote_markdown,
     ].compact.join("\n\n") + "\n"
   end
 
@@ -25,7 +26,7 @@ private
 
   attr_reader :content_change
 
-  delegate :title, :description, :change_note, to: :content_change
+  delegate :title, :description, :change_note, :footnote, to: :content_change
 
   def content_url
     PublicUrlService.url_for(base_path: content_change.base_path)
@@ -54,5 +55,10 @@ private
 
   def change_note_markdown
     "#{public_updated_at}: #{strip_markdown(change_note)}"
+  end
+
+  def footnote_markdown
+    return nil if footnote.blank?
+    strip_markdown(footnote)
   end
 end

--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -38,6 +38,7 @@ private
       publishing_app: params[:publishing_app],
       priority: params.fetch(:priority, "normal").to_sym,
       signon_user_uid: user&.uid,
+      footnote: params.fetch(:footnote, ""),
     }
   end
 end

--- a/db/migrate/20180305094418_add_footnote_to_content_change.rb
+++ b/db/migrate/20180305094418_add_footnote_to_content_change.rb
@@ -1,0 +1,5 @@
+class AddFootnoteToContentChange < ActiveRecord::Migration[5.1]
+  def change
+    add_column :content_changes, :footnote, :text, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180305091124) do
+ActiveRecord::Schema.define(version: 20180305094418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20180305091124) do
     t.datetime "processed_at"
     t.integer "priority", default: 0
     t.string "signon_user_uid"
+    t.text "footnote", default: "", null: false
   end
 
   create_table "delivery_attempts", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -66,5 +66,28 @@ RSpec.describe ContentChangePresenter do
         expect(described_class.call(content_change)).to eq(expected)
       end
     end
+
+    context "when the content change has a footnote" do
+      let(:content_change) {
+        build(
+          :content_change, footnote: "footnote",
+          public_updated_at: Time.parse("10:00 1/1/2018")
+        )
+      }
+
+      it "includes the footnote at the bottom" do
+        expected = <<~CONTENT_CHANGE
+          [title](http://www.dev.gov.uk/government/base_path)
+
+          description
+
+          10:00am, 1 January 2018: change note
+
+          footnote
+        CONTENT_CHANGE
+
+        expect(described_class.call(content_change)).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds support for "footnotes" in content change which get rendered at the bottom of the email. This will be used to include an extra line for MHRA emails.

This replaces #483 as a more generic solution.

[Trello Card](https://trello.com/c/f9gAAlay/627-add-an-extra-blurb-for-medical-device-alert-emails)