### PR TITLE
Stop retrying after 24 hours

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -3,13 +3,28 @@ class DeliveryAttempt < ApplicationRecord
 
   validates :email, :status, :provider, presence: true
 
-  FINAL_STATUSES = %i[delivered permanent_failure].freeze
+  FINAL_STATUSES = %i[
+    delivered
+    permanent_failure
+    retries_exhausted_failure
+  ].freeze
 
-  enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4 }
+  enum status: {
+    sending: 0,
+    delivered: 1,
+    permanent_failure: 2,
+    temporary_failure: 3,
+    technical_failure: 4,
+    retries_exhausted_failure: 5
+  }
+
   enum provider: { pseudo: 0, notify: 1 }
 
   def failure?
-    permanent_failure? || temporary_failure? || technical_failure?
+    permanent_failure? ||
+      temporary_failure? ||
+      technical_failure? ||
+      retries_exhausted_failure?
   end
 
   def should_report_failure?

--- a/spec/models/delivery_attempt_spec.rb
+++ b/spec/models/delivery_attempt_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe DeliveryAttempt, type: :model do
     include_examples "is marked as a failure"
   end
 
+  context "with a retries_exhausted_failure" do
+    subject { create(:delivery_attempt, status: :retries_exhausted_failure) }
+
+    include_examples "is marked as a failure"
+  end
+
   context "with a technical failure" do
     subject { create(:delivery_attempt, status: :technical_failure) }
 

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -107,4 +107,44 @@ RSpec.describe StatusUpdateService do
         .to raise_error(StatusUpdateService::DeliveryAttemptStatusConflictError)
     end
   end
+
+  context "when a delivery attempts is a temporary failure and the first "\
+    "delivery attempt was less than a day ago" do
+    let(:status) { "temporary-failure" }
+    let(:completed_at) { Time.zone.now.rfc3339 }
+
+    before do
+      create(
+        :delivery_attempt,
+        email: delivery_attempt.email,
+        completed_at: 20.hours.ago,
+      )
+    end
+
+    it "sets the delivery attempt status to temporary_failure" do
+      expect { status_update }
+        .to change { delivery_attempt.reload.status }
+        .to("temporary_failure")
+    end
+  end
+
+  context "when a delivery attempts is a temporary failure and the first "\
+    "delivery attempt was more than a day ago" do
+    let(:status) { "temporary-failure" }
+    let(:completed_at) { Time.zone.now.rfc3339 }
+
+    before do
+      create(
+        :delivery_attempt,
+        email: delivery_attempt.email,
+        completed_at: 25.hours.ago,
+      )
+    end
+
+    it "sets the delivery attempt status to retries_exhausted_failure" do
+      expect { status_update }
+        .to change { delivery_attempt.reload.status }
+        .to("retries_exhausted_failure")
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/Dgf0fbal/703-stop-retrying-for-temporary-failures-after-24-hours

Note: I'm putting this up at the end of Friday as I'm on leave Monday and didn't know if we were in a rush to get this out or not. It may need some additional thought alongside the review if there's any edge cases I've missed.

This sets up a new state on DeliveryAttempt for when they have had 24 hours of temporary_failure statuses from Notify and then ceases to retry. It is a final state. 

This isn't a particularly good solution to the problem though as it leaves us with the slightly thorny situation where we can have DeliveryAttempts that have returned as temporary_failure and are marked as different states in the db. This basically loads DeliveryAttempt with accumulative state which is far better served on Email.

I've done some work implementing this into state into email but it will require a couple of deploys so I've put this together as a faster approach to getting the situation looked at. Storing state on Email will resolve a few other complexities with archiving too.
