### PR TITLE
Only deactivate a subscriber if not already

### DIFF
--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -18,7 +18,7 @@ module UnsubscribeService
           subscription.end(reason: reason)
         end
 
-        if no_other_subscriptions?(subscriber, subscriptions)
+        if !subscriber.deactivated? && no_other_subscriptions?(subscriber, subscriptions)
           subscriber.deactivate!
         end
       end


### PR DESCRIPTION
We're seeing an issue with the status updates where we get back a permenant failure multiple times for the same subscriber leading to us deactiviting it multiple times which raises an exception.

[Sentry](https://sentry.io/govuk/app-email-alert-api/issues/483226884/)