### PR TITLE
Add API endpoint to list a user’s subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,50 @@ The following fields are accepted on this endpoint: `subject`, `from_address_id`
 `document_type`, `content_id`, `public_updated_at`, `publishing_app`, `email_document_supertype`,
 `government_document_supertype`, `title`, `description`, `change_note`, `base_path`, `priority` and `footnote`.
 
+* `GET /subscribers/test@example.com/subscriptions` - gets a subscriber's subscriptions, in the form:
+
+```json
+{
+  "subscriber": {
+    "id": 1,
+    "address": "test@example.com",
+    "created_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+    "updated_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+    "signon_user_uid": null,
+    "deactivated_at": null
+  },
+  "subscriptions": [
+    {
+      "subscriber_id": 1,
+      "subscriber_list_id": 4232,
+      "created_at": "Wed, 07 Mar 2018 18:52:25 UTC +00:00",
+      "updated_at": "Wed, 07 Mar 2018 18:52:25 UTC +00:00",
+      "frequency": "daily",
+      "signon_user_uid": null,
+      "id": "476e1439-f5ba-4d7a-b4aa-1090563c5c36",
+      "source": "imported",
+      "ended_at": null,
+      "ended_reason": null,
+      "subscriber_list": {
+        "id": 4232,
+        "title": "All types of document about all topics by Foreign & Commonwealth Office",
+        "created_at": "Thu, 01 Aug 2013 12:53:34 UTC +00:00",
+        "updated_at": "Tue, 13 Mar 2018 15:11:29 UTC +00:00",
+        "document_type": "",
+        "tags": {},
+        "links": {
+          "organisations": ["9adfc4ed-9f6c-4976-a6d8-18d34356367c"]
+        },
+        "email_document_supertype": "",
+        "government_document_supertype": "",
+        "signon_user_uid": null,
+        "slug": "all-types-of-document-about-all-topics-by-foreign-commonwealth-office"
+      }
+    }
+  ]
+}
+```
+
 * `POST /subscriptions` with data:
 
 ```json
@@ -222,9 +266,9 @@ A queue health check endpoint is available at `/healthcheck`.
 
 ### Manually retrying failed notification jobs
 
-In the event of a GovDelivery outage, the Email Alert API will enqueue
-failed notification jobs in the Sidekiq retry queue. The retry queue
-size can be viewed via Sidekiq monitoring or by running the following
+In the event of an outage, the Email Alert API will enqueue failed
+notification jobs in the Sidekiq retry queue. The retry queue size
+can be viewed via Sidekiq monitoring or by running the following
 command in a rails console:
 
 ```ruby

--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -1,0 +1,25 @@
+class SubscribersController < ApplicationController
+  def subscriptions
+    subscriptions = Subscription.active.
+      includes(:subscriber_list).
+      where(subscriber: subscriber).
+      order('subscriber_lists.title').
+      as_json(include: :subscriber_list)
+
+    render json: { subscriber: subscriber.as_json, subscriptions: subscriptions }
+  end
+
+private
+
+  def subscriber
+    @subscriber ||= Subscriber.find_by!("LOWER(address) = ?", address.downcase)
+  end
+
+  def address
+    subscriber_params.require(:address)
+  end
+
+  def subscriber_params
+    params.permit(:address)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
 
     get "/healthcheck", to: "healthcheck#check"
 
+    get "/subscribers/:address/subscriptions", to: "subscribers#subscriptions",
+      constraints: { address: /.+@.+\..+/ }
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
   end
 end

--- a/spec/integration/subscribers_spec.rb
+++ b/spec/integration/subscribers_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe "Subscriptions", type: :request do
+  context "with authentication and authorisation" do
+    before do
+      login_with_internal_app
+    end
+
+    context "when listing subscriptions for a subscriber" do
+      context "with an existing subscriber" do
+        let!(:subscriber) { create(:subscriber) }
+        let!(:subscriber_list_1) { create(:subscriber_list) }
+        let!(:subscriber_list_2) { create(:subscriber_list) }
+        let!(:subscriber_list_3) { create(:subscriber_list) }
+        let!(:subscription_1) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list_1) }
+        let!(:subscription_2) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list_2, ended_at: Time.now, ended_reason: :frequency_changed) }
+        let!(:subscription_3) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list_3, frequency: :daily) }
+
+        it "lists all active subscriptions" do
+          get "/subscribers/#{subscriber.address}/subscriptions"
+          expect(data[:subscriptions].length).to eq(2)
+        end
+
+        it "does not list any ended subscriptions" do
+          get "/subscribers/#{subscriber.address}/subscriptions"
+          ended_subscription = data[:subscriptions].detect { |s| s[:id] == subscription_2.id }
+          expect(ended_subscription).to be_nil
+        end
+      end
+
+      context "without an existing subscriber" do
+        it "returns status code 404" do
+          get "/subscribers/doesnotexist@example.com/subscriptions"
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
+
+  context "without authentication" do
+    it "returns a 403" do
+      get "/subscribers/test@example.com/subscriptions"
+      expect(response.status).to eq(403)
+    end
+  end
+
+  context "without authorisation" do
+    it "returns a 403" do
+      login_with_signin
+      get "/subscribers/test@example.com/subscriptions"
+      expect(response.status).to eq(403)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an API endpoint at `GET /subscribers/:address/subscriptions` that lists a user’s active subscriptions given an email address.

Trello: https://trello.com/c/t9GWD8Rj/691-add-an-endpoint-to-email-alert-api-to-list-a-users-subscriptions