### PR TITLE
Use environment variables for bulk email task

### DIFF
--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -1,13 +1,10 @@
 namespace :bulk do
   desc "Send a bulk email to many subscriber lists"
-  task :email, %i(subject body) => :environment do |_t, args|
-    subscriber_list_ids = args.extras
-    subscriber_lists = SubscriberList.where(id: subscriber_list_ids)
-
+  task :email, [] => :environment do |_t, args|
     BulkEmailSenderService.call(
-      subject: args.subject,
-      body: args.body,
-      subscriber_lists: subscriber_lists,
+      subject: ENV.fetch("SUBJECT"),
+      body: ENV.fetch("BODY"),
+      subscriber_lists: SubscriberList.where(id: args.extras),
     )
   end
 end


### PR DESCRIPTION
It's not possible to pass newlines in as arguments.

[Trello Card](https://trello.com/c/e90wvivv/49-build-tooling-for-bulk-contacting-email-subscribers-for-a-given-subscriber-list-2)