### PR TITLE
Remove duplicate content changes which appear in multiple subscriber lists

### DIFF
--- a/app/queries/subscription_content_change_query.rb
+++ b/app/queries/subscription_content_change_query.rb
@@ -46,5 +46,6 @@ private
       .where("content_changes.created_at < ?", digest_run.ends_at)
       .merge(Subscription.active)
       .order("subscriber_list_title ASC", "content_changes.title ASC")
+      .uniq(&:content_id)
   end
 end

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "creating and delivering digests", type: :request do
         change_note: "Change note two",
         public_updated_at: "2017-01-01 09:00:00",
         links: {
-          topics: [list_one_topic_id]
+          topics: [list_one_topic_id, list_two_topic_id]
         }
       )
     end

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     )
 
     #publish two items to each list
-    Timecop.freeze "2017-01-01 10:00" do
+    Timecop.freeze "2017-01-01 09:30:00" do
       create_content_change(
         title: "Title one",
         content_id: SecureRandom.uuid,
@@ -159,7 +159,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       )
     end
 
-    Timecop.freeze "2017-01-01 09:00" do
+    Timecop.freeze "2017-01-01 09:30:01" do
       create_content_change(
         title: "Title two",
         content_id: SecureRandom.uuid,
@@ -172,7 +172,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       )
     end
 
-    Timecop.freeze "2017-01-01 09:00:00" do
+    Timecop.freeze "2017-01-01 09:30:02" do
       create_content_change(
         title: "Title three",
         content_id: SecureRandom.uuid,
@@ -186,7 +186,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       )
     end
 
-    Timecop.freeze "2017-01-01 09:30:00" do
+    Timecop.freeze "2017-01-01 09:30:03" do
       create_content_change(
         title: "Title four",
         content_id: SecureRandom.uuid,
@@ -201,7 +201,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     #TODO retrieve this via the API when we have an endpoint
     subscriptions = Subscription.all
-    content_changes = ContentChange.all
+    content_changes = ContentChange.order(:created_at)
     subscribers = Subscriber.all
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")

--- a/spec/queries/subscription_content_change_query_spec.rb
+++ b/spec/queries/subscription_content_change_query_spec.rb
@@ -150,6 +150,12 @@ RSpec.describe SubscriptionContentChangeQuery do
         content_change: content_change_2,
         subscriber_list: subscriber_list_2,
       )
+
+      create(
+        :matched_content_change,
+        content_change: content_change_1,
+        subscriber_list: subscriber_list_2,
+      )
     end
 
     it "returns correctly ordered" do
@@ -160,6 +166,10 @@ RSpec.describe SubscriptionContentChangeQuery do
       expect(subject.second.subscription_id).to eq("b8c3fd84-5f00-460d-a812-edb628f28c8f")
       expect(subject.second.subscriber_list_title).to eq("list-2")
       expect(subject.second.content_changes.first.id).to eq("70ac31fa-505e-4060-b7bb-bfa15028cc99")
+    end
+
+    it "returns only two changes" do
+      expect(subject.length).to eq(2)
     end
   end
 end


### PR DESCRIPTION
If someone is subscribed to two overlapping lists (eg, "all publications" and "arts and culture"), then a change to one may appear in the other.  So now, we just keep a change in the first subscriber list in which it appears.

[Trello card](https://trello.com/c/dQN7V6Ko/62-stop-digest-emails-including-duplicate-content)