### PR TITLE
Make subscriber_id optional in the delivery rake task

### DIFF
--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -1,5 +1,5 @@
 namespace :deliver do
-  def test_email(address, subscriber_id)
+  def test_email(address, subscriber_id = nil)
     Email.create(
       address: address,
       subject: "Test email",


### PR DESCRIPTION
The task was broken for sending test emails, but this will fix it by making the suscriber id optional.

This fixes a bug that was introduced in #538.