### PR TITLE
SubscriptionShowPresenter class

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -30,7 +30,7 @@ class SubscriptionsController < ApplicationController
 
   def show
     subscription = Subscription.find(subscription_params.require(:id))
-    render json: { subscription: subscription }
+    render json: { subscription: SubscriptionShowPresenter.call(subscription) }
   end
 
   def update
@@ -59,7 +59,7 @@ class SubscriptionsController < ApplicationController
       end
     end
 
-    render json: { subscription: subscription }, status: :ok
+    render json: { subscription: SubscriptionShowPresenter.call(subscription) }, status: :ok
   end
 
 private

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -13,12 +13,6 @@ class Subscription < ApplicationRecord
   scope :active, -> { where(ended_at: nil) }
   scope :ended, -> { where.not(ended_at: nil) }
 
-  def as_json(options = {})
-    options[:except] ||= %i(signon_user_uid subscriber_list_id subscriber_id)
-    options[:include] ||= %i(subscriber_list subscriber)
-    super(options)
-  end
-
   def active?
     ended_at.nil?
   end

--- a/app/presenters/subscription_show_presenter.rb
+++ b/app/presenters/subscription_show_presenter.rb
@@ -1,0 +1,20 @@
+class SubscriptionShowPresenter
+  def self.call(subscription)
+    new.call(subscription)
+  end
+
+  def call(subscription)
+    {
+      id: subscription.id,
+      frequency: subscription.frequency,
+      source: subscription.source,
+      ended: subscription.ended?,
+      ended_at: subscription.ended_at,
+      ended_reason: subscription.ended_reason,
+      created_at: subscription.created_at,
+      updated_at: subscription.updated_at,
+      subscriber_list: subscription.subscriber_list.as_json,
+      subscriber: subscription.subscriber.as_json,
+    }
+  end
+end

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Subscriptions", type: :request do
           subscriber
           created_at
           updated_at
+          ended
           ended_at
           ended_reason
           frequency

--- a/spec/presenters/subscription_show_presenter_spec.rb
+++ b/spec/presenters/subscription_show_presenter_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe SubscriptionShowPresenter do
+  describe ".call" do
+    let(:expected_fields) do
+      %i[
+        id
+        frequency
+        source
+        ended
+        ended_at
+        ended_reason
+        created_at
+        updated_at
+        subscriber_list
+        subscriber
+      ]
+    end
+    let(:subscription) { create(:subscription) }
+
+    it "has expected fields" do
+      response = described_class.call(subscription)
+      expect(response.keys).to match(expected_fields)
+    end
+  end
+end


### PR DESCRIPTION
This is to replace the increasing complex logic that is going into the
as_json method on Subscription to serialize it for rendering as part of
HTTP responses.

It also included an ended boolean value that can be used to work out if
a subscription has ended for dealing with unsubscribing.