### PR TITLE
Further increase retry size thresholds

### DIFF
--- a/app/models/healthcheck/retry_size_healthcheck.rb
+++ b/app/models/healthcheck/retry_size_healthcheck.rb
@@ -25,11 +25,11 @@ class Healthcheck
     end
 
     def critical_size
-      ENV.fetch("SIDEKIQ_RETRY_SIZE_CRITICAL", 15000).to_i
+      ENV.fetch("SIDEKIQ_RETRY_SIZE_CRITICAL", 50000).to_i
     end
 
     def warning_size
-      ENV.fetch("SIDEKIQ_RETRY_SIZE_WARNING", 10000).to_i
+      ENV.fetch("SIDEKIQ_RETRY_SIZE_WARNING", 40000).to_i
     end
   end
 end

--- a/spec/models/healthcheck/retry_size_healthcheck_spec.rb
+++ b/spec/models/healthcheck/retry_size_healthcheck_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Healthcheck::RetrySizeHealthcheck do
   end
 
   context "when the warning threshold is reached" do
-    let(:size) { 10005 }
+    let(:size) { 40005 }
     specify { expect(subject.status).to eq(:warning) }
   end
 
   context "when the critical threshold is reached" do
-    let(:size) { 15010 }
+    let(:size) { 50010 }
     specify { expect(subject.status).to eq(:critical) }
   end
 


### PR DESCRIPTION
After some further experimentation, it looks we still see alerts for the retry size. Today so far it has reached a peak of 47K in staging while sending digests, and when there is a content change it regularly reaches 20K.