### PR TITLE
Limit unprocessed Subscribers by subscriber_id

### DIFF
--- a/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
+++ b/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
@@ -10,18 +10,10 @@ class UnprocessedSubscriptionContentsBySubscriberQuery
   end
 
   def call
-    from_query = <<-SQL
-      (
-        select subscription_contents.*, subscriptions.subscriber_id AS subscriber_id
-        from subscription_contents
-        join subscriptions on subscription_contents.subscription_id = subscriptions.id
-      ) as subscription_contents
-    SQL
-
     subscription_contents = SubscriptionContent
-      .from(from_query)
+      .joins(:subscription)
       .includes(:subscription)
-      .where(email_id: nil)
+      .where(email_id: nil, "subscriptions.subscriber_id": subscriber_ids)
 
     transform_results(subscription_contents)
   end
@@ -32,11 +24,12 @@ private
 
   def transform_results(subscription_contents)
     subscription_contents.each_with_object({}) do |subscription_content, results|
-      current_value = results[subscription_content.subscriber_id] || {}
+      subscriber_id = subscription_content.subscription.subscriber_id
+      current_value = results[subscriber_id] || {}
       subscription_contents_for_content_change = Array(current_value[subscription_content.content_change_id])
       subscription_contents_for_content_change << subscription_content
 
-      results[subscription_content.subscriber_id] = current_value.merge(
+      results[subscriber_id] = current_value.merge(
         subscription_content.content_change_id => subscription_contents_for_content_change
       )
     end

--- a/spec/queries/unprocessed_subscription_contents_by_subscriber_query_spec.rb
+++ b/spec/queries/unprocessed_subscription_contents_by_subscriber_query_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe UnprocessedSubscriptionContentsBySubscriberQuery do
-  let(:subscriber_one) { create(:subscriber) }
-  let(:subscriber_two) { create(:subscriber) }
+  let!(:subscriber_one) { create(:subscriber) }
+  let!(:subscriber_two) { create(:subscriber) }
+  let!(:subscriber_three) { create(:subscriber) }
   let(:content_change_one) { create(:content_change) }
   let(:content_change_two) { create(:content_change) }
 
@@ -10,12 +11,13 @@ RSpec.describe UnprocessedSubscriptionContentsBySubscriberQuery do
     create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_one), content_change: content_change_one)
     create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_one), content_change: content_change_one)
     create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_one), content_change: content_change_two)
+    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_three), content_change: content_change_two)
   end
 
-  subject { described_class.call(Subscriber.pluck(:id)) }
+  subject { described_class.call([subscriber_one.id, subscriber_two.id]) }
 
   it "returns a hash keyed by subscriber_id" do
-    expect(subject.keys).to match_array(Subscriber.pluck(:id))
+    expect(subject.keys).to match_array([subscriber_one.id])
   end
 
   it "creates a hash keyed by content_change_id per subscriber key" do
@@ -25,5 +27,9 @@ RSpec.describe UnprocessedSubscriptionContentsBySubscriberQuery do
   it "creates an array of subscription contents at each content change key" do
     expect(subject[subscriber_one.id][content_change_one.id])
       .to match_array(SubscriptionContent.where(content_change: content_change_one))
+  end
+
+  it "only returns the subscribers requested" do
+    expect(subject[subscriber_three.id]).to be_nil
   end
 end


### PR DESCRIPTION
Previously this query accepted an argument of subscriber_ids which was
used to filter these results, however the query did not make any actual
use of it.

We have since hit an issue where the ImmediateEmailGenerationWorker has
been failing with the following query:

```
ActiveRecord::StatementInvalid: PG::UnableToSend: number of parameters
must be between 0 and 65535 : SELECT "subscriptions".* FROM
"subscriptions" WHERE "subscriptions"."id" IN ($1, $2, $3, $4, $5,
$6,...
```

This seems to be from the `includes(:subscription)` in this query and
was trying to query such a vast amount of records because there were no
limits applied.

In editing this I was confused by the JOIN within the FROM clause and
refactored this into a traditional JOIN. I'm not sure why this was done
in the first place, so hopefully I'm not missing something that breaks
this.