### PR TITLE
[DO NOT MERGE] Don't send title with unsubscribe link

### DIFF
--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -1,26 +1,6 @@
 class UnsubscribeLinkPresenter
-  def initialize(id:, title:)
-    @id = id
-    @title = title
-  end
-
-  def self.call(*args)
-    new(*args).call
-  end
-
-  def call
+  def self.call(id:, title:)
+    url = PublicUrlService.url_for(base_path: "/email/unsubscribe/#{id}")
     "Unsubscribe from [#{title}](#{url})"
-  end
-
-  private_class_method :new
-
-private
-
-  attr_reader :id, :title
-
-  def url
-    escaped_title = ERB::Util.url_encode(title)
-    base_path = "/email/unsubscribe/#{id}?title=#{escaped_title}"
-    PublicUrlService.url_for(base_path: base_path)
   end
 end

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
 
       &nbsp;
 
@@ -56,7 +56,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id})
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
@@ -86,7 +86,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id})
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
@@ -251,7 +251,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
 
       &nbsp;
 
@@ -273,7 +273,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id})
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 
@@ -303,7 +303,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id})
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
 

--- a/spec/presenters/unsubscribe_link_presenter_spec.rb
+++ b/spec/presenters/unsubscribe_link_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UnsubscribeLinkPresenter do
   describe ".call" do
     it "returns a presented unsubscribe link" do
-      expected = "Unsubscribe from [Test title](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
+      expected = "Unsubscribe from [Test title](http://www.dev.gov.uk/email/unsubscribe/abc123)"
       expect(described_class.call(id: "abc123", title: "Test title")).to eq(expected)
     end
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -84,7 +84,7 @@ module FeatureHelpers
 
   def extract_unsubscribe_id(email_data)
     body = email_data.dig(:personalisation, :body)
-    body[%r{/unsubscribe/(.*)\?}, 1]
+    body[%r{/unsubscribe/([a-zA-Z0-9\-]+)}, 1]
   end
 
   def clear_any_requests_that_have_been_recorded!


### PR DESCRIPTION
This stops sending the title with unsubscribe links as a URL parameter. 

Depends on https://github.com/alphagov/email-alert-frontend/pull/174 being deployed.

[Trello Card](https://trello.com/c/tQznyVfV/704-remove-the-need-to-specify-a-subscriber-list-name-on-the-unsubscribe-page)