### PR TITLE
Enable new health checks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.draw do
+Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   scope format: false, defaults: { format: :json } do
     root "welcome#index"
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       Healthcheck::QueueSizeHealthcheck.new,
       Healthcheck::RetrySizeHealthcheck.new,
       Healthcheck::StatusUpdateHealthcheck.new,
+      Healthcheck::SubscriptionContentHealthcheck.new,
       Healthcheck::TechnicalFailureHealthcheck.new,
     )
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
     get "/healthcheck", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::SidekiqRedis,
       GovukHealthcheck::ActiveRecord,
+      Healthcheck::ContentChangeHealthcheck.new,
+      Healthcheck::DigestRunHealthcheck.new,
       Healthcheck::QueueLatencyHealthcheck.new,
       Healthcheck::QueueSizeHealthcheck.new,
       Healthcheck::RetrySizeHealthcheck.new,

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe "Healthcheck", type: :request do
 
     expect(data.fetch(:checks)).to include(
       database_connectivity: { status: "ok" },
+      content_changes:       { status: "ok", critical: 0, warning: 0 },
+      digest_runs:           { status: "ok", critical: 0, warning: 0 },
       queue_latency:         { status: "ok", queues: a_kind_of(Hash) },
       queue_size:            { status: "ok", queues: a_kind_of(Hash) },
       redis_connectivity:    { status: "ok" },

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "Healthcheck", type: :request do
       queue_size:            { status: "ok", queues: a_kind_of(Hash) },
       redis_connectivity:    { status: "ok" },
       retry_size:            { status: "ok", retry_size: 0 },
+      subscription_content:  { status: "ok", critical: 0, warning: 0 },
       technical_failure:     hash_including(status: "ok", failing: 0),
     )
   end


### PR DESCRIPTION
The various indexes necessary for these health checks to run fast have been added now so we can enable these health checks.

[Trello Card](https://trello.com/c/yGEsHaY9/253-email-alert-api-healthcheck-should-monitor-more-critical-areas)