### PR TITLE
Add GA UTM params to all links in emails

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -74,7 +74,8 @@ private
 
   def presented_content_changes(content_changes)
     changes = content_changes.map do |content_change|
-      ContentChangePresenter.call(content_change)
+      frequency = digest_run.daily? ? "daily" : "weekly"
+      ContentChangePresenter.call(content_change, frequency: frequency)
     end
 
     changes.join("\n---\n\n")

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -56,7 +56,7 @@ private
   end
 
   def presented_content_change(content_change)
-    ContentChangePresenter.call(content_change)
+    ContentChangePresenter.call(content_change, frequency: "immediate")
   end
 
   def presented_unsubscribe_links(subscriptions)

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -3,8 +3,9 @@ require 'redcarpet/render_strip'
 class ContentChangePresenter
   EMAIL_DATE_FORMAT = "%l:%M%P, %-d %B %Y".freeze
 
-  def initialize(content_change)
+  def initialize(content_change, frequency: "immediate")
     @content_change = content_change
+    @frequency = frequency
   end
 
   def self.call(*args)
@@ -24,12 +25,17 @@ class ContentChangePresenter
 
 private
 
-  attr_reader :content_change
+  attr_reader :content_change, :frequency
 
   delegate :title, :description, :change_note, :footnote, to: :content_change
 
   def content_url
-    PublicUrlService.url_for(base_path: content_change.base_path)
+    utm_source = content_change.id
+    utm_medium = "email"
+    utm_campaign = "govuk-notifications"
+    utm_content = frequency
+    base_path = "#{content_change.base_path}?utm_source=#{utm_source}&utm_medium=#{utm_medium}&utm_campaign=#{utm_campaign}&utm_content=#{utm_content}"
+    PublicUrlService.url_for(base_path: base_path)
   end
 
   def public_updated_at

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "creating and delivering digests", type: :request do
     Timecop.return
   end
 
-  def first_expected_daily_email_body(subscription_one, subscription_two)
+  def first_expected_daily_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four)
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path)
+      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'daily')})
 
       Description one
 
@@ -26,7 +26,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path)
+      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'daily')})
 
       Description two
 
@@ -40,7 +40,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       #Subscriber list two&nbsp;
 
-      [Title four](http://www.dev.gov.uk/base-path)
+      [Title four](http://www.dev.gov.uk/base-path?#{utm_params(content_change_four.id, 'daily')})
 
       Description four
 
@@ -48,7 +48,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Title three](http://www.dev.gov.uk/base-path)
+      [Title three](http://www.dev.gov.uk/base-path?#{utm_params(content_change_three.id, 'daily')})
 
       Description three
 
@@ -66,11 +66,11 @@ RSpec.describe "creating and delivering digests", type: :request do
     BODY
   end
 
-  def second_expected_daily_email_body(subscription)
+  def second_expected_daily_email_body(subscription, content_change_one, content_change_two)
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path)
+      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'daily')})
 
       Description one
 
@@ -78,7 +78,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path)
+      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'daily')})
 
       Description two
 
@@ -199,6 +199,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     #TODO retrieve this via the API when we have an endpoint
     subscriptions = Subscription.all
+    content_changes = ContentChange.all
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
@@ -206,7 +207,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => first_expected_daily_email_body(subscriptions[0], subscriptions[1])
+            "body" => first_expected_daily_email_body(subscriptions[0], subscriptions[1], content_changes[0], content_changes[1], content_changes[2], content_changes[3])
           )
         )
       )
@@ -218,7 +219,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => second_expected_daily_email_body(subscriptions[2])
+            "body" => second_expected_daily_email_body(subscriptions[2], content_changes[0], content_changes[1])
           )
         )
       )
@@ -231,11 +232,11 @@ RSpec.describe "creating and delivering digests", type: :request do
     expect(second_digest_stub).to have_been_requested
   end
 
-  def first_expected_weekly_email_body(subscription_one, subscription_two)
+  def first_expected_weekly_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four)
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path)
+      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'weekly')})
 
       Description one
 
@@ -243,7 +244,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path)
+      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'weekly')})
 
       Description two
 
@@ -257,7 +258,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       #Subscriber list two&nbsp;
 
-      [Title four](http://www.dev.gov.uk/base-path)
+      [Title four](http://www.dev.gov.uk/base-path?#{utm_params(content_change_four.id, 'weekly')})
 
       Description four
 
@@ -265,7 +266,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Title three](http://www.dev.gov.uk/base-path)
+      [Title three](http://www.dev.gov.uk/base-path?#{utm_params(content_change_three.id, 'weekly')})
 
       Description three
 
@@ -283,11 +284,11 @@ RSpec.describe "creating and delivering digests", type: :request do
     BODY
   end
 
-  def second_expected_weekly_email_body(subscription)
+  def second_expected_weekly_email_body(subscription, content_change_one, content_change_two)
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path)
+      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'weekly')})
 
       Description one
 
@@ -295,7 +296,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path)
+      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'weekly')})
 
       Description two
 
@@ -413,6 +414,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     #TODO retrieve this via the API when we have an endpoint
     subscriptions = Subscription.all
+    content_changes = ContentChange.all
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
@@ -420,7 +422,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => first_expected_weekly_email_body(subscriptions[0], subscriptions[1])
+            "body" => first_expected_weekly_email_body(subscriptions[0], subscriptions[1], content_changes[0], content_changes[1], content_changes[2], content_changes[3])
           )
         )
       )
@@ -432,7 +434,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => second_expected_weekly_email_body(subscriptions[2])
+            "body" => second_expected_weekly_email_body(subscriptions[2], content_changes[0], content_changes[1])
           )
         )
       )

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ContentChangePresenter do
   describe ".call" do
     it "returns a presenter content change" do
       expected = <<~CONTENT_CHANGE
-        [Change title](http://www.dev.gov.uk/government/test-slug)
+        [Change title](http://www.dev.gov.uk/government/test-slug?#{utm_params(content_change.id, 'immediate')})
 
         Test description
 
@@ -37,7 +37,7 @@ RSpec.describe ContentChangePresenter do
 
       it "strips markdown" do
         expected = <<~CONTENT_CHANGE
-          [Change title](http://www.dev.gov.uk/government/test-slug)
+          [Change title](http://www.dev.gov.uk/government/test-slug?#{utm_params(content_change.id, 'immediate')})
 
           more markdown
 
@@ -58,7 +58,7 @@ RSpec.describe ContentChangePresenter do
 
       it "doesn't leave an empty gap" do
         expected = <<~CONTENT_CHANGE
-          [title](http://www.dev.gov.uk/government/base_path)
+          [title](http://www.dev.gov.uk/government/base_path?#{utm_params(content_change.id, 'immediate')})
 
           10:00am, 1 January 2018: change note
         CONTENT_CHANGE
@@ -77,7 +77,7 @@ RSpec.describe ContentChangePresenter do
 
       it "includes the footnote at the bottom" do
         expected = <<~CONTENT_CHANGE
-          [title](http://www.dev.gov.uk/government/base_path)
+          [title](http://www.dev.gov.uk/government/base_path?#{utm_params(content_change.id, 'immediate')})
 
           description
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,3 +37,7 @@ JSON_HEADERS = {
 def data(body = response.body)
   JSON.parse(body).deep_symbolize_keys
 end
+
+def utm_params(content_change_id, frequency)
+  "utm_source=#{content_change_id}&utm_medium=email&utm_campaign=govuk-notifications&utm_content=#{frequency}"
+end


### PR DESCRIPTION
This commit adds the UTM parameters used by Google Analytics to all links in emails sent from the system. This allows anonymous statistics to be collected.

Trello: https://trello.com/c/lO6tqY1H/696-add-tracking-to-links-within-email-alerts