### PR TITLE
Add a Rake task to export subscriber counts

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,24 @@
+require 'csv'
+
+namespace :export do
+  def present_subscriber_list(list_id)
+    list = SubscriberList.find(list_id)
+    { subscriber_list_id: list_id, title: list.title, count: list.subscribers.count }
+  rescue ActiveRecord::RecordNotFound
+    warn "could not fetch record for #{list_id}"
+  end
+
+  desc "Export the number of subscribers for a collection of lists as a csv, accepts multiple arguments"
+  task :csv, [:subscriber_list_id] => :environment do |_, args|
+    CSV($stdout, headers: %i[subscriber_list_id title count], write_headers: true) do |csv|
+      rows = args.to_a.map { |list_id| present_subscriber_list(list_id) }
+      rows.compact.each { |row| csv << row }
+    end
+  end
+
+  desc "Export the number of subscribers for a list"
+  task :count, [:subscriber_list_id] => :environment do |_, args|
+    list = present_subscriber_list(args[:subscriber_list_id])
+    puts list[:count] unless list.nil?
+  end
+end


### PR DESCRIPTION
Adds a couple of rake tasks to get information about subscriber lists.

Possible discussion points:

- What happens if the same list ID is given twice?  There's no `uniq`ificiation here.
- What fields should be included in the CSV output?  I only included one non-essential field (the title), as it's probably essential to people who don't have access to our rails console.
- Are stdout and stderr good outputs?  If this is going to get a pretty Jenkins UI, probably.

I wish `csv << nil` didn't do anything, then I could make things slightly more concise.  Oh well.

---

Missing lists show up first (on stderr), before any csv output (on stdout).

```
$ bundle exec rake export:csv[1223,1224,1225,999999999999999999999,1223]
could not fetch record for 999999999999999999999
subscriber_list_id,title,count
1223,Niger  - travel advice,5421
1224,Nigeria  - travel advice,8511
1225,North Korea  - travel advice,4935
1223,Niger  - travel advice,5421

$ bundle exec rake export:count[1223]
5421

$ bundle exec rake export:count[1223999999]
could not fetch record for 1223999999
```

---

[Trello card](https://trello.com/c/KI1ebOiL/114-get-email-subscriptions-figures-for-different-subscriber-lists-2)