### PR TITLE
Use subscriber_id in archiving

### DIFF
--- a/app/queries/email_archive_query.rb
+++ b/app/queries/email_archive_query.rb
@@ -17,21 +17,12 @@ private
       :subject,
       :finished_sending_at,
       :created_at,
-      subscriber_ids,
+      :subscriber_id,
       subscription_ids,
       content_change_ids,
       digest_run_ids,
       sent,
     ]
-  end
-
-  def subscriber_ids
-    query = Subscription
-      .joins(:subscription_contents)
-      .where("subscription_contents.email_id = emails.id")
-      .distinct
-      .select(:subscriber_id)
-    "ARRAY(#{query.to_sql}) AS subscriber_ids"
   end
 
   def subscription_ids

--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -47,7 +47,7 @@ private
       id: email_data.fetch("id"),
       sent: email_data.fetch("sent"),
       subject: email_data.fetch("subject"),
-      subscriber_id: build_subscriber_id(email_data),
+      subscriber_id: email_data.fetch("subscriber_id"),
     }
   end
 
@@ -65,16 +65,6 @@ private
       digest_run_id: email_data.fetch("digest_run_ids").first,
       subscription_ids: email_data.fetch("subscription_ids"),
     }
-  end
-
-  def build_subscriber_id(email_data)
-    if email_data.fetch("subscriber_ids").count > 1
-      error = "Email with id: #{email_data['id']} is associated with "\
-        "multiple subscribers: #{email_data['subscribers'].join(', ')}"
-      GovukError.notify(error)
-    end
-
-    email_data.fetch("subscriber_ids").first
   end
 
   def log_complete(archived, start_time, end_time)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -114,6 +114,10 @@ FactoryBot.define do
 
     trait :with_archivable_email do
       association :email, factory: :archivable_email
+
+      after(:create) do |subscription_content, _evaluator|
+        subscription_content.email.update(subscriber_id: subscription_content.subscription.subscriber.id)
+      end
     end
   end
 

--- a/spec/queries/email_archive_query_spec.rb
+++ b/spec/queries/email_archive_query_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe EmailArchiveQuery do
     end
 
     context "when an email is associated with content changes" do
-      let!(:email) { create(:archivable_email) }
       let!(:subscriber) { create(:subscriber) }
+      let!(:email) { create(:archivable_email, subscriber_id: subscriber.id) }
       let!(:subscription_contents) do
         [
           create(
@@ -37,12 +37,12 @@ RSpec.describe EmailArchiveQuery do
         ]
       end
 
-      it "has subscriber_ids, subscription_ids and content_change_ids" do
+      it "has subscriber_id, subscription_ids and content_change_ids" do
         first = scope.first
         subscription_ids = subscription_contents.map(&:subscription_id)
         content_change_ids = subscription_contents.map(&:content_change_id)
 
-        expect(first.subscriber_ids).to match_array(subscriber.id)
+        expect(first.subscriber_id).to eq(subscriber.id)
         expect(first.subscription_ids).to match_array(subscription_ids)
         expect(first.content_change_ids).to match_array(content_change_ids)
       end
@@ -51,9 +51,9 @@ RSpec.describe EmailArchiveQuery do
     context "when an email is not associated with content changes" do
       before { create(:archivable_email) }
 
-      it "has empty subscriber_ids, subscription_ids and content_change_ids" do
+      it "has nil subscriber_id and emptpy subscription_ids and content_change_ids" do
         first = scope.first
-        expect(first.subscriber_ids).to be_empty
+        expect(first.subscriber_id).to be_nil
         expect(first.subscription_ids).to be_empty
         expect(first.content_change_ids).to be_empty
       end


### PR DESCRIPTION
Since we've added this field in #527 we can now use it to simplify the archiving process.

[Trello Card](https://trello.com/c/xEP0zV7E/686-store-subscriberid-with-email)