### PR TITLE
Don't create subscription contents for ended subscriptions

### DIFF
--- a/app/queries/content_change_immediate_subscription_query.rb
+++ b/app/queries/content_change_immediate_subscription_query.rb
@@ -4,6 +4,7 @@ class ContentChangeImmediateSubscriptionQuery
       .joins(subscriber_list: :matched_content_changes)
       .where(matched_content_changes: { content_change_id: content_change.id })
       .where(frequency: "immediately")
+      .active
       .distinct
   end
 end

--- a/spec/queries/content_change_immediate_subscription_query_spec.rb
+++ b/spec/queries/content_change_immediate_subscription_query_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe ContentChangeImmediateSubscriptionQuery do
       end
     end
 
+    context "with an ended subscription" do
+      before do
+        create(:subscription, :ended, subscriber_list: subscriber_list)
+      end
+
+      it "returns no subscriptions" do
+        expect(subject.count).to eq(0)
+      end
+    end
+
     context "with two subscriptions" do
       before do
         create(:subscription, subscriber_list: subscriber_list)


### PR DESCRIPTION
Currently we create subscription contents for all subscriptions, even ones that are ended (i.e. people have unsubscribed to them). This means they would end up still getting emails.