### PR TITLE
Add a healthcheck for complete digest runs

### DIFF
--- a/app/models/healthcheck/content_change_healthcheck.rb
+++ b/app/models/healthcheck/content_change_healthcheck.rb
@@ -1,7 +1,7 @@
 module Healthcheck
   class ContentChangeHealthcheck
     def name
-      :content_change
+      :content_changes
     end
 
     def status

--- a/app/models/healthcheck/digest_run_healthcheck.rb
+++ b/app/models/healthcheck/digest_run_healthcheck.rb
@@ -1,0 +1,41 @@
+module Healthcheck
+  class DigestRunHealthcheck
+    def name
+      :digest_runs
+    end
+
+    def status
+      if count_digest_runs(critical_latency).positive?
+        :critical
+      elsif count_digest_runs(warning_latency).positive?
+        :warning
+      else
+        :ok
+      end
+    end
+
+    def details
+      {
+        critical: count_digest_runs(critical_latency),
+        warning: count_digest_runs(warning_latency),
+      }
+    end
+
+  private
+
+    def count_digest_runs(age)
+      DigestRun
+        .where("created_at < ?", age.ago)
+        .where(completed_at: nil)
+        .count
+    end
+
+    def critical_latency
+      1.hour
+    end
+
+    def warning_latency
+      20.minutes
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     get "/healthcheck", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::SidekiqRedis,
       GovukHealthcheck::ActiveRecord,
-
+      Healthcheck::ContentChangeHealthcheck.new,
       Healthcheck::DigestRunHealthcheck.new,
       Healthcheck::QueueLatencyHealthcheck.new,
       Healthcheck::QueueSizeHealthcheck.new,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
     get "/healthcheck", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::SidekiqRedis,
       GovukHealthcheck::ActiveRecord,
+
+      Healthcheck::DigestRunHealthcheck.new,
       Healthcheck::QueueLatencyHealthcheck.new,
       Healthcheck::QueueSizeHealthcheck.new,
       Healthcheck::RetrySizeHealthcheck.new,

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Healthcheck", type: :request do
 
     expect(data.fetch(:checks)).to include(
       database_connectivity: { status: "ok" },
+      content_changes:       { status: "ok", critical: 0, warning: 0 },
       digest_runs:           { status: "ok", critical: 0, warning: 0 },
       queue_latency:         { status: "ok", queues: a_kind_of(Hash) },
       queue_size:            { status: "ok", queues: a_kind_of(Hash) },

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Healthcheck", type: :request do
 
     expect(data.fetch(:checks)).to include(
       database_connectivity: { status: "ok" },
+      digest_runs:           { status: "ok", critical: 0, warning: 0 },
       queue_latency:         { status: "ok", queues: a_kind_of(Hash) },
       queue_size:            { status: "ok", queues: a_kind_of(Hash) },
       redis_connectivity:    { status: "ok" },

--- a/spec/models/healthcheck/digest_run_healthcheck_spec.rb
+++ b/spec/models/healthcheck/digest_run_healthcheck_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Healthcheck::DigestRunHealthcheck do
+  shared_examples "an ok healthcheck" do
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  shared_examples "a warning healthcheck" do
+    specify { expect(subject.status).to eq(:warning) }
+  end
+
+  shared_examples "a critical healthcheck" do
+    specify { expect(subject.status).to eq(:critical) }
+  end
+
+  context "when a content change was created 5 minute ago" do
+    before { create(:digest_run, created_at: 5.minute.ago) }
+    it_behaves_like "an ok healthcheck"
+  end
+
+  context "when a content change was created 30 minutes ago" do
+    before { create(:digest_run, created_at: 30.minutes.ago) }
+    it_behaves_like "a warning healthcheck"
+  end
+
+  context "when a content change was created 60 minutes ago" do
+    before { create(:digest_run, created_at: 60.minutes.ago) }
+    it_behaves_like "a critical healthcheck"
+  end
+end


### PR DESCRIPTION
This adds a healthcheck that alerts us to if there are any digest runs that were created a certain number of minutes ago and haven't yet completed. For critical this is one hour, for warning this is 20 minutes.

I looked in the database and the average time for a digest run to be complete is 14 minutes, the maximum is 1 hour and 15 minutes.

This PR also completes some work that was missed in #618.

[Trello Card](https://trello.com/c/yGEsHaY9/253-email-alert-api-healthcheck-should-monitor-more-critical-areas)