### PR TITLE
Add slug field to subscriber list (1/4)

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -21,10 +21,12 @@ private
 
   def subscriber_list_params
     title = params.fetch(:title)
+    slug = slugify(title)
 
     find_exact_query_params.merge(
       title: title,
-      gov_delivery_id: slugify(title),
+      gov_delivery_id: slug,
+      slug: slug,
       signon_user_uid: current_user.uid,
     )
   end

--- a/db/migrate/20180313081514_add_slug_to_subscriber_list.rb
+++ b/db/migrate/20180313081514_add_slug_to_subscriber_list.rb
@@ -1,0 +1,5 @@
+class AddSlugToSubscriberList < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subscriber_lists, :slug, :string, limit: 1000
+  end
+end

--- a/db/migrate/20180313081630_make_subscriber_list_gov_delivery_id_not_null.rb
+++ b/db/migrate/20180313081630_make_subscriber_list_gov_delivery_id_not_null.rb
@@ -1,0 +1,5 @@
+class MakeSubscriberListGovDeliveryIdNotNull < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :subscriber_lists, :gov_delivery_id, false
+  end
+end

--- a/db/migrate/20180313081909_make_subscriber_list_gov_delivery_id_longer.rb
+++ b/db/migrate/20180313081909_make_subscriber_list_gov_delivery_id_longer.rb
@@ -1,0 +1,5 @@
+class MakeSubscriberListGovDeliveryIdLonger < ActiveRecord::Migration[5.1]
+  def change
+    change_column :subscriber_lists, :gov_delivery_id, :string, limit: 1000
+  end
+end

--- a/db/migrate/20180313090745_make_subscriber_list_slug_unique.rb
+++ b/db/migrate/20180313090745_make_subscriber_list_slug_unique.rb
@@ -1,0 +1,5 @@
+class MakeSubscriberListSlugUnique < ActiveRecord::Migration[5.1]
+  def change
+    add_index :subscriber_lists, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180308105331) do
+ActiveRecord::Schema.define(version: 20180313081630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 20180308105331) do
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
     t.string "title", limit: 1000, null: false
-    t.string "gov_delivery_id", limit: 255
+    t.string "gov_delivery_id", limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180313081630) do
+ActiveRecord::Schema.define(version: 20180313081909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 20180313081630) do
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
     t.string "title", limit: 1000, null: false
-    t.string "gov_delivery_id", limit: 255, null: false
+    t.string "gov_delivery_id", limit: 1000, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 20180308105331) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
+    t.string "slug", limit: 1000
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180313081909) do
+ActiveRecord::Schema.define(version: 20180313090745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(version: 20180313081909) do
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
+    t.index ["slug"], name: "index_subscriber_lists_on_slug", unique: true
     t.index ["title"], name: "index_subscriber_lists_on_title", unique: true
   end
 

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
     it "returns the created subscriber list" do
       create_subscriber_list(
+        title: "oil and gas licensing",
         tags: { topics: ["oil-and-gas/licensing"] },
         links: { topics: ["uuid-888"] }
       )
@@ -44,6 +45,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
         %w{
           id
           title
+          slug
           document_type
           subscription_url
           gov_delivery_id
@@ -55,6 +57,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
           government_document_supertype
         }.to_set
       )
+
       expect(subscriber_list).to include(
         "tags" => {
           "topics" => ["oil-and-gas/licensing"]
@@ -63,6 +66,9 @@ RSpec.describe "Creating a subscriber list", type: :request do
           "topics" => ["uuid-888"]
         }
       )
+
+      expect(subscriber_list["gov_delivery_id"]).to eq("oil-and-gas-licensing")
+      expect(subscriber_list["slug"]).to eq("oil-and-gas-licensing")
     end
 
     it "returns an error if tag isn't an array" do


### PR DESCRIPTION
This PR introduces a new `slug` field which will eventually replace the `gov_delivery_id` field, but the work has to split up into various deploys to avoid any downtime.

The follow up PRs after this will be to populate the new field fully (#517), stop using the old field (#518) and then drop the old field from the table (#519).

[Trello Card](https://trello.com/c/15q8s623/683-change-subscriber-list-creation-process-to-not-rely-on-govdelivery)