### PR TITLE
More indexes for healthchecks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,6 @@ Rails.application.routes.draw do
     get "/healthcheck", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::SidekiqRedis,
       GovukHealthcheck::ActiveRecord,
-      Healthcheck::ContentChangeHealthcheck.new,
-      Healthcheck::DigestRunHealthcheck.new,
       Healthcheck::QueueLatencyHealthcheck.new,
       Healthcheck::QueueSizeHealthcheck.new,
       Healthcheck::RetrySizeHealthcheck.new,

--- a/db/migrate/20180628071838_add_index_to_content_change_processed_at.rb
+++ b/db/migrate/20180628071838_add_index_to_content_change_processed_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToContentChangeProcessedAt < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :content_changes, :processed_at, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20180628072213_add_index_to_digest_run_completed_at.rb
+++ b/db/migrate/20180628072213_add_index_to_digest_run_completed_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToDigestRunCompletedAt < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :digest_runs, :completed_at, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20180628072318_add_index_to_digest_run_created_at.rb
+++ b/db/migrate/20180628072318_add_index_to_digest_run_created_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToDigestRunCreatedAt < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :digest_runs, :created_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_25_143326) do
+ActiveRecord::Schema.define(version: 2018_06_28_071838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2018_06_25_143326) do
     t.string "signon_user_uid"
     t.text "footnote", default: "", null: false
     t.index ["created_at"], name: "index_content_changes_on_created_at"
+    t.index ["processed_at"], name: "index_content_changes_on_processed_at"
     t.index ["updated_at"], name: "index_content_changes_on_updated_at"
   end
 
@@ -161,8 +162,8 @@ ActiveRecord::Schema.define(version: 2018_06_25_143326) do
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "frequency", default: 0, null: false
     t.string "signon_user_uid"
+    t.integer "frequency", default: 0, null: false
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
     t.integer "ended_reason"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_071838) do
+ActiveRecord::Schema.define(version: 2018_06_28_072318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,8 @@ ActiveRecord::Schema.define(version: 2018_06_28_071838) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "subscriber_count"
+    t.index ["completed_at"], name: "index_digest_runs_on_completed_at"
+    t.index ["created_at"], name: "index_digest_runs_on_created_at"
   end
 
   create_table "email_archives", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe "Healthcheck", type: :request do
 
     expect(data.fetch(:checks)).to include(
       database_connectivity: { status: "ok" },
-      content_changes:       { status: "ok", critical: 0, warning: 0 },
-      digest_runs:           { status: "ok", critical: 0, warning: 0 },
       queue_latency:         { status: "ok", queues: a_kind_of(Hash) },
       queue_size:            { status: "ok", queues: a_kind_of(Hash) },
       redis_connectivity:    { status: "ok" },


### PR DESCRIPTION
This adds some more indexes which will be used by the new health checks. I've run an `EXPLAIN` on all the queries and adding these indexes makes the queries much faster.

I've also temporarily disabled the new health checks as I want to deploy the app without migrations and then run the migrations manually before re-enabling the health checks again. This is because the migrations take a long time to run and time out in Jenkins.

[Trello Card](https://trello.com/c/yGEsHaY9/253-email-alert-api-healthcheck-should-monitor-more-critical-areas)