### PR TITLE
Add API endpoint to unsubscribe a subscriber completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The following fields are accepted on this endpoint: `subject`, `from_address_id`
 `document_type`, `content_id`, `public_updated_at`, `publishing_app`, `email_document_supertype`,
 `government_document_supertype`, `title`, `description`, `change_note`, `base_path`, `priority` and `footnote`.
 
-* `GET /subscribers/test@example.com/subscriptions` - gets a subscriber's subscriptions, in the form:
+* `GET /subscribers/xxx/subscriptions` - gets a subscriber's subscriptions, in the form:
 
 ```json
 {
@@ -243,7 +243,7 @@ The following fields are accepted on this endpoint: `subject`, `from_address_id`
 }
 ```
 
-* `PATCH /subscribers/test@example.com` with data:
+* `PATCH /subscribers/xxx` with data:
 
 ```json
 {
@@ -253,6 +253,8 @@ The following fields are accepted on this endpoint: `subject`, `from_address_id`
 
 and it will respond with the details of the subscriber including the
 new email address.
+
+* `DELETE /subscribers/xxx` - unsubscribes a provided subscriber and returns `204 No Content`.
 
 * `POST /subscriptions` with data:
 
@@ -277,6 +279,8 @@ subscription or a `200 OK` if the subscription already exists.
 
 and it will respond with the details of the subscription including the
 new frequency.
+
+* `POST /unsubscribe/xxx` - unsubscribes a subscriber from the provided subscription and returns `204 No Content`.
 
 #### healthcheck API
 

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -3,10 +3,18 @@ class UnsubscribeController < ApplicationController
     UnsubscribeService.subscription!(subscription, :unsubscribed)
   end
 
+  def unsubscribe_all
+    UnsubscribeService.subscriber!(subscriber, :unsubscribed)
+  end
+
 private
 
   def subscription
     Subscription.active.find(id)
+  end
+
+  def subscriber
+    Subscriber.activated.find(id)
   end
 
   def id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     resources :subscriptions, only: %i[create show update]
 
     patch "/subscribers/:id", to: "subscribers#change_address"
+    delete "/subscribers/:id", to: "unsubscribe#unsubscribe_all"
     get "/subscribers/:id/subscriptions", to: "subscribers#subscriptions"
 
     get "/healthcheck", to: "healthcheck#check"

--- a/spec/integration/subscribers_spec.rb
+++ b/spec/integration/subscribers_spec.rb
@@ -57,6 +57,39 @@ RSpec.describe "Subscriptions", type: :request do
         end
       end
     end
+
+    context "when unsubscribing a subscriber from everything" do
+      context "when the subscriber exists" do
+        let!(:subscriber) { create(:subscriber) }
+        let(:subscription) { create(:subscription, subscriber: subscriber) }
+
+        before do
+          delete "/subscribers/#{subscriber.id}"
+        end
+
+        it "deletes the subscription" do
+          expect(Subscription.active.count).to eq(0)
+        end
+
+        it "deactivates the subscriber" do
+          expect(Subscriber.activated.count).to eq(0)
+        end
+
+        it "responds with a 204 status" do
+          expect(response.status).to eq(204)
+        end
+      end
+
+      context "when the subscriber doesn't exist" do
+        before do
+          delete "/subscribers/123"
+        end
+
+        it "responds with a 404 status" do
+          expect(response.status).to eq(404)
+        end
+      end
+    end
   end
 
   context "without authentication" do

--- a/spec/integration/unsubscribe_spec.rb
+++ b/spec/integration/unsubscribe_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Unsubscribing", type: :request do
           expect(Subscription.active.count).to eq(0)
         end
 
-        it "responds with a 200 status" do
+        it "responds with a 204 status" do
           expect(response.status).to eq(204)
         end
       end


### PR DESCRIPTION
This commit adds an API endpoint at `DELETE /subscribers/:subscriber_id` that unsubscribes a subscriber from all their subscriptions and marks their account as deactivated.