### PR TITLE
Ignore duplicates on subscription content import

### DIFF
--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -35,8 +35,25 @@ private
 
   def import_subscription_contents_batch(batch)
     columns = %i(content_change_id subscription_id)
-    SubscriptionContent.import!(columns, batch)
+
+    begin
+      SubscriptionContent.transaction do
+        SubscriptionContent.import!(columns, batch)
+      end
+    rescue ActiveRecord::RecordNotUnique
+      handle_failed_subscription_content_import(batch)
+    end
+
     ImmediateEmailGenerationWorker.perform_async
+  end
+
+  def handle_failed_subscription_content_import(batch)
+    SubscriptionContent.transaction do
+      batch.each do |(content_change_id, subscription_id)|
+        params = { content_change_id: content_change_id, subscription_id: subscription_id }
+        SubscriptionContent.create!(params) unless SubscriptionContent.where(params).exists?
+      end
+    end
   end
 
   def grouped_subscription_ids_by_subscriber(content_change)

--- a/db/migrate/20180315084923_add_unique_index_on_subscription_content.rb
+++ b/db/migrate/20180315084923_add_unique_index_on_subscription_content.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexOnSubscriptionContent < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscription_contents,
+      %w(subscription_id content_change_id),
+      name: "index_subscription_contents_on_subscription_and_content_change",
+      unique: true,
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180313152401) do
+ActiveRecord::Schema.define(version: 20180315084923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 20180313152401) do
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
+    t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"
   end
 

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe SubscriptionContentWorker do
       expect(content_change).to receive(:mark_processed!)
       subject.perform(content_change.id)
     end
+
+    context "when the subscription content has already been imported" do
+      before { create(:subscription_content, content_change: content_change, subscription: subscription) }
+
+      it "doesn't create another subscription content" do
+        expect { subject.perform(content_change.id) }
+          .to_not change { SubscriptionContent.count }
+          .from(1)
+      end
+    end
   end
 
   context "with more subscriptions than the batch size" do
@@ -52,6 +62,17 @@ RSpec.describe SubscriptionContentWorker do
       expect(SubscriptionContent).to receive(:import!).once
 
       subject.perform(content_change.id, 1)
+    end
+
+    context "when one subscription content has already been imported" do
+      before { create(:subscription_content, content_change: content_change, subscription: Subscription.first) }
+
+      it "only creates one additional content change" do
+        expect { subject.perform(content_change.id) }
+          .to change { SubscriptionContent.count }
+          .from(1)
+          .to(2)
+      end
     end
   end
 


### PR DESCRIPTION
If there are already subscription contents imported, perhaps because the previous worker failed, we now won't error out and end up in an infinite loop of importing subscription contents.

[Trello Card](https://trello.com/c/BwN5Rqn0/695-fix-potential-subscription-content-infinite-loop)