### PR TITLE
Archive emails to S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '~> 5.2'
 gem 'activerecord-import', '~> 0.24'
 gem 'with_advisory_lock', '~> 3.2'
 
+gem 'aws-sdk-s3', '~> 1'
 gem 'faraday', '0.12.2'
 gem 'foreman', '~> 0.85'
 gem 'gds-api-adapters', '~> 52.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,21 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.94.0)
+    aws-sdk-core (3.22.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.6.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.15.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     builder (3.2.3)
     byebug (10.0.2)
     climate_control (0.2.0)
@@ -119,6 +134,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     jwt (1.5.6)
     kgio (2.11.2)
     link_header (0.0.8)
@@ -335,6 +351,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import (~> 0.24)
+  aws-sdk-s3 (~> 1)
   climate_control
   equivalent-xml
   factory_bot_rails
@@ -363,4 +380,4 @@ DEPENDENCIES
   with_advisory_lock (~> 3.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/presenters/email_archive_presenter.rb
+++ b/app/presenters/email_archive_presenter.rb
@@ -1,15 +1,33 @@
 class EmailArchivePresenter
   # This is expected to be called with a JSON representation of a record
   # returned from EmailArchiveQuery
-  def self.call(*args)
-    new.call(*args)
+  def self.for_s3(*args)
+    new.for_s3(*args)
   end
 
-  def call(record, archived_at)
+  def for_s3(record, archived_at)
+    {
+      archived_at: archived_at.utc.to_s(:db),
+      content_change: build_content_change(record),
+      created_at: record.fetch("created_at").utc.to_s(:db),
+      finished_sending_at: record.fetch("finished_sending_at").utc.to_s(:db),
+      id: record.fetch("id"),
+      sent: record.fetch("sent"),
+      subject: record.fetch("subject"),
+      subscriber_id: record.fetch("subscriber_id"),
+    }
+  end
+
+  def self.for_db(*args)
+    new.for_db(*args)
+  end
+
+  def for_db(record, archived_at, exported_at = nil)
     {
       archived_at: archived_at,
       content_change: build_content_change(record),
       created_at: record.fetch("created_at"),
+      exported_at: exported_at,
       finished_sending_at: record.fetch("finished_sending_at"),
       id: record.fetch("id"),
       sent: record.fetch("sent"),

--- a/app/presenters/email_archive_presenter.rb
+++ b/app/presenters/email_archive_presenter.rb
@@ -1,0 +1,40 @@
+class EmailArchivePresenter
+  # This is expected to be called with a JSON representation of a record
+  # returned from EmailArchiveQuery
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  def call(record, archived_at)
+    {
+      archived_at: archived_at,
+      content_change: build_content_change(record),
+      created_at: record.fetch("created_at"),
+      finished_sending_at: record.fetch("finished_sending_at"),
+      id: record.fetch("id"),
+      sent: record.fetch("sent"),
+      subject: record.fetch("subject"),
+      subscriber_id: record.fetch("subscriber_id"),
+    }
+  end
+
+  private_class_method :new
+
+private
+
+  def build_content_change(record)
+    return if record.fetch("content_change_ids").empty?
+
+    if record.fetch("digest_run_ids").count > 1
+      error = "Email with id: #{record['id']} is associated with "\
+        "multiple digest runs: #{record['digest_run_ids'].join(', ')}"
+      GovukError.notify(error)
+    end
+
+    {
+      content_change_ids: record.fetch("content_change_ids"),
+      digest_run_id: record.fetch("digest_run_ids").first,
+      subscription_ids: record.fetch("subscription_ids"),
+    }
+  end
+end

--- a/app/presenters/email_archive_presenter.rb
+++ b/app/presenters/email_archive_presenter.rb
@@ -1,4 +1,6 @@
 class EmailArchivePresenter
+  S3_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%L".freeze
+
   # This is expected to be called with a JSON representation of a record
   # returned from EmailArchiveQuery
   def self.for_s3(*args)
@@ -7,10 +9,10 @@ class EmailArchivePresenter
 
   def for_s3(record, archived_at)
     {
-      archived_at: archived_at.utc.to_s(:db),
+      archived_at_utc: archived_at.utc.strftime(S3_DATETIME_FORMAT),
       content_change: build_content_change(record),
-      created_at: record.fetch("created_at").utc.to_s(:db),
-      finished_sending_at: record.fetch("finished_sending_at").utc.to_s(:db),
+      created_at_utc: record.fetch("created_at").utc.strftime(S3_DATETIME_FORMAT),
+      finished_sending_at_utc: record.fetch("finished_sending_at").utc.strftime(S3_DATETIME_FORMAT),
       id: record.fetch("id"),
       sent: record.fetch("sent"),
       subject: record.fetch("subject"),

--- a/app/services/s3_email_archive_service.rb
+++ b/app/services/s3_email_archive_service.rb
@@ -18,14 +18,14 @@ private
       # we group by date in this way to create partitions for s3/athena
       # these are grouped in case dates span more than one day
       Date.parse(
-        item.fetch(:finished_sending_at)
+        item.fetch(:finished_sending_at_utc)
       ).strftime("year=%Y/month=%m/date=%d")
     end
   end
 
   def send_to_s3(prefix, records)
-    records = records.sort_by { |r| r.fetch(:finished_sending_at) }
-    last_time = records.last[:finished_sending_at]
+    records = records.sort_by { |r| r.fetch(:finished_sending_at_utc) }
+    last_time = records.last[:finished_sending_at_utc]
     obj = bucket.object(object_name(prefix, last_time))
     obj.put(
       body: object_body(records),

--- a/app/services/s3_email_archive_service.rb
+++ b/app/services/s3_email_archive_service.rb
@@ -17,7 +17,9 @@ private
     batch.group_by do |item|
       # we group by date in this way to create partitions for s3/athena
       # these are grouped in case dates span more than one day
-      item.fetch(:finished_sending_at).utc.strftime("year=%Y/month=%m/date=%d")
+      Date.parse(
+        item.fetch(:finished_sending_at)
+      ).strftime("year=%Y/month=%m/date=%d")
     end
   end
 
@@ -40,7 +42,8 @@ private
 
   def object_name(prefix, last_time)
     uuid = SecureRandom.uuid
-    "email-archive/#{prefix}/#{last_time.utc.to_s(:iso8601)}-#{uuid}.json.gz"
+    time = ActiveSupport::TimeZone["UTC"].parse(last_time)
+    "email-archive/#{prefix}/#{time.to_s(:iso8601)}-#{uuid}.json.gz"
   end
 
   def object_body(records)

--- a/app/services/s3_email_archive_service.rb
+++ b/app/services/s3_email_archive_service.rb
@@ -1,0 +1,50 @@
+class S3EmailArchiveService
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  # For batch we expect an array of hashes containing email data in the format
+  # from EmailArchivePresenter
+  def call(batch)
+    group_by_date(batch).map { |prefix, records| send_to_s3(prefix, records) }
+  end
+
+  private_class_method :new
+
+private
+
+  def group_by_date(batch)
+    batch.group_by do |item|
+      # we group by date in this way to create partitions for s3/athena
+      # these are grouped in case dates span more than one day
+      item.fetch(:finished_sending_at).utc.strftime("year=%Y/month=%m/date=%d")
+    end
+  end
+
+  def send_to_s3(prefix, records)
+    records = records.sort_by { |r| r.fetch(:finished_sending_at) }
+    last_time = records.last[:finished_sending_at]
+    obj = bucket.object(object_name(prefix, last_time))
+    obj.put(
+      body: object_body(records),
+      content_encoding: "gzip"
+    )
+  end
+
+  def bucket
+    @bucket ||= begin
+                  s3 = Aws::S3::Resource.new
+                  s3.bucket(ENV.fetch("EMAIL_ARCHIVE_S3_BUCKET"))
+                end
+  end
+
+  def object_name(prefix, last_time)
+    uuid = SecureRandom.uuid
+    "email-archive/#{prefix}/#{last_time.utc.to_s(:iso8601)}-#{uuid}.json.gz"
+  end
+
+  def object_body(records)
+    data = records.map(&:to_json).join("\n") + "\n"
+    ActiveSupport::Gzip.compress(data, Zlib::BEST_COMPRESSION)
+  end
+end

--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -12,7 +12,7 @@ class EmailArchiveWorker
 
       EmailArchiveQuery.call.in_batches do |batch|
         Email.transaction do
-          archived_count += archive_batch(batch)
+          archived_count += archive_batch(batch.as_json)
         end
       end
 
@@ -24,47 +24,34 @@ private
 
   def archive_batch(batch)
     archived_at = Time.zone.now
+    exported_at = nil
 
-    import_batch(batch, archived_at)
-    Email.where(id: batch.pluck(:id)).update_all(archived_at: archived_at)
+    if ENV.include?("EMAIL_ARCHIVE_S3_ENABLED")
+      send_to_s3(batch, archived_at)
+      exported_at = archived_at
+    end
+
+    import_batch(batch, archived_at, exported_at)
+    mark_emails_as_archived(batch.pluck("id"), archived_at)
   end
 
-  def import_batch(batch, archived_at)
-    to_import = batch.as_json.map { |e| build_email_archive(e, archived_at) }
-    columns = to_import.first.keys.map(&:to_s)
-    values = to_import.map(&:values)
+  def import_batch(batch, archived_at, exported_at)
+    archive = batch.map do |b|
+      EmailArchivePresenter.for_db(b, archived_at, exported_at)
+    end
+
+    columns = archive.first.keys.map(&:to_s)
+    values = archive.map(&:values)
     EmailArchive.import(columns, values, validate: false)
   end
 
-  def build_email_archive(email_data, archived_at)
-    content_change = build_content_change(email_data)
-
-    {
-      archived_at: archived_at,
-      content_change: content_change,
-      created_at: email_data.fetch("created_at"),
-      finished_sending_at: email_data.fetch("finished_sending_at"),
-      id: email_data.fetch("id"),
-      sent: email_data.fetch("sent"),
-      subject: email_data.fetch("subject"),
-      subscriber_id: email_data.fetch("subscriber_id"),
-    }
+  def send_to_s3(batch, archived_at)
+    archive = batch.map { |b| EmailArchivePresenter.for_s3(b, archived_at) }
+    S3EmailArchiveService.call(archive)
   end
 
-  def build_content_change(email_data)
-    return if email_data.fetch("content_change_ids").empty?
-
-    if email_data.fetch("digest_run_ids").count > 1
-      error = "Email with id: #{email_data['id']} is associated with "\
-        "multiple digest runs: #{email_data['digest_run_ids'].join(', ')}"
-      GovukError.notify(error)
-    end
-
-    {
-      content_change_ids: email_data.fetch("content_change_ids"),
-      digest_run_id: email_data.fetch("digest_run_ids").first,
-      subscription_ids: email_data.fetch("subscription_ids"),
-    }
+  def mark_emails_as_archived(ids, archived_at)
+    Email.where(id: ids).update_all(archived_at: archived_at)
   end
 
   def log_complete(archived, start_time, end_time)

--- a/db/migrate/20180628134912_add_exported_at_to_email_archives.rb
+++ b/db/migrate/20180628134912_add_exported_at_to_email_archives.rb
@@ -1,0 +1,5 @@
+class AddExportedAtToEmailArchives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :email_archives, :exported_at, :datetime
+  end
+end

--- a/db/migrate/20180628135936_add_indexes_to_email_archive.rb
+++ b/db/migrate/20180628135936_add_indexes_to_email_archive.rb
@@ -1,0 +1,7 @@
+class AddIndexesToEmailArchive < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  def change
+    add_index :email_archives, :finished_sending_at, algorithm: :concurrently
+    add_index :email_archives, :exported_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_072318) do
+ActiveRecord::Schema.define(version: 2018_06_28_134912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2018_06_28_072318) do
     t.datetime "created_at", null: false
     t.datetime "archived_at", null: false
     t.datetime "finished_sending_at", null: false
+    t.datetime "exported_at"
   end
 
   create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -164,8 +165,8 @@ ActiveRecord::Schema.define(version: 2018_06_28_072318) do
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "signon_user_uid"
     t.integer "frequency", default: 0, null: false
+    t.string "signon_user_uid"
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
     t.integer "ended_reason"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_28_134912) do
+ActiveRecord::Schema.define(version: 2018_06_28_135936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,8 @@ ActiveRecord::Schema.define(version: 2018_06_28_134912) do
     t.datetime "archived_at", null: false
     t.datetime "finished_sending_at", null: false
     t.datetime "exported_at"
+    t.index ["exported_at"], name: "index_email_archives_on_exported_at"
+    t.index ["finished_sending_at"], name: "index_email_archives_on_finished_sending_at"
   end
 
   create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/lib/email_archive_exporter.rb
+++ b/lib/email_archive_exporter.rb
@@ -1,0 +1,91 @@
+class EmailArchiveExporter
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  def call(from_date, until_date)
+    from_date = Date.parse(from_date)
+    until_date = Date.parse(until_date)
+
+    puts "Exporting records that finished sending from #{from_date} and before #{until_date}"
+
+    total = (from_date...until_date).inject(0) { |sum, date| sum + export(date) }
+
+    puts "Exported #{total} records"
+  end
+
+  private_class_method :new
+
+private
+
+  def export(date)
+    puts "Exporting #{date}"
+    start = Time.now
+
+    count = 0
+
+    loop do
+      records = email_archive_records(date)
+
+      break unless records.any?
+
+      ExportToS3.call(records)
+
+      count += records.count
+      puts "Processed #{count} emails"
+    end
+
+    seconds = Time.now.to_i - start.to_i
+    puts "Completed #{date} in #{seconds} seconds"
+
+    count
+  end
+
+  def email_archive_records(date)
+    EmailArchive
+      .where(
+        "finished_sending_at >= ? AND finished_sending_at < ?",
+        date,
+        date + 1.day
+      )
+      .where(exported_at: nil)
+      .order(finished_sending_at: :asc, id: :asc)
+      .limit(50_000)
+      .as_json
+  end
+
+  class ExportToS3
+    def self.call(*args)
+      new.call(*args)
+    end
+
+    def call(records)
+      send_to_s3(records)
+      mark_as_exported(records)
+    end
+
+  private
+
+    def send_to_s3(records)
+      batch = records.map do |r|
+        r.symbolize_keys.slice(
+          :archived_at,
+          :content_change,
+          :created_at,
+          :finished_sending_at,
+          :id,
+          :sent,
+          :subject,
+          :subscriber_id
+        )
+      end
+
+      S3EmailArchiveService.call(batch)
+    end
+
+    def mark_as_exported(records)
+      ids = records.map { |r| r["id"] }
+      EmailArchive.where(id: ids).update_all(exported_at: Time.now)
+    end
+  end
+end

--- a/lib/email_archive_exporter.rb
+++ b/lib/email_archive_exporter.rb
@@ -69,10 +69,10 @@ private
     def send_to_s3(records)
       batch = records.map do |r|
         {
-          archived_at: r["archived_at"].utc.to_s(:db),
+          archived_at_utc: r["archived_at"].utc.strftime(EmailArchivePresenter::S3_DATETIME_FORMAT),
           content_change: r["content_change"],
-          created_at: r["created_at"].utc.to_s(:db),
-          finished_sending_at: r["finished_sending_at"].utc.to_s(:db),
+          created_at_utc: r["created_at"].utc.strftime(EmailArchivePresenter::S3_DATETIME_FORMAT),
+          finished_sending_at_utc: r["finished_sending_at"].utc.strftime(EmailArchivePresenter::S3_DATETIME_FORMAT),
           id: r["id"],
           sent: r["sent"],
           subject: r["subject"],

--- a/lib/email_archive_exporter.rb
+++ b/lib/email_archive_exporter.rb
@@ -68,16 +68,16 @@ private
 
     def send_to_s3(records)
       batch = records.map do |r|
-        r.symbolize_keys.slice(
-          :archived_at,
-          :content_change,
-          :created_at,
-          :finished_sending_at,
-          :id,
-          :sent,
-          :subject,
-          :subscriber_id
-        )
+        {
+          archived_at: r["archived_at"].utc.to_s(:db),
+          content_change: r["content_change"],
+          created_at: r["created_at"].utc.to_s(:db),
+          finished_sending_at: r["finished_sending_at"].utc.to_s(:db),
+          id: r["id"],
+          sent: r["sent"],
+          subject: r["subject"],
+          subscriber_id: r["subscriber_id"]
+        }
       end
 
       S3EmailArchiveService.call(batch)

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -13,4 +13,9 @@ namespace :export do
   task csv_from_living_in_europe: :environment do
     DataExporter.new.export_csv_from_living_in_europe
   end
+
+  desc "Export data from Email Archives to S3 - accepts arguments for the date range of emails to export"
+  task :email_archives_to_s3, %i[from_date until_date] => :environment do |_, args|
+    EmailArchiveExporter.call(args.from_date, args.until_date)
+  end
 end

--- a/spec/presenters/email_archive_presenter_spec.rb
+++ b/spec/presenters/email_archive_presenter_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe EmailArchivePresenter do
+  describe ".call" do
+    let(:record) do
+      {
+        "content_change_ids" => [SecureRandom.uuid],
+        "digest_run_ids" => [1],
+        "created_at" => Time.now,
+        "finished_sending_at" => Time.now,
+        "id" => SecureRandom.uuid,
+        "sent" => true,
+        "subject" => "Test email",
+        "subscriber_id" => 1,
+        "subscription_ids" => [SecureRandom.uuid]
+      }
+    end
+
+    let(:archived_at) { Time.now }
+
+    it "presents the data" do
+      expect(described_class.call(record, archived_at)).to eq(
+        archived_at: archived_at,
+        content_change: {
+          content_change_ids: record["content_change_ids"],
+          digest_run_id: record["digest_run_ids"].first,
+          subscription_ids: record["subscription_ids"]
+        },
+        created_at: record["created_at"],
+        finished_sending_at: record["finished_sending_at"],
+        id: record["id"],
+        sent: record["sent"],
+        subject: record["subject"],
+        subscriber_id: record["subscriber_id"],
+      )
+    end
+
+
+    context "when there are required keys missing" do
+      it "raises a KeyError" do
+        expect { described_class.call(record.except("id"), archived_at) }
+          .to raise_error(KeyError)
+      end
+    end
+
+    context "when there are multiple digest_run_ids" do
+      before do
+        record["digest_run_ids"] = [1, 2, 3]
+        allow(GovukError).to receive(:notify)
+      end
+
+      it "only returns one of them" do
+        expect(described_class.call(record, archived_at)).to match(
+          hash_including(content_change: hash_including(digest_run_id: 1))
+        )
+      end
+
+      it "notifies the error service" do
+        expect(GovukError).to receive(:notify)
+        described_class.call(record, archived_at)
+      end
+    end
+  end
+end

--- a/spec/presenters/email_archive_presenter_spec.rb
+++ b/spec/presenters/email_archive_presenter_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe EmailArchivePresenter do
   let(:time_bst) { Time.parse("2018-07-01 10:00 +0100") }
-  let(:time_for_s3) { "2018-07-01 09:00:00" }
+  let(:time_for_s3) { "2018-07-01 09:00:00.000" }
 
   let(:record) do
     {
@@ -23,14 +23,14 @@ RSpec.describe EmailArchivePresenter do
   describe ".for_s3" do
     it "presents the data" do
       expect(described_class.for_s3(record, archived_at)).to eq(
-        archived_at: time_for_s3,
+        archived_at_utc: time_for_s3,
         content_change: {
           content_change_ids: record["content_change_ids"],
           digest_run_id: record["digest_run_ids"].first,
           subscription_ids: record["subscription_ids"]
         },
-        created_at: time_for_s3,
-        finished_sending_at: time_for_s3,
+        created_at_utc: time_for_s3,
+        finished_sending_at_utc: time_for_s3,
         id: record["id"],
         sent: record["sent"],
         subject: record["subject"],

--- a/spec/services/s3_email_archive_service_spec.rb
+++ b/spec/services/s3_email_archive_service_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe S3EmailArchiveService do
 
   def create_record(time: Time.now)
     {
-      archived_at: time.utc.to_s(:db),
+      archived_at_utc: time.utc.to_s(:db),
       content_change: nil,
-      created_at: time.utc.to_s(:db),
-      finished_sending_at: time.utc.to_s(:db),
+      created_at_utc: time.utc.to_s(:db),
+      finished_sending_at_utc: time.utc.to_s(:db),
       id: SecureRandom.uuid,
       sent: true,
       subject: "Test email",
@@ -42,7 +42,7 @@ RSpec.describe S3EmailArchiveService do
 
     expect_any_instance_of(Aws::S3::Object).to receive(:put)
       .with(
-        body: gzipped_match(%r/^{"archived_at":"2018-06-27/),
+        body: gzipped_match(%r/^{"archived_at_utc":"2018-06-27/),
         content_encoding: "gzip"
       ) do |args|
       end

--- a/spec/services/s3_email_archive_service_spec.rb
+++ b/spec/services/s3_email_archive_service_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe S3EmailArchiveService do
 
   def create_record(time: Time.now)
     {
-      archived_at: time,
+      archived_at: time.utc.to_s(:db),
       content_change: nil,
-      created_at: time,
-      finished_sending_at: time,
+      created_at: time.utc.to_s(:db),
+      finished_sending_at: time.utc.to_s(:db),
       id: SecureRandom.uuid,
       sent: true,
       subject: "Test email",
@@ -42,7 +42,7 @@ RSpec.describe S3EmailArchiveService do
 
     expect_any_instance_of(Aws::S3::Object).to receive(:put)
       .with(
-        body: gzipped_match(%r/^{"archived_at":"2018-06-28/),
+        body: gzipped_match(%r/^{"archived_at":"2018-06-27/),
         content_encoding: "gzip"
       ) do |args|
       end

--- a/spec/services/s3_email_archive_service_spec.rb
+++ b/spec/services/s3_email_archive_service_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe S3EmailArchiveService do
+  before :each do
+    Aws.config[:s3] = { stub_responses: true }
+  end
+
+  around do |example|
+    ClimateControl.modify(EMAIL_ARCHIVE_S3_BUCKET: 'my-bucket') { example.run }
+  end
+
+  def create_record(time: Time.now)
+    {
+      archived_at: time,
+      content_change: nil,
+      created_at: time,
+      finished_sending_at: time,
+      id: SecureRandom.uuid,
+      sent: true,
+      subject: "Test email",
+      subscriber_id: SecureRandom.uuid,
+    }
+  end
+
+  it "Returns PutObjectOutput instances" do
+    expect(described_class.call([create_record])).to match(
+      [an_instance_of(Aws::S3::Types::PutObjectOutput)]
+    )
+  end
+
+  it "creates a partioned path on S3" do
+    time = "2018-06-28T09:00:00Z"
+
+    expect_any_instance_of(Aws::S3::Bucket).to receive(:object)
+      .with(%r{^email-archive/year=2018/month=06/date=28/#{time}-[a-z0-9-]*.json.gz$})
+      .and_call_original
+    described_class.call(
+      [create_record(time: Time.parse(time))]
+    )
+  end
+
+  it "puts a gzipped object onto S3" do
+    time = Time.zone.parse("2018-06-28 00:00:00 BST")
+
+    expect_any_instance_of(Aws::S3::Object).to receive(:put)
+      .with(
+        body: gzipped_match(%r/^{"archived_at":"2018-06-28/),
+        content_encoding: "gzip"
+      ) do |args|
+      end
+    described_class.call(
+      [create_record(time: time)]
+    )
+  end
+
+  context "when the batch contains items with different finished_sending_at days" do
+    let(:batch) do
+      [
+        create_record(time: Time.zone.parse("2018-06-28 10:00")),
+        create_record(time: Time.zone.parse("2018-06-27 10:00")),
+        create_record(time: Time.zone.parse("2018-06-27 11:00")),
+        create_record(time: Time.zone.parse("2018-06-26 10:00")),
+      ]
+    end
+
+    it "creates multiple objects" do
+      expect(described_class.call(batch).length).to be(3)
+    end
+  end
+end

--- a/spec/support/gzipped_matchers.rb
+++ b/spec/support/gzipped_matchers.rb
@@ -1,0 +1,6 @@
+RSpec::Matchers.define :gzipped_match do |regex|
+  match do |contents|
+    decrypted = ActiveSupport::Gzip.decompress(contents)
+    decrypted.match(regex)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/FM3MCuAl/255-investigate-email-alert-api-database-size-and-push-email-archives-to-s3

This PR sets up archiving emails to S3 when the EmailArchiveWorker runs and creates a rake job that can do archiving. 

Further details can be found in individual commits.