### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ruby:2.5.1
+RUN apt-get update -qq && apt-get install -y \
+  build-essential \
+  libpq-dev \
+  libxml2-dev \
+  libxslt1-dev
+RUN apt-get clean
+RUN gem install foreman
+
+ENV DATABASE_URL postgresql://postgres@postgres/email-alert-api
+ENV GOVUK_APP_NAME email-alert-api
+ENV PORT 3088
+ENV RAILS_ENV development
+ENV REDIS_HOST redis
+ENV TEST_DATABASE_URL postgresql://postgres@postgres/email-alert-api-test
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+
+WORKDIR $APP_HOME
+ADD Gemfile* $APP_HOME/
+RUN bundle install
+ADD . $APP_HOME
+
+CMD foreman run web

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,6 @@ gds_organisation_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
 
 User.create!(
   name: "Test user",
-  permissions: %w[signin status_updates],
+  permissions: %w[signin status_updates internal_app],
   organisation_content_id: gds_organisation_id,
 )

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -153,9 +153,11 @@ RSpec.describe "Creating a subscriber list", type: :request do
   end
 
   context "without authentication" do
-    it "returns a 403" do
-      post "/subscriber-lists", params: {}, headers: {}
-      expect(response.status).to eq(403)
+    it "returns a 401" do
+      without_login do
+        post "/subscriber-lists", params: {}, headers: {}
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -98,9 +98,11 @@ RSpec.describe "Creating a subscription", type: :request do
   end
 
   context "without authentication" do
-    it "returns a 403" do
-      post "/subscriptions", params: {}, headers: {}
-      expect(response.status).to eq(403)
+    it "returns a 401" do
+      without_login do
+        post "/subscriptions", params: {}, headers: {}
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/integration/get_subscriber_list_spec.rb
+++ b/spec/integration/get_subscriber_list_spec.rb
@@ -189,9 +189,11 @@ RSpec.describe "Getting a subscriber list", type: :request do
   end
 
   context "without authentication" do
-    it "returns a 403" do
-      get_subscriber_list({})
-      expect(response.status).to eq(403)
+    it "returns a 401" do
+      without_login do
+        get_subscriber_list({})
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/integration/notifications_spec.rb
+++ b/spec/integration/notifications_spec.rb
@@ -107,9 +107,11 @@ RSpec.describe "Receiving a notification", type: :request do
   end
 
   context "without authentication" do
-    it "returns a 403" do
-      post "/notifications", params: {}
-      expect(response.status).to eq(403)
+    it "returns a 401" do
+      without_login do
+        post "/notifications", params: {}
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/integration/send_notification_spec.rb
+++ b/spec/integration/send_notification_spec.rb
@@ -36,10 +36,11 @@ RSpec.describe "Sending a notification", type: :request do
   end
 
   context "without authentication" do
-    it "returns 403" do
-      post "/notifications", params: {}, headers: {}
-
-      expect(response.status).to eq(403)
+    it "returns 401" do
+      without_login do
+        post "/notifications", params: {}, headers: {}
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/integration/subscribables_controller_spec.rb
+++ b/spec/integration/subscribables_controller_spec.rb
@@ -27,10 +27,11 @@ RSpec.describe "Getting a subscribable", type: :request do
     end
 
     context "without authentication" do
-      it "returns a 403" do
-        get "/subscribables/test135"
-
-        expect(response.status).to eq(403)
+      it "returns a 401" do
+        without_login do
+          get "/subscribables/test135"
+          expect(response.status).to eq(401)
+        end
       end
     end
 

--- a/spec/integration/subscribers_spec.rb
+++ b/spec/integration/subscribers_spec.rb
@@ -93,9 +93,11 @@ RSpec.describe "Subscriptions", type: :request do
   end
 
   context "without authentication" do
-    it "returns a 403" do
-      get "/subscribers/1/subscriptions"
-      expect(response.status).to eq(403)
+    it "returns a 401" do
+      without_login do
+        get "/subscribers/1/subscriptions"
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -162,9 +162,11 @@ RSpec.describe "Subscriptions", type: :request do
   end
 
   context "without authentication" do
-    it "returns a 403" do
-      post "/subscriptions", params: { subscribable_id: 10, address: "test@example.com" }
-      expect(response.status).to eq(403)
+    it "returns a 401" do
+      without_login do
+        post "/subscriptions", params: { subscribable_id: 10, address: "test@example.com" }
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/integration/unsubscribe_spec.rb
+++ b/spec/integration/unsubscribe_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe "Unsubscribing", type: :request do
   end
 
   context "without authentication" do
-    it "returns a 403" do
-      post "/unsubscribe/123"
-      expect(response.status).to eq(403)
+    it "returns a 401" do
+      without_login do
+        post "/unsubscribe/123"
+        expect(response.status).to eq(401)
+      end
     end
   end
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -15,6 +15,10 @@ module AuthenticationHelpers
     login_as(create(:user, permissions: Array(permissions)))
   end
 
+  def without_login
+    ClimateControl.modify(GDS_SSO_MOCK_INVALID: "1") { yield }
+  end
+
   def login_as(user)
     GDS::SSO.test_user = user
   end


### PR DESCRIPTION
Trello: https://trello.com/c/U9nNDFrH/222-decide-on-whether-e2e-tests-should-include-email-alert-api-following-on-from-content-tagger-work

This will allow this app to be part of [publishing-e2e-tests](https://github.com/alphagov/publishing-e2e-tests) 