### PR TITLE
Store subscriber IDs on emails

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -13,7 +13,8 @@ class DigestEmailBuilder
     Email.create!(
       subject: subject,
       body: body,
-      address: subscriber.address
+      address: subscriber.address,
+      subscriber_id: subscriber.id,
     )
   end
 

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -22,13 +22,14 @@ private
       [
         recipient_and_content.fetch(:address),
         subject(recipient_and_content.fetch(:content_change)),
-        body(recipient_and_content.fetch(:content_change), recipient_and_content.fetch(:subscriptions))
+        body(recipient_and_content.fetch(:content_change), recipient_and_content.fetch(:subscriptions)),
+        recipient_and_content.fetch(:subscriber_id),
       ]
     end
   end
 
   def columns
-    %i(address subject body)
+    %i(address subject body subscriber_id)
   end
 
   def subject(content_change)

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -108,7 +108,8 @@ private
       {
         address: subscriber.address,
         content_change: content_changes[content_change_id],
-        subscriptions: subscription_contents[subscriber.id][content_change_id].map(&:subscription)
+        subscriptions: subscription_contents[subscriber.id][content_change_id].map(&:subscription),
+        subscriber_id: subscriber.id,
       }
     end
 

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -69,7 +69,12 @@ private
 
     Subscriber.where(address: addresses).find_each do |subscriber|
       email_id = ImmediateEmailBuilder.call([
-        { address: subscriber.address, subscriptions: [], content_change: content_change }
+        {
+          address: subscriber.address,
+          subscriptions: [],
+          content_change: content_change,
+          subscriber_id: subscriber.id,
+        }
       ]).ids.first
 
       DeliveryRequestWorker.perform_async_in_queue(

--- a/db/migrate/20180315080842_add_subscriber_id_to_emails.rb
+++ b/db/migrate/20180315080842_add_subscriber_id_to_emails.rb
@@ -1,0 +1,6 @@
+class AddSubscriberIdToEmails < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :emails, :subscriber, index: true
+    add_foreign_key :emails, :subscribers, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -88,8 +88,10 @@ ActiveRecord::Schema.define(version: 20180315084923) do
     t.string "address", null: false
     t.datetime "finished_sending_at"
     t.datetime "archived_at"
+    t.bigint "subscriber_id"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
+    t.index ["subscriber_id"], name: "index_emails_on_subscriber_id"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|
@@ -172,6 +174,7 @@ ActiveRecord::Schema.define(version: 20180315084923) do
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "digest_runs", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "subscribers", on_delete: :cascade
+  add_foreign_key "emails", "subscribers", on_delete: :restrict
   add_foreign_key "matched_content_changes", "content_changes", on_delete: :cascade
   add_foreign_key "matched_content_changes", "subscriber_lists", on_delete: :cascade
   add_foreign_key "subscription_contents", "content_changes", on_delete: :restrict

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -1,15 +1,17 @@
 namespace :deliver do
-  def test_email(address)
+  def test_email(address, subscriber_id)
     Email.create(
       address: address,
       subject: "Test email",
-      body: "This is a test email."
+      body: "This is a test email.",
+      subscriber_id: subscriber_id,
     )
   end
 
   desc "Send a test email to a subscriber by id"
   task :to_subscriber, [:id] => :environment do |_t, args|
-    email = test_email(Subscriber.find(args[:id]).address)
+    subscriber = Subscriber.find(args[:id])
+    email = test_email(subscriber.address, subscriber.id)
     DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
   end
 

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe DigestEmailBuilder do
     expect(email).to be_a(Email)
   end
 
+  it "sets the subscriber id on the email" do
+    expect(email.subscriber_id).to eq(subscriber.id)
+  end
+
   it "adds an entry to body for each content change" do
     expect(UnsubscribeLinkPresenter).to receive(:call).with(
       id: "ABC1",

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe ImmediateEmailBuilder do
         {
           address: subscriber.address,
           content_change: content_change,
-          subscriptions: []
+          subscriptions: [],
+          subscriber_id: subscriber.id,
         }
       ]
     }
@@ -70,6 +71,10 @@ RSpec.describe ImmediateEmailBuilder do
       )
     end
 
+    it "sets the subscriber id" do
+      expect(email.subscriber_id).to eq(subscriber.id)
+    end
+
     context "with a subscription" do
       let(:subscription_content) do
         double(subscription: subscription_one, content_change: content_change)
@@ -80,7 +85,8 @@ RSpec.describe ImmediateEmailBuilder do
           {
             address: subscriber.address,
             content_change: content_change,
-            subscriptions: [subscription_one]
+            subscriptions: [subscription_one],
+            subscriber_id: subscriber.id,
           }
         ]
       }


### PR DESCRIPTION
This PR introduces a new `subscriber_id` field to emails and sets it in the immediate email builder and
the digest email builder.

[Trello Card](https://trello.com/c/xEP0zV7E/686-store-subscriberid-with-email)