### PR TITLE
Add API endpoint to change a user’s email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ subscriber lists.
 ```
 
 * `POST /subscriber-lists` with data:
+
 ```json
 {
   "title": "My title",
@@ -176,6 +177,7 @@ subscriber lists.
   }
 }
 ```
+
 and it will respond with the JSON response for the `GET` call above.
 
 * `POST /notifications` with data:
@@ -240,6 +242,17 @@ The following fields are accepted on this endpoint: `subject`, `from_address_id`
   ]
 }
 ```
+
+* `PATCH /subscribers/test@example.com` with data:
+
+```json
+{
+  "new_address": "test2@example.com"
+}
+```
+
+and it will respond with the details of the subscriber including the
+new email address.
 
 * `POST /subscriptions` with data:
 

--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -9,10 +9,19 @@ class SubscribersController < ApplicationController
     render json: { subscriber: subscriber.as_json, subscriptions: subscriptions }
   end
 
+  def change_address
+    subscriber.update!(address: new_address)
+    render json: { subscriber: subscriber }
+  end
+
 private
 
   def subscriber
     @subscriber ||= Subscriber.find_by!("LOWER(address) = ?", address.downcase)
+  end
+
+  def new_address
+    subscriber_params.require(:new_address)
   end
 
   def address
@@ -20,6 +29,6 @@ private
   end
 
   def subscriber_params
-    params.permit(:address)
+    params.permit(:address, :new_address)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,11 @@ Rails.application.routes.draw do
 
     get "/healthcheck", to: "healthcheck#check"
 
-    get "/subscribers/:address/subscriptions", to: "subscribers#subscriptions",
-      constraints: { address: /.+@.+\..+/ }
+    constraints address: /.+@.+\..+/ do
+      patch "/subscribers/:address", to: "subscribers#change_address"
+      get "/subscribers/:address/subscriptions", to: "subscribers#subscriptions"
+    end
+
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
   end
 end

--- a/spec/integration/subscribers_spec.rb
+++ b/spec/integration/subscribers_spec.rb
@@ -33,6 +33,30 @@ RSpec.describe "Subscriptions", type: :request do
         end
       end
     end
+
+    context "when changing a subscriber's email address" do
+      context "with an existing subscriber" do
+        let!(:subscriber) { create(:subscriber) }
+
+        it "changes the email address if the new email address is valid" do
+          patch "/subscribers/#{subscriber.address}", params: { new_address: "new-test@example.com" }
+          expect(response.status).to eq(200)
+          expect(data[:subscriber][:address]).to eq("new-test@example.com")
+        end
+
+        it "returns an error message if the new email address is invalid" do
+          patch "/subscribers/#{subscriber.address}", params: { new_address: "invalid" }
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "without an existing subscriber" do
+        it "returns a 404" do
+          patch "/subscribers/doesnotexist@example.com", params: { new_address: "new-doesnotexist@example.com" }
+          expect(response.status).to eq(404)
+        end
+      end
+    end
   end
 
   context "without authentication" do


### PR DESCRIPTION
This commit adds an API endpoint at `PATCH /subscribers/:address` that changes a user’s email address given an existing and new email address.

Trello: https://trello.com/c/1maT3NIT/692-add-an-endpoint-to-email-alert-api-to-change-a-subscribers-email-address