### PR TITLE
Populate all slug fields (2/4)

### DIFF
--- a/db/migrate/20180313083354_populate_all_slug_fields.rb
+++ b/db/migrate/20180313083354_populate_all_slug_fields.rb
@@ -1,0 +1,29 @@
+class PopulateAllSlugFields < ActiveRecord::Migration[5.1]
+  def up
+    @taken_slugs = SubscriberList.pluck(:slug)
+
+    SubscriberList.find_each.with_index do |subscriber_list, i|
+      puts "Slugified #{i} subscriber lists..." if (i % 1000).zero?
+
+      slug = slugify(subscriber_list.title)
+      subscriber_list.update(slug: slug)
+      taken_slugs << slug
+    end
+  end
+
+private
+
+  attr_reader :taken_slugs
+
+  def slugify(title)
+    slug = title.parameterize
+    index = 1
+
+    while taken_slugs.include?(slug)
+      index += 1
+      slug = "#{title.parameterize}-#{index}"
+    end
+
+    slug
+  end
+end

--- a/db/migrate/20180313084148_make_subscriber_list_slug_not_null.rb
+++ b/db/migrate/20180313084148_make_subscriber_list_slug_not_null.rb
@@ -1,0 +1,5 @@
+class MakeSubscriberListSlugNotNull < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :subscriber_lists, :slug, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,7 +128,7 @@ ActiveRecord::Schema.define(version: 20180313090745) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
-    t.string "slug", limit: 1000
+    t.string "slug", limit: 1000, null: false
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -85,6 +85,7 @@ FactoryBot.define do
   factory :subscriber_list do
     sequence(:title) { |n| "title #{n}" }
     sequence(:gov_delivery_id) { |n| "title-#{n}" }
+    sequence(:slug) { |n| "title-#{n}" }
     tags(topics: ["motoring/road_rage"])
     created_at { 1.year.ago }
 


### PR DESCRIPTION
This PR fills out all the new `slug` fields to ensure that they are ready to be used.

Rather than setting it to the `gov_delivery_id`, we can set it to a slug of the `title` to ensure that all the new slugs are in the same format. The migration takes about 40 seconds to run on my laptop, so I suspect it will take about a minute on production, but it doesn't block the tables.

Depends on #516 being merged and deployed already.

[Trello Card](https://trello.com/c/15q8s623/683-change-subscriber-list-creation-process-to-not-rely-on-govdelivery)