### PR TITLE
Reduce unnecessary rate limiting when a delivery hasn't been attempted

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -21,7 +21,7 @@ class DeliveryRequestService
     reference = SecureRandom.uuid
 
     address = determine_address(email, reference)
-    return if address.nil?
+    return false if address.nil?
 
     delivery_attempt = create_delivery_attempt(email, reference)
 
@@ -39,6 +39,8 @@ class DeliveryRequestService
         email.finish_sending(delivery_attempt) if delivery_attempt.has_final_status?
       end
     end
+
+    true
   end
 
 private

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -19,10 +19,12 @@ class DeliveryRequestWorker
   def perform(email_id, queue)
     @email_id = email_id
     @queue = queue
+
     check_rate_limit!
-    increment_rate_limiter
+
     email = Email.find(email_id)
-    DeliveryRequestService.call(email: email)
+    attempted = DeliveryRequestService.call(email: email)
+    increment_rate_limiter if attempted
   end
 
   def self.perform_async_in_queue(*args, queue:)

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe DeliveryRequestService do
         )
         .and_return(:sending)
 
-      subject.call(email: email)
+      attempted = subject.call(email: email)
+      expect(attempted).to be true
     end
 
     context "when the email address is overridden" do
@@ -74,6 +75,21 @@ RSpec.describe DeliveryRequestService do
         expect(Rails.logger).to receive(:info)
           .with(match(/Overriding email address/))
         subject.call(email: email)
+      end
+    end
+
+    context "when the email address isn't whitelisted" do
+      let(:subject) do
+        described_class.new(config: config.merge(
+          email_address_override: "overridden@example.com", email_address_override_whitelist_only: true
+        ))
+      end
+
+      it "doesn't call the provider with the overridden email address" do
+        expect(subject.provider).to_not receive(:call)
+
+        attempted = subject.call(email: email)
+        expect(attempted).to be false
       end
     end
 

--- a/spec/workers/delivery_request_worker_spec.rb
+++ b/spec/workers/delivery_request_worker_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe DeliveryRequestWorker do
 
     context "with an email and a subscriber" do
       it "calls the DeliveryRequestService" do
-        expect(DeliveryRequestService).to receive(:call).with(email: email)
+        expect(DeliveryRequestService).to receive(:call).with(email: email).and_return(true)
+        expect(subject).to receive(:increment_rate_limiter)
         subject.perform(email.id, queue)
       end
     end


### PR DESCRIPTION
When we have a whitelist of valid email addresses, we still want to exercise as much of the code as possible. This meant that previously we would be reaching out low rate limit in staging and integration all the time and ending up with a high retry set and it can take a long time for test emails to come through. This PR should mean we no longer record the delivery requests which will end up doing nothing (because they are not whitelisted) in the rate limiter, so they don't get put on the retry set and go straight through.

This is related to the potential work out of [this Trello Card](https://trello.com/c/49Xs9xKo/482-better-logging-of-psuedo-override-process) but that's a bigger piece of work whereas this PR should solve the immediate problem.