### PR TITLE
Truncate email_archives table in rake task

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -7,9 +7,9 @@ namespace :deploy do
     end
   end
 
-  desc "Truncate tables for live deploy. This will truncate emails, delivery_attempts, subscription_contents, subscribers, subscriptions, digest_runs, digest_run_subscriptions, content_changes and matched_content_changes"
+  desc "Truncate tables for live deploy. This will truncate emails, delivery_attempts, subscription_contents, subscribers, subscriptions, digest_runs, digest_run_subscriptions, content_changes, matched_content_changes and email_archives"
   task truncate_tables: :environment do
-    ActiveRecord::Base.connection.execute("TRUNCATE emails, subscribers, content_changes, digest_runs RESTART IDENTITY CASCADE;")
+    ActiveRecord::Base.connection.execute("TRUNCATE emails, subscribers, content_changes, digest_runs, email_archives  RESTART IDENTITY CASCADE;")
 
     puts "** Sanity check row counts ** "
     puts_table_counts


### PR DESCRIPTION
The rake task to truncate new table before switching to Notify should
also truncate the email_archives table.