### PR TITLE
Update Land registry titles

### DIFF
--- a/db/migrate/20180501155601_update_land_registry_titles.rb
+++ b/db/migrate/20180501155601_update_land_registry_titles.rb
@@ -1,0 +1,10 @@
+class UpdateLandRegistryTitles < ActiveRecord::Migration[5.2]
+  def change
+    list = SubscriberList.where("title LIKE '%Land Registry%' AND title NOT LIKE '%HM Land Registry%'")
+
+    list.each do |item|
+      item.title.sub! 'Land Registry', 'HM Land Registry'
+      item.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180321125113) do
+ActiveRecord::Schema.define(version: 2018_05_01_155601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
In email subscription alerts about Land Registry, there is some inconsistency where some titles are displayed as 'Land registry' or 'HM Land Registry'.

This migration finds all titles containing 'Land Registry' and replaces them with 'HM Land Registry', and skips those which are already correct.

Trello card: [Land Registry title fields in email-alert-api SubscriptionList are inconsistent - make them all HM Land Registry (2)](https://trello.com/c/AB2qHyp0/116-land-registry-title-fields-in-email-alert-api-subscriptionlist-are-inconsistent-make-them-all-hm-land-registry-2)

Before:
![land_registry_subscriptionlist_title](https://user-images.githubusercontent.com/19667619/39513853-84b2e5b8-4ded-11e8-8c13-49bd054681f3.png)
