### PR TITLE
Fix undeployable migration

### DIFF
--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -12,8 +12,6 @@ module UnsubscribeService
 
     def unsubscribe!(subscriber, subscriptions, reason)
       ActiveRecord::Base.transaction do
-        nullify_references_to_subscriptions!(subscriptions)
-
         subscriptions.each do |subscription|
           subscription.end(reason: reason)
         end
@@ -22,12 +20,6 @@ module UnsubscribeService
           subscriber.deactivate!
         end
       end
-    end
-
-    def nullify_references_to_subscriptions!(subscriptions)
-      SubscriptionContent
-        .where(subscription: subscriptions)
-        .update_all(subscription_id: nil)
     end
 
     def no_other_subscriptions?(subscriber, subscriptions)

--- a/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
+++ b/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
@@ -1,0 +1,7 @@
+class MakeSubscriptionIdOnSubscriptionContentsNotNull < ActiveRecord::Migration[5.1]
+  def up
+    SubscriptionContent.where(subscription_id: nil).delete_all
+
+    change_column_null :subscription_contents, :subscription_id, false
+  end
+end

--- a/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
+++ b/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
@@ -1,6 +1,8 @@
 class MakeSubscriptionIdOnSubscriptionContentsNotNull < ActiveRecord::Migration[5.1]
   def up
-    SubscriptionContent.where(subscription_id: nil).delete_all
+    deleted_count = SubscriptionContent.where(subscription_id: nil).delete_all
+
+    puts "deleted #{deleted_count} rows"
 
     change_column_null :subscription_contents, :subscription_id, false
   end

--- a/db/migrate/20180315000001_clear_out_duplicate_subscription_contents.rb
+++ b/db/migrate/20180315000001_clear_out_duplicate_subscription_contents.rb
@@ -1,0 +1,15 @@
+class ClearOutDuplicateSubscriptionContents < ActiveRecord::Migration[5.1]
+  def up
+    all_ids = SubscriptionContent.pluck(:id)
+
+    ids_to_keep = SubscriptionContent
+      .group(:content_change_id, :subscription_id)
+      .pluck("MIN(id)")
+
+    ids_to_delete = all_ids - ids_to_keep
+
+    deleted_count = SubscriptionContent.where(id: ids_to_delete).delete_all
+
+    puts "deleted #{deleted_count} rows"
+  end
+end

--- a/db/migrate/20180315080842_add_subscriber_id_to_emails.rb
+++ b/db/migrate/20180315080842_add_subscriber_id_to_emails.rb
@@ -1,6 +1,5 @@
 class AddSubscriberIdToEmails < ActiveRecord::Migration[5.1]
   def change
-    add_reference :emails, :subscriber, index: true
-    add_foreign_key :emails, :subscribers, on_delete: :restrict
+    add_reference :emails, :subscriber, index: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,7 +91,6 @@ ActiveRecord::Schema.define(version: 20180315084923) do
     t.bigint "subscriber_id"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
-    t.index ["subscriber_id"], name: "index_emails_on_subscriber_id"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|
@@ -174,7 +173,6 @@ ActiveRecord::Schema.define(version: 20180315084923) do
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "digest_runs", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "subscribers", on_delete: :cascade
-  add_foreign_key "emails", "subscribers", on_delete: :restrict
   add_foreign_key "matched_content_changes", "content_changes", on_delete: :cascade
   add_foreign_key "matched_content_changes", "subscriber_lists", on_delete: :cascade
   add_foreign_key "subscription_contents", "content_changes", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 20180315084923) do
     t.datetime "updated_at", null: false
     t.integer "digest_run_subscriber_id"
     t.uuid "email_id"
-    t.uuid "subscription_id"
+    t.uuid "subscription_id", null: false
     t.uuid "content_change_id", null: false
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -73,18 +73,5 @@ RSpec.describe UnsubscribeService do
         expect(subscriber.reload.address).not_to be_nil
       end
     end
-
-    context "when there are subscription contents for the subscription" do
-      let!(:subscription_content) do
-        create(:subscription_content, subscription: subscription)
-      end
-
-      it "nullifies the subscription on the subscription_content" do
-        expect { subject.subscription!(subscription, :unsubscribed) }
-          .to change { subscription_content.reload.subscription }
-          .from(subscription)
-          .to(nil)
-      end
-    end
   end
 end


### PR DESCRIPTION
This PR fixes a migration which is currently undeployable due to the existing data we have.

This firstly fixes an issue where we have a load of `nil` `subscription_id`s for subscription contents which we wouldn't expect to have, and secondly clears out any duplicate subscription contents we may have.

It also turns out that the potential subscription content infinite loop we thought we had, we actually didn't have, because there was no unique index to prevent duplicates from being created and any duplicates would be reduplicated at the end. However, it is less surprising for there to be a unique index on subscriptions contents to the work was still relevant.

Also, I've modified a migrated but undeployed migration to not add an index and foreign key as they will lock the tables.

The migrations are inserted prior to existing one as they must run first.

[Trello Card](https://trello.com/c/BwN5Rqn0/695-fix-potential-subscription-content-infinite-loop)