### PR TITLE
Only return active subscription content changes

### DIFF
--- a/app/queries/subscription_content_change_query.rb
+++ b/app/queries/subscription_content_change_query.rb
@@ -43,6 +43,7 @@ private
       .where(subscribers: { id: subscriber.id })
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
+      .merge(Subscription.active)
       .order("subscriber_list_title ASC", "content_changes.title ASC")
   end
 end

--- a/spec/queries/subscription_content_change_query_spec.rb
+++ b/spec/queries/subscription_content_change_query_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe SubscriptionContentChangeQuery do
         it "returns one result" do
           expect(subject.first.content_changes.count).to eq(1)
         end
+
+        context "with an ended subscription" do
+          before do
+            subscription.end(reason: :unsubscribed)
+          end
+
+          it "returns no results" do
+            expect(subject.count).to eq(0)
+          end
+        end
       end
 
       context "with two matched content changes" do


### PR DESCRIPTION
Previously we were returning the subscription content changes for all subscriptions which means users would have received digest emails about things they had unsubscribed to.