### PR TITLE
Don't create an index on subscriber_id

### DIFF
--- a/db/migrate/20180315080842_add_subscriber_id_to_emails.rb
+++ b/db/migrate/20180315080842_add_subscriber_id_to_emails.rb
@@ -1,6 +1,6 @@
 class AddSubscriberIdToEmails < ActiveRecord::Migration[5.1]
   def up
-    add_reference :emails, :subscriber
+    add_reference :emails, :subscriber, index: false
 
     execute %(
       ALTER TABLE "emails"


### PR DESCRIPTION
This modifies an existing migration, but it's not yet deployed and we need this change this migration so it doesn't lock the email table.

Unfortunately, when I wrote the migration, I was looking at the documentation for an older version of Rails where the default was to not create an index, but this has changed in Rails 5 to create an index by default. I didn't notice because it ran fast locally and on integration, but on staging the deploy is taking a very long time and locking the table.

This doesn't need to update `schema.rb` as for some reason, it doesn't contain the index. I suspect this is some rebasing that went wrong somewhere.