### PR TITLE
Remove uniq validation for title in SubscriberList

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -7,7 +7,6 @@ class SubscriberList < ApplicationRecord
   validate :link_values_are_valid
 
   validates :title, presence: true
-  validates_uniqueness_of :title
   validates_uniqueness_of :slug
 
   has_many :subscriptions

--- a/db/migrate/20180618132321_remove_title_index_from_subscriber_list.rb
+++ b/db/migrate/20180618132321_remove_title_index_from_subscriber_list.rb
@@ -1,0 +1,5 @@
+class RemoveTitleIndexFromSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    remove_index "subscriber_lists", name: "index_subscriber_lists_on_title"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_01_155601) do
+ActiveRecord::Schema.define(version: 2018_06_18_132321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,7 +130,6 @@ ActiveRecord::Schema.define(version: 2018_05_01_155601) do
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
     t.index ["slug"], name: "index_subscriber_lists_on_slug", unique: true
-    t.index ["title"], name: "index_subscriber_lists_on_title", unique: true
   end
 
   create_table "subscribers", force: :cascade do |t|

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -80,11 +80,11 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(response.status).to eq(422)
     end
 
-    it "returns an error if creating the same topic" do
-      create_subscriber_list(title: "oil and gas", tags: { topics: ["oil-and-gas/licensing"] })
-      create_subscriber_list(title: "oil and gas", tags: { topics: ["oil-and-gas/licensing"] })
+    it "successfully creates two SubscriberList objects with the same title" do
+      create_subscriber_list(title: "oil and gas", links: { taxons: ["oil-and-gas"] })
+      create_subscriber_list(title: "oil and gas", links: { policies: ["oil-and-gas/licensing"] })
 
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(201)
     end
 
     it "returns an error if link isn't an array" do


### PR DESCRIPTION
https://trello.com/c/C9Dr0Acy/167-investigate-a-solution-for-certain-taxons-signup-errors

Signing up for email alerts for certain taxon's throws an error due to the uniq
constraint on title in the SubscriberList model. This validation was
needed when Email was using GovDelivery, but now serves no purpose.

The removal of this validation will allow users to sign up for email
alerts for taxons which share the same title as other legacy taxonomies
instead of returning an error.