### PR TITLE
Relax required sent_at param for StatusUpdateService

### DIFF
--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -11,7 +11,7 @@ class StatusUpdatesController < ApplicationController
 
   def create
     StatusUpdateService.call(
-      sent_at: params.require(:sent_at),
+      sent_at: params[:sent_at],
       completed_at: params.require(:completed_at),
       reference: params.require(:reference),
       status: params.require(:status),

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -70,5 +70,34 @@ RSpec.describe "Receiving a status update", type: :request do
         expect(response.status).to eq(422)
       end
     end
+
+    context "without sent_at" do
+      let(:params_without_sent_at) { params.reject { |k, _v| k == :sent_at } }
+
+      it "updates the delivery attempt" do
+        expect(StatusUpdateService).to receive(:call).with(
+          sent_at: nil,
+          completed_at: Time.parse("2017-05-14T12:15:30.000000Z"),
+          reference: reference,
+          status: "delivered",
+          user: user,
+        )
+
+        post "/status-updates", params: params_without_sent_at
+      end
+
+      it "renders 204 no content" do
+        post "/status-updates", params: params_without_sent_at
+
+        expect(response.status).to eq(204)
+        expect(response.body).to eq("")
+      end
+
+      it "updates the delivery attempt" do
+        expect { post "/status-updates", params: params_without_sent_at }
+          .to change { delivery_attempt.reload.status }
+          .to eq("delivered")
+      end
+    end
   end
 end


### PR DESCRIPTION
When Notify send us status updates, the `sent_at` paramter can be `nil`.
Currently we return a 400 when `sent_at` is `nil` and do not update
the database.

Allow `sent_at` to be `nil` or absent in StatusUpdateService so we
accept these status updates without error and write them to the db.

[Trello](https://trello.com/c/8NL9gEzB/734-sentat-param-missing)