### PR TITLE
Store a status on Email table

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -11,6 +11,7 @@ class DigestEmailBuilder
 
   def call
     Email.create!(
+      status: :pending,
       subject: subject,
       body: body,
       address: subscriber.address,

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -20,6 +20,7 @@ private
   def records
     recipients_and_content.map do |recipient_and_content|
       [
+        :pending,
         recipient_and_content.fetch(:address),
         subject(recipient_and_content.fetch(:content_change)),
         body(recipient_and_content.fetch(:content_change), recipient_and_content.fetch(:subscriptions)),
@@ -29,7 +30,7 @@ private
   end
 
   def columns
-    %i(address subject body subscriber_id)
+    %i(status address subject body subscriber_id)
   end
 
   def subject(content_change)

--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -8,18 +8,6 @@ class DeliveryAttempt < ApplicationRecord
   enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4 }
   enum provider: { pseudo: 0, notify: 1 }
 
-  def failure?
-    permanent_failure? || temporary_failure? || technical_failure?
-  end
-
-  def should_report_failure?
-    technical_failure?
-  end
-
-  def should_remove_subscriber?
-    permanent_failure?
-  end
-
   def has_final_status?
     self.class.final_status?(status)
   end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -13,10 +13,4 @@ class Email < ApplicationRecord
   enum failure_reason: { permanent_failure: 0, retries_exhausted_failure: 1 }
 
   validates :address, :subject, :body, presence: true
-
-  # Mark an email to indicate the process of sending it is complete
-  def finish_sending(delivery_attempt)
-    raise ArgumentError, "DeliveryAttempt for different email" if delivery_attempt.email_id != id
-    update!(finished_sending_at: delivery_attempt.finished_sending_at)
-  end
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -9,6 +9,9 @@ class Email < ApplicationRecord
     where.not(archived_at: nil).where("finished_sending_at < ?", 14.days.ago)
   }
 
+  enum status: { pending: 0, sent: 1, failed: 2 }
+  enum failure_reason: { permanent_failure: 0, retries_exhausted_failure: 1 }
+
   validates :address, :subject, :body, presence: true
 
   # Mark an email to indicate the process of sending it is complete

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -35,8 +35,7 @@ class DeliveryRequestService
 
       ActiveRecord::Base.transaction do
         delivery_attempt.update!(status: status) if status != :sending
-
-        email.finish_sending(delivery_attempt) if delivery_attempt.has_final_status?
+        UpdateEmailStatusService.call(delivery_attempt)
       end
     end
 

--- a/app/services/update_email_status_service.rb
+++ b/app/services/update_email_status_service.rb
@@ -1,0 +1,54 @@
+class UpdateEmailStatusService
+  def initialize(delivery_attempt)
+    @delivery_attempt = delivery_attempt
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    handle_temporary_failure if delivery_attempt.temporary_failure?
+    handle_permanent_failure if delivery_attempt.permanent_failure?
+    handle_delivered if delivery_attempt.delivered?
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :delivery_attempt
+  delegate :email, to: :delivery_attempt
+
+  def handle_temporary_failure
+    return unless retries_exhausted?
+    email.update!(
+      status: :failed,
+      failure_reason: :retries_exhausted_failure,
+      finished_sending_at: delivery_attempt.finished_sending_at,
+    )
+  end
+
+  def retries_exhausted?
+    first_completed = DeliveryAttempt
+                       .where(email: email, status: :temporary_failure)
+                       .minimum(:completed_at)
+
+    first_completed && first_completed < 1.days.ago
+  end
+
+  def handle_permanent_failure
+    email.update!(
+      status: :failed,
+      failure_reason: :permanent_failure,
+      finished_sending_at: delivery_attempt.finished_sending_at,
+    )
+  end
+
+  def handle_delivered
+    email.update!(
+      status: :sent,
+      finished_sending_at: delivery_attempt.finished_sending_at,
+    )
+  end
+end

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -1,6 +1,7 @@
 namespace :deliver do
   def test_email(address, subscriber_id = nil)
     Email.create(
+      status: :pending,
       address: address,
       subject: "Test email",
       body: "This is a test email.",

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -104,6 +104,8 @@ RSpec.describe ImmediateEmailBuilder do
         expect(ContentChangePresenter).to receive(:call)
           .and_return("presented_content_change\n")
 
+        expect(email.status).to eq "pending"
+
         expect(email.body).to eq(
           <<~BODY
             presented_content_change

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     end
 
     factory :permanent_failure_delivery_attempt do
-      status :temporary_failure
+      status :permanent_failure
       sent_at nil
       completed_at { Time.zone.now }
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -61,21 +61,25 @@ FactoryBot.define do
     subscriber
   end
 
-  factory :email, aliases: [:unarchivable_email] do
+  factory :email, aliases: %i[unarchivable_email pending_email] do
     address "test@example.com"
     subject "subject"
     body "body"
+    status :pending
 
     factory :archivable_email do
+      status :sent
       finished_sending_at { 2.days.ago }
     end
 
     factory :archived_email do
+      status :sent
       finished_sending_at { 2.days.ago }
       archived_at { 1.day.ago }
     end
 
     factory :deleteable_email do
+      status :sent
       finished_sending_at { 15.days.ago }
       archived_at { 14.days.ago }
     end

--- a/spec/models/delivery_attempt_spec.rb
+++ b/spec/models/delivery_attempt_spec.rb
@@ -1,41 +1,9 @@
 RSpec.describe DeliveryAttempt, type: :model do
-  shared_examples "is marked as a failure" do
-    it "is marked as a failure" do
-      expect(subject.failure?).to be_truthy
-    end
-  end
-
   describe "validations" do
     subject { create(:delivery_attempt) }
 
     it "is valid for the default factory" do
       expect(subject).to be_valid
-    end
-  end
-
-  context "with a permanent failure" do
-    subject { create(:delivery_attempt, status: :permanent_failure) }
-
-    include_examples "is marked as a failure"
-
-    it "is marked as remove the subscriber" do
-      expect(subject.should_remove_subscriber?).to be_truthy
-    end
-  end
-
-  context "with a temporary failure" do
-    subject { create(:delivery_attempt, status: :temporary_failure) }
-
-    include_examples "is marked as a failure"
-  end
-
-  context "with a technical failure" do
-    subject { create(:delivery_attempt, status: :technical_failure) }
-
-    include_examples "is marked as a failure"
-
-    it "is marked as should report failure" do
-      expect(subject.should_report_failure?).to be_truthy
     end
   end
 

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -10,35 +10,4 @@ RSpec.describe Email do
       expect(subject.errors[:body]).not_to be_empty
     end
   end
-
-  describe "#finish_sending" do
-    context "when delivery attempt is for same email" do
-      let(:email) { create(:email) }
-      let(:sent_at) { Time.zone.now }
-      let(:delivery_attempt) do
-        create(
-          :delivery_attempt,
-          email: email,
-          sent_at: sent_at,
-        )
-      end
-
-      it "sets the finished_sending_at field" do
-        expect { email.finish_sending(delivery_attempt) }
-          .to change { email.finished_sending_at }
-          .from(nil)
-          .to(sent_at)
-      end
-    end
-
-    context "when delivery_attempt is for a different email" do
-      let(:email) { create(:email) }
-      let(:delivery_attempt) { build(:delivery_attempt) }
-
-      it "raises an error" do
-        expect { email.finish_sending(delivery_attempt) }
-          .to raise_error(ArgumentError)
-      end
-    end
-  end
 end

--- a/spec/services/update_email_status_service_spec.rb
+++ b/spec/services/update_email_status_service_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe UpdateEmailStatusService do
+  describe ".call" do
+    let!(:email) { create(:pending_email) }
+
+    shared_examples "email finished_sending_at timestamp" do
+      it "changes the email finished_sending_at timestamp" do
+        expect { described_class.call(delivery_attempt) }
+          .to change { email.reload.finished_sending_at }
+          .from(nil)
+          .to(delivery_attempt.reload.finished_sending_at)
+      end
+    end
+
+    context "when a delivery attempt is the first temporary failure" do
+      let(:delivery_attempt) do
+        create(:temporary_failure_delivery_attempt, email: email)
+      end
+
+      it "doesn't change email status" do
+        expect { described_class.call(delivery_attempt) }
+          .not_to change { email.reload.status }
+          .from("pending")
+      end
+
+      it "doesn't change the email finished_sending_at timestamp" do
+        expect { described_class.call(delivery_attempt) }
+          .not_to change { email.reload.finished_sending_at }
+          .from(nil)
+      end
+    end
+
+    context "when a delivery attempt is a temporary failure and there was a previous one over 24 hours ago" do
+      before do
+        create(:temporary_failure_delivery_attempt, email: email, completed_at: 25.hours.ago)
+      end
+
+      let(:delivery_attempt) do
+        create(:temporary_failure_delivery_attempt, email: email)
+      end
+
+      it "marks an email as failed" do
+        expect { described_class.call(delivery_attempt) }
+          .to change { email.reload.status }
+          .to("failed")
+      end
+
+      it "sets failure reason to retries_exhausted_failure" do
+        expect { described_class.call(delivery_attempt) }
+          .to change { email.reload.failure_reason }
+          .to("retries_exhausted_failure")
+      end
+
+      include_examples "email finished_sending_at timestamp"
+    end
+
+    context "when a delivery attempt is delivered" do
+      let(:delivery_attempt) do
+        create(:delivered_delivery_attempt, email: email)
+      end
+
+      it "marks an email as sent" do
+        expect { described_class.call(delivery_attempt) }
+          .to change { email.reload.status }
+          .to("sent")
+      end
+      include_examples "email finished_sending_at timestamp"
+    end
+
+    context "when a delivery attempt is a permanent failure" do
+      let(:delivery_attempt) do
+        create(:permanent_failure_delivery_attempt, email: email)
+      end
+
+      it "marks an email as failed" do
+        expect { described_class.call(delivery_attempt) }
+          .to change { email.reload.status }
+          .to("failed")
+      end
+
+      it "sets failure reason to permanent_failure" do
+        expect { described_class.call(delivery_attempt) }
+          .to change { email.reload.failure_reason }
+          .to("permanent_failure")
+      end
+
+      include_examples "email finished_sending_at timestamp"
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/Dgf0fbal/703-stop-retrying-for-temporary-failures-after-24-hours

This uses the status and failure_reason attributes on Email. It uses them in our process to determine whether to retry emails or not.