### PR TITLE
Add rake task to change a subscriber’s email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ To send a test email to an email address (doesn't have to be subscribed to anyth
 $ bundle exec rake deliver:to_test_email[<email_address>]
 ```
 
+#### Change a subscriber's email address
+
+This task changes a subscriber's email address.
+
+```bash
+$ bundle exec rake manage:change_email_address[<old_email_address>, <new_email_address>]
+```
+
 #### Manually unsubscribe subscribers
 
 This task unsubscribes one or more subscribers from everything they

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -1,6 +1,17 @@
 require 'csv'
 
 namespace :manage do
+  def change_email_address(old_email_address:, new_email_address:)
+    subscriber = Subscriber.find_by("LOWER(address) = ?", old_email_address.downcase)
+    raise "Cannot find subscriber with email address #{old_email_address}" if subscriber.nil?
+    subscriber.address = new_email_address
+    if subscriber.save!
+      puts "Changed email address for #{old_email_address} to #{new_email_address}"
+    else
+      puts "Error changing email address for #{old_email_address} to #{new_email_address}"
+    end
+  end
+
   def unsubscribe(email_address:)
     subscriber = Subscriber.find_by(address: email_address)
     if subscriber.nil?
@@ -47,6 +58,11 @@ namespace :manage do
     end
 
     puts "#{subscribers.count} active subscribers moved from #{from_slug} to #{to_slug}"
+  end
+
+  desc "Change the email address of a subscriber"
+  task :change_email_address, %i[old_email_address new_email_address] => :environment do |_t, args|
+    change_email_address(old_email_address: args[:old_email_address], new_email_address: args[:new_email_address])
   end
 
   desc "Unsubscribe a single subscriber"


### PR DESCRIPTION
This commit adds a rake task to change a subscriber’s email address.

Trello: https://trello.com/c/KhYdhB2q/702-add-a-rake-task-to-change-a-subscribers-email-address