### PR TITLE
Fix the encoding of an email address in emails

### DIFF
--- a/app/presenters/manage_subscriptions_link_presenter.rb
+++ b/app/presenters/manage_subscriptions_link_presenter.rb
@@ -18,7 +18,6 @@ private
   attr_reader :address
 
   def url
-    base_path = "/email/authenticate?address=#{address}"
-    PublicUrlService.url_for(base_path: base_path)
+    PublicUrlService.authenticate_url(address: address)
   end
 end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -13,6 +13,10 @@ module PublicUrlService
       "#{website_root}/email/subscriptions/new?#{params}"
     end
 
+    def authenticate_url(address:)
+      "#{website_root}/email/authenticate?#{param('address', address)}"
+    end
+
   private
 
     def website_root

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe DigestEmailBuilder do
         unsubscribe_link_2
 
         You’re getting this email because you subscribed to these topic updates on GOV.UK.
-        [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
+        [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
         &nbsp;
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ImmediateEmailBuilder do
             You’re getting this email because you subscribed to ‘#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
 
             unsubscribe_link
-            [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test@example.com)
+            [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
 
             &nbsp;
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 
@@ -92,7 +92,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 
@@ -282,7 +282,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 
@@ -313,7 +313,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{subscriber.address})
+      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 

--- a/spec/presenters/manage_subscriptions_link_presenter_spec.rb
+++ b/spec/presenters/manage_subscriptions_link_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ManageSubscriptionsLinkPresenter do
   describe ".call" do
     it "returns a manage subscriptions link" do
-      expected = "[View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-email@test.com)"
+      expected = "[View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-email%40test.com)"
       expect(described_class.call(address: 'test-email@test.com')).to eq(expected)
     end
   end


### PR DESCRIPTION
Specifically the "View and manage ..." link. Previously it wansn't
encoded, which meant that something like foo+bar@example.com would
show up in the form on the page as "foo bar@example.com", missing the
+.

Change the tests to reflect the now encoded email address.


You can try this yourself by following this link https://www.gov.uk/email/authenticate?address=foo+bar@example.com