### PR TITLE
Ignore null addresses when sanitising

### DIFF
--- a/lib/data_hygiene/anonymise_email_addresses.sql
+++ b/lib/data_hygiene/anonymise_email_addresses.sql
@@ -21,8 +21,9 @@ WHERE created_at < current_timestamp - interval '1 day';
 CREATE TABLE addresses (id SERIAL, address VARCHAR NOT NULL);
 
 # Copy all email addresses into the table.
+# Ignore nulled out subscriber addresses.
 INSERT INTO addresses (address)
-  SELECT address FROM subscribers
+  SELECT address FROM subscribers WHERE address IS NOT NULL
   UNION DISTINCT
   SELECT address FROM emails;
 

--- a/spec/integration/anonymise_email_addresses_spec.rb
+++ b/spec/integration/anonymise_email_addresses_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe "Anonymising email addresses" do
       .to("anonymous-1@example.com")
   end
 
+  it "keeps the pre-existing null addresses in the subscribers table" do
+    create(:subscriber, address: "foo@example.com")
+    create(:subscriber, :nullified)
+
+    execute_sql
+
+    expect(Subscriber.count).to eq(2)
+    expect(Subscriber.all.map(&:address)).to include(nil)
+  end
+
   it "anonymises addresses in the emails table" do
     email = create(:email, address: "foo@example.com")
 


### PR DESCRIPTION
The sanitise script should not try to anonymise nullified Subscriber
records because this violates the not-null constraint on the addresses
table.

