### PR TITLE
[DO NOT MERGE] Migration to set email statuses on old records

### DIFF
--- a/db/migrate/20180316221116_set_email_statuses.rb
+++ b/db/migrate/20180316221116_set_email_statuses.rb
@@ -1,0 +1,26 @@
+class SetEmailStatuses < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    DeliveryAttempt
+      .where(status: :delivered)
+      .in_batches(of: 10_000)
+      .each_with_index do |batch, index|
+        puts "Processed #{10_000 * index} sent emails"
+        Email.where(id: batch.pluck(:email_id)).update_all(status: :sent)
+        sleep(0.1)
+      end
+
+    DeliveryAttempt
+      .where(status: :permanent_failure)
+      .in_batches(of: 10_000)
+      .each_with_index do |batch, index|
+        puts "Processed #{10_000 * index} failed emails"
+        Email.where(id: batch.pluck(:email_id)).update_all(status: :failed, failure_reason: :permanent_failure)
+        sleep(0.1)
+      end
+
+    pending = Email.where(status: nil).update_all(status: :pending)
+    puts "#{pending} emails marked as pending"
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/Dgf0fbal/703-stop-retrying-for-temporary-failures-after-24-hours

This shouldn't be merged before https://github.com/alphagov/email-alert-api/pull/550
is merged

This populates the status field on Email, and will probably take ages. I'll
update this PR with some times once I have time.