### PR TITLE
Add separate queue latency thresholds for different queues

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -28,6 +28,7 @@ private
   def all
     @all ||= [
       DatabaseHealthcheck.new,
+      QueueLatencyHealthcheck.new,
       QueueSizeHealthcheck.new,
       RedisHealthcheck.new,
       RetrySizeHealthcheck.new,

--- a/app/models/healthcheck/queue_latency_healthcheck.rb
+++ b/app/models/healthcheck/queue_latency_healthcheck.rb
@@ -1,0 +1,49 @@
+class Healthcheck
+  class QueueLatencyHealthcheck
+    def name
+      :queue_latency
+    end
+
+    def status
+      if queue_latencies.any? { |s| s >= critical_size }
+        :critical
+      elsif queue_latencies.any? { |s| s >= warning_size }
+        :warning
+      else
+        :ok
+      end
+    end
+
+    def details
+      { queues: queues }
+    end
+
+  private
+
+    def queue_latencies
+      queues.values
+    end
+
+    def queues
+      @queues ||= queue_names.each.with_object({}) do |name, hash|
+        hash[name] = latency_for(name)
+      end
+    end
+
+    def latency_for(name)
+      Sidekiq::Queue.new(name).latency
+    end
+
+    def queue_names
+      @queues ||= Sidekiq::Stats.new.queues.keys
+    end
+
+    def critical_size
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_CRITICAL", 15 * 60).to_i
+    end
+
+    def warning_size
+      ENV.fetch("SIDEKIQ_QUEUE_LATENCY_WARNING", 10 * 60).to_i
+    end
+  end
+end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Healthcheck", type: :request do
 
     expect(data.fetch(:checks)).to include(
       database:          { status: "ok" },
+      queue_latency:     { status: "ok", queues: a_kind_of(Hash) },
       queue_size:        { status: "ok", queues: a_kind_of(Hash) },
       redis:             { status: "ok" },
       retry_size:        { status: "ok", retry_size: 0 },

--- a/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
@@ -1,18 +1,68 @@
 RSpec.describe Healthcheck::QueueLatencyHealthcheck do
-  before { allow(subject).to receive(:queue_latencies).and_return [latency] }
+  let(:delivery_immediate_high_latency) { 0 }
+  let(:delivery_immediate_latency) { 0 }
+  let(:delivery_digest_latency) { 0 }
 
-  context "when it is quick to respond" do
-    let(:latency) { 2 }
+  before do
+    allow(subject).to receive(:latency_for).with(:delivery_immediate_high).and_return(delivery_immediate_high_latency)
+    allow(subject).to receive(:latency_for).with(:delivery_immediate).and_return(delivery_immediate_latency)
+    allow(subject).to receive(:latency_for).with(:delivery_digest).and_return(delivery_digest_latency)
+  end
+
+  shared_examples "an ok healthcheck" do
     specify { expect(subject.status).to eq(:ok) }
   end
 
-  context "when the warning threshold is reached" do
-    let(:latency) { 750 }
+  shared_examples "a warning healthcheck" do
     specify { expect(subject.status).to eq(:warning) }
   end
 
-  context "when the critical threshold is reached" do
-    let(:latency) { 1000 }
+  shared_examples "a critical healthcheck" do
     specify { expect(subject.status).to eq(:critical) }
+  end
+
+  context "when the delivery_immediate_high queue latency is critical" do
+    let(:delivery_immediate_high_latency) { 10.minutes.to_i }
+    it_behaves_like "a critical healthcheck"
+  end
+
+  context "when the delivery_immediate_high queue latency is warning" do
+    let(:delivery_immediate_high_latency) { 3.minutes.to_i }
+    it_behaves_like "a warning healthcheck"
+  end
+
+  context "when the delivery_immediate_high queue latency is ok" do
+    let(:delivery_immediate_high_latency) { 1.minutes.to_i }
+    it_behaves_like "an ok healthcheck"
+  end
+
+  context "when the delivery_immediate queue latency is critical" do
+    let(:delivery_immediate_latency) { 10.minutes.to_i }
+    it_behaves_like "a critical healthcheck"
+  end
+
+  context "when the delivery_immediate queue latency is warning" do
+    let(:delivery_immediate_latency) { 3.minutes.to_i }
+    it_behaves_like "a warning healthcheck"
+  end
+
+  context "when the delivery_immediate queue latency is ok" do
+    let(:delivery_immediate_latency) { 1.minutes.to_i }
+    it_behaves_like "an ok healthcheck"
+  end
+
+  context "when the delivery_digest queue latency is critical" do
+    let(:delivery_digest_latency) { 95.minutes.to_i }
+    it_behaves_like "a critical healthcheck"
+  end
+
+  context "when the delivery_digest queue latency is warning" do
+    let(:delivery_digest_latency) { 65.minutes.to_i }
+    it_behaves_like "a warning healthcheck"
+  end
+
+  context "when the delivery_digest queue latency is ok" do
+    let(:delivery_digest_latency) { 10.minutes.to_i }
+    it_behaves_like "an ok healthcheck"
   end
 end

--- a/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
+++ b/spec/models/healthcheck/queue_latency_healthcheck_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Healthcheck::QueueLatencyHealthcheck do
+  before { allow(subject).to receive(:queue_latencies).and_return [latency] }
+
+  context "when it is quick to respond" do
+    let(:latency) { 2 }
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when the warning threshold is reached" do
+    let(:latency) { 750 }
+    specify { expect(subject.status).to eq(:warning) }
+  end
+
+  context "when the critical threshold is reached" do
+    let(:latency) { 1000 }
+    specify { expect(subject.status).to eq(:critical) }
+  end
+end


### PR DESCRIPTION
This means we can have a higher latency on digest emails as they are less important.

[Trello Card](https://trello.com/c/DOtvUmsU/443-reinstate-queuelatencyhealthcheck)