### PR TITLE
Create enum fields on emails for status and failure_reason

### DIFF
--- a/db/migrate/20180316115057_add_status_and_failure_reason_to_emails.rb
+++ b/db/migrate/20180316115057_add_status_and_failure_reason_to_emails.rb
@@ -1,0 +1,6 @@
+class AddStatusAndFailureReasonToEmails < ActiveRecord::Migration[5.1]
+  def change
+    add_column :emails, :status, :integer
+    add_column :emails, :failure_reason, :integer
+  end
+end

--- a/db/migrate/20180316120328_add_status_and_failure_reasons_indexes_to_emails.rb
+++ b/db/migrate/20180316120328_add_status_and_failure_reasons_indexes_to_emails.rb
@@ -1,0 +1,8 @@
+class AddStatusAndFailureReasonsIndexesToEmails < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :emails, :status, algorithm: :concurrently
+    add_index :emails, :failure_reason, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180315084923) do
+ActiveRecord::Schema.define(version: 20180316120328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,8 +89,12 @@ ActiveRecord::Schema.define(version: 20180315084923) do
     t.datetime "finished_sending_at"
     t.datetime "archived_at"
     t.bigint "subscriber_id"
+    t.integer "status"
+    t.integer "failure_reason"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
+    t.index ["failure_reason"], name: "index_emails_on_failure_reason"
     t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
+    t.index ["status"], name: "index_emails_on_status"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|


### PR DESCRIPTION
Trello: https://trello.com/c/Dgf0fbal/703-stop-retrying-for-temporary-failures-after-24-hours

This is part of adding in the feature to stop retrying emails after a
certain number of attempts. To store the difference between a delivery
attempt that is a final state and a temporary state we either need to
store accumulative state on a DeliveryAttempt or utilise Email for a
view of all DeliveryAttempts.

This moves this to be stored on Email so that we don't have to store
DeliveryAttempts that have failed for different reasons with different
states.