### PR TITLE
Create worker to mark digest runs as complete

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -6,10 +6,13 @@ class DigestRun < ApplicationRecord
   has_many :digest_run_subscribers, dependent: :destroy
   has_many :subscribers, through: :digest_run_subscribers
 
+  scope :incomplete, -> { where(completed_at: nil) }
+
   enum range: { daily: 0, weekly: 1 }
 
   def mark_complete!
-    update_attributes!(completed_at: Time.zone.now)
+    completed_at = digest_run_subscribers.maximum(:completed_at) || Time.zone.now
+    update_attributes!(completed_at: completed_at)
   end
 
   def check_and_mark_complete!

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -8,7 +8,7 @@ class DigestEmailGenerationWorker
     content_changes = fetch_subscriber_content_changes(digest_run_subscriber)
 
     if content_changes.count.zero?
-      mark_digest_run_completed(digest_run_subscriber)
+      mark_digest_run_subscriber_completed(digest_run_subscriber)
     else
       create_and_send_email(digest_run_subscriber, content_changes)
     end
@@ -21,7 +21,7 @@ private
 
     MetricsService.digest_email_generation(range) do
       email = Email.transaction do
-        mark_digest_run_completed(digest_run_subscriber)
+        mark_digest_run_subscriber_completed(digest_run_subscriber)
         generate_email_and_subscription_contents(
           digest_run_subscriber,
           content_changes
@@ -32,9 +32,8 @@ private
     end
   end
 
-  def mark_digest_run_completed(digest_run_subscriber)
+  def mark_digest_run_subscriber_completed(digest_run_subscriber)
     digest_run_subscriber.mark_complete!
-    digest_run_subscriber.digest_run.check_and_mark_complete!
   end
 
   def generate_email_and_subscription_contents(digest_run_subscriber, content_changes)

--- a/app/workers/digest_run_completion_marker_worker.rb
+++ b/app/workers/digest_run_completion_marker_worker.rb
@@ -1,0 +1,7 @@
+class DigestRunCompletionMarkerWorker
+  include Sidekiq::Worker
+
+  def perform(*_)
+    DigestRun.incomplete.each(&:check_and_mark_complete!)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -29,3 +29,6 @@
   email_deleter:
     every: '1h'
     class: EmailDeletionWorker
+  digest_run_completion_marker:
+    every: '1m'
+    class: DigestRunCompletionMarkerWorker

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -89,23 +89,9 @@ RSpec.describe DigestEmailGenerationWorker do
         .by(subscription_content_change_query_results.count)
     end
 
-    it "marks the digest run complete" do
+    it "doesn't mark the digest run complete" do
       expect { subject.perform(digest_run_subscriber.id) }
-        .to change { digest_run.reload.completed? }
-        .from(false)
-        .to(true)
-    end
-
-    context "when there are incomplete DigestRunSubscribers left" do
-      before do
-        # Create an extra instance of digest run subscriber so more are left
-        create(:digest_run_subscriber, digest_run: digest_run)
-      end
-
-      it "doesn't mark the digest run complete" do
-        expect { subject.perform(digest_run_subscriber.id) }
-          .not_to(change { digest_run.reload.completed? })
-      end
+        .not_to(change { digest_run.reload.completed? })
     end
 
     context "when there are no content changes to send" do
@@ -119,13 +105,6 @@ RSpec.describe DigestEmailGenerationWorker do
       it "marks the digest run subscriber completed" do
         expect { subject.perform(digest_run_subscriber.id) }
           .to change { digest_run_subscriber.reload.completed? }
-          .from(false)
-          .to(true)
-      end
-
-      it "can mark the digest run complete" do
-        expect { subject.perform(digest_run_subscriber.id) }
-          .to change { digest_run.reload.completed? }
           .from(false)
           .to(true)
       end

--- a/spec/workers/digest_run_completion_marker_worker_spec.rb
+++ b/spec/workers/digest_run_completion_marker_worker_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe DigestRunCompletionMarkerWorker, type: :worker do
+  describe "#perform" do
+    let(:digest_run) { create(:digest_run) }
+
+    context "when a digest_run has incomplete subscribers" do
+      before do
+        create(:digest_run_subscriber, digest_run: digest_run)
+        create(:digest_run_subscriber, digest_run: digest_run, completed_at: Time.now)
+      end
+
+      it "doesn't mark the digest run complete" do
+        expect { subject.perform }
+          .not_to(change { digest_run.reload.completed? })
+      end
+    end
+
+    context "when a digest_run has complete subscribers" do
+      before do
+        create(:digest_run_subscriber, digest_run: digest_run, completed_at: Time.mktime(2018, 1, 1, 10))
+        create(:digest_run_subscriber, digest_run: digest_run, completed_at: Time.mktime(2018, 1, 1, 9))
+      end
+
+      it "marks the digest run as complete at the most recent subscriber completion time" do
+        expect { subject.perform }
+          .to(change { digest_run.reload.completed? }
+            .from(false)
+            .to(true))
+
+        expect(digest_run.completed_at).to eq Time.mktime(2018, 1, 1, 10)
+      end
+    end
+  end
+end


### PR DESCRIPTION
After every digest email is sent, the worker checks if it was the last
email to be sent for that digest run. If it is, it marks the run as
complete. The check required is expensive, between 2 to 4 seconds in
the database while under load. We've been unable to make Postgres use
an index to speed up the operation.

This commit adds a new worker that finds all runs that haven't yet been
marked as completed, checks if all the subscribers are marked as
completed then uses the most recent completion time as the run's
completion time. Running this every minute will still give us accurate
statistics and will greatly reduce the load on Postgres.
