### PR TITLE
Temporarily disable subscription content healthcheck

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
+Rails.application.routes.draw do
   scope format: false, defaults: { format: :json } do
     root "welcome#index"
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
@@ -25,7 +25,6 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       Healthcheck::QueueSizeHealthcheck.new,
       Healthcheck::RetrySizeHealthcheck.new,
       Healthcheck::StatusUpdateHealthcheck.new,
-      Healthcheck::SubscriptionContentHealthcheck.new,
       Healthcheck::TechnicalFailureHealthcheck.new,
     )
   end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe "Healthcheck", type: :request do
       queue_size:            { status: "ok", queues: a_kind_of(Hash) },
       redis_connectivity:    { status: "ok" },
       retry_size:            { status: "ok", retry_size: 0 },
-      subscription_content:  { status: "ok", critical: 0, warning: 0 },
       technical_failure:     hash_including(status: "ok", failing: 0),
     )
   end


### PR DESCRIPTION
The index added in 0e4be2ac95b19eb23c54dd2850538a3353c1cb6c is taking too long to run during a deploy and times out. So I have to deploy the app without migrations first and then run the migrations manually afterwards.

I want to temporarily disable this healthcheck so it doesn't try and run the query without the index which would be very slow.