### PR TITLE
Add an export of EU "Living in" taxons

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -22,6 +22,10 @@ class SubscriberList < ApplicationRecord
     slug
   end
 
+  def active_subscriptions_count
+    subscriptions.active.count
+  end
+
   def to_json(options = {})
     options[:except] ||= %i{signon_user_uid}
     options[:methods] ||= %i{subscription_url gov_delivery_id}

--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -1,6 +1,16 @@
 class DataExporter
   CSV_HEADERS = %i(id title count)
 
+  EU_COUNTRIES = %w(
+    austria belgium bulgaria croatia cyprus czech-republic denmark estonia finland france germany greece hungary
+    ireland italy latvia lithuania luxembourg malta netherlands poland portugal slovakia slovenia spain sweeden
+  )
+
+  def living_in_eu_subscriber_lists
+    slugs = EU_COUNTRIES.map { |country| "living-in-#{country}" }
+    SubscriberList.where(slug: slugs)
+  end
+
   def present_subscriber_list(subscriber_list)
     {
       id: subscriber_list.id,
@@ -9,11 +19,19 @@ class DataExporter
     }
   end
 
-  def export_csv(list_ids)
+  def export_csv(subscriber_lists)
     CSV($stdout, headers: CSV_HEADERS, write_headers: true) do |csv|
-      SubscriberList
-        .where(id: list_ids)
-        .find_each { |subscriber_list| csv << present_subscriber_list(subscriber_list) }
+      subscriber_lists.find_each do |subscriber_list|
+        csv << present_subscriber_list(subscriber_list)
+      end
     end
+  end
+
+  def export_csv_from_ids(ids)
+    export_csv(SubscriberList.where(id: ids))
+  end
+
+  def export_csv_from_living_in_eu
+    export_csv(living_in_eu_subscriber_lists)
   end
 end

--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -1,15 +1,19 @@
 class DataExporter
-  def present_subscriber_list(list_id)
-    list = SubscriberList.find(list_id)
-    { subscriber_list_id: list_id, title: list.title, count: list.subscribers.count }
-  rescue ActiveRecord::RecordNotFound
-    warn "could not fetch record for #{list_id}"
+  CSV_HEADERS = %i(id title count)
+
+  def present_subscriber_list(subscriber_list)
+    {
+      id: subscriber_list.id,
+      title: subscriber_list.title,
+      count: subscriber_list.active_subscriptions_count,
+    }
   end
 
   def export_csv(list_ids)
-    CSV($stdout, headers: %i[subscriber_list_id title count], write_headers: true) do |csv|
-      rows = list_ids.map { |list_id| present_subscriber_list(list_id) }
-      rows.compact.each { |row| csv << row }
+    CSV($stdout, headers: CSV_HEADERS, write_headers: true) do |csv|
+      SubscriberList
+        .where(id: list_ids)
+        .find_each { |subscriber_list| csv << present_subscriber_list(subscriber_list) }
     end
   end
 end

--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -1,0 +1,15 @@
+class DataExporter
+  def present_subscriber_list(list_id)
+    list = SubscriberList.find(list_id)
+    { subscriber_list_id: list_id, title: list.title, count: list.subscribers.count }
+  rescue ActiveRecord::RecordNotFound
+    warn "could not fetch record for #{list_id}"
+  end
+
+  def export_csv(list_ids)
+    CSV($stdout, headers: %i[subscriber_list_id title count], write_headers: true) do |csv|
+      rows = list_ids.map { |list_id| present_subscriber_list(list_id) }
+      rows.compact.each { |row| csv << row }
+    end
+  end
+end

--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -1,10 +1,10 @@
 class DataExporter
-  CSV_HEADERS = %i(id title count)
+  CSV_HEADERS = %i(id title count).freeze
 
   EU_COUNTRIES = %w(
     austria belgium bulgaria croatia cyprus czech-republic denmark estonia finland france germany greece hungary
     ireland italy latvia lithuania luxembourg malta netherlands poland portugal slovakia slovenia spain sweeden
-  )
+  ).freeze
 
   def living_in_eu_subscriber_lists
     slugs = EU_COUNTRIES.map { |country| "living-in-#{country}" }

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,24 +1,12 @@
-require 'csv'
-
 namespace :export do
-  def present_subscriber_list(list_id)
-    list = SubscriberList.find(list_id)
-    { subscriber_list_id: list_id, title: list.title, count: list.subscribers.count }
-  rescue ActiveRecord::RecordNotFound
-    warn "could not fetch record for #{list_id}"
-  end
-
   desc "Export the number of subscribers for a collection of lists as a csv, accepts multiple arguments"
   task :csv, [:subscriber_list_id] => :environment do |_, args|
-    CSV($stdout, headers: %i[subscriber_list_id title count], write_headers: true) do |csv|
-      rows = args.to_a.map { |list_id| present_subscriber_list(list_id) }
-      rows.compact.each { |row| csv << row }
-    end
+    DataExporter.new.export_csv(args.to_a)
   end
 
   desc "Export the number of subscribers for a list"
   task :count, [:subscriber_list_id] => :environment do |_, args|
-    list = present_subscriber_list(args[:subscriber_list_id])
+    list = DataExporter.new.present_subscriber_list(args[:subscriber_list_id])
     puts list[:count] unless list.nil?
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,11 +1,11 @@
 namespace :export do
-  desc "Export the number of subscriptions for a collection of lists as a csv, accepts multiple arguments"
-  task :csv_from_ids, [] => :environment do |_, args|
+  desc "Export the number of subscriptions for a collection of lists given as arguments of list IDs"
+  task csv_from_ids: :environment do |_, args|
     DataExporter.new.export_csv_from_ids(args.to_a)
   end
 
   desc "Export the number of subscriptions for the 'Living in' taxons for EU countries"
-  task :csv_from_living_in_eu, [] => :environment do
+  task csv_from_living_in_eu: :environment do
     DataExporter.new.export_csv_from_living_in_eu
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,10 +1,15 @@
 namespace :export do
-  desc "Export the number of subscribers for a collection of lists as a csv, accepts multiple arguments"
-  task :csv, [:subscriber_list_id] => :environment do |_, args|
-    DataExporter.new.export_csv(args.to_a)
+  desc "Export the number of subscriptions for a collection of lists as a csv, accepts multiple arguments"
+  task :csv_from_ids, [] => :environment do |_, args|
+    DataExporter.new.export_csv_from_ids(args.to_a)
   end
 
-  desc "Export the number of subscribers for a list"
+  desc "Export the number of subscriptions for the 'Living in' taxons for EU countries"
+  task :csv_from_living_in_eu, [] => :environment do |_, args|
+    DataExporter.new.export_csv_from_living_in_eu
+  end
+
+  desc "Export the number of subscriptions for a list"
   task :count, [:subscriber_list_id] => :environment do |_, args|
     puts SubscriberList.find(args[:subscriber_list_id]).active_subscriptions_count
   end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -5,12 +5,7 @@ namespace :export do
   end
 
   desc "Export the number of subscriptions for the 'Living in' taxons for EU countries"
-  task :csv_from_living_in_eu, [] => :environment do |_, args|
+  task :csv_from_living_in_eu, [] => :environment do
     DataExporter.new.export_csv_from_living_in_eu
-  end
-
-  desc "Export the number of subscriptions for a list"
-  task :count, [:subscriber_list_id] => :environment do |_, args|
-    puts SubscriberList.find(args[:subscriber_list_id]).active_subscriptions_count
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -6,7 +6,6 @@ namespace :export do
 
   desc "Export the number of subscribers for a list"
   task :count, [:subscriber_list_id] => :environment do |_, args|
-    list = DataExporter.new.present_subscriber_list(args[:subscriber_list_id])
-    puts list[:count] unless list.nil?
+    puts SubscriberList.find(args[:subscriber_list_id]).active_subscriptions_count
   end
 end


### PR DESCRIPTION
We need to send the FCO statistics on the EU "Living in" taxons regularly. Unfortunately, there's currently no way for them to self serve this data so we have to add code to do this for them.

We're going to merge this feature now so we can give the results to FCO, [but in the near future we will move this into Content Tagger](https://trello.com/c/3fxFsB93/360-add-subscriber-list-count-stats-to-taxons-in-content-tagger) and remove these Rake tasks from here.

[Trello Card](https://trello.com/c/KI1ebOiL/114-get-email-subscriptions-figures-for-different-subscriber-lists-2)