### PR TITLE
DB changes for exporting Email Archives table

### DIFF
--- a/db/migrate/20180628134912_add_exported_at_to_email_archives.rb
+++ b/db/migrate/20180628134912_add_exported_at_to_email_archives.rb
@@ -1,0 +1,5 @@
+class AddExportedAtToEmailArchives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :email_archives, :exported_at, :datetime
+  end
+end

--- a/db/migrate/20180628135936_add_indexes_to_email_archive.rb
+++ b/db/migrate/20180628135936_add_indexes_to_email_archive.rb
@@ -1,0 +1,7 @@
+class AddIndexesToEmailArchive < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  def change
+    add_index :email_archives, :finished_sending_at, algorithm: :concurrently
+    add_index :email_archives, :exported_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_072318) do
+ActiveRecord::Schema.define(version: 2018_06_28_134912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2018_06_28_072318) do
     t.datetime "created_at", null: false
     t.datetime "archived_at", null: false
     t.datetime "finished_sending_at", null: false
+    t.datetime "exported_at"
   end
 
   create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -164,8 +165,8 @@ ActiveRecord::Schema.define(version: 2018_06_28_072318) do
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "signon_user_uid"
     t.integer "frequency", default: 0, null: false
+    t.string "signon_user_uid"
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
     t.integer "ended_reason"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_134912) do
+ActiveRecord::Schema.define(version: 2018_06_28_135936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,8 @@ ActiveRecord::Schema.define(version: 2018_06_28_134912) do
     t.datetime "archived_at", null: false
     t.datetime "finished_sending_at", null: false
     t.datetime "exported_at"
+    t.index ["exported_at"], name: "index_email_archives_on_exported_at"
+    t.index ["finished_sending_at"], name: "index_email_archives_on_finished_sending_at"
   end
 
   create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|


### PR DESCRIPTION
Trello: https://trello.com/c/FM3MCuAl/255-investigate-email-alert-api-database-size-and-push-email-archives-to-s3

This adds two indexes for traversing the table as part of exporting this data to S3 and a field, `exported_at` which we can use to exclude things that have already been excluded.