### PR TITLE
Stop using GovDelivery IDs

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -12,18 +12,6 @@ class SubscriberList < ApplicationRecord
   has_many :subscribers, through: :subscriptions
   has_many :matched_content_changes
 
-  def self.build_from(params:, gov_delivery_id:)
-    new(
-      title: params[:title],
-      tags:  params[:tags],
-      links: params[:links],
-      document_type: params[:document_type],
-      email_document_supertype: params[:email_document_supertype],
-      government_document_supertype: params[:government_document_supertype],
-      gov_delivery_id: gov_delivery_id,
-    )
-  end
-
   def subscription_url
     PublicUrlService.subscription_url(gov_delivery_id: gov_delivery_id)
   end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -7,6 +7,7 @@ class SubscriberList < ApplicationRecord
   validate :link_values_are_valid
 
   validates :title, presence: true
+  validates_uniqueness_of :title
   validates_uniqueness_of :gov_delivery_id
 
   has_many :subscriptions

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -7,6 +7,7 @@ class SubscriberList < ApplicationRecord
   validate :link_values_are_valid
 
   validates :title, presence: true
+  validates_uniqueness_of :gov_delivery_id
 
   has_many :subscriptions
   has_many :subscribers, through: :subscriptions

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -84,7 +84,7 @@ FactoryBot.define do
 
   factory :subscriber_list do
     sequence(:title) { |n| "title #{n}" }
-    sequence(:gov_delivery_id) { |n| "UKGOVUK_#{n}" }
+    sequence(:gov_delivery_id) { |n| "title-#{n}" }
     tags(topics: ["motoring/road_rage"])
     created_at { 1.year.ago }
 

--- a/spec/features/creating_subscribables_spec.rb
+++ b/spec/features/creating_subscribables_spec.rb
@@ -1,25 +1,21 @@
 RSpec.describe "Creating subscribables", type: :request do
-  before do
-    stub_govdelivery("UKGOVUK_1234")
-  end
-
   scenario "creating and looking up subscribables" do
     login_with(%w(internal_app status_updates))
 
     params = { title: "Example", tags: {}, links: { person: ["test-123"] } }
 
-    lookup_subscribable("UKGOVUK_1234", expected_status: 404)
+    lookup_subscribable("example", expected_status: 404)
     lookup_subscriber_list(params, expected_status: 404)
 
     create_subscribable(links: { person: ["test-123"] })
 
-    lookup_subscribable("UKGOVUK_1234", expected_status: 200)
+    lookup_subscribable("example", expected_status: 200)
     expect(data.fetch(:subscribable)).to include(params)
 
     lookup_subscriber_list(params, expected_status: 200)
     expect(data.fetch(:subscriber_list)).to include(params)
 
     gov_delivery_id = data.dig(:subscriber_list, :gov_delivery_id)
-    expect(gov_delivery_id).to eq("UKGOVUK_1234")
+    expect(gov_delivery_id).to eq("example")
   end
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -1,32 +1,4 @@
 RSpec.describe SubscriberList, type: :model do
-  describe ".build_from(params:, gov_delivery_id:)" do
-    let(:params) {
-      {
-        title: "Ronnie Pickering",
-        tags: { topics: ["motoring/road_rage"] },
-        links: { topics: ["uuid-888"] },
-      }
-    }
-    let(:gov_delivery_id) { "GOVUK_888" }
-
-    let(:list) {
-      SubscriberList.build_from(params: params, gov_delivery_id: gov_delivery_id)
-    }
-
-    it "builds a new SubscriberList without a format" do
-      expect(list.title).to eq "Ronnie Pickering"
-      expect(list.tags).to eq(topics: ["motoring/road_rage"])
-      expect(list.links).to eq(topics: ["uuid-888"])
-      expect(list.gov_delivery_id).to eq "GOVUK_888"
-      expect(list.document_type).to be_nil
-    end
-
-    it "builds a new SubscriberList with a format" do
-      params[:document_type] = "travel_advice"
-      expect(list.document_type).to eq "travel_advice"
-    end
-  end
-
   describe "validations" do
     subject { build(:subscriber_list) }
 


### PR DESCRIPTION
This stops us from using GovDelivery IDs as our topic IDs. This generates GovDelivery IDs by slugifying the title of the subscriber list.

The follow up PRs for this will be to remove the old GovDelivery client library code and cleanup references to GovDelivery in the tests, introduce a new `topic_id` or `slug` field which we can use instead of `gov_delivery_id` and then remove the old `gov_delivery_id` field.

[Trello Card](https://trello.com/c/15q8s623/683-change-subscriber-list-creation-process-to-not-rely-on-govdelivery)