### PR TITLE
Bulk emails

### DIFF
--- a/app/builders/bulk_email_builder.rb
+++ b/app/builders/bulk_email_builder.rb
@@ -1,0 +1,41 @@
+class BulkEmailBuilder
+  def initialize(subject:, body:, subscriber_lists:)
+    @subject = subject
+    @body = body
+    @subscriber_lists = subscriber_lists
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    Email.import!(columns, records)
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subject, :body, :subscriber_lists
+
+  def columns
+    %i(address subject body subscriber_id)
+  end
+
+  def records
+    subscribers.map do |address, subscriber_id|
+      [address, subject, body, subscriber_id]
+    end
+  end
+
+  def subscribers
+    Subscriber
+      .activated
+      .not_nullified
+      .joins(:subscriptions)
+      .where(subscriptions: { ended_at: nil, subscriber_list: subscriber_lists })
+      .distinct
+      .pluck(:address, :id)
+  end
+end

--- a/app/services/bulk_email_sender_service.rb
+++ b/app/services/bulk_email_sender_service.rb
@@ -1,0 +1,9 @@
+class BulkEmailSenderService
+  def self.call(subject:, body:, subscriber_lists:, queue: :delivery_immediate)
+    email_ids = BulkEmailBuilder.call(subject: subject, body: body, subscriber_lists: subscriber_lists).ids
+
+    email_ids.each do |email_id|
+      DeliveryRequestWorker.perform_async(email_id, queue)
+    end
+  end
+end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -1,0 +1,13 @@
+namespace :bulk do
+  desc "Send a bulk email to many subscriber lists"
+  task :email, %i(subject body) => :environment do |_t, args|
+    subscriber_list_ids = args.extras
+    subscriber_lists = SubscriberList.where(id: subscriber_list_ids)
+
+    BulkEmailSenderService.call(
+      subject: args.subject,
+      body: args.body,
+      subscriber_lists: subscriber_lists,
+    )
+  end
+end

--- a/spec/builders/bulk_email_builder_spec.rb
+++ b/spec/builders/bulk_email_builder_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe BulkEmailBuilder do
+  let(:email_subject) { "email subject" }
+  let(:body) { "email body" }
+
+  describe ".call" do
+    subject(:email_import) do
+      described_class.call(subject: email_subject, body: body, subscriber_lists: subscriber_lists)
+    end
+
+    context "with one subscriber" do
+      let(:subscriber_lists) { [create(:subscription).subscriber_list] }
+
+      it "returns an email import" do
+        expect(email_import.ids.count).to eq(1)
+      end
+
+      let(:email) { Email.find(email_import.ids.first) }
+
+      it "sets the subject" do
+        expect(email.subject).to eq("email subject")
+      end
+
+      it "sets the body" do
+        expect(email.body).to eq("email body")
+      end
+    end
+
+    context "with an ended subscriptions" do
+      let(:subscriber_lists) { [create(:subscription, :ended).subscriber_list] }
+
+      it "imports no emails" do
+        expect(email_import.ids.count).to eq(0)
+      end
+    end
+
+    context "with a deactivated subscriber" do
+      let(:subscriber) { create(:subscriber, :deactivated) }
+      let(:subscriber_lists) { [create(:subscription, subscriber: subscriber).subscriber_list] }
+
+      it "imports no emails" do
+        expect(email_import.ids.count).to eq(0)
+      end
+    end
+
+    context "with many subscribers" do
+      let(:subscriber_1) { create(:subscriber) }
+      let(:subscriber_2) { create(:subscriber) }
+      let(:subscriber_3) { create(:subscriber) }
+
+      let(:subscriber_lists) do
+        [
+          create(:subscription, subscriber: subscriber_1).subscriber_list,
+          create(:subscription, subscriber: subscriber_2).subscriber_list,
+          create(:subscription, subscriber: subscriber_3).subscriber_list,
+          create(:subscription, subscriber: subscriber_1).subscriber_list,
+          create(:subscription, subscriber: subscriber_2).subscriber_list,
+        ]
+      end
+
+      it "should only create one email per subscriber" do
+        expect(email_import.ids.count).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/services/bulk_email_sender_service_spec.rb
+++ b/spec/services/bulk_email_sender_service_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe BulkEmailSenderService do
+  let(:email_subject) { "email subject" }
+  let(:body) { "body" }
+  let(:subscriber_lists) { [create(:subscription).subscriber_list] }
+
+  describe ".call" do
+    it "adds a delivery request to the queue" do
+      expect(DeliveryRequestWorker).to receive(:perform_async).with(
+        kind_of(String), :delivery_immediate
+      ).and_call_original
+
+      Sidekiq::Testing.fake! do
+        described_class.call(subject: email_subject, body: body, subscriber_lists: subscriber_lists)
+      end
+
+      expect(DeliveryRequestWorker.jobs.size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to bulk send out an email to many subscriber lists.

Once this is deployed, there will be a custom Jenkins task set up to run this rake task with a more friendly user interface.

[Trello Card](https://trello.com/c/e90wvivv/49-build-tooling-for-bulk-contacting-email-subscribers-for-a-given-subscriber-list-2)