### PR TITLE
Presents the time to the user at the correct time of publishing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ Bundler.require(*Rails.groups)
 
 module EmailAlertAPI
   class Application < Rails::Application
+    config.time_zone = 'London'
     config.api_only = true
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ContentChangePresenter do
       base_path: "/government/test-slug",
       change_note: "Test change note",
       description: "Test description",
-      public_updated_at: Time.parse("10:00 1/1/2018")
+      public_updated_at: Time.parse("2018-03-28 10:00:00 UTC")
     )
   }
 
@@ -18,7 +18,7 @@ RSpec.describe ContentChangePresenter do
 
         Test description
 
-        10:00am, 1 January 2018: Test change note
+        11:00am, 28 March 2018: Test change note
       CONTENT_CHANGE
 
       expect(described_class.call(content_change)).to eq(expected)
@@ -31,7 +31,7 @@ RSpec.describe ContentChangePresenter do
           base_path: "/government/test-slug",
           change_note:  "#Test change note **markdown** [test](https://gov.uk)",
           description: "more _markdown_",
-          public_updated_at: Time.parse("10:00 1/1/2018")
+          public_updated_at: Time.parse("2018-03-28 09:30:00 UTC")
         )
       }
 
@@ -41,7 +41,7 @@ RSpec.describe ContentChangePresenter do
 
           more markdown
 
-          10:00am, 1 January 2018: Test change note markdown test (https://gov.uk)
+          10:30am, 28 March 2018: Test change note markdown test (https://gov.uk)
         CONTENT_CHANGE
 
         expect(described_class.call(content_change)).to eq(expected)


### PR DESCRIPTION
Converts UTC to BTS in the ContentChangePresenter to ensure the
correct time of publishing is always displayed to the user.