### PR TITLE
Create an auth token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'foreman', '~> 0.84'
 gem 'gds-api-adapters', '~> 52.4'
 gem 'gds-sso', '~> 13.6'
 gem 'govuk_app_config', '~> 1.4'
+# This is pinned < 2 until gds-sso supports JWT > 2
+gem 'jwt', '~> 1.5'
 gem 'nokogiri', '~> 1.8'
 gem 'notifications-ruby-client', '~> 2.6'
 gem 'plek', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,7 @@ DEPENDENCIES
   govuk-lint (~> 3.7)
   govuk_app_config (~> 1.4)
   govuk_sidekiq (~> 3.0)
+  jwt (~> 1.5)
   listen (= 3.1.5)
   nokogiri (~> 1.8)
   notifications-ruby-client (~> 2.6)

--- a/README.md
+++ b/README.md
@@ -282,6 +282,20 @@ new frequency.
 
 * `POST /unsubscribe/xxx` - unsubscribes a subscriber from the provided subscription and returns `204 No Content`.
 
+* `POST /subscribers/auth-token` with data:
+
+```json
+{
+  "address": "test@example.com",
+  "destination": "/authentication-page-on-govuk",
+  "redirect": "/page-user-wanted-on-govuk",
+}
+```
+
+This will trigger an email to the address specified with a link to the
+destination with a query string of token and a [JWT](https://jwt.io/) token.
+Returns a 201 status code on success.
+
 #### healthcheck API
 
 A queue health check endpoint is available at `/healthcheck`.

--- a/app/builders/auth_email_builder.rb
+++ b/app/builders/auth_email_builder.rb
@@ -1,0 +1,45 @@
+class AuthEmailBuilder
+  def initialize(subscriber:, destination:, token:)
+    @subscriber = subscriber
+    @destination = destination
+    @token = token
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    Email.create!(
+      subject: subject,
+      body: body,
+      address: subscriber.address,
+      subscriber_id: subscriber.id,
+    )
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscriber, :destination, :token
+
+  def subject
+    # @TODO make this better
+    "Log into your Subsciption Management"
+  end
+
+  def body
+    # @TODO make this better as well
+    <<-BODY
+      [Subscription Management](#{link})
+    BODY
+  end
+
+  def link
+    Plek.new.website_uri.tap do |uri|
+      uri.path = destination
+      uri.query = "token=#{token}"
+    end
+  end
+end

--- a/app/builders/auth_email_builder.rb
+++ b/app/builders/auth_email_builder.rb
@@ -25,14 +25,22 @@ private
   attr_reader :subscriber, :destination, :token
 
   def subject
-    # @TODO make this better
-    "Log into your Subsciption Management"
+    "Confirm your email address"
   end
 
   def body
-    # @TODO make this better as well
-    <<-BODY
-      [Subscription Management](#{link})
+    <<~BODY
+      # Click the link to confirm your email address
+
+      ^ [Confirm your email address](#{link})
+
+      We need to check that #{subscriber.address} is your email address so that you can manage your GOV.UK email subscriptions. This link will stop working in 7 days.
+
+      # Didn’t request this email?
+
+      Ignore or delete this email if you didn’t request it. Your subscriptions won’t be changed.
+
+      [Contact us](https://www.gov.uk/contact/govuk) if you have problems with your GOV.UK email subscription.
     BODY
   end
 

--- a/app/builders/auth_email_builder.rb
+++ b/app/builders/auth_email_builder.rb
@@ -38,8 +38,14 @@ private
 
   def link
     Plek.new.website_uri.tap do |uri|
-      uri.path = destination
-      uri.query = "token=#{token}"
+      destination_uri = URI.parse(destination)
+      uri.path = destination_uri.path
+      uri.query = if destination_uri.query.present?
+                    "#{destination_uri.query}&token=#{token}"
+                  else
+                    "token=#{token}"
+                  end
+      uri.fragment = destination_uri.fragment
     end
   end
 end

--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -1,5 +1,5 @@
 class SubscribersAuthTokenController < ApplicationController
-  # @TODO - there is no validation here
+  before_action :validate_params
 
   def auth_token
     subscriber = find_or_create_subscriber(expected_params.require(:address))
@@ -41,5 +41,20 @@ private
 
   def expected_params
     params.permit(:address, :destination, :redirect)
+  end
+
+  def validate_params
+    ParamsValidator.new(expected_params).validate!
+  end
+
+  class ParamsValidator < OpenStruct
+    include ActiveModel::Validations
+
+    validates :address, presence: true
+    validates :address, email_address: true, allow_blank: true
+
+    validates :destination, presence: true
+    validates :destination, absolute_path: true, allow_blank: true
+    validates :redirect, absolute_path: true, allow_blank: true
   end
 end

--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -1,0 +1,45 @@
+class SubscribersAuthTokenController < ApplicationController
+  # @TODO - there is no validation here
+
+  def auth_token
+    subscriber = find_or_create_subscriber(expected_params.require(:address))
+    token = generate_token(subscriber)
+    email = build_email(subscriber, token)
+
+    DeliveryRequestWorker
+      .perform_async_in_queue(email.id, queue: :delivery_immediate_high)
+
+    render json: { subscriber: subscriber }, status: :created
+  end
+
+private
+
+  def find_or_create_subscriber(address)
+    found = Subscriber.find_by_address(address)
+    found.activate! if found&.deactivated?
+    found || Subscriber.create!(
+      address: address,
+      signon_user_uid: current_user.uid,
+    )
+  end
+
+  def generate_token(subscriber)
+    AuthTokenGeneratorService.call(
+      subscriber,
+      redirect: expected_params[:redirect],
+      expiry: 1.week.from_now
+    )
+  end
+
+  def build_email(subscriber, token)
+    AuthEmailBuilder.call(
+      subscriber: subscriber,
+      destination: expected_params.require(:destination),
+      token: token,
+    )
+  end
+
+  def expected_params
+    params.permit(:address, :destination, :redirect)
+  end
+end

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,6 +1,6 @@
 class Subscriber < ApplicationRecord
   with_options allow_nil: true do
-    validates_with EmailAddressValidator, fields: [:address]
+    validates :address, email_address: true
     validates_uniqueness_of :address, case_sensitive: false
   end
 

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -58,6 +58,11 @@ class Subscriber < ApplicationRecord
     update!(address: nil)
   end
 
+  def as_json(options = {})
+    options[:except] ||= %i(signon_user_uid)
+    super(options)
+  end
+
 private
 
   def not_nullified_and_activated

--- a/app/services/auth_token_generator_service.rb
+++ b/app/services/auth_token_generator_service.rb
@@ -1,0 +1,18 @@
+class AuthTokenGeneratorService
+  def self.call(subscriber)
+    new.call(subscriber)
+  end
+
+  def call(subscriber)
+    data = { "data" => { "subscriber_id" => subscriber.id } }
+    JWT.encode(data, secret, "HS256")
+  end
+
+  private_class_method :new
+
+private
+
+  def secret
+    Rails.application.secrets.email_alert_auth_token
+  end
+end

--- a/app/services/auth_token_generator_service.rb
+++ b/app/services/auth_token_generator_service.rb
@@ -1,16 +1,28 @@
 class AuthTokenGeneratorService
-  def self.call(subscriber)
-    new.call(subscriber)
+  def self.call(*args)
+    new.call(*args)
   end
 
-  def call(subscriber)
-    data = { "data" => { "subscriber_id" => subscriber.id } }
+  def call(subscriber, redirect: nil, expiry: 1.week.from_now)
+    data = token_data(subscriber, redirect, expiry)
     JWT.encode(data, secret, "HS256")
   end
 
   private_class_method :new
 
 private
+
+  def token_data(subscriber, redirect, expiry)
+    {
+      "data" => {
+        "subscriber_id" => subscriber.id,
+        "redirect" => redirect,
+      },
+      "exp" => expiry.to_i,
+      "iat" => Time.now.to_i,
+      "iss" => "https://www.gov.uk",
+    }
+  end
 
   def secret
     Rails.application.secrets.email_alert_auth_token

--- a/app/validators/absolute_path_validator.rb
+++ b/app/validators/absolute_path_validator.rb
@@ -1,0 +1,16 @@
+class AbsolutePathValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless valid_path?(value)
+      record.errors.add(attribute, "must be an absolute path")
+    end
+  end
+
+private
+
+  def valid_path?(path)
+    parsed = URI.parse(path)
+    parsed.relative? && path[0] == "/"
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,8 +1,7 @@
-class EmailAddressValidator < ActiveModel::Validator
-  def validate(record)
-    email_address = record.address
-    unless email_address.nil? || valid_email_address?(email_address)
-      record.errors.add(:address, 'is not an email address')
+class EmailAddressValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if !value.nil? && !valid_email_address?(value)
+      record.errors.add(attribute, 'is not an email address')
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,10 @@ module EmailAlertAPI
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.eager_load_paths << Rails.root.join('lib')
+
+    unless Rails.application.secrets.email_alert_auth_token
+      raise "Email Alert Auth Token is not configured. See config/secrets.yml"
+    end
   end
 
   cattr_accessor :config

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,9 @@ module EmailAlertAPI
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-    config.eager_load_paths << Rails.root.join('lib')
+    config.eager_load_paths << Rails.root.join("lib")
+
+    config.action_dispatch.rescue_responses["ActiveModel::ValidationError"] = :unprocessable_entity
 
     unless Rails.application.secrets.email_alert_auth_token
       raise "Email Alert Auth Token is not configured. See config/secrets.yml"
@@ -31,5 +33,5 @@ module EmailAlertAPI
   cattr_accessor :config
 end
 
-require_relative '../lib/email_alert_api/config'
+require_relative "../lib/email_alert_api/config"
 EmailAlertAPI.config = EmailAlertAPI::Config.new(Rails.env)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     patch "/subscribers/:id", to: "subscribers#change_address"
     delete "/subscribers/:id", to: "unsubscribe#unsubscribe_all"
     get "/subscribers/:id/subscriptions", to: "subscribers#subscriptions"
+    post "/subscribers/auth-token", to: "subscribers_auth_token#auth_token"
 
     get "/healthcheck", to: "healthcheck#check"
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -21,9 +21,11 @@
 
 development:
   secret_key_base: 68c093e39d8ac8ecbaca8cc09dc573c3fd7d6942a9cd1a88474c50f028cb85f653a2d2d7c0579da6e172519518e77fc557d5dca7920bae925a6e2e8f3ad7c514
+  email_alert_auth_token: b132e4dde18854890516866be3ef3a2885addd6a47fc1d6173f3069290b6753ec28ccbe9dee580837f9027be18b36f8983dc03d1230e4d23818049b1777c8a2b
 
 test:
   secret_key_base: 8bcfe54ee0999f12fc3a57eb369fc010788e3e4335ea8a7d85dea34859265260b9bfdce6bc92296c2e8d4af1ca534276759b14de510de9347b67b0b1c8532bee
+  email_alert_auth_token: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
 
 # Do not keep production secrets in the unencrypted secrets file.
 # Instead, either read values from the environment.
@@ -32,3 +34,4 @@ test:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  email_alert_auth_token: <%= ENV["EMAIL_ALERT_AUTH_TOKEN"] %>

--- a/spec/builders/auth_email_builder_spec.rb
+++ b/spec/builders/auth_email_builder_spec.rb
@@ -23,5 +23,15 @@ RSpec.describe AuthEmailBuilder do
       email = call
       expect(email.body).to include(link)
     end
+
+    context "when destination has a query string and fragment" do
+      let(:destination) { "/destination?query#fragment" }
+
+      it "merges the token" do
+        link = "http://www.dev.gov.uk/destination?query&token=secret#fragment"
+        email = call
+        expect(email.body).to include(link)
+      end
+    end
   end
 end

--- a/spec/builders/auth_email_builder_spec.rb
+++ b/spec/builders/auth_email_builder_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe AuthEmailBuilder do
+  describe ".call" do
+    let(:subscriber) { create(:subscriber) }
+    let(:destination) { "/destination" }
+    let(:token) { "secret" }
+
+    subject(:call) do
+      described_class.call(
+        subscriber: subscriber,
+        destination: destination,
+        token: token,
+      )
+    end
+
+    it { is_expected.to be_instance_of(Email) }
+
+    it "creates an email" do
+      expect { call }.to change(Email, :count).by(1)
+    end
+
+    it "has a link to authenticate" do
+      link = "http://www.dev.gov.uk/destination?token=secret"
+      email = call
+      expect(email.body).to include(link)
+    end
+  end
+end

--- a/spec/features/create_an_auth_token_spec.rb
+++ b/spec/features/create_an_auth_token_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Create an auth token", type: :request do
         "body" => hash_including(
           "email_address" => subscriber.address,
           "personalisation" => hash_including(
-            "subject" => "Log into your Subsciption Management",
+            "subject" => "Confirm your email address",
             "body" => include(sign_in_link),
           )
         )

--- a/spec/features/create_an_auth_token_spec.rb
+++ b/spec/features/create_an_auth_token_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe "Create an auth token", type: :request do
+  before do
+    allow_any_instance_of(DeliveryRequestService)
+      .to receive(:provider_name).and_return("notify")
+
+    stub_notify
+  end
+
+  around do |example|
+    Timecop.freeze do
+      Sidekiq::Testing.inline! { example.run }
+    end
+  end
+
+  let(:address) { "test@example.com" }
+  let!(:subscriber) { create(:subscriber, address: address) }
+  let(:destination) { "/authenticate" }
+  let(:redirect) { "/logged-in-page" }
+
+  scenario "successful auth token" do
+    login_with_internal_app
+
+    post "/subscribers/auth-token", params: {
+      address: address,
+      destination: destination,
+      redirect: redirect,
+    }
+
+    notify_email_stub = notify_email(subscriber, destination, redirect)
+    expect(response.status).to be 201
+    expect(notify_email_stub).to have_been_requested
+  end
+
+  def notify_email(subscriber, destination, redirect)
+    sign_in_link = generate_sign_in_link(subscriber, destination, redirect)
+
+    stub_request(:post, "http://fake-notify.com/v2/notifications/email")
+      .with(
+        "body" => hash_including(
+          "email_address" => subscriber.address,
+          "personalisation" => hash_including(
+            "subject" => "Log into your Subsciption Management",
+            "body" => include(sign_in_link),
+          )
+        )
+      )
+      .to_return(body: {}.to_json)
+  end
+
+  def generate_sign_in_link(subscriber, destination, redirect)
+    token = generate_token(subscriber, redirect)
+    "http://www.dev.gov.uk#{destination}?token=#{token}"
+  end
+
+  def generate_token(subscriber, redirect)
+    data = {
+      "data" => {
+        "subscriber_id" => subscriber.id,
+        "redirect" => redirect,
+      },
+      "exp" => 1.week.from_now.to_i,
+      "iat" => Time.now.to_i,
+      "iss" => "https://www.gov.uk",
+    }
+    secret = Rails.application.secrets.email_alert_auth_token
+    JWT.encode(data, secret, "HS256")
+  end
+end

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -4,10 +4,13 @@ RSpec.describe "Subscribers auth token", type: :request do
   describe "creating an auth token" do
     let(:path) { "/subscribers/auth-token" }
     let(:address) { "test@example.com" }
+    let(:destination) { "/test" }
+    let(:redirect) { nil }
     let(:params) do
       {
         address: address,
-        destination: "/test",
+        destination: destination,
+        redirect: redirect,
       }
     end
 
@@ -50,8 +53,54 @@ RSpec.describe "Subscribers auth token", type: :request do
     end
 
     context "when we're provided with a bad email address" do
+      let(:address) { "bad-address" }
+
       it "returns a 422" do
-        pending("validation")
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context "when we're provided with no email address" do
+      let(:address) { nil }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context "when we're not given a destination" do
+      let(:destination) { nil }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context "when we're given a bad destination" do
+      let(:destination) { "http://example.com/test" }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context "when we're given a path redirect" do
+      let(:redirect) { "/test" }
+
+      it "returns a 201" do
+        post path, params: params
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "when we're given a bad redirect" do
+      let(:redirect) { "http://example.com/test" }
+
+      it "returns a 422" do
         post path, params: params
         expect(response.status).to eq(422)
       end

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe "Subscribers auth token", type: :request do
+  before { login_with_internal_app }
+
+  describe "creating an auth token" do
+    let(:path) { "/subscribers/auth-token" }
+    let(:address) { "test@example.com" }
+    let(:params) do
+      {
+        address: address,
+        destination: "/test",
+      }
+    end
+
+    it "returns 201" do
+      post path, params: params
+      expect(response.status).to eq(201)
+    end
+
+    it "sends an email" do
+      expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+      post path, params: params
+    end
+
+    context "when we have an existing user" do
+      let!(:subscriber) { create(:subscriber, address: address) }
+
+      it "returns subscriber details" do
+        post path, params: params
+        expect(data[:subscriber][:id]).to eq(subscriber.id)
+      end
+    end
+
+    context "when we user we didn't previously know" do
+      it "creates the new user" do
+        expect { post path, params: params }
+          .to change { Subscriber.count }
+          .by(1)
+      end
+    end
+
+    context "when we have a deactivated user" do
+      let!(:subscriber) { create(:subscriber, :deactivated, address: address) }
+
+      it "re-activates the subscriber" do
+        expect { post path, params: params }
+          .to change { subscriber.reload.activated? }
+          .from(false)
+          .to(true)
+      end
+    end
+
+    context "when we're provided with a bad email address" do
+      it "returns a 422" do
+        pending("validation")
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/services/auth_token_generator_service_spec.rb
+++ b/spec/services/auth_token_generator_service_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe AuthTokenGeneratorService do
+  describe ".call" do
+    let(:subscriber) { create(:subscriber) }
+    let(:secret) { Rails.application.secrets.email_alert_auth_token }
+    let(:algorithim) { "HS256" }
+
+    subject(:token) { described_class.call(subscriber) }
+
+    it { is_expected.to be_a(String) }
+
+    it "can be decoded to include a subscriber_id" do
+      decoded = JWT.decode(token, secret, true, algorithim: algorithim)
+      expect(decoded).to match(
+        a_hash_including(
+          "data" => { "subscriber_id" => subscriber.id }
+        )
+      )
+    end
+  end
+end

--- a/spec/validators/absolute_path_validator_spec.rb
+++ b/spec/validators/absolute_path_validator_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe AbsolutePathValidator do
+  class AbsolutePathValidatable
+    include ActiveModel::Validations
+    include ActiveModel::Model
+
+    attr_accessor :path
+    validates :path, absolute_path: true
+  end
+
+  subject(:model) { AbsolutePathValidatable.new }
+
+  context "when an absolute path is provided" do
+    before { model.path = "/test" }
+    it { is_expected.to be_valid }
+  end
+
+  context "when a relative path is provided" do
+    before { model.path = "test" }
+
+    it "has an error" do
+      expect(model.valid?).to be false
+      expect(model.errors[:path]).to match(["must be an absolute path"])
+    end
+  end
+
+  context "when an invalid URI is provided" do
+    before { model.path = "bad URI" }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when a full url is provided" do
+    before { model.path = "https://example.com/test" }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when a path with query string is provided" do
+    before { model.path = "/test?test=this" }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when a path with a fragment is provided" do
+    before { model.path = "/test#fragment" }
+
+    it { is_expected.to be_valid }
+  end
+end

--- a/spec/validators/email_address_validator_spec.rb
+++ b/spec/validators/email_address_validator_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe EmailAddressValidator do
+  class EmailAddressValidatable
+    include ActiveModel::Validations
+    include ActiveModel::Model
+
+    attr_accessor :email
+    validates :email, email_address: true
+  end
+
+  subject(:model) { EmailAddressValidatable.new }
+
+  context "when a valid email is provided" do
+    before { model.email = "test@example.com" }
+    it { is_expected.to be_valid }
+  end
+
+  context "when an invalid email is provided" do
+    before { model.email = "bad email" }
+
+    it "has an error" do
+      expect(model.valid?).to be false
+      expect(model.errors[:email]).to match(["is not an email address"])
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/6YmlH3Mq/725-add-token-based-login-for-the-subscription-management-interface-to-email-alert-frontend

This adds an endpoint which can be posted to and will create a token that is encrypted with a shared secret containing the subscribers id. This can then be decrypted by Email Alert Frontend to authenticate the user.

The token is sent to a user via an email.