### PR TITLE
Stop nullifying subscription_id

### DIFF
--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -12,8 +12,6 @@ module UnsubscribeService
 
     def unsubscribe!(subscriber, subscriptions, reason)
       ActiveRecord::Base.transaction do
-        nullify_references_to_subscriptions!(subscriptions)
-
         subscriptions.each do |subscription|
           subscription.end(reason: reason)
         end
@@ -22,12 +20,6 @@ module UnsubscribeService
           subscriber.deactivate!
         end
       end
-    end
-
-    def nullify_references_to_subscriptions!(subscriptions)
-      SubscriptionContent
-        .where(subscription: subscriptions)
-        .update_all(subscription_id: nil)
     end
 
     def no_other_subscriptions?(subscriber, subscriptions)

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -73,18 +73,5 @@ RSpec.describe UnsubscribeService do
         expect(subscriber.reload.address).not_to be_nil
       end
     end
-
-    context "when there are subscription contents for the subscription" do
-      let!(:subscription_content) do
-        create(:subscription_content, subscription: subscription)
-      end
-
-      it "nullifies the subscription on the subscription_content" do
-        expect { subject.subscription!(subscription, :unsubscribed) }
-          .to change { subscription_content.reload.subscription }
-          .from(subscription)
-          .to(nil)
-      end
-    end
   end
 end


### PR DESCRIPTION
This was never meant to be the case as subscriptions now store the time at which they were deactivated, meaning we don't need to nullify the subscription contents.