### PR TITLE
Email status indexes

### DIFF
--- a/db/migrate/20180316221116_set_email_statuses.rb
+++ b/db/migrate/20180316221116_set_email_statuses.rb
@@ -1,0 +1,26 @@
+class SetEmailStatuses < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    DeliveryAttempt
+      .where(status: :delivered)
+      .in_batches(of: 10_000)
+      .each_with_index do |batch, index|
+        puts "Processed #{10_000 * index} sent emails"
+        Email.where(id: batch.pluck(:email_id)).update_all(status: :sent)
+        sleep(0.1)
+      end
+
+    DeliveryAttempt
+      .where(status: :permanent_failure)
+      .in_batches(of: 10_000)
+      .each_with_index do |batch, index|
+        puts "Processed #{10_000 * index} failed emails"
+        Email.where(id: batch.pluck(:email_id)).update_all(status: :failed, failure_reason: :permanent_failure)
+        sleep(0.1)
+      end
+
+    pending = Email.where(status: nil).update_all(status: :pending)
+    puts "#{pending} emails marked as pending"
+  end
+end

--- a/db/migrate/20180321125113_add_email_status_indexes.rb
+++ b/db/migrate/20180321125113_add_email_status_indexes.rb
@@ -1,0 +1,9 @@
+class AddEmailStatusIndexes < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :emails, %i[status archived_at], algorithm: :concurrently
+    add_index :emails, :status, algorithm: :concurrently
+    add_index :emails, :failure_reason, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180321104249) do
+ActiveRecord::Schema.define(version: 20180321125113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,7 +98,10 @@ ActiveRecord::Schema.define(version: 20180321104249) do
     t.index ["address"], name: "index_emails_on_address"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["created_at"], name: "index_emails_on_created_at"
+    t.index ["failure_reason"], name: "index_emails_on_failure_reason"
     t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
+    t.index ["status", "archived_at"], name: "index_emails_on_status_and_archived_at"
+    t.index ["status"], name: "index_emails_on_status"
     t.index ["updated_at"], name: "index_emails_on_updated_at"
   end
 


### PR DESCRIPTION
For when https://github.com/alphagov/email-alert-api/pull/551 is deployed and run

This adds indexes for quicker look up of emails via status, failure_reason and status/archive combo.