### PR TITLE
Stop using gov_delivery_id field (3/4)

### DIFF
--- a/app/controllers/subscribables_controller.rb
+++ b/app/controllers/subscribables_controller.rb
@@ -6,7 +6,7 @@ class SubscribablesController < ApplicationController
 private
 
   def subscribable
-    @subscribable ||= SubscriberList.find_by(gov_delivery_id: params[:gov_delivery_id])
+    @subscribable ||= SubscriberList.find_by(slug: params[:slug])
   end
 
   def subscribable_attributes

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -48,7 +48,7 @@ private
     slug = title.parameterize
     index = 1
 
-    while SubscriberList.where(gov_delivery_id: slug).exists?
+    while SubscriberList.where(slug: slug).exists?
       index += 1
       slug = "#{title.parameterize}-#{index}"
     end

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -25,7 +25,6 @@ private
 
     find_exact_query_params.merge(
       title: title,
-      gov_delivery_id: slug,
       slug: slug,
       signon_user_uid: current_user.uid,
     )

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -40,7 +40,7 @@ private
       document_type: permitted_params.fetch(:document_type, ""),
       email_document_supertype: permitted_params.fetch(:email_document_supertype, ""),
       government_document_supertype: permitted_params.fetch(:government_document_supertype, ""),
-      gov_delivery_id: params[:gov_delivery_id],
+      slug: params[:gov_delivery_id],
     }
   end
 

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -15,7 +15,7 @@ class SubscriberList < ApplicationRecord
   has_many :matched_content_changes
 
   def subscription_url
-    PublicUrlService.subscription_url(gov_delivery_id: gov_delivery_id)
+    PublicUrlService.subscription_url(slug: slug)
   end
 
   def to_json(options = {})

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -8,7 +8,7 @@ class SubscriberList < ApplicationRecord
 
   validates :title, presence: true
   validates_uniqueness_of :title
-  validates_uniqueness_of :gov_delivery_id
+  validates_uniqueness_of :slug
 
   has_many :subscriptions
   has_many :subscribers, through: :subscriptions
@@ -18,9 +18,13 @@ class SubscriberList < ApplicationRecord
     PublicUrlService.subscription_url(slug: slug)
   end
 
+  def gov_delivery_id
+    slug
+  end
+
   def to_json(options = {})
     options[:except] ||= %i{signon_user_uid}
-    options[:methods] ||= %i{subscription_url}
+    options[:methods] ||= %i{subscription_url gov_delivery_id}
     super(options)
   end
 

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -1,13 +1,13 @@
 class FindExactQuery
   class InvalidFindCriteria < StandardError; end
 
-  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:, gov_delivery_id: nil)
+  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:, slug: nil)
     @tags = tags.symbolize_keys
     @links = links.symbolize_keys
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
-    @gov_delivery_id = gov_delivery_id
+    @slug = slug
   end
 
   def exact_match
@@ -24,7 +24,7 @@ private
         .where(document_type: @document_type)
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)
-      scope = scope.where(gov_delivery_id: @gov_delivery_id) if @gov_delivery_id.present?
+      scope = scope.where(slug: @slug) if @slug.present?
       scope
     end
   end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -8,8 +8,8 @@ module PublicUrlService
     # enters their email address. At present, multiple frontends start the
     # journey, e.g. collections, but eventually all these will be consolidated
     # into email-alert-frontend and this URL will no longer be needed.
-    def subscription_url(gov_delivery_id:)
-      params = param(:topic_id, gov_delivery_id)
+    def subscription_url(slug:)
+      params = param(:topic_id, slug)
       "#{website_root}/email/subscriptions/new?#{params}"
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     root "welcome#index"
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
     get "/subscriber-lists", to: "subscriber_lists#show"
-    get "/subscribables/:gov_delivery_id", to: "subscribables#show"
+    get "/subscribables/:slug", to: "subscribables#show"
 
     resources :notifications, only: %i[create index show]
     resources :status_updates, path: "status-updates", only: %i[create]

--- a/db/migrate/20180313093530_make_subscriber_list_gov_delivery_id_nullable.rb
+++ b/db/migrate/20180313093530_make_subscriber_list_gov_delivery_id_nullable.rb
@@ -1,0 +1,5 @@
+class MakeSubscriberListGovDeliveryIdNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :subscriber_lists, :gov_delivery_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180313090745) do
+ActiveRecord::Schema.define(version: 20180313093530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 20180313090745) do
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
     t.string "title", limit: 1000, null: false
-    t.string "gov_delivery_id", limit: 1000, null: false
+    t.string "gov_delivery_id", limit: 1000
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -84,7 +84,6 @@ FactoryBot.define do
 
   factory :subscriber_list do
     sequence(:title) { |n| "title #{n}" }
-    sequence(:gov_delivery_id) { |n| "title-#{n}" }
     sequence(:slug) { |n| "title-#{n}" }
     tags(topics: ["motoring/road_rage"])
     created_at { 1.year.ago }

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
     context "with an existing subsciber list with the same slug" do
       before do
-        create(:subscriber_list, gov_delivery_id: "oil-and-gas")
+        create(:subscriber_list, slug: "oil-and-gas")
       end
 
       it "creates another subscriber list with a different slug" do

--- a/spec/integration/get_subscriber_list_spec.rb
+++ b/spec/integration/get_subscriber_list_spec.rb
@@ -171,9 +171,9 @@ RSpec.describe "Getting a subscriber list", type: :request do
       end
 
       it "finds the subscriber list if the gov_delivery_id matches" do
-        _alpha = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "alpha")
-        beta = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "beta")
-        _gamma = create(:subscriber_list, tags: { topics: ["vat-rates"] }, gov_delivery_id: "gamma")
+        _alpha = create(:subscriber_list, tags: { topics: ["vat-rates"] }, slug: "alpha")
+        beta = create(:subscriber_list, tags: { topics: ["vat-rates"] }, slug: "beta")
+        _gamma = create(:subscriber_list, tags: { topics: ["vat-rates"] }, slug: "gamma")
 
         get_subscriber_list(
           tags: { topics: ["vat-rates"] },

--- a/spec/integration/get_subscriber_list_spec.rb
+++ b/spec/integration/get_subscriber_list_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe "Getting a subscriber list", type: :request do
         links: database_subscriber_list.links,
         tags: database_subscriber_list.tags,
         document_type: database_subscriber_list.document_type,
-        gov_delivery_id: database_subscriber_list.gov_delivery_id,
+        gov_delivery_id: database_subscriber_list.slug,
+        slug: database_subscriber_list.slug,
         subscription_url: database_subscriber_list.subscription_url,
         title: database_subscriber_list.title,
       )

--- a/spec/integration/subscribables_controller_spec.rb
+++ b/spec/integration/subscribables_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Getting a subscribable", type: :request do
       end
 
       context "the subscribable exists" do
-        let!(:subscribable) { create(:subscriber_list, gov_delivery_id: "test135") }
+        let!(:subscribable) { create(:subscriber_list, slug: "test135") }
 
         it "returns it" do
           get "/subscribables/test135"

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe SubscriberList, type: :model do
   end
 
   describe "#subscription_url" do
-    subject { SubscriberList.new(gov_delivery_id: "UKGOVUK_4567") }
+    subject { SubscriberList.new(slug: "UKGOVUK_4567") }
 
     it "returns the correct subscription URL" do
       expect(subject.subscription_url).to eq(

--- a/spec/services/public_url_service_spec.rb
+++ b/spec/services/public_url_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PublicUrlService do
 
   describe ".subscription_url" do
     it "returns the GOV.UK for the new subscription page" do
-      result = subject.subscription_url(gov_delivery_id: "foo_bar")
+      result = subject.subscription_url(slug: "foo_bar")
       expect(result).to eq("http://www.dev.gov.uk/email/subscriptions/new?topic_id=foo_bar")
     end
   end


### PR DESCRIPTION
This PR stops using the `gov_delivery_id` field on subscriber lists and instead uses the `slug` field. This leaves out any external input changes so the the PR is backwards compatible. 

This depends on #517 being merged and deployed.

[Trello Card](https://trello.com/c/15q8s623/683-change-subscriber-list-creation-process-to-not-rely-on-govdelivery)