### PR TITLE
Add a healthcheck for subscription content processing time

### DIFF
--- a/app/models/healthcheck/subscription_content_healthcheck.rb
+++ b/app/models/healthcheck/subscription_content_healthcheck.rb
@@ -1,0 +1,50 @@
+module Healthcheck
+  class SubscriptionContentHealthcheck
+    def name
+      :subscription_content
+    end
+
+    def status
+      if count_subscription_contents(critical_latency).positive?
+        :critical
+      elsif count_subscription_contents(warning_latency).positive?
+        :warning
+      else
+        :ok
+      end
+    end
+
+    def details
+      {
+        critical: count_subscription_contents(critical_latency),
+        warning: count_subscription_contents(warning_latency),
+      }
+    end
+
+  private
+
+    def count_subscription_contents(age)
+      # The `merge(Subscription.active)` check is because there is a
+      # race condition in email generation: if someone unsubscribes
+      # after the `ContentChange` has been processed but before the
+      # generated `SubscriptionContent`s have been, then those
+      # `SubscriptionContent`s will never get an email associated with
+      # them - this is the correct behaviour, we don't want to email
+      # people who have unsubscribed.
+      SubscriptionContent
+        .where("subscription_contents.created_at < ?", age.ago)
+        .where(email: nil)
+        .joins(:subscription)
+        .merge(Subscription.active)
+        .count
+    end
+
+    def critical_latency
+      1.minute
+    end
+
+    def warning_latency
+      30.seconds
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
       Healthcheck::QueueSizeHealthcheck.new,
       Healthcheck::RetrySizeHealthcheck.new,
       Healthcheck::StatusUpdateHealthcheck.new,
+      Healthcheck::SubscriptionContentHealthcheck.new,
       Healthcheck::TechnicalFailureHealthcheck.new,
     )
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.draw do
+Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   scope format: false, defaults: { format: :json } do
     root "welcome#index"
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]

--- a/db/migrate/20180625135732_add_index_to_subscription_content.rb
+++ b/db/migrate/20180625135732_add_index_to_subscription_content.rb
@@ -1,0 +1,7 @@
+class AddIndexToSubscriptionContent < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscription_contents, :created_at, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20180625143326_disable_subscriptions_with_inactive_subscribers.rb
+++ b/db/migrate/20180625143326_disable_subscriptions_with_inactive_subscribers.rb
@@ -1,0 +1,8 @@
+class DisableSubscriptionsWithInactiveSubscribers < ActiveRecord::Migration[5.2]
+  def up
+    subscriptions = Subscription.active.where(subscriber: Subscriber.deactivated)
+    subscriptions.find_each do |subscription|
+      subscription.end(reason: :unsubscribed)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_18_132321) do
+ActiveRecord::Schema.define(version: 2018_06_25_143326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,6 +149,7 @@ ActiveRecord::Schema.define(version: 2018_06_18_132321) do
     t.uuid "subscription_id", null: false
     t.uuid "content_change_id", null: false
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
+    t.index ["created_at"], name: "index_subscription_contents_on_created_at"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
     t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Healthcheck", type: :request do
       queue_size:            { status: "ok", queues: a_kind_of(Hash) },
       redis_connectivity:    { status: "ok" },
       retry_size:            { status: "ok", retry_size: 0 },
+      subscription_content:  { status: "ok", critical: 0, warning: 0 },
       technical_failure:     hash_including(status: "ok", failing: 0),
     )
   end

--- a/spec/models/healthcheck/subscription_content_healthcheck.rb
+++ b/spec/models/healthcheck/subscription_content_healthcheck.rb
@@ -1,0 +1,37 @@
+RSpec.describe Healthcheck::SubscriptionContentHealthcheck do
+  shared_examples "an ok healthcheck" do
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  shared_examples "a warning healthcheck" do
+    specify { expect(subject.status).to eq(:warning) }
+  end
+
+  shared_examples "a critical healthcheck" do
+    specify { expect(subject.status).to eq(:critical) }
+  end
+
+  context "when a subscription content was created 1 second ago" do
+    before do
+      create(:subscription_content, created_at: 1.second.ago)
+    end
+
+    it_behaves_like "an ok healthcheck"
+  end
+
+  context "when a subscription content was created 30 seconds ago" do
+    before do
+      create(:subscription_content, created_at: 30.seconds.ago)
+    end
+
+    it_behaves_like "a warning healthcheck"
+  end
+
+  context "when a subscription content was created 1 minute ago" do
+    before do
+      create(:subscription_content, created_at: 1.minute.ago)
+    end
+
+    it_behaves_like "a critical healthcheck"
+  end
+end


### PR DESCRIPTION
This also creates an index on `SubscriptionContent.created_at`, as we query that field.

Tests are failing because they're not running the migrations.

---

[Trello card](https://trello.com/c/yGEsHaY9/253-email-alert-api-healthcheck-should-monitor-more-critical-areas)