### PR TITLE
Ignore case when creating subscriptions

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -36,7 +36,7 @@ private
 
   def subscriber
     @subscriber ||= begin
-                      found = Subscriber.find_by(address: address)
+                      found = Subscriber.where("LOWER(address) = ?", address.downcase).first
                       found || Subscriber.create!(
                         address: address,
                         signon_user_uid: current_user.uid,

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe "Creating a subscription", type: :request do
           end
         end
 
+        context "with an existing subscription but a different case" do
+          it "returns a successful response" do
+            params = JSON.dump(address: "Test@example.com", subscribable_id: subscribable.id, frequency: "daily")
+            post "/subscriptions", params: params, headers: JSON_HEADERS
+
+            expect(response.status).to eq(201)
+
+            params = JSON.dump(address: "test@example.com", subscribable_id: subscribable.id, frequency: "weekly")
+            post "/subscriptions", params: params, headers: JSON_HEADERS
+
+            expect(response.status).to eq(200)
+          end
+        end
+
         context "with a notify email address" do
           it "returns a 201 but doesn't create a subscriber or subscription" do
             params = JSON.dump(address: "simulate-delivered@notifications.service.gov.uk", subscribable_id: subscribable.id, frequency: "daily")


### PR DESCRIPTION
Currently if someone uses a different case in their email address while subscribing to multiple things, it will show an error when using the different case. Instead we can be sure it is the same email address they meant and search for the existing subscriber ignoring case.