### PR TITLE
Limit amount of emails copied to integration

### DIFF
--- a/lib/data_hygiene/anonymise_email_addresses.sql
+++ b/lib/data_hygiene/anonymise_email_addresses.sql
@@ -9,6 +9,10 @@
 # Please make changes to this script in email-alert-api where it is tested.
 # Then copy it to the env-sync-and-backup repository.
 
+# Deletes all email_archives that are older than 1 day old.
+DELETE FROM email_archives
+WHERE created_at < current_timestamp - interval '1 day';
+
 # Deletes all emails that are older than 1 day old.
 DELETE FROM emails
 WHERE created_at < current_timestamp - interval '1 day';

--- a/lib/data_hygiene/anonymise_email_addresses.sql
+++ b/lib/data_hygiene/anonymise_email_addresses.sql
@@ -9,6 +9,10 @@
 # Please make changes to this script in email-alert-api where it is tested.
 # Then copy it to the env-sync-and-backup repository.
 
+# Deletes all emails that are older than 1 day old.
+DELETE FROM emails
+WHERE created_at < current_timestamp - interval '1 day';
+
 # Create a table to store all email addresses.
 CREATE TABLE addresses (id SERIAL, address VARCHAR NOT NULL);
 

--- a/spec/integration/anonymise_email_addresses_spec.rb
+++ b/spec/integration/anonymise_email_addresses_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe "Anonymising email addresses" do
     ActiveRecord::Base.connection.execute(sql.gsub(/#.*$/, ""))
   end
 
+  it "deletes an email older than a day old" do
+    email = create(:email, address: "foo@example.com", created_at: Time.parse('13/03/2018 16:30:17'))
+    execute_sql
+
+    expect { email.reload }
+      .to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "doesn't delete an email thats a day old or less" do
+    email = create(:email, address: "foo@example.com")
+    execute_sql
+
+    expect(email).to be_present
+  end
+
   it "anonymises addresses in the subscribers table" do
     subscriber = create(:subscriber, address: "foo@example.com")
 


### PR DESCRIPTION
This query runs when data is getting copied to integration, currently
emails up to 14 days old are being transferred over from production, this query deletes all
emails that are older than 1 day old from the time of the query call.