### PR TITLE
Don't create accounts for users who don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ new frequency.
 
 This will trigger an email to the address specified with a link to the
 destination with a query string of token and a [JWT](https://jwt.io/) token.
-Returns a 201 status code on success.
+Returns a 201 status code on success or 404 if the subscriber is not known
+to Email Alert API.
 
 #### healthcheck API
 

--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -2,7 +2,7 @@ class SubscribersAuthTokenController < ApplicationController
   before_action :validate_params
 
   def auth_token
-    subscriber = find_or_create_subscriber(expected_params.require(:address))
+    subscriber = find_subscriber(expected_params.require(:address))
     token = generate_token(subscriber)
     email = build_email(subscriber, token)
 
@@ -14,13 +14,10 @@ class SubscribersAuthTokenController < ApplicationController
 
 private
 
-  def find_or_create_subscriber(address)
-    found = Subscriber.find_by_address(address)
-    found.activate! if found&.deactivated?
-    found || Subscriber.create!(
-      address: address,
-      signon_user_uid: current_user.uid,
-    )
+  def find_subscriber(address)
+    Subscriber.find_by_address!(address).tap do |subscriber|
+      subscriber.activate! if subscriber.deactivated?
+    end
   end
 
   def generate_token(subscriber)


### PR DESCRIPTION
Trello: https://trello.com/c/6YmlH3Mq/725-add-token-based-login-for-the-subscription-management-interface

This changes the behaviour of the /subscribers/auth-token endpoint to
return a 404 when it tries to look up a subscriber that is not known in
the system. This previously created a record for that subscriber.

The reason for this is to store a minimal amount of personally
idenitifiable information on a user of this system.