### PR TITLE
Fix broken test due to ordering

### DIFF
--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe DigestEmailBuilder do
         unsubscribe_link_2
 
         You’re getting this email because you subscribed to these topic updates on GOV.UK.
-        [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-3@example.com)
+        [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
 
         &nbsp;
 


### PR DESCRIPTION
Instead of hard coding the address, we can use the one in the database. This means it doesn't matter what order the tests run in.