### PR TITLE
Isolate Sidkiq state changes in tests that don't adhere to the default `inline!`

### DIFF
--- a/spec/services/notification_handler_service_spec.rb
+++ b/spec/services/notification_handler_service_spec.rb
@@ -1,11 +1,10 @@
 RSpec.describe NotificationHandlerService do
-  before do
-    Timecop.freeze(Time.local(2017, 1, 1, 9))
-    Sidekiq::Testing.fake!
-  end
-
-  after do
-    Timecop.return
+  around(:example) do |example|
+    Timecop.freeze(Time.local(2017, 1, 1, 9)) do
+      Sidekiq::Testing.fake! do
+        example.run
+      end
+    end
   end
 
   let(:params) {

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe SubscriptionContentWorker do
         .to receive(:call)
         .with([hash_including(address: subscriber.address)])
         .and_return(double(ids: [0]))
+        .and_return(double(ids: ["9a6fa854-9d73-4769-aff7-f340729cf524"]))
+
+      allow(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .and_return(true)
 
       subject.perform(content_change.id)
     end


### PR DESCRIPTION
Properly isolate the Sidekiq state in spec/services/notification_handler_service_spec.rb and fix the subsequent failing tests. 

We set `Sidekiq::Testing.inline!` in `spec/rails_helper.rb`. In the `before` block in spec/services/notification_handler_service_spec.rb we set `Sidekiq::Testing.fake!`. Doing this means that `Sidekiq::Testing.inline?` returns `false` instead of our default `true`. This then sets the Sidekiq state for any subsequent tests, even in other files.

Since we are likely to make the assumption that `inline` is true when writing new tests, we should isolate any deviation - using an around block in `spec/services/notification_handler_service_spec.rb` accomplishes this.
