### PR TITLE
Add ability to export subscription counts up to a certain date

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,29 @@ $ bundle exec rake manage:move_all_subscribers[<from_slug>, <to_slug>]
 You need to supply the `slug` for the source and destination
 subscriber lists.
 
+#### Export data
+
+There are a number of tasks available which export subscriber list data into CSV files on standard output. In
+particular this includes the active subscription count.
+
+```bash
+$ bundle exec rake export:csv_from_ids[<subscriber_list_id>, ...]
+```
+
+```bash
+$ bundle exec rake export:csv_from_ids_at[<date>, <subscriber_list_id>, ...]
+```
+
+This is the same as above, but exports the active subscription count of the subscriber list as it was on a particular
+date.
+
+```bash
+$ bundle exec rake export:csv_from_living_in_europe
+```
+
+This is a convenience export which does the same as above but with all the "Living in Europe" taxon subscriber lists
+without needing to know their IDs.
+
 ### Available endpoints
 
 #### application API

--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -1,4 +1,20 @@
+require "csv"
+
 class DataExporter
+  def export_csv_from_ids(ids)
+    export_csv(SubscriberList.where(id: ids))
+  end
+
+  def export_csv_from_ids_at(date, ids)
+    export_csv(SubscriberList.where(id: ids), at: date)
+  end
+
+  def export_csv_from_living_in_europe
+    export_csv(living_in_europe_subscriber_lists)
+  end
+
+private
+
   CSV_HEADERS = %i(id title count).freeze
 
   EUROPEAN_COUNTRIES = %w(
@@ -12,27 +28,29 @@ class DataExporter
     SubscriberList.where(slug: slugs)
   end
 
-  def present_subscriber_list(subscriber_list)
+  def subscriber_list_count(subscriber_list, date)
+    return subscriber_list.active_subscriptions_count unless date
+
+    subscriber_list
+      .subscriptions
+      .where("created_at < ?", date)
+      .where("ended_at IS NULL OR ended_at >= ?", date)
+      .count
+  end
+
+  def present_subscriber_list(subscriber_list, at:)
     {
       id: subscriber_list.id,
       title: subscriber_list.title,
-      count: subscriber_list.active_subscriptions_count,
+      count: subscriber_list_count(subscriber_list, at),
     }
   end
 
-  def export_csv(subscriber_lists)
+  def export_csv(subscriber_lists, at: nil)
     CSV($stdout, headers: CSV_HEADERS, write_headers: true) do |csv|
       subscriber_lists.find_each do |subscriber_list|
-        csv << present_subscriber_list(subscriber_list)
+        csv << present_subscriber_list(subscriber_list, at: at)
       end
     end
-  end
-
-  def export_csv_from_ids(ids)
-    export_csv(SubscriberList.where(id: ids))
-  end
-
-  def export_csv_from_living_in_europe
-    export_csv(living_in_europe_subscriber_lists)
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -4,6 +4,11 @@ namespace :export do
     DataExporter.new.export_csv_from_ids(args.to_a)
   end
 
+  desc "Export the number of subscriptions for a collection of lists given as arguments of list IDs at a given date"
+  task :csv_from_ids_at, [:date] => :environment do |_, args|
+    DataExporter.new.export_csv_from_ids_at(args.date, args.extras)
+  end
+
   desc "Export the number of subscriptions for the 'Living in' taxons for European countries"
   task csv_from_living_in_europe: :environment do
     DataExporter.new.export_csv_from_living_in_europe

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe DataExporter do
+  describe "#export_csv_from_ids_at" do
+    let(:date) { "2018-02-01" }
+    let(:subscriber_list) { create(:subscriber_list, id: 1, title: "title") }
+
+    before do
+      # not within time period
+      Timecop.freeze("2018-03-01") do
+        create(:subscription, subscriber_list: subscriber_list)
+        create(:subscription, :ended, subscriber_list: subscriber_list)
+      end
+
+      # within time period but only one is active
+      Timecop.freeze("2018-01-01") do
+        create(:subscription, subscriber_list: subscriber_list)
+        create(:subscription, :ended, subscriber_list: subscriber_list)
+      end
+
+      # resubscribed within the time period, only one is active
+      same_subscriber = create(:subscriber)
+      create(
+        :subscription, :ended, subscriber: same_subscriber, subscriber_list: subscriber_list,
+        created_at: "2018-01-04", ended_at: "2018-01-05", updated_at: "2018-01-05",
+      )
+      create(
+        :subscription, subscriber: same_subscriber, subscriber_list: subscriber_list,
+        created_at: "2018-01-06", updated_at: "2018-01-06",
+      )
+    end
+
+    subject { DataExporter.new.export_csv_from_ids_at(date, [subscriber_list.id]) }
+
+    it "returns the correct number of subscriptions" do
+      expect { subject }.to output("id,title,count\n1,title,2\n").to_stdout
+    end
+  end
+end


### PR DESCRIPTION
This allows us to see the active subscription count for a particular subscriber list on a certain date.

[Trello Card](https://trello.com/c/aCTaSZCS/208-get-email-subscription-figures-russia-travel-advice)