### PR TITLE
Fix blank emails

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -16,6 +16,10 @@ class DigestRun < ApplicationRecord
     mark_complete! unless has_incomplete_subscribers?
   end
 
+  def completed?
+    completed_at.present?
+  end
+
 private
 
   def starts_at=(value)

--- a/app/models/digest_run_subscriber.rb
+++ b/app/models/digest_run_subscriber.rb
@@ -8,4 +8,8 @@ class DigestRunSubscriber < ApplicationRecord
   def mark_complete!
     update_attributes!(completed_at: Time.now)
   end
+
+  def completed?
+    completed_at.present?
+  end
 end

--- a/app/queries/digest_run_subscriber_query.rb
+++ b/app/queries/digest_run_subscriber_query.rb
@@ -1,7 +1,11 @@
 class DigestRunSubscriberQuery
   def self.call(digest_run:)
     Subscriber
-      .joins(subscriptions: { subscriber_list: { matched_content_changes: :content_change } })
+      .joins(
+        active_subscriptions: {
+          subscriber_list: { matched_content_changes: :content_change }
+        }
+      )
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
       .where("subscriptions.frequency": digest_run.range)

--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -1,5 +1,9 @@
 class SubscribersForImmediateEmailQuery
   def self.call
+    new.call
+  end
+
+  def call
     Subscriber
       .activated
       .where(
@@ -7,7 +11,9 @@ class SubscribersForImmediateEmailQuery
        )
   end
 
-  def self.unprocessed_subscription_contents_exist_for_subscribers
+private
+
+  def unprocessed_subscription_contents_exist_for_subscribers
     SubscriptionContent
       .joins(:subscription)
       .where(email_id: nil)

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -4,41 +4,57 @@ class DigestEmailGenerationWorker
   sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)
-    @digest_run_subscriber = DigestRunSubscriber.includes(:subscriber, :digest_run).find(digest_run_subscriber_id)
-    @subscriber = digest_run_subscriber.subscriber
-    @digest_run = digest_run_subscriber.digest_run
+    digest_run_subscriber = DigestRunSubscriber.includes(:subscriber, :digest_run).find(digest_run_subscriber_id)
+    content_changes = fetch_subscriber_content_changes(digest_run_subscriber)
 
-    MetricsService.digest_email_generation(digest_run.range) do
-      Email.transaction do
-        generate_email_and_subscription_contents
-        digest_run_subscriber.mark_complete!
-      end
-
-      DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_digest)
-
-      digest_run.check_and_mark_complete!
+    if content_changes.count.zero?
+      mark_digest_run_completed(digest_run_subscriber)
+    else
+      create_and_send_email(digest_run_subscriber, content_changes)
     end
   end
 
 private
 
-  attr_reader :digest_run, :digest_run_subscriber, :email, :results, :subscriber
+  def create_and_send_email(digest_run_subscriber, content_changes)
+    range = digest_run_subscriber.digest_run.range
 
-  def generate_email_and_subscription_contents
-    @email = create_email
+    MetricsService.digest_email_generation(range) do
+      email = Email.transaction do
+        mark_digest_run_completed(digest_run_subscriber)
+        generate_email_and_subscription_contents(
+          digest_run_subscriber,
+          content_changes
+        )
+      end
 
-    SubscriptionContent.import!(
-      formatted_subscription_content_change_columns,
-      formatted_subscription_content_changes,
+      DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_digest)
+    end
+  end
+
+  def mark_digest_run_completed(digest_run_subscriber)
+    digest_run_subscriber.mark_complete!
+    digest_run_subscriber.digest_run.check_and_mark_complete!
+  end
+
+  def generate_email_and_subscription_contents(digest_run_subscriber, content_changes)
+    email = create_email(digest_run_subscriber, content_changes)
+    columns = formatted_subscription_content_change_columns
+    values = formatted_subscription_content_changes(
+      email, digest_run_subscriber, content_changes
     )
+
+    SubscriptionContent.import!(columns, values)
+
+    email
   end
 
   def formatted_subscription_content_change_columns
     %i(email_id subscription_id content_change_id digest_run_subscriber_id)
   end
 
-  def formatted_subscription_content_changes
-    subscriber_content_changes.flat_map do |result|
+  def formatted_subscription_content_changes(email, digest_run_subscriber, content_changes)
+    content_changes.flat_map do |result|
       result.content_changes.map do |content_change|
         [
           email.id,
@@ -50,18 +66,18 @@ private
     end
   end
 
-  def create_email
+  def create_email(digest_run_subscriber, content_changes)
     DigestEmailBuilder.call(
-      subscriber: subscriber,
-      digest_run: digest_run,
-      subscription_content_change_results: subscriber_content_changes,
+      subscriber: digest_run_subscriber.subscriber,
+      digest_run: digest_run_subscriber.digest_run,
+      subscription_content_change_results: content_changes,
     )
   end
 
-  def subscriber_content_changes
-    @subscriber_content_changes ||= SubscriptionContentChangeQuery.call(
-      subscriber: subscriber,
-      digest_run: digest_run
+  def fetch_subscriber_content_changes(digest_run_subscriber)
+    SubscriptionContentChangeQuery.call(
+      subscriber: digest_run_subscriber.subscriber,
+      digest_run: digest_run_subscriber.digest_run,
     )
   end
 end

--- a/spec/queries/digest_run_subscriber_query_spec.rb
+++ b/spec/queries/digest_run_subscriber_query_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe DigestRunSubscriberQuery do
       end
     end
 
+    context "with an ended subscription" do
+      let!(:subscription) do
+        create(:subscription, :ended, subscriber_list: subscriber_list_one, frequency: :daily)
+      end
+
+      context "with a matched content change" do
+        before do
+          create_and_match_content_change
+        end
+
+        it "returns no subscribers" do
+          expect(subscribers.count).to eq(0)
+        end
+      end
+    end
+
     context "with a weekly subscription" do
       let!(:subscription) do
         create(:subscription, :weekly, subscriber_list: subscriber_list_one)

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -14,33 +14,36 @@ RSpec.describe DigestEmailGenerationWorker do
   end
 
   describe ".perform" do
-    let(:subscriber) { create(:subscriber, id: 1) }
-    let!(:subscription_one) {
-      create(:subscription, id: "7879434f-d83c-47d2-b04b-b3dd69c1931e", subscriber_id: subscriber.id)
-    }
-    let!(:subscription_two) {
-      create(:subscription, id: "e4704303-a1b1-4a26-a231-4efecd9d21be", subscriber_id: subscriber.id)
-    }
-    let!(:digest_run) { create(:digest_run, id: 10) }
+    let(:subscriber) { create(:subscriber) }
 
-    let(:subscription_content_change_query_results) {
+    let(:subscription_one) do
+      create(:subscription, subscriber: subscriber)
+    end
+
+    let(:subscription_two) do
+      create(:subscription, subscriber: subscriber)
+    end
+
+    let(:digest_run) { create(:digest_run) }
+
+    let(:digest_run_subscriber) do
+      create(:digest_run_subscriber, digest_run: digest_run, subscriber: subscriber)
+    end
+
+    let(:subscription_content_change_query_results) do
       [
         double(
           subscription_id: subscription_one.id,
           subscriber_list_title: "Test title 1",
-          content_changes: [
-            create(:content_change, public_updated_at: "1/1/2016 10:00"),
-          ],
+          content_changes: [create(:content_change)],
         ),
         double(
           subscription_id: subscription_two.id,
           subscriber_list_title: "Test title 2",
-          content_changes: [
-            create(:content_change, public_updated_at: "4/1/2016 10:00"),
-          ],
+          content_changes: [create(:content_change)],
         ),
       ]
-    }
+    end
 
     before do
       allow(SubscriptionContentChangeQuery).to receive(:call).and_return(
@@ -49,17 +52,13 @@ RSpec.describe DigestEmailGenerationWorker do
     end
 
     it "accepts digest_run_subscriber_id" do
-      create(:digest_run_subscriber, id: 1)
-
       expect {
-        subject.perform(1)
+        subject.perform(digest_run_subscriber.id)
       }.not_to raise_error
     end
 
     it "creates an email" do
-      create(:digest_run_subscriber, id: 1)
-
-      expect { subject.perform(1) }
+      expect { subject.perform(digest_run_subscriber.id) }
         .to change { Email.count }.by(1)
     end
 
@@ -67,63 +66,45 @@ RSpec.describe DigestEmailGenerationWorker do
       expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
         .with(instance_of(String), queue: :delivery_digest)
 
-      create(:digest_run_subscriber, id: 1)
-
-      subject.perform(1)
+      subject.perform(digest_run_subscriber.id)
     end
 
     it "records a metric for the delivery attempt" do
       expect(MetricsService).to receive(:digest_email_generation)
         .with("daily")
 
-      create(:digest_run_subscriber, id: 1)
-
-      subject.perform(1)
+      subject.perform(digest_run_subscriber.id)
     end
 
     it "marks the DigestRunSubscriber completed" do
-      digest_run_subscriber = create(
-        :digest_run_subscriber,
-        id: 1,
-        subscriber_id: subscriber.id
-      )
-
-      allow(DigestRunSubscriber).to receive(:includes).and_return(DigestRunSubscriber)
-
-      allow(DigestRunSubscriber).to receive(:find)
-        .with(1)
-        .and_return(digest_run_subscriber)
-
-      expect(digest_run_subscriber).to receive(:mark_complete!)
-
-      subject.perform(1)
+      expect { subject.perform(digest_run_subscriber.id) }
+        .to change { digest_run_subscriber.reload.completed? }
+        .from(false)
+        .to(true)
     end
 
-    it "creates a SubscriptionContent" do
-      create(
-        :digest_run_subscriber,
-        id: 1,
-        subscriber_id: subscriber.id
-      )
-
-      subject.perform(1)
-
-      subscription_content = SubscriptionContent.last
-      expect(subscription_content.digest_run_subscriber_id).to eq(1)
+    it "creates SubscriptionContents" do
+      expect { subject.perform(digest_run_subscriber.id) }
+        .to change(SubscriptionContent, :count)
+        .by(subscription_content_change_query_results.count)
     end
 
     it "marks the digest run complete" do
-      create(:digest_run_subscriber, id: 1)
-      expect_any_instance_of(DigestRun).to receive(:mark_complete!)
-      subject.perform(1)
+      expect { subject.perform(digest_run_subscriber.id) }
+        .to change { digest_run.reload.completed? }
+        .from(false)
+        .to(true)
     end
 
     context "when there are incomplete DigestRunSubscribers left" do
+      before do
+        # Create an extra instance of digest run subscriber so more are left
+        create(:digest_run_subscriber, digest_run: digest_run)
+      end
+
       it "doesn't mark the digest run complete" do
-        create(:digest_run_subscriber, id: 1, digest_run_id: digest_run.id)
-        create(:digest_run_subscriber, digest_run_id: digest_run.id)
-        expect_any_instance_of(DigestRun).not_to receive(:mark_complete!)
-        subject.perform(1)
+        expect { subject.perform(digest_run_subscriber.id) }
+          .not_to(change { digest_run.reload.completed? })
       end
     end
   end

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -107,5 +107,28 @@ RSpec.describe DigestEmailGenerationWorker do
           .not_to(change { digest_run.reload.completed? })
       end
     end
+
+    context "when there are no content changes to send" do
+      let(:subscription_content_change_query_results) { [] }
+
+      it "doesn't create an email" do
+        expect { subject.perform(digest_run_subscriber.id) }
+          .to_not change(Email, :count)
+      end
+
+      it "marks the digest run subscriber completed" do
+        expect { subject.perform(digest_run_subscriber.id) }
+          .to change { digest_run_subscriber.reload.completed? }
+          .from(false)
+          .to(true)
+      end
+
+      it "can mark the digest run complete" do
+        expect { subject.perform(digest_run_subscriber.id) }
+          .to change { digest_run.reload.completed? }
+          .from(false)
+          .to(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR contains a couple of fixes for the blank email situation we've experienced over the weekend.

1. It only looks up subscribers that have active subscriptions for sending out digest emails to them. This was the immediate cause of the problem which was caused by the changing of scope in: https://github.com/alphagov/email-alert-api/commit/10196e4680e561807584ab6186ce27180209e8b6
2. It prevents sending out digest emails where no content changes are found.

It does a bit of refactoring too - more details in the commits.