### PR TITLE
Add more countries to the living in Europe exporter

### DIFF
--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -1,13 +1,14 @@
 class DataExporter
   CSV_HEADERS = %i(id title count).freeze
 
-  EU_COUNTRIES = %w(
+  EUROPEAN_COUNTRIES = %w(
     austria belgium bulgaria croatia cyprus czech-republic denmark estonia finland france germany greece hungary
     ireland italy latvia lithuania luxembourg malta netherlands poland portugal slovakia slovenia spain sweeden
+    switzerland iceland norway liechtenstein
   ).freeze
 
-  def living_in_eu_subscriber_lists
-    slugs = EU_COUNTRIES.map { |country| "living-in-#{country}" }
+  def living_in_europe_subscriber_lists
+    slugs = EUROPEAN_COUNTRIES.map { |country| "living-in-#{country}" }
     SubscriberList.where(slug: slugs)
   end
 
@@ -31,7 +32,7 @@ class DataExporter
     export_csv(SubscriberList.where(id: ids))
   end
 
-  def export_csv_from_living_in_eu
-    export_csv(living_in_eu_subscriber_lists)
+  def export_csv_from_living_in_europe
+    export_csv(living_in_europe_subscriber_lists)
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -4,8 +4,8 @@ namespace :export do
     DataExporter.new.export_csv_from_ids(args.to_a)
   end
 
-  desc "Export the number of subscriptions for the 'Living in' taxons for EU countries"
-  task csv_from_living_in_eu: :environment do
-    DataExporter.new.export_csv_from_living_in_eu
+  desc "Export the number of subscriptions for the 'Living in' taxons for European countries"
+  task csv_from_living_in_europe: :environment do
+    DataExporter.new.export_csv_from_living_in_europe
   end
 end


### PR DESCRIPTION
FCO have asked that a few more countries be added to the list and it is no longer specific to EU countries but also across Europe.

This follows on from #595 which added the data exporter, and once the ability to self-serve this from content tagger has been added we can remove this code.

[Trello Card](https://trello.com/c/3fxFsB93/360-add-subscriber-list-count-stats-to-taxons-in-content-tagger)