### PR TITLE
Unsubscribe users who marked us as spam

### DIFF
--- a/app/controllers/spam_reports_controller.rb
+++ b/app/controllers/spam_reports_controller.rb
@@ -1,0 +1,15 @@
+class SpamReportsController < ApplicationController
+  wrap_parameters false
+
+  def create
+    delivery_attempt = DeliveryAttempt.find(params[:reference])
+    UnsubscribeService.spam_report!(delivery_attempt)
+    head :no_content
+  end
+
+private
+
+  def authorise
+    authorise_user!("status_updates")
+  end
+end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -8,13 +8,21 @@ module UnsubscribeService
       unsubscribe!(subscription.subscriber, [subscription], reason)
     end
 
+    def spam_report!(delivery_attempt)
+      subscriber_id = delivery_attempt.email.subscriber_id
+      subscriber = Subscriber.find(subscriber_id)
+      unsubscribe!(subscriber, subscriber.active_subscriptions, :marked_as_spam, delivery_attempt.email)
+    end
+
   private
 
-    def unsubscribe!(subscriber, subscriptions, reason)
+    def unsubscribe!(subscriber, subscriptions, reason, email = nil)
       ActiveRecord::Base.transaction do
         subscriptions.each do |subscription|
           subscription.end(reason: reason)
         end
+
+        email.update!(marked_as_spam: true) if email && reason == :marked_as_spam
 
         if !subscriber.deactivated? && no_other_subscriptions?(subscriber, subscriptions)
           subscriber.deactivate!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     get "/subscribables/:slug", to: "subscribables#show"
 
     resources :notifications, only: %i[create index show]
+    resources :spam_reports, path: "spam-reports", only: %i[create]
     resources :status_updates, path: "status-updates", only: %i[create]
     resources :subscriptions, only: %i[create show update]
 

--- a/spec/integration/spam_reports_spec.rb
+++ b/spec/integration/spam_reports_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Receiving a spam report", type: :request do
+  let(:subscriber) { create(:subscriber) }
+  let(:email) { create(:email, subscriber_id: subscriber.id) }
+  let(:delivery_attempt) { create(:delivery_attempt, email_id: email.id) }
+  let(:reference) { delivery_attempt.id }
+
+  let(:permissions) { %w[signin status_updates] }
+  let(:user) { create(:user, permissions: permissions) }
+  before { login_as(user) }
+
+  describe "#create" do
+    let(:params) { { reference: reference } }
+    let(:permissions) { %w[signin status_updates] }
+
+    it "calls the unsubscribe service" do
+      expect(UnsubscribeService).to receive(:spam_report!).with(delivery_attempt)
+
+      post "/spam-reports", params: params
+    end
+
+    it "renders 204 no content" do
+      post "/spam-reports", params: params
+
+      expect(response.status).to eq(204)
+      expect(response.body).to eq("")
+    end
+
+    it "marks the email as spam" do
+      expect { post "/spam-reports", params: params }
+        .to change { email.reload.marked_as_spam }
+        .to eq(true)
+    end
+
+    context "when a user does not have 'status_updates' permission" do
+      let(:permissions) { %w[signin] }
+
+      it "renders 403" do
+        post "/spam-reports", params: params
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -74,4 +74,25 @@ RSpec.describe UnsubscribeService do
       end
     end
   end
+
+  describe "spam_report" do
+    let!(:subscription) { create(:subscription) }
+    let(:subscriber) { subscription.subscriber }
+    let(:email) { create(:email, subscriber_id: subscriber.id) }
+    let(:delivery_attempt) { create(:delivery_attempt, email: email) }
+
+    it "unsubscribes the subscriber" do
+      expect { subject.spam_report!(delivery_attempt) }
+        .to change { email.reload.marked_as_spam }
+        .from(nil)
+        .to(true)
+    end
+
+    it "marks the subscription as ended" do
+      expect { subject.spam_report!(delivery_attempt) }
+        .to change { subscription.reload.ended_reason }
+        .from(nil)
+        .to("marked_as_spam")
+    end
+  end
 end


### PR DESCRIPTION
This adds an endpoint that Notify will call when our users have marked one of our emails as spam. Calling that endpoint will unsubscribe the user from all our subscription lists.

Paired with @thomasleese 
https://trello.com/c/DRM82ETh/328-auto-unsubscribe-email-alert-api-users-who-report-spam