### PR TITLE
Remove in_batches from the EmailDeletionWorker

### DIFF
--- a/app/workers/email_deletion_worker.rb
+++ b/app/workers/email_deletion_worker.rb
@@ -8,9 +8,7 @@ class EmailDeletionWorker
   def perform
     Email.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
       start_time = Time.zone.now
-      deleted_count = Email.deleteable.in_batches.inject(0) do |memo, batch|
-        memo + batch.delete_all
-      end
+      deleted_count = Email.deleteable.delete_all
       log_complete(deleted_count, start_time, Time.zone.now)
     end
   end


### PR DESCRIPTION
Email uses a UUID field as the id, and in_batches orders the results
by the id field. This is very expensive, and unnecessary.

Just delete the rows directly, to make this faster, and less expensive
for PostgreSQL to handle.