### PR TITLE
Allow failed timestamps to update Email finished_sending_at

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -24,6 +24,10 @@ class DeliveryAttempt < ApplicationRecord
     self.class.final_status?(status)
   end
 
+  def finished_sending_at
+    sent_at || completed_at
+  end
+
   def self.final_status?(status)
     FINAL_STATUSES.include?(status.to_sym)
   end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -14,6 +14,6 @@ class Email < ApplicationRecord
   # Mark an email to indicate the process of sending it is complete
   def finish_sending(delivery_attempt)
     raise ArgumentError, "DeliveryAttempt for different email" if delivery_attempt.email_id != id
-    update!(finished_sending_at: delivery_attempt.sent_at)
+    update!(finished_sending_at: delivery_attempt.finished_sending_at)
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,10 +15,34 @@ FactoryBot.define do
     publishing_app "publishing app"
   end
 
-  factory :delivery_attempt do
+  factory :delivery_attempt, aliases: [:sending_delivery_attempt] do
     email
     status :sending
     provider :notify
+
+    factory :delivered_delivery_attempt do
+      status :delivered
+      sent_at { Time.zone.now }
+      completed_at { Time.zone.now }
+    end
+
+    factory :temporary_failure_delivery_attempt do
+      status :temporary_failure
+      sent_at nil
+      completed_at { Time.zone.now }
+    end
+
+    factory :permanent_failure_delivery_attempt do
+      status :temporary_failure
+      sent_at nil
+      completed_at { Time.zone.now }
+    end
+
+    factory :technical_failure_delivery_attempt do
+      status :technical_failure
+      sent_at nil
+      completed_at { Time.zone.now }
+    end
   end
 
   factory :digest_run do

--- a/spec/models/delivery_attempt_spec.rb
+++ b/spec/models/delivery_attempt_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe DeliveryAttempt, type: :model do
     end
   end
 
+  describe ".finished_sending_at" do
+    subject { delivery_attempt.finished_sending_at }
+
+    context "when email is sent" do
+      let(:delivery_attempt) { build(:delivered_delivery_attempt) }
+      it { is_expected.to eq delivery_attempt.sent_at }
+    end
+
+    context "when email failed" do
+      let(:delivery_attempt) { build(:permanent_failure_delivery_attempt) }
+      it { is_expected.to eq delivery_attempt.completed_at }
+    end
+
+    context "when email is sending" do
+      let(:delivery_attempt) { build(:sending_delivery_attempt) }
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe ".final_status?" do
     subject { described_class.final_status?(status) }
     context "when given a final status" do

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -14,17 +14,20 @@ RSpec.describe Email do
   describe "#finish_sending" do
     context "when delivery attempt is for same email" do
       let(:email) { create(:email) }
-      let(:completed_at) { Time.parse("2017-05-14T12:15:30.000000Z") }
-      let(:sent_at) { Time.parse("2017-05-14T12:15:30.000000Z") }
-      let(:delivery_attempt) { create(:delivery_attempt, email: email, completed_at: completed_at, sent_at: sent_at) }
+      let(:sent_at) { Time.zone.now }
+      let(:delivery_attempt) do
+        create(
+          :delivery_attempt,
+          email: email,
+          sent_at: sent_at,
+        )
+      end
 
       it "sets the finished_sending_at field" do
-        Timecop.freeze do
-          expect { email.finish_sending(delivery_attempt) }
-            .to change { email.finished_sending_at }
-            .from(nil)
-            .to(sent_at)
-        end
+        expect { email.finish_sending(delivery_attempt) }
+          .to change { email.finished_sending_at }
+          .from(nil)
+          .to(sent_at)
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/Dgf0fbal/703-stop-retrying-for-temporary-failures-after-24-hours

By storing delivery_attempt.sent_at on Email we were at risk of setting
this to be nil on Emails that failed to send. By setting this to sent_at
or completed_at we have a much lower risk of this.

As we're not actually validating that these always send through a
timestamp we're still at a small risk that if Notify don't send through
a timestamp we'll end up with inconsistent data. Some of the follow up
PR's I'm working on for Email status should alleviate this risk.