### PR TITLE
Change subscription management endpoints to use IDs

### DIFF
--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -17,18 +17,18 @@ class SubscribersController < ApplicationController
 private
 
   def subscriber
-    @subscriber ||= Subscriber.find_by!("LOWER(address) = ?", address.downcase)
+    @subscriber ||= Subscriber.find(id)
   end
 
   def new_address
     subscriber_params.require(:new_address)
   end
 
-  def address
-    subscriber_params.require(:address)
+  def id
+    subscriber_params.require(:id)
   end
 
   def subscriber_params
-    params.permit(:address, :new_address)
+    params.permit(:id, :new_address)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,12 +9,10 @@ Rails.application.routes.draw do
     resources :status_updates, path: "status-updates", only: %i[create]
     resources :subscriptions, only: %i[create show update]
 
-    get "/healthcheck", to: "healthcheck#check"
+    patch "/subscribers/:id", to: "subscribers#change_address"
+    get "/subscribers/:id/subscriptions", to: "subscribers#subscriptions"
 
-    constraints address: /.+@.+\..+/ do
-      patch "/subscribers/:address", to: "subscribers#change_address"
-      get "/subscribers/:address/subscriptions", to: "subscribers#subscriptions"
-    end
+    get "/healthcheck", to: "healthcheck#check"
 
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
   end

--- a/spec/integration/subscribers_spec.rb
+++ b/spec/integration/subscribers_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe "Subscriptions", type: :request do
         let!(:subscription_3) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list_3, frequency: :daily) }
 
         it "lists all active subscriptions" do
-          get "/subscribers/#{subscriber.address}/subscriptions"
+          get "/subscribers/#{subscriber.id}/subscriptions"
           expect(data[:subscriptions].length).to eq(2)
         end
 
         it "does not list any ended subscriptions" do
-          get "/subscribers/#{subscriber.address}/subscriptions"
+          get "/subscribers/#{subscriber.id}/subscriptions"
           ended_subscription = data[:subscriptions].detect { |s| s[:id] == subscription_2.id }
           expect(ended_subscription).to be_nil
         end
@@ -28,7 +28,7 @@ RSpec.describe "Subscriptions", type: :request do
 
       context "without an existing subscriber" do
         it "returns status code 404" do
-          get "/subscribers/doesnotexist@example.com/subscriptions"
+          get "/subscribers/x12345/subscriptions"
           expect(response.status).to eq(404)
         end
       end
@@ -39,20 +39,20 @@ RSpec.describe "Subscriptions", type: :request do
         let!(:subscriber) { create(:subscriber) }
 
         it "changes the email address if the new email address is valid" do
-          patch "/subscribers/#{subscriber.address}", params: { new_address: "new-test@example.com" }
+          patch "/subscribers/#{subscriber.id}", params: { new_address: "new-test@example.com" }
           expect(response.status).to eq(200)
           expect(data[:subscriber][:address]).to eq("new-test@example.com")
         end
 
         it "returns an error message if the new email address is invalid" do
-          patch "/subscribers/#{subscriber.address}", params: { new_address: "invalid" }
+          patch "/subscribers/#{subscriber.id}", params: { new_address: "invalid" }
           expect(response.status).to eq(422)
         end
       end
 
       context "without an existing subscriber" do
         it "returns a 404" do
-          patch "/subscribers/doesnotexist@example.com", params: { new_address: "new-doesnotexist@example.com" }
+          patch "/subscribers/x12345", params: { new_address: "new-doesnotexist@example.com" }
           expect(response.status).to eq(404)
         end
       end
@@ -61,7 +61,7 @@ RSpec.describe "Subscriptions", type: :request do
 
   context "without authentication" do
     it "returns a 403" do
-      get "/subscribers/test@example.com/subscriptions"
+      get "/subscribers/1/subscriptions"
       expect(response.status).to eq(403)
     end
   end
@@ -69,7 +69,7 @@ RSpec.describe "Subscriptions", type: :request do
   context "without authorisation" do
     it "returns a 403" do
       login_with_signin
-      get "/subscribers/test@example.com/subscriptions"
+      get "/subscribers/1/subscriptions"
       expect(response.status).to eq(403)
     end
   end


### PR DESCRIPTION
This commit changes the two endpoints created for email-alert-frontend to accept a subscriber ID rather than an email address since we’ll be using the ID as an email address can change. The endpoints are not currently in use so they can be changed.