### PR TITLE
 Import subscription contents in batches grouped by subscriber

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -12,4 +12,8 @@ class ContentChange < ApplicationRecord
   def mark_processed!
     update!(processed_at: Time.now)
   end
+
+  def processed?
+    processed_at.present?
+  end
 end

--- a/app/queries/content_change_immediate_subscription_query.rb
+++ b/app/queries/content_change_immediate_subscription_query.rb
@@ -5,6 +5,5 @@ class ContentChangeImmediateSubscriptionQuery
       .where(matched_content_changes: { content_change_id: content_change.id })
       .where(frequency: "immediately")
       .active
-      .distinct
   end
 end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -1,28 +1,45 @@
 class SubscriptionContentWorker
   include Sidekiq::Worker
 
-  def perform(content_change_id)
+  def perform(content_change_id, batch_size = 1000)
     content_change = ContentChange.find(content_change_id)
-    queue_delivery_to_subscribers(content_change)
+    queue_delivery_to_subscribers(content_change, batch_size: batch_size)
     queue_delivery_to_courtesy_subscribers(content_change)
     content_change.mark_processed!
   end
 
 private
 
-  def queue_delivery_to_subscribers(content_change)
-    subscriptions_for(content_change: content_change).find_in_batches do |group|
-      columns = %i(content_change_id subscription_id)
+  def queue_delivery_to_subscribers(content_change, batch_size: 1000)
+    content_change_id = content_change.id
+    batch = []
 
-      content_change_id = content_change.id
-      records = group.pluck(:id).map do |subscription_id|
+    grouped_subscription_ids_by_subscriber(content_change).each do |subscription_ids|
+      records = subscription_ids.map do |subscription_id|
         [content_change_id, subscription_id]
       end
 
-      SubscriptionContent.import!(columns, records)
+      batch.concat(records)
 
-      ImmediateEmailGenerationWorker.perform_async
+      if batch.size >= batch_size
+        import_subscription_contents_batch(batch)
+        batch.clear
+      end
     end
+
+    import_subscription_contents_batch(batch) unless batch.empty?
+  end
+
+  def import_subscription_contents_batch(batch)
+    columns = %i(content_change_id subscription_id)
+    SubscriptionContent.import!(columns, batch)
+    ImmediateEmailGenerationWorker.perform_async
+  end
+
+  def grouped_subscription_ids_by_subscriber(content_change)
+    ContentChangeImmediateSubscriptionQuery.call(content_change: content_change)
+      .group(:subscriber_id)
+      .pluck("ARRAY_AGG(subscriptions.id)")
   end
 
   def queue_delivery_to_courtesy_subscribers(content_change)
@@ -39,9 +56,5 @@ private
         email_id, queue: :delivery_immediate,
       )
     end
-  end
-
-  def subscriptions_for(content_change:)
-    ContentChangeImmediateSubscriptionQuery.call(content_change: content_change)
   end
 end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -3,8 +3,11 @@ class SubscriptionContentWorker
 
   def perform(content_change_id, batch_size = 1000)
     content_change = ContentChange.find(content_change_id)
+    return if content_change.processed?
+
     queue_delivery_to_subscribers(content_change, batch_size: batch_size)
     queue_delivery_to_courtesy_subscribers(content_change)
+
     content_change.mark_processed!
   end
 

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe SubscriptionContentWorker do
     end
   end
 
+  context "with more subscriptions than the batch size" do
+    let(:subscriber) { create(:subscriber) }
+    let(:content_change) { create(:content_change) }
+
+    before do
+      2.times do
+        subscription = create(:subscription, subscriber: subscriber)
+        create(:matched_content_change, subscriber_list: subscription.subscriber_list, content_change: content_change)
+      end
+    end
+
+    it "calls SubscriptionContent.import! once" do
+      expect(SubscriptionContent).to receive(:import!).once
+
+      subject.perform(content_change.id, 1)
+    end
+  end
+
   context "with a courtesy subscription" do
     let!(:subscriber) do
       create(:subscriber, address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk")

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -23,25 +23,6 @@ RSpec.describe SubscriptionContentWorker do
       end
     end
 
-    context "when we error" do
-      it "reports errors when creating a SubscriptionContent in the database to Sentry and swallows them" do
-        allow(SubscriptionContent)
-          .to receive(:import!)
-          .and_raise(ActiveRecord::RecordInvalid)
-
-        expect(Raven)
-          .to receive(:capture_exception)
-          .with(
-            instance_of(ActiveRecord::RecordInvalid),
-            tags: { version: 2 }
-          )
-
-        expect {
-          subject.perform(content_change.id)
-        }.not_to raise_error
-      end
-    end
-
     it "creates subscription content for the content change" do
       expect(SubscriptionContent)
         .to receive(:import!)

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -77,4 +77,15 @@ RSpec.describe SubscriptionContentWorker do
       subject.perform(content_change.id)
     end
   end
+
+  context "with an already processed content change" do
+    before do
+      content_change.mark_processed!
+    end
+
+    it "should return immediate" do
+      expect(content_change).to_not receive(:mark_processed!)
+      subject.perform(content_change.id)
+    end
+  end
 end


### PR DESCRIPTION
We are seeing a problem where we are importing subscription contents in constant sized batches which could lead to not importing all the subscription contents for a particular subscriber in one go.

This can lead to users receiving duplicate emails for a content change since the deduplication relies on the assumption that all subscription contents are imported.

The alternative would be to import all subscription contents in one go, but that prevents us from being able to start sending emails as quick as possible as it can take a bit of time to generate the emails in the first place. It would also lead to a huge delivery queue which could use more memory.

[Trello Card](https://trello.com/c/LQ48zPbL/699-fix-any-post-deploy-bugs)