### PR TITLE
Slightly increase subscription content healthcheck thresholds

### DIFF
--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -48,11 +48,11 @@ module Healthcheck
     end
 
     def critical_latency
-      3.minutes
+      5.minutes
     end
 
     def warning_latency
-      90.seconds
+      2.minutes
     end
   end
 end

--- a/spec/models/healthcheck/subscription_contents_spec.rb
+++ b/spec/models/healthcheck/subscription_contents_spec.rb
@@ -11,25 +11,25 @@ RSpec.describe Healthcheck::SubscriptionContents do
     specify { expect(subject.status).to eq(:critical) }
   end
 
-  context "when a subscription content was created 1 second ago" do
+  context "when a subscription content was created 10 second ago" do
     before do
-      create(:subscription_content, created_at: 1.second.ago)
+      create(:subscription_content, created_at: 10.seconds.ago)
     end
 
     it_behaves_like "an ok healthcheck"
   end
 
-  context "when a subscription content was created 90 seconds ago" do
+  context "when a subscription content was created 2 minutes ago" do
     before do
-      create(:subscription_content, created_at: 90.seconds.ago)
+      create(:subscription_content, created_at: 2.minutes.ago)
     end
 
     it_behaves_like "a warning healthcheck"
   end
 
-  context "when a subscription content was created 3 minutes ago" do
+  context "when a subscription content was created 5 minutes ago" do
     before do
-      create(:subscription_content, created_at: 3.minutes.ago)
+      create(:subscription_content, created_at: 5.minutes.ago)
     end
 
     it_behaves_like "a critical healthcheck"


### PR DESCRIPTION
We often see this go critical in the morning while it's sending out the digests and the 9:30 scheduled publishings. It seems fine to increase the threshold a bit since there isn't anything wrong but we're seeing a critical alert.