### PR TITLE
Add sent_at and completed_at to DeliveryAttempt

### DIFF
--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -11,6 +11,8 @@ class StatusUpdatesController < ApplicationController
 
   def create
     StatusUpdateService.call(
+      sent_at: params.require(:sent_at),
+      completed_at: params.require(:completed_at),
       reference: params.require(:reference),
       status: params.require(:status),
       user: current_user,

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -14,7 +14,6 @@ class Email < ApplicationRecord
   # Mark an email to indicate the process of sending it is complete
   def finish_sending(delivery_attempt)
     raise ArgumentError, "DeliveryAttempt for different email" if delivery_attempt.email_id != id
-    # @FIXME We should use a timestamp from the provider if possible
-    update!(finished_sending_at: delivery_attempt.updated_at)
+    update!(finished_sending_at: delivery_attempt.sent_at)
   end
 end

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -1,7 +1,9 @@
 class StatusUpdateService
-  def initialize(reference:, status:, user: nil)
+  def initialize(reference:, status:, completed_at:, sent_at:, user: nil)
     @reference = reference
     @status = status
+    @completed_at = completed_at
+    @sent_at = sent_at
     @user = user
     @delivery_attempt = find_delivery_attempt(reference)
   end
@@ -13,6 +15,8 @@ class StatusUpdateService
   def call
     begin
       delivery_attempt.update!(
+        sent_at: sent_at,
+        completed_at: completed_at,
         status: status.underscore,
         signon_user_uid: user&.uid,
       )
@@ -42,7 +46,7 @@ class StatusUpdateService
 
 private
 
-  attr_reader :delivery_attempt, :reference, :status, :user
+  attr_reader :delivery_attempt, :reference, :status, :user, :completed_at, :sent_at
   delegate :email, to: :delivery_attempt
 
   def subscriber

--- a/db/migrate/20180309114801_add_completed_at_column_to_delivery_attempt.rb
+++ b/db/migrate/20180309114801_add_completed_at_column_to_delivery_attempt.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtColumnToDeliveryAttempt < ActiveRecord::Migration[5.1]
+  def change
+    add_column :delivery_attempts, :completed_at, :datetime
+  end
+end

--- a/db/migrate/20180312105539_add_sent_at_column_to_delivery_attempts.rb
+++ b/db/migrate/20180312105539_add_sent_at_column_to_delivery_attempts.rb
@@ -1,0 +1,5 @@
+class AddSentAtColumnToDeliveryAttempts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :delivery_attempts, :sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 20180313090745) do
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
     t.uuid "email_id", null: false
+    t.datetime "completed_at"
+    t.datetime "sent_at"
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"
   end

--- a/spec/features/delivery_success_spec.rb
+++ b/spec/features/delivery_success_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe "Delivering an email successfully via Notify", type: :request do
     email_data = expect_an_email_was_sent
 
     reference = email_data.fetch(:reference)
+    completed_at = Time.parse("2017-05-14T12:15:30.000000Z")
+    sent_at = Time.parse("2017-05-14T12:15:30.000000Z")
 
-    send_status_update(reference, "delivered", expected_status: 204)
-    send_status_update("missing", "delivered", expected_status: 404)
-    send_status_update(nil,       "delivered", expected_status: 400)
+    send_status_update(reference, "delivered", completed_at, sent_at, expected_status: 204)
+    send_status_update("missing", "delivered", completed_at, sent_at, expected_status: 404)
+    send_status_update(nil,       "delivered", completed_at, sent_at, expected_status: 400)
   end
 end

--- a/spec/features/permanent_failure_spec.rb
+++ b/spec/features/permanent_failure_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe "Failing to deliver an email via Notify (permanent failure)", typ
     email_data = expect_an_email_was_sent
 
     reference = email_data.fetch(:reference)
-    send_status_update(reference, "permanent-failure", expected_status: 204)
+    completed_at = Time.parse("2017-05-14T12:15:30.000000Z")
+    sent_at = completed_at
 
+    send_status_update(reference, "permanent-failure", completed_at, sent_at, expected_status: 204)
     clear_any_requests_that_have_been_recorded!
 
     3.times { create_content_change }

--- a/spec/features/technical_failure_spec.rb
+++ b/spec/features/technical_failure_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe "Failing to deliver an email via Notify (technical failure)", typ
     expect(data.fetch(:status)).to eq("ok")
 
     reference = email_data.fetch(:reference)
-    send_status_update(reference, "technical-failure", expected_status: 204)
+    completed_at = Time.parse("2017-05-14T12:15:30.000000Z")
+    sent_at = completed_at
 
+    send_status_update(reference, "technical-failure", completed_at, sent_at, expected_status: 204)
     check_health_of_the_app
     expect(data.fetch(:status)).to eq("critical")
 

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -7,11 +7,21 @@ RSpec.describe "Receiving a status update", type: :request do
   before { login_as(user) }
 
   describe "#create" do
-    let(:params) { { reference: reference, status: "delivered" } }
+    let(:params) do
+      {
+        sent_at: Time.parse("2017-05-14T12:15:30.000000Z"),
+        completed_at: Time.parse("2017-05-14T12:15:30.000000Z"),
+        reference: reference,
+        status: "delivered"
+      }
+    end
+
     let(:permissions) { %w[signin status_updates] }
 
     it "calls the status update service" do
       expect(StatusUpdateService).to receive(:call).with(
+        sent_at: Time.parse("2017-05-14T12:15:30.000000Z"),
+        completed_at: Time.parse("2017-05-14T12:15:30.000000Z"),
         reference: reference,
         status: "delivered",
         user: user,

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -14,14 +14,16 @@ RSpec.describe Email do
   describe "#finish_sending" do
     context "when delivery attempt is for same email" do
       let(:email) { create(:email) }
-      let(:delivery_attempt) { create(:delivery_attempt, email: email) }
+      let(:completed_at) { Time.parse("2017-05-14T12:15:30.000000Z") }
+      let(:sent_at) { Time.parse("2017-05-14T12:15:30.000000Z") }
+      let(:delivery_attempt) { create(:delivery_attempt, email: email, completed_at: completed_at, sent_at: sent_at) }
 
       it "sets the finished_sending_at field" do
         Timecop.freeze do
           expect { email.finish_sending(delivery_attempt) }
             .to change { email.finished_sending_at }
             .from(nil)
-            .to(Time.now)
+            .to(sent_at)
         end
       end
     end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -125,13 +125,6 @@ RSpec.describe DeliveryRequestService do
         subject.call(email: email)
         expect(DeliveryAttempt.last).to be_delivered
       end
-
-      it "marks the email as being finished sending" do
-        expect { subject.call(email: email) }
-          .to change { email.finished_sending_at }
-          .from(nil)
-          .to(an_instance_of(ActiveSupport::TimeWithZone))
-      end
     end
 
     it "sets the delivery attempt's provider to the name of the provider" do

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe StatusUpdateService do
   end
 
   let(:status) { "delivered" }
+  let(:completed_at) { Time.parse("2017-05-14T12:15:30.000000Z") }
+  let(:sent_at) { Time.parse("2017-05-14T12:15:30.000000Z") }
 
-  subject(:status_update) { described_class.call(reference: reference, status: status) }
+  subject(:status_update) { described_class.call(reference: reference, status: status, completed_at: completed_at, sent_at: sent_at) }
 
   it "updates the delivery attempt's status" do
     expect { status_update }
@@ -15,11 +17,23 @@ RSpec.describe StatusUpdateService do
       .to("delivered")
   end
 
+  it "updates the completed_at field" do
+    expect { status_update }
+      .to change { delivery_attempt.reload.completed_at }
+      .to(completed_at)
+  end
+
+  it "updates the sent_at field on delivery" do
+    expect { status_update }
+      .to change { delivery_attempt.reload.sent_at }
+      .to(sent_at)
+  end
+
   it "updates the emails finished_sending_at timestamp" do
     expect { status_update }
       .to change { delivery_attempt.reload.email.finished_sending_at }
       .from(nil)
-      .to(an_instance_of(ActiveSupport::TimeWithZone))
+      .to(sent_at)
   end
 
   context "with a temporary failure" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -65,8 +65,8 @@ module FeatureHelpers
     expect(response.status).to eq(202)
   end
 
-  def send_status_update(reference, status, expected_status: 204)
-    params = { reference: reference, status: status }
+  def send_status_update(reference, status, completed_at, sent_at, expected_status: 204)
+    params = { reference: reference, status: status, completed_at: completed_at, sent_at: sent_at }
     post "/status-updates", params: params.to_json, headers: JSON_HEADERS
     expect(response.status).to eq(expected_status)
   end


### PR DESCRIPTION
Email-alert-api now records when the email was delivered by notify(sent_at)
and when a delivery status update occurs(completed_at), e.g from temp-failure to
permanent failure. This information is recorded in the DeliveryAttempt
model. Also in the Email model, the 'finished_sending_at' column is now
populated with the 'sent_at' value from the DeliveryAttempt, instead of the 'updated_at' field.