### PR TITLE
Add task to unsubscribe people

### DIFF
--- a/lib/tasks/unsubscribe.rake
+++ b/lib/tasks/unsubscribe.rake
@@ -1,0 +1,26 @@
+require 'csv'
+
+namespace :unsubscribe do
+  def unsubscribe(email_address)
+    subscriber = Subscriber.find_by(address: email_address)
+    if subscriber.nil?
+      puts "Subscriber #{email_address} not found"
+    else
+      puts "Unsubscribing #{email_address}"
+      UnsubscribeService.subscriber!(subscriber, :unsubscribed)
+    end
+  end
+
+  desc "Unsubscribe a single subscriber"
+  task :single, [:email_address] => :environment do |_t, args|
+    unsubscribe(args[:email_address])
+  end
+
+  desc "Unsubscribe a list of subscribers from a CSV file"
+  task :bulk_from_csv, [:csv_file_path] => :environment do |_t, args|
+    email_addresses = CSV.read(args[:csv_file_path])
+    email_addresses.each do |email_address|
+      unsubscribe(email_address[0])
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a rake task that can be used to unsubscribe people from all emails. This will be used during the GovDelivery transition to unsubscribe people from the new system when they unsubscribe from the old system.

Trello: https://trello.com/c/bYeZh4Zd/681-make-a-rake-task-to-unsubscribe-people-in-bulk-from-a-csv