### PR TITLE
Always use email-alert-frontend for subscriptions

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -25,11 +25,7 @@ class SubscriberList < ApplicationRecord
   end
 
   def subscription_url
-    if use_email_alert_frontend_for_email_collection?
-      PublicUrlService.subscription_url(gov_delivery_id: gov_delivery_id)
-    else
-      PublicUrlService.deprecated_subscription_url(gov_delivery_id: gov_delivery_id)
-    end
+    PublicUrlService.subscription_url(gov_delivery_id: gov_delivery_id)
   end
 
   def to_json(options = {})
@@ -62,10 +58,5 @@ private
 
   def gov_delivery_config
     EmailAlertAPI.config.gov_delivery
-  end
-
-  # We could make this more sophisticated if needed, e.g. check document_type.
-  def use_email_alert_frontend_for_email_collection?
-    ENV.include?("USE_EMAIL_ALERT_FRONTEND_FOR_EMAIL_COLLECTION")
   end
 end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -13,19 +13,6 @@ module PublicUrlService
       "#{website_root}/email/subscriptions/new?#{params}"
     end
 
-    # This url is for the page mid-way through the signup journey where the user
-    # enters their email address. This is where we handover to govdelivery.
-    def deprecated_subscription_url(gov_delivery_id:)
-      config = EmailAlertAPI.config.gov_delivery
-
-      proto = config.fetch(:protocol)
-      host = config.fetch(:public_hostname)
-      code = config.fetch(:account_code)
-      params = param(:topic_id, gov_delivery_id)
-
-      "#{proto}://#{host}/accounts/#{code}/subscriber/new?#{params}"
-    end
-
   private
 
     def website_root

--- a/doc/transition-from-govdelivery-to-notify.md
+++ b/doc/transition-from-govdelivery-to-notify.md
@@ -7,13 +7,6 @@ It will be safe to remove this once the migration has been completed.
 
 ## ENV vars
 
-### `USE_EMAIL_ALERT_FRONTEND_FOR_EMAIL_COLLECTION`
-
-When this environment variable set the redirect location that is returned
-as part of a subscriber list JSON serialization. Once this is returning
-frontend apps will redirect users to the Email Alert Frontend signup which
-does not use govdelivery.
-
 ### `EMAIL_ADDRESS_OVERRIDE`
 
 By setting this environment variable all emails sent will have their address

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -123,26 +123,10 @@ RSpec.describe SubscriberList, type: :model do
   describe "#subscription_url" do
     subject { SubscriberList.new(gov_delivery_id: "UKGOVUK_4567") }
 
-    it "returns the govdelivery subscription URL" do
+    it "returns the correct subscription URL" do
       expect(subject.subscription_url).to eq(
-        "http://govdelivery-public.example.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_4567"
+        "http://www.dev.gov.uk/email/subscriptions/new?topic_id=UKGOVUK_4567"
       )
-    end
-
-    context "when switching over to use email alert frontend for email collection" do
-      before do
-        allow(ENV).to receive(:include?).and_call_original
-
-        allow(ENV).to receive(:include?)
-          .with("USE_EMAIL_ALERT_FRONTEND_FOR_EMAIL_COLLECTION")
-          .and_return(true)
-      end
-
-      it "returns the email alert frontend subscription URL" do
-        expect(subject.subscription_url).to eq(
-          "http://www.dev.gov.uk/email/subscriptions/new?topic_id=UKGOVUK_4567"
-        )
-      end
     end
   end
 end

--- a/spec/services/public_url_service_spec.rb
+++ b/spec/services/public_url_service_spec.rb
@@ -12,14 +12,4 @@ RSpec.describe PublicUrlService do
       expect(result).to eq("http://www.dev.gov.uk/email/subscriptions/new?topic_id=foo_bar")
     end
   end
-
-  describe ".deprecated_subscription_url" do
-    it "returns the govdelivery URL for creating a new subscription" do
-      result = subject.deprecated_subscription_url(gov_delivery_id: "foo_bar")
-
-      expect(result).to eq(
-        "http://govdelivery-public.example.com/accounts/UKGOVUK/subscriber/new?topic_id=foo_bar"
-      )
-    end
-  end
 end


### PR DESCRIPTION
We no longer want people to be subscribing via GovDelivery as we are using GOV.UK Notify.

[Trello Card](https://trello.com/c/iKEAnrN2/680-post-deploy-development-cleanup)