### PR TITLE
Fix broken data

### DIFF
--- a/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
+++ b/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
@@ -1,0 +1,7 @@
+class MakeSubscriptionIdOnSubscriptionContentsNotNull < ActiveRecord::Migration[5.1]
+  def up
+    SubscriptionContent.where(subscription_id: nil).delete_all
+
+    change_column_null :subscription_contents, :subscription_id, false
+  end
+end

--- a/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
+++ b/db/migrate/20180315000000_make_subscription_id_on_subscription_contents_not_null.rb
@@ -1,6 +1,8 @@
 class MakeSubscriptionIdOnSubscriptionContentsNotNull < ActiveRecord::Migration[5.1]
   def up
-    SubscriptionContent.where(subscription_id: nil).delete_all
+    deleted_count = SubscriptionContent.where(subscription_id: nil).delete_all
+
+    puts "deleted #{deleted_count} rows"
 
     change_column_null :subscription_contents, :subscription_id, false
   end

--- a/db/migrate/20180315000001_clear_out_duplicate_subscription_contents.rb
+++ b/db/migrate/20180315000001_clear_out_duplicate_subscription_contents.rb
@@ -1,0 +1,15 @@
+class ClearOutDuplicateSubscriptionContents < ActiveRecord::Migration[5.1]
+  def up
+    all_ids = SubscriptionContent.pluck(:id)
+
+    ids_to_keep = SubscriptionContent
+      .group(:content_change_id, :subscription_id)
+      .pluck("MIN(id)")
+
+    ids_to_delete = all_ids - ids_to_keep
+
+    deleted_count = SubscriptionContent.where(id: ids_to_delete).delete_all
+
+    puts "deleted #{deleted_count} rows"
+  end
+end

--- a/db/migrate/20180315084923_add_unique_index_on_subscription_content.rb
+++ b/db/migrate/20180315084923_add_unique_index_on_subscription_content.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexOnSubscriptionContent < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscription_contents,
+      %w(subscription_id content_change_id),
+      name: "index_subscription_contents_on_subscription_and_content_change",
+      unique: true,
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 20180313152401) do
     t.datetime "updated_at", null: false
     t.integer "digest_run_subscriber_id"
     t.uuid "email_id"
-    t.uuid "subscription_id"
+    t.uuid "subscription_id", null: false
     t.uuid "content_change_id", null: false
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180315000001) do
+ActiveRecord::Schema.define(version: 20180315084923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 20180315000001) do
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
+    t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180313152401) do
+ActiveRecord::Schema.define(version: 20180315000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This fixes some broken data we have in production related to missing some database restrictions on our columns.

This replaces #531 as the undeployable migration was reverted.