### PR TITLE
Show subscription endpoint

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -28,6 +28,11 @@ class SubscriptionsController < ApplicationController
     render json: { id: subscription.id }, status: status
   end
 
+  def show
+    subscription = Subscription.find(subscription_params.require(:id))
+    render json: { subscription: subscription }
+  end
+
   def change_frequency
     existing_subscription = nil
     subscription = nil
@@ -86,6 +91,6 @@ private
   end
 
   def subscription_params
-    params.permit(:address, :subscribable_id, :frequency, :subscription_id)
+    params.permit(:id, :address, :subscribable_id, :frequency, :subscription_id)
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -33,13 +33,13 @@ class SubscriptionsController < ApplicationController
     render json: { subscription: subscription }
   end
 
-  def change_frequency
+  def update
     existing_subscription = nil
     subscription = nil
 
     Subscription.transaction do
       existing_subscription = Subscription.active.lock.find(
-        subscription_params.require(:subscription_id)
+        subscription_params.require(:id)
       )
 
       existing_subscription.end(reason: :frequency_changed)
@@ -91,6 +91,6 @@ private
   end
 
   def subscription_params
-    params.permit(:id, :address, :subscribable_id, :frequency, :subscription_id)
+    params.permit(:id, :address, :subscribable_id, :frequency)
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,6 +12,12 @@ class Subscription < ApplicationRecord
 
   scope :active, -> { where(ended_at: nil) }
 
+  def as_json(options = {})
+    options[:except] ||= %i(signon_user_uid subscriber_list_id subscriber_id)
+    options[:include] ||= %i(subscriber_list subscriber)
+    super(options)
+  end
+
   def active?
     ended_at.nil?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,7 @@ Rails.application.routes.draw do
 
     resources :notifications, only: %i[create index show]
     resources :status_updates, path: "status-updates", only: %i[create]
-    resources :subscriptions, only: %i[create show]
-    patch "/subscriptions/:subscription_id", to: "subscriptions#change_frequency"
+    resources :subscriptions, only: %i[create show update]
 
     get "/healthcheck", to: "healthcheck#check"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
     resources :notifications, only: %i[create index show]
     resources :status_updates, path: "status-updates", only: %i[create]
-    resources :subscriptions, only: %i[create]
+    resources :subscriptions, only: %i[create show]
     patch "/subscriptions/:subscription_id", to: "subscriptions#change_frequency"
 
     get "/healthcheck", to: "healthcheck#check"

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe "Subscriptions", type: :request do
           expect(subscription.reload.ended?).to be true
         end
       end
+
+      it "lets you query the subscription" do
+        get "/subscriptions/#{subscription.id}"
+        expect(response.status).to eq(200)
+        expect(data[:subscription].keys).to match_array(%i(
+          id
+          subscriber_list
+          subscriber
+          created_at
+          updated_at
+          ended_at
+          ended_reason
+          frequency
+          source
+        ))
+      end
     end
 
     context "without an existing subscription" do
@@ -127,6 +143,11 @@ RSpec.describe "Subscriptions", type: :request do
             expect(response.status).to eq(404)
           end
         end
+      end
+
+      it "raises a 404 querying a non-existing subscription" do
+        get "/subscriptions/3c926708-ecfa-4165-889d-c0d45cbdc01c"
+        expect(response.status).to eq(404)
       end
     end
 


### PR DESCRIPTION
This will be used by email-alert-frontend to present the correct title of the subscription instead of taking it from the query string.

[Trello Card](https://trello.com/c/tQznyVfV/704-remove-the-need-to-specify-a-subscriber-list-name-on-the-unsubscribe-page)