### PR TITLE
Handle capitalisation differences in anonymisation

### DIFF
--- a/lib/data_hygiene/anonymise_email_addresses.sql
+++ b/lib/data_hygiene/anonymise_email_addresses.sql
@@ -28,7 +28,7 @@ INSERT INTO addresses (address)
   SELECT address FROM emails;
 
 # Index the table so we can efficiently lookup addresses.
-CREATE UNIQUE INDEX addresses_index ON addresses (lower(address));
+CREATE UNIQUE INDEX addresses_index ON addresses (address);
 
 # Set subscribers.address from the auto-incremented id in addresses table.
 UPDATE subscribers s

--- a/spec/integration/anonymise_email_addresses_spec.rb
+++ b/spec/integration/anonymise_email_addresses_spec.rb
@@ -112,6 +112,13 @@ RSpec.describe "Anonymising email addresses" do
     expect(bar_subscriber.reload.address).to_not eq(foo_subscriber.reload.address)
   end
 
+  it "handles addresses only differing in capitalisation" do
+    create(:email, address: "foo@example.com")
+    create(:email, address: "Foo@example.com")
+
+    execute_sql
+  end
+
   it "cleans up after itself" do
     expect { execute_sql }.not_to(change { connection.tables.count })
   end


### PR DESCRIPTION
For email addresses. There can be duplicates in the emails table when
you normalise the capitalisation, this breaks creating the index as
it's a unique index on the lower form of the address. To fix this,
just use the unchanged address for the index.