### PR TITLE
Export subscriber lists by slug

### DIFF
--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -13,6 +13,10 @@ class DataExporter
     export_csv(living_in_europe_subscriber_lists)
   end
 
+  def export_csv_from_slugs(slugs)
+    export_csv(SubscriberList.where(slug: slugs))
+  end
+
 private
 
   CSV_HEADERS = %i(id title count).freeze

--- a/lib/data_exporter.rb
+++ b/lib/data_exporter.rb
@@ -9,12 +9,16 @@ class DataExporter
     export_csv(SubscriberList.where(id: ids), at: date)
   end
 
-  def export_csv_from_living_in_europe
-    export_csv(living_in_europe_subscriber_lists)
-  end
-
   def export_csv_from_slugs(slugs)
     export_csv(SubscriberList.where(slug: slugs))
+  end
+
+  def export_csv_from_slugs_at(date, slugs)
+    export_csv(SubscriberList.where(slug: slugs), at: date)
+  end
+
+  def export_csv_from_living_in_europe
+    export_csv(living_in_europe_subscriber_lists)
   end
 
 private

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -9,13 +9,18 @@ namespace :export do
     DataExporter.new.export_csv_from_ids_at(args.date, args.extras)
   end
 
+  desc "Export the number of subscriptions for a collection of lists given as arguments of list slugs"
+  task :csv_from_slugs, [:slugs] => :environment do |_, args|
+    DataExporter.new.export_csv_from_slugs(args.slugs.split)
+  end
+
+  desc "Export the number of subscriptions for a collection of lists given as arguments of list slugs at a given date"
+  task :csv_from_slugs_at, [:date] => :environment do |_, args|
+    DataExporter.new.export_csv_from_slugs_at(args.date, args.extras)
+  end
+
   desc "Export the number of subscriptions for the 'Living in' taxons for European countries"
   task csv_from_living_in_europe: :environment do
     DataExporter.new.export_csv_from_living_in_europe
-  end
-
-  desc "Export the number of subscriptions for the given subscription list slug(s). eg. rake csv_from_slugs['foo bar baz']"
-  task :csv_from_slugs, [:slugs] => :environment do |_, args|
-    DataExporter.new.export_csv_from_slugs(args.slugs.split)
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -13,4 +13,9 @@ namespace :export do
   task csv_from_living_in_europe: :environment do
     DataExporter.new.export_csv_from_living_in_europe
   end
+
+  desc "Export the number of subscriptions for the given subscription list slug(s). eg. rake csv_from_slugs['foo bar baz']"
+  task :csv_from_slugs, [:slugs] => :environment do |_, args|
+    DataExporter.new.export_csv_from_slugs(args.slugs.split)
+  end
 end

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -34,4 +34,22 @@ RSpec.describe DataExporter do
       expect { subject }.to output("id,title,count\n1,title,2\n").to_stdout
     end
   end
+
+  describe "#export_csv_from_slugs" do
+    let(:subscriber_list_foo) { create(:subscriber_list, id: 1, title: "Foo", slug: "foo") }
+    let(:subscriber_list_bar) { create(:subscriber_list, id: 2, title: "Bar", slug: "bar") }
+    let(:subscriber_list_baz) { create(:subscriber_list, id: 3, title: "Baz", slug: "baz") }
+
+    before do
+      create(:subscription, subscriber_list: subscriber_list_foo)
+      create(:subscription, subscriber_list: subscriber_list_bar)
+      create(:subscription, subscriber_list: subscriber_list_baz)
+    end
+
+    subject { DataExporter.new.export_csv_from_slugs(%w(foo bar)) }
+
+    it "exports subscriber lists by slug" do
+      expect { subject }.to output("id,title,count\n1,Foo,1\n2,Bar,1\n").to_stdout
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/8HwDgibA/340-make-it-easier-to-get-subscriber-numbers-for-a-given-email-list-slug

Add rake task to export active subscriber counts by subscription list slug(s).

#### Integration benchmark

```
lists = SubscriberList.take(50)

irb(main):031:0> puts Benchmark.measure { SubscriberList.where(slug: lists.map(&:slug)) }
  0.001285   0.000000   0.001285 (  0.000288)
=> nil
irb(main):032:0> puts Benchmark.measure { SubscriberList.where(slug: lists.map(&:slug)) }
  0.000758   0.000000   0.000758 (  0.000283)
=> nil
```

versus ID based query...

```
irb(main):033:0> puts Benchmark.measure { SubscriberList.where(slug: lists.map(&:id)) }
  0.000204   0.000000   0.000204 (  0.000275)
=> nil
irb(main):034:0> puts Benchmark.measure { SubscriberList.where(slug: lists.map(&:id)) }
  0.000198   0.000072   0.000270 (  0.000266)
=> nil

```