### PR TITLE
Remove gov_delivery_id field (4/4)

### DIFF
--- a/db/migrate/20180313093731_remove_gov_delivery_id_from_subscriber_lists.rb
+++ b/db/migrate/20180313093731_remove_gov_delivery_id_from_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class RemoveGovDeliveryIdFromSubscriberLists < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :subscriber_lists, :gov_delivery_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -104,7 +104,6 @@ ActiveRecord::Schema.define(version: 20180313152401) do
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
     t.string "title", limit: 1000, null: false
-    t.string "gov_delivery_id", limit: 1000
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false
@@ -116,7 +115,6 @@ ActiveRecord::Schema.define(version: 20180313152401) do
     t.string "slug", limit: 1000, null: false
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
-    t.index ["gov_delivery_id"], name: "index_subscriber_lists_on_gov_delivery_id", unique: true
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
     t.index ["slug"], name: "index_subscriber_lists_on_slug", unique: true
     t.index ["title"], name: "index_subscriber_lists_on_title", unique: true


### PR DESCRIPTION
This removes the `gov_delivery_id` field from subscriber lists since it has been replaced by the `slug` field.

This PR depends on #518 being merged and deployed.

[Trello Card](https://trello.com/c/15q8s623/683-change-subscriber-list-creation-process-to-not-rely-on-govdelivery)