### PR TITLE
[WIP] Insert directly into subscription content

### DIFF
--- a/app/queries/subscription_contents_immediate_insert.rb
+++ b/app/queries/subscription_contents_immediate_insert.rb
@@ -1,0 +1,45 @@
+class SubscriptionContentsImmediateInsert
+  def initialize(content_change_id)
+    @content_change_id = content_change_id
+  end
+
+  def self.call(content_change_id:)
+    new(content_change_id).call
+  end
+
+  def call
+    ActiveRecord::Base.connection.execute(
+      sql
+    )
+  end
+
+private
+
+  attr_reader :content_change_id
+
+  def sql
+    date = Time.zone.now
+    <<-SQL
+      INSERT INTO
+        subscription_contents(
+          subscription_id,
+          content_change_id,
+          created_at,
+          updated_at
+        )
+      SELECT
+        subscriptions.id,
+        uuid('#{content_change_id}'),
+        '#{date}',
+        '#{date}'
+      FROM
+        subscriptions
+        INNER JOIN subscriber_lists
+          ON subscriptions.subscriber_list_id = subscriber_lists.id
+        INNER JOIN matched_content_changes
+          ON subscriber_lists.id = matched_content_changes.subscriber_list_id
+      WHERE
+        matched_content_changes.content_change_id = uuid('#{content_change_id}')
+    SQL
+  end
+end

--- a/app/workers/sql_subscription_content_worker.rb
+++ b/app/workers/sql_subscription_content_worker.rb
@@ -1,0 +1,37 @@
+class SqlSubscriptionContentWorker
+  include Sidekiq::Worker
+
+  def perform(content_change_id)
+    content_change = ContentChange.find(content_change_id)
+    return if content_change.processed?
+
+    insert_subscription_contents(content_change_id)
+    queue_delivery_to_courtesy_subscribers(content_change)
+
+    ImmediateEmailGenerationWorker.perform_async
+
+    content_change.mark_processed!
+  end
+
+private
+
+  def insert_subscription_contents(content_change_id)
+    SubscriptionContentsImmediateInsert.call(content_change_id: content_change_id)
+  end
+
+  def queue_delivery_to_courtesy_subscribers(content_change)
+    addresses = [
+      "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk",
+    ]
+
+    Subscriber.where(address: addresses).find_each do |subscriber|
+      email_id = ImmediateEmailBuilder.call([
+        { address: subscriber.address, subscriptions: [], content_change: content_change }
+      ]).ids.first
+
+      DeliveryRequestWorker.perform_async_in_queue(
+        email_id, queue: :delivery_immediate,
+      )
+    end
+  end
+end

--- a/spec/workers/sql_subscription_content_worker_spec.rb
+++ b/spec/workers/sql_subscription_content_worker_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe SqlSubscriptionContentWorker do
+  let(:content_change) { create(:content_change, tags: { topics: ["oil-and-gas/licensing"] }) }
+  let(:email) { create(:email) }
+
+  before do
+    allow(ContentChange).to receive(:find).with(content_change.id).and_return(content_change)
+  end
+
+  context "with a subscription" do
+    let(:subscriber) { create(:subscriber) }
+    let(:subscriber_list) { create(:subscriber_list, tags: { topics: ["oil-and-gas/licensing"] }) }
+    let!(:matched_content_change) { create(:matched_content_change, subscriber_list: subscriber_list, content_change: content_change) }
+    let!(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
+
+    context "asynchronously" do
+      it "does not raise an error" do
+        expect {
+          Sidekiq::Testing.fake! do
+            SubscriptionContentWorker.perform_async(content_change.id)
+            described_class.drain
+          end
+        }.not_to raise_error
+      end
+    end
+
+    it "creates subscription content for the content change" do
+      expect { subject.perform(content_change.id) }
+        .to change { SubscriptionContent.count }.by(1)
+    end
+
+    it "marks the content_change as processed" do
+      expect(content_change).to receive(:mark_processed!)
+      subject.perform(content_change.id)
+    end
+  end
+
+  context "with a courtesy subscription" do
+    let!(:subscriber) do
+      create(:subscriber, address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk")
+    end
+
+    it "creates and enqueues an email for the courtesy email group" do
+      expect(ImmediateEmailBuilder)
+        .to receive(:call)
+        .with([hash_including(address: subscriber.address)])
+        .and_return(double(ids: ["random-guid"]))
+
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(kind_of(String), queue: :delivery_immediate)
+
+      subject.perform(content_change.id)
+    end
+  end
+
+  context "with an already processed content change" do
+    before do
+      content_change.mark_processed!
+    end
+
+    it "should return immediate" do
+      expect(content_change).to_not receive(:mark_processed!)
+      subject.perform(content_change.id)
+    end
+  end
+
+  context "benchmarking" do
+    let(:subscriber) { create(:subscriber) }
+    let(:content_change) { create(:content_change) }
+
+    before do
+      1000.times do
+        subscription = create(:subscription, subscriber: subscriber)
+        create(:matched_content_change, subscriber_list: subscription.subscriber_list, content_change: content_change)
+      end
+    end
+
+    it "reports the benchmark" do
+      r = Benchmark.measure do
+        subject.perform(content_change.id)
+      end
+      pp r
+    end
+  end
+end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe SubscriptionContentWorker do
     end
   end
 
+  context "benchmarking" do
+    let(:subscriber) { create(:subscriber) }
+    let(:content_change) { create(:content_change) }
+
+    before do
+      1000.times do
+        subscription = create(:subscription, subscriber: subscriber)
+        create(:matched_content_change, subscriber_list: subscription.subscriber_list, content_change: content_change)
+      end
+    end
+
+    it "reports the benchmark" do
+      r = Benchmark.measure do
+        subject.perform(content_change.id)
+      end
+      pp r
+    end
+  end
+
   context "with more subscriptions than the batch size" do
     let(:subscriber) { create(:subscriber) }
     let(:content_change) { create(:content_change) }


### PR DESCRIPTION
I'm opening this so we can get some discussion on the approach because I've spent long enough on  a proof of concept. If we like the approach I'll fix it up and remove the unnecessary code paths.

Currently, to generate SubscriptionContent for immediate emails, we have https://github.com/alphagov/email-alert-api/blob/master/app/workers/subscription_content_worker.rb. Part of this worker's work (ahem) is to run this query https://github.com/alphagov/email-alert-api/blob/master/app/queries/content_change_immediate_subscription_query.rb. 

This basically finds all Subscriptions that match the current ContentChange with a frequency of `immediate` and then manually batches them up to insert them as SubscriptionContent items.

The proposed change is to use some sql to accomplish the same thing. Instead of having to write our own batch processor or complicate our code with grouping by subscriber. The idea is to run SubscriptionContentsImmediateInsert to populate the SubscriptionContent data, bypassing any ruby objects. Then continue as normal kicking off the ImmediateEmailGenerationWorker.

The advantage here is speed, and perhaps code readability (depending on your penchant for SQL). The disadvantage is we don't kick off the ImmediateEmailGenerationWorker until after the query has completed (currently we kick it off after every batch).

I've left some benchmark code in the specs for anyone to play with, but my results look like this for 1000 records:

Before:

```
#<Benchmark::Tms:0x000055a8211ab458
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=3.9506940889987163,
 @stime=0.11999999999999988,
 @total=3.0599999999999996,
 @utime=2.9399999999999995>
```

after:

```
#<Benchmark::Tms:0x00005598a099fd98
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=1.292155400995398,
 @stime=0.039999999999999813,
 @total=1.0200000000000002,
 @utime=0.9800000000000004>
```