### PR TITLE
Anonymise email addresses in subjects/bodies

### DIFF
--- a/lib/data_hygiene/anonymise_email_addresses.sql
+++ b/lib/data_hygiene/anonymise_email_addresses.sql
@@ -38,7 +38,9 @@ WHERE a.address = s.address;
 
 # Set emails.address from the auto-incremented id in addresses table.
 UPDATE emails e
-SET address = CONCAT('anonymous-', a.id, '@example.com')
+SET address = CONCAT('anonymous-', a.id, '@example.com'),
+subject = REPLACE(e.subject, e.address, CONCAT('anonymous-', a.id, '@example.com')),
+body = REPLACE(e.body, e.address, CONCAT('anonymous-', a.id, '@example.com'))
 FROM addresses a
 WHERE a.address = e.address;
 


### PR DESCRIPTION
A problem that we currently have is that our sanitisation script doesn't
replace instances of email addresses that are within emails themselves
which can render some of our other anonymising work superfluous.

This uses the postgres replace function to change references to the
subscribers email address in subject and body parts of the email.

I'm hoping to try determine the effects this has on performance but this
is quite difficult as performance without this is currently so poor.