### PR TITLE
Add subscription management links to emails

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -46,8 +46,9 @@ private
   def spam_prevention_survey_links
     <<~BODY
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-
-      &nbsp;
+      [View and manage your subscriptions](/magic-manage-link)
+      
+      \u00A0
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -48,7 +48,7 @@ private
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
       #{presented_manage_subscriptions_links}
 
-      \u00A0
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -89,6 +89,6 @@ private
   end
 
   def presented_manage_subscriptions_links
-    ManageSubscriptionsLinkPresenter.call(subscriber_id: subscriber.id)
+    ManageSubscriptionsLinkPresenter.call(address: subscriber.address)
   end
 end

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -46,8 +46,8 @@ private
   def spam_prevention_survey_links
     <<~BODY
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](/magic-manage-link)
-      
+      #{presented_manage_subscriptions_links}
+
       \u00A0
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
@@ -86,5 +86,9 @@ private
       id: result.subscription_id,
       title: result.subscriber_list_title
     )
+  end
+
+  def presented_manage_subscriptions_links
+    ManageSubscriptionsLinkPresenter.call(subscriber_id: subscriber.id)
   end
 end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -43,11 +43,12 @@ private
       <<~BODY
         #{presented_content_change(content_change)}
         ---
-        You’re getting this email because you subscribed to #{subscriptions.first.subscriber_list.title} updates on GOV.UK.
+        You’re getting this email because you subscribed to ‛#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
 
         #{presented_unsubscribe_links(subscriptions)}
+        [View and manage your subscriptions](/magic-manage-link)
 
-        &nbsp;
+        \u00A0
 
         ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
       BODY

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -46,7 +46,7 @@ private
         You’re getting this email because you subscribed to ‛#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
 
         #{presented_unsubscribe_links(subscriptions)}
-        [View and manage your subscriptions](/magic-manage-link)
+        #{presented_manage_subscriptions_links}
 
         \u00A0
 
@@ -57,6 +57,13 @@ private
 
   def presented_content_change(content_change)
     ContentChangePresenter.call(content_change, frequency: "immediate")
+  end
+
+  def presented_manage_subscriptions_links
+    address = recipients_and_content.map do |recipient_and_content|
+      recipient_and_content.fetch(:subscriber_id)
+    end.join
+    ManageSubscriptionsLinkPresenter.call(subscriber_id: subscriber_id)
   end
 
   def presented_unsubscribe_links(subscriptions)

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -20,9 +20,9 @@ private
   def records
     recipients_and_content.map do |recipient_and_content|
       [
-        recipient_and_content.fetch(:address),
+        address = recipient_and_content.fetch(:address),
         subject(recipient_and_content.fetch(:content_change)),
-        body(recipient_and_content.fetch(:content_change), recipient_and_content.fetch(:subscriptions)),
+        body(recipient_and_content.fetch(:content_change), recipient_and_content.fetch(:subscriptions), address),
         recipient_and_content.fetch(:subscriber_id),
       ]
     end
@@ -36,19 +36,19 @@ private
     "GOV.UK update – #{content_change.title}"
   end
 
-  def body(content_change, subscriptions)
+  def body(content_change, subscriptions, address)
     if Array(subscriptions).empty?
       presented_content_change(content_change)
     else
       <<~BODY
         #{presented_content_change(content_change)}
         ---
-        You’re getting this email because you subscribed to ‛#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
+        You’re getting this email because you subscribed to ‘#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
 
         #{presented_unsubscribe_links(subscriptions)}
-        #{presented_manage_subscriptions_links}
+        #{presented_manage_subscriptions_links(address)}
 
-        \u00A0
+        &nbsp;
 
         ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
       BODY
@@ -59,11 +59,8 @@ private
     ContentChangePresenter.call(content_change, frequency: "immediate")
   end
 
-  def presented_manage_subscriptions_links
-    address = recipients_and_content.map do |recipient_and_content|
-      recipient_and_content.fetch(:subscriber_id)
-    end.join
-    ManageSubscriptionsLinkPresenter.call(subscriber_id: subscriber_id)
+  def presented_manage_subscriptions_links(address)
+    ManageSubscriptionsLinkPresenter.call(address: address)
   end
 
   def presented_unsubscribe_links(subscriptions)

--- a/app/presenters/manage_subscriptions_link_presenter.rb
+++ b/app/presenters/manage_subscriptions_link_presenter.rb
@@ -1,0 +1,24 @@
+class ManageSubscriptionsLinkPresenter
+  def initialize(subscriber_id:)
+    @subscriber_id = subscriber_id
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    "[View and manage your subscriptions](#{url})"
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscriber_id
+
+  def url
+    base_path = "/email/authentication?id=#{subscriber_id}"
+    PublicUrlService.url_for(base_path: base_path)
+  end
+end

--- a/app/presenters/manage_subscriptions_link_presenter.rb
+++ b/app/presenters/manage_subscriptions_link_presenter.rb
@@ -1,6 +1,6 @@
 class ManageSubscriptionsLinkPresenter
-  def initialize(subscriber_id:)
-    @subscriber_id = subscriber_id
+  def initialize(address:)
+    @address = address
   end
 
   def self.call(*args)
@@ -15,10 +15,10 @@ class ManageSubscriptionsLinkPresenter
 
 private
 
-  attr_reader :subscriber_id
+  attr_reader :address
 
   def url
-    base_path = "/email/authentication?id=#{subscriber_id}"
+    base_path = "/email/authenticate?address=#{address}"
     PublicUrlService.url_for(base_path: base_path)
   end
 end

--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -9,7 +9,7 @@ class UnsubscribeLinkPresenter
   end
 
   def call
-    "Unsubscribe from [#{title}](#{url})"
+    "[Unsubscribe from ‛#{title}’](#{url})"
   end
 
   private_class_method :new

--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -9,7 +9,7 @@ class UnsubscribeLinkPresenter
   end
 
   def call
-    "[Unsubscribe from ‛#{title}’](#{url})"
+    "[Unsubscribe from ‘#{title}’](#{url})"
   end
 
   private_class_method :new

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -104,8 +104,9 @@ RSpec.describe DigestEmailBuilder do
         unsubscribe_link_2
 
         You’re getting this email because you subscribed to these topic updates on GOV.UK.
+        [View and manage your subscriptions](/magic-manage-link)
 
-        &nbsp;
+        \u00A0
 
         ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
       BODY

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -104,9 +104,9 @@ RSpec.describe DigestEmailBuilder do
         unsubscribe_link_2
 
         You’re getting this email because you subscribed to these topic updates on GOV.UK.
-        [View and manage your subscriptions](/magic-manage-link)
+        [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-3@example.com)
 
-        \u00A0
+        &nbsp;
 
         ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
       BODY

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -114,8 +114,9 @@ RSpec.describe ImmediateEmailBuilder do
             You’re getting this email because you subscribed to #{subscriptions.first.subscriber_list.title} updates on GOV.UK.
 
             unsubscribe_link
+            [View and manage your subscriptions](/magic-manage-link)
 
-            &nbsp;
+            \u00A0
 
             ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
           BODY

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe ImmediateEmailBuilder do
             presented_content_change
 
             ---
-            You’re getting this email because you subscribed to #{subscriptions.first.subscriber_list.title} updates on GOV.UK.
+            You’re getting this email because you subscribed to ‘#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
 
             unsubscribe_link
-            [View and manage your subscriptions](/magic-manage-link)
+            [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test@example.com)
 
-            \u00A0
+            &nbsp;
 
             ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
           BODY

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
 
       &nbsp;
 
@@ -56,11 +56,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      [Unsubscribe from Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
+      [View and manage your subscriptions](/magic-manage-link)
 
-      &nbsp;
+      \u00A0
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -86,11 +87,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
+      [View and manage your subscriptions](/magic-manage-link)
 
-      &nbsp;
+      \u00A0
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -252,9 +254,9 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
 
-      &nbsp;
+      \u00A0
 
       #Subscriber list two&nbsp;
 
@@ -274,11 +276,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      [Unsubscribe from Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
+      [View and manage your subscriptions](/magic-manage-link)
 
-      &nbsp;
+      \u00A0
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -304,11 +307,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      Unsubscribe from [Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
+      [View and manage your subscriptions](/magic-manage-link)
 
-      &nbsp;
+      \u00A0
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     Timecop.return
   end
 
-  def first_expected_daily_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four)
+  def first_expected_daily_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four, subscriber)
     <<~BODY
       #Subscriber list one&nbsp;
 
@@ -34,7 +34,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
 
       &nbsp;
 
@@ -56,18 +56,18 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](/magic-manage-link)
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
 
-      \u00A0
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
-  def second_expected_daily_email_body(subscription, content_change_one, content_change_two)
+  def second_expected_daily_email_body(subscription, content_change_one, content_change_two, subscriber)
     <<~BODY
       #Subscriber list one&nbsp;
 
@@ -87,12 +87,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](/magic-manage-link)
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
 
-      \u00A0
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -202,6 +202,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     #TODO retrieve this via the API when we have an endpoint
     subscriptions = Subscription.all
     content_changes = ContentChange.all
+    subscribers = Subscriber.all
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
@@ -209,7 +210,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => first_expected_daily_email_body(subscriptions[0], subscriptions[1], content_changes[0], content_changes[1], content_changes[2], content_changes[3])
+            "body" => first_expected_daily_email_body(subscriptions[0], subscriptions[1], content_changes[0], content_changes[1], content_changes[2], content_changes[3], subscribers[0])
           )
         )
       )
@@ -221,7 +222,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => second_expected_daily_email_body(subscriptions[2], content_changes[0], content_changes[1])
+            "body" => second_expected_daily_email_body(subscriptions[2], content_changes[0], content_changes[1], subscribers[1])
           )
         )
       )
@@ -234,7 +235,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     expect(second_digest_stub).to have_been_requested
   end
 
-  def first_expected_weekly_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four)
+  def first_expected_weekly_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four, subscriber)
     <<~BODY
       #Subscriber list one&nbsp;
 
@@ -254,9 +255,9 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
 
-      \u00A0
+      &nbsp;
 
       #Subscriber list two&nbsp;
 
@@ -276,18 +277,18 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from Subscriber list two](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](/magic-manage-link)
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
 
-      \u00A0
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
-  def second_expected_weekly_email_body(subscription, content_change_one, content_change_two)
+  def second_expected_weekly_email_body(subscription, content_change_one, content_change_two, subscriber)
     <<~BODY
       #Subscriber list one&nbsp;
 
@@ -307,12 +308,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from Subscriber list one](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](/magic-manage-link)
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
 
-      \u00A0
+      &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -419,6 +420,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     #TODO retrieve this via the API when we have an endpoint
     subscriptions = Subscription.all
     content_changes = ContentChange.all
+    subscribers = Subscriber.all
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
@@ -426,7 +428,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => first_expected_weekly_email_body(subscriptions[0], subscriptions[1], content_changes[0], content_changes[1], content_changes[2], content_changes[3])
+            "body" => first_expected_weekly_email_body(subscriptions[0], subscriptions[1], content_changes[0], content_changes[1], content_changes[2], content_changes[3], subscribers[0])
           )
         )
       )
@@ -438,7 +440,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       .with(
         body: hash_including(
           personalisation: hash_including(
-            "body" => second_expected_weekly_email_body(subscriptions[2], content_changes[0], content_changes[1])
+            "body" => second_expected_weekly_email_body(subscriptions[2], content_changes[0], content_changes[1], subscribers[1])
           )
         )
       )

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Sending an email", type: :request do
     expect(body).to include("gov.uk/base-path")
     expect(body).to include("12:00am, 1 January 2017: Change note")
 
-    expect(body).to include("Unsubscribe from [Example]")
+    expect(body).to include("[Unsubscribe from Example]")
     expect(body).to include("gov.uk/email/unsubscribe/")
   end
 end

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "Sending an email", type: :request do
     expect(body).to include("Description")
     expect(body).to include("gov.uk/base-path")
     expect(body).to include("12:00am, 1 January 2017: Change note")
-
-    expect(body).to include("[Unsubscribe from Example]")
+    expect(body).to include("[Unsubscribe from ‘Example’]")
     expect(body).to include("gov.uk/email/unsubscribe/")
   end
 end

--- a/spec/presenters/manage_subscriptions_link_presenter_spec.rb
+++ b/spec/presenters/manage_subscriptions_link_presenter_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe ManageSubscriptionsLinkPresenter do
+  describe ".call" do
+    it "returns a manage subscriptions link" do
+      expected = "[Manage your subscriptions](http://www.dev.gov.uk/email/authentication?id=1)"
+      expect(described_class.call(subscriber_id: 1)).to eq(expected)
+    end
+  end
+end

--- a/spec/presenters/manage_subscriptions_link_presenter_spec.rb
+++ b/spec/presenters/manage_subscriptions_link_presenter_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe ManageSubscriptionsLinkPresenter do
   describe ".call" do
     it "returns a manage subscriptions link" do
-      expected = "[Manage your subscriptions](http://www.dev.gov.uk/email/authentication?id=1)"
-      expect(described_class.call(subscriber_id: 1)).to eq(expected)
+      expected = "[View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-email@test.com)"
+      expect(described_class.call(address: 'test-email@test.com')).to eq(expected)
     end
   end
 end

--- a/spec/presenters/unsubscribe_link_presenter_spec.rb
+++ b/spec/presenters/unsubscribe_link_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UnsubscribeLinkPresenter do
   describe ".call" do
     it "returns a presented unsubscribe link" do
-      expected = "Unsubscribe from [Test title](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
+      expected = "[Unsubscribe from Test title](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
       expect(described_class.call(id: "abc123", title: "Test title")).to eq(expected)
     end
   end

--- a/spec/presenters/unsubscribe_link_presenter_spec.rb
+++ b/spec/presenters/unsubscribe_link_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UnsubscribeLinkPresenter do
   describe ".call" do
     it "returns a presented unsubscribe link" do
-      expected = "[Unsubscribe from Test title](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
+      expected = "[Unsubscribe from ‘Test title’](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
       expect(described_class.call(id: "abc123", title: "Test title")).to eq(expected)
     end
   end


### PR DESCRIPTION
By clicking the 'View and manage your subscriptions link' in an email, the user will be redirected to a landing page 'email/authenticate', where a query string will also be passed in of the users email address. Keith made some changes, removing `nbsp;`, in favour of `\u00A0`. After a discussion with Kevin, decided to make the format standardised and convert the existing `&nbsp;` to `\u00A0` (Unicode).