### PR TITLE
Increase retry size healthcheck thresholds

### DIFF
--- a/app/models/healthcheck/retry_size_healthcheck.rb
+++ b/app/models/healthcheck/retry_size_healthcheck.rb
@@ -25,11 +25,11 @@ class Healthcheck
     end
 
     def critical_size
-      ENV.fetch("SIDEKIQ_RETRY_SIZE_CRITICAL", 10).to_i
+      ENV.fetch("SIDEKIQ_RETRY_SIZE_CRITICAL", 15000).to_i
     end
 
     def warning_size
-      ENV.fetch("SIDEKIQ_RETRY_SIZE_WARNING", 5).to_i
+      ENV.fetch("SIDEKIQ_RETRY_SIZE_WARNING", 10000).to_i
     end
   end
 end

--- a/spec/models/healthcheck/retry_size_healthcheck_spec.rb
+++ b/spec/models/healthcheck/retry_size_healthcheck_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Healthcheck::RetrySizeHealthcheck do
   end
 
   context "when the warning threshold is reached" do
-    let(:size) { 5 }
+    let(:size) { 10005 }
     specify { expect(subject.status).to eq(:warning) }
   end
 
   context "when the critical threshold is reached" do
-    let(:size) { 10 }
+    let(:size) { 15010 }
     specify { expect(subject.status).to eq(:critical) }
   end
 


### PR DESCRIPTION
We rely on the retry set to perform our rate limiting so it's normal for these to be relatively high. These numbers are based on what we've seen happen in staging, but they may need tweaking in the future.