### PR TITLE
Add unpublish message feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,8 @@ AllCops:
   Exclude:
     - tmp/**/**
     - db/schema.rb
+
+Metrics/BlockLength:
+  Exclude:
+    - config/routes.rb
+    - spec/**/**

--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -1,0 +1,40 @@
+class UnpublishEmailBuilder
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  def call(emails)
+    ids = Email.import!(email_records(emails)).ids
+    Email.where(id: ids)
+  end
+
+private
+
+  def email_records(emails)
+    emails.map do |email|
+      {
+        address: email.fetch(:address),
+        subject: email.fetch(:subject),
+        body: body(email.fetch(:subject), email.fetch(:address)),
+        subscriber_id: email.fetch(:subscriber_id)
+      }
+    end
+  end
+
+  def body(title, address)
+    <<~BODY
+      Your subscription to ‘#{title}’ no longer exists, as a result you will no longer receive emails
+      about this subject.
+
+      #{presented_manage_subscriptions_links(address)}
+
+      &nbsp;
+
+      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
+    BODY
+  end
+
+  def presented_manage_subscriptions_links(address)
+    ManageSubscriptionsLinkPresenter.call(address: address)
+  end
+end

--- a/app/controllers/unpublish_messages_controller.rb
+++ b/app/controllers/unpublish_messages_controller.rb
@@ -1,0 +1,16 @@
+class UnpublishMessagesController < ApplicationController
+  def create
+    UnpublishHandlerService.call(
+      unpublishing_params[:content_id]
+    )
+
+    render json: { message: "Unpublish message queued for sending" }, status: 202
+  end
+
+private
+
+  def unpublishing_params
+    permitted_params = params.permit!.to_h
+    permitted_params.slice(:content_id)
+  end
+end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,4 +1,5 @@
 class Email < ApplicationRecord
+  COURTESY_EMAIL = "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk".freeze
   has_many :delivery_attempts
 
   scope :archivable, lambda {

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,7 +6,7 @@ class Subscription < ApplicationRecord
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
   enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2, subscriber_list_changed: 3 }, _prefix: true
-  enum ended_reason: { unsubscribed: 0, non_existant_email: 1, frequency_changed: 2, subscriber_list_changed: 3, marked_as_spam: 4 }, _prefix: :ended
+  enum ended_reason: { unsubscribed: 0, non_existant_email: 1, frequency_changed: 2, subscriber_list_changed: 3, marked_as_spam: 4, unpublished: 5 }, _prefix: :ended
 
   validates_uniqueness_of :subscriber, scope: :subscriber_list, conditions: -> { active }
 

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -30,7 +30,7 @@ private
 
   def unsubscribe(subscriber_lists)
     subscriber_lists.each do |subscriber_list|
-      UnsubscribeService.subscriber_list!(subscriber_list, :unpublished)
+      UnsubscribeSubscriberListWorker.perform_async(subscriber_list.id, :unpublished)
     end
   end
 

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -1,0 +1,102 @@
+class UnpublishHandlerService
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  def call(content_id)
+    lists = subscriber_list(content_id)
+    taxon_subscriber_lists, other_subscriber_lists = split_subscriber_lists(lists)
+
+    taxon_emails = build_emails(taxon_subscriber_lists)
+    emails = UnpublishEmailBuilder.call(taxon_emails + courtesy_emails(taxon_emails))
+
+    queue_delivery_request_workers(emails)
+
+    log_taxon_emails(emails)
+    log_non_taxon_lists(other_subscriber_lists)
+
+    unsubscribe(taxon_subscriber_lists)
+  end
+
+private
+
+  def split_subscriber_lists(lists)
+    list_groupings = lists.group_by do |list|
+      list.links.has_key?(:taxon_tree) ? :taxon : :other
+    end
+
+    [list_groupings.fetch(:taxon, []), list_groupings.fetch(:other, [])]
+  end
+
+  def unsubscribe(subscriber_lists)
+    subscriber_lists.each do |subscriber_list|
+      UnsubscribeService.subscriber_list!(subscriber_list, :unpublished)
+    end
+  end
+
+  def queue_delivery_request_workers(emails)
+    emails.each do |email|
+      DeliveryRequestWorker.perform_async_in_queue(
+        email.id, queue: :delivery_immediate
+      )
+    end
+  end
+
+  # For this query to return the content id has to be wrapped in a double quote blame psql 9.3
+  def subscriber_list(content_id)
+    SubscriberList
+      .where(":id IN (SELECT json_array_elements((json_each(links)).value)::text)", id: "\"#{content_id}\"")
+      .includes(:subscribers)
+  end
+
+  def build_emails(subscriber_lists)
+    subscriber_lists.flat_map do |subscriber_list|
+      subscriber_list.subscribers.activated.map do |subscriber|
+        {
+          subject: subscriber_list.title,
+          address: subscriber.address,
+          subscriber_id: subscriber.id
+        }
+      end
+    end
+  end
+
+  def courtesy_emails(taxon_emails)
+    return [] if taxon_emails.empty?
+    Subscriber.where(address: Email::COURTESY_EMAIL).map do |subscriber|
+      {
+        subject: taxon_emails.first.fetch(:subject),
+        address: subscriber.address,
+        subscriber_id: subscriber.id
+      }
+    end
+  end
+
+  def log_taxon_emails(emails)
+    emails.each do |email|
+      Rails.logger.info(<<-INFO.strip_heredoc)
+        ----
+        Created Email:
+        id: #{email.id}
+        subject: #{email.subject}
+        body: #{email.body}
+        subscriber_id: #{email.subscriber_id}
+        ----
+      INFO
+    end
+  end
+
+  def log_non_taxon_lists(subscriber_lists)
+    subscriber_lists.each do |list|
+      Rails.logger.info(<<-INFO.strip_heredoc)
+        ++++
+        Not sending notification about non-Topic SubscriberList.
+        id: #{list.id}
+        title: #{list.title}
+        links: #{list.links}
+        tags: #{list.tags}
+        ++++
+      INFO
+    end
+  end
+end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -1,37 +1,52 @@
 module UnsubscribeService
   class << self
     def subscriber!(subscriber, reason)
-      unsubscribe!(subscriber, subscriber.active_subscriptions, reason)
+      ActiveRecord::Base.transaction do
+        unsubscribe_subscriptions!(subscriber.active_subscriptions, reason)
+        unsubscribe_subscriber!(subscriber)
+      end
     end
 
     def subscription!(subscription, reason)
-      unsubscribe!(subscription.subscriber, [subscription], reason)
+      ActiveRecord::Base.transaction do
+        unsubscribe_subscriptions!([subscription], reason)
+        unsubscribe_subscriber!(subscription.subscriber)
+      end
     end
 
     def spam_report!(delivery_attempt)
       subscriber_id = delivery_attempt.email.subscriber_id
       subscriber = Subscriber.find(subscriber_id)
-      unsubscribe!(subscriber, subscriber.active_subscriptions, :marked_as_spam, delivery_attempt.email)
+      ActiveRecord::Base.transaction do
+        unsubscribe_subscriptions!(subscriber.active_subscriptions, :marked_as_spam, delivery_attempt.email)
+        unsubscribe_subscriber!(subscriber)
+      end
     end
 
-  private
-
-    def unsubscribe!(subscriber, subscriptions, reason, email = nil)
+    def subscriber_list!(list, reason)
       ActiveRecord::Base.transaction do
-        subscriptions.each do |subscription|
-          subscription.end(reason: reason)
-        end
-
-        email.update!(marked_as_spam: true) if email && reason == :marked_as_spam
-
-        if !subscriber.deactivated? && no_other_subscriptions?(subscriber, subscriptions)
-          subscriber.deactivate!
+        subscriptions = list.subscriptions
+        unsubscribe_subscriptions!(subscriptions, reason)
+        Subscriber.where(subscriptions: subscriptions).each do |subscriber|
+          unsubscribe_subscriber!(subscriber)
         end
       end
     end
 
-    def no_other_subscriptions?(subscriber, subscriptions)
-      (subscriber.subscriptions - subscriptions).empty?
+  private
+
+    def unsubscribe_subscriptions!(subscriptions, reason, email = nil)
+      subscriptions.each do |subscription|
+        subscription.end(reason: reason)
+      end
+
+      email.update!(marked_as_spam: true) if email && reason == :marked_as_spam
+    end
+
+    def unsubscribe_subscriber!(subscriber)
+      if !subscriber.deactivated? && subscriber.reload.active_subscriptions.empty?
+        subscriber.deactivate!
+      end
     end
   end
 end

--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -64,7 +64,7 @@ private
 
   def queue_delivery_to_courtesy_subscribers(content_change)
     addresses = [
-      "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk",
+      Email::COURTESY_EMAIL,
     ]
 
     Subscriber.where(address: addresses).find_each do |subscriber|

--- a/app/workers/unsubscribe_subscriber_list_worker.rb
+++ b/app/workers/unsubscribe_subscriber_list_worker.rb
@@ -1,0 +1,10 @@
+class UnsubscribeSubscriberListWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 3
+
+  def perform(subscriber_list_id, reason)
+    list = SubscriberList.find(subscriber_list_id)
+    UnsubscribeService.subscriber_list!(list, reason)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     get "/subscriber-lists", to: "subscriber_lists#show"
     get "/subscribables/:slug", to: "subscribables#show"
 
+    post "/unpublish-messages", to: "unpublish_messages#create"
+
     resources :notifications, only: %i[create index show]
     resources :spam_reports, path: "spam-reports", only: %i[create]
     resources :status_updates, path: "status-updates", only: %i[create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
+Rails.application.routes.draw do
   scope format: false, defaults: { format: :json } do
     root "welcome#index"
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]

--- a/spec/builders/unpublish_email_builder_spec.rb
+++ b/spec/builders/unpublish_email_builder_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe UnpublishEmailBuilder do
+  describe ".call" do
+    describe 'No emails sent' do
+      it 'does not return any emails' do
+        expect(described_class.call([])).to be_empty
+      end
+      it 'does not save and email objects' do
+        expect { described_class.call([]) }.to_not(change { Email.count })
+      end
+    end
+
+    describe 'One email sent' do
+      let!(:subscriber) {
+        create(
+          :subscriber,
+          address: "address@test.com",
+          id: 123
+)
+      }
+      let(:emails) {
+        [
+          {
+            address: "address@test.com",
+            subject: "subject_test",
+            subscriber_id: 123,
+          }
+        ]
+      }
+      it 'Saves an email object' do
+        expect { described_class.call(emails) }.to change { Email.count }.by(1)
+      end
+      describe 'return one email' do
+        before :each do
+          @imported_email = described_class.call(emails).first
+        end
+        it 'sets the subject' do
+          expect(@imported_email.subject).to eq("subject_test")
+        end
+        it 'contains the subscriber id' do
+          expect(@imported_email.subscriber_id).to eq(123)
+        end
+        it 'sets the status' do
+          expect(@imported_email.status).to eq("pending")
+        end
+        it 'sets the addess' do
+          expect(@imported_email.address).to eq("address@test.com")
+        end
+
+        it 'contains the body for the regular email' do
+          expect(@imported_email.body).to include("Your subscription to ‘subject_test’ no longer exists, as a result you will no longer receive emails")
+        end
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -112,6 +112,16 @@ FactoryBot.define do
     trait :medical_safety_alert do
       tags format: ["medical_safety_alert"], alert_type: %w(devices drugs field-safety-notices company-led-drugs)
     end
+
+    factory :subscriber_list_with_subscribers do
+      transient do
+        subscriber_count 5
+      end
+
+      after(:create) do |list, evaluator|
+        create_list(:subscriber, evaluator.subscriber_count, subscriber_lists: [list])
+      end
+    end
   end
 
   factory :subscription do

--- a/spec/integration/unpublish_message_spec.rb
+++ b/spec/integration/unpublish_message_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "Sending an unpublish message", type: :request do
+  context "with authentication and authorisation" do
+    before :each do
+      subscriber = create(
+        :subscriber,
+        address: "test@example.com",
+      )
+
+      create(
+        :subscriber,
+        address: Email::COURTESY_EMAIL,
+      )
+
+      subscriber_list = create(
+        :subscriber_list,
+        links: { taxon_tree: [SecureRandom.uuid] },
+        title: "First Subscription",
+      )
+
+      @subscription = create(
+        :subscription,
+        subscriber: subscriber,
+        subscriber_list: subscriber_list
+      )
+
+      @request_params = { content_id: subscriber_list.links.values.flatten.join }.to_json
+    end
+
+    before do
+      allow(DeliveryRequestService).to receive(:call)
+      login_with_internal_app
+      post "/unpublish-messages", params: @request_params, headers: JSON_HEADERS
+    end
+
+    it "creates an Email and a courtesy email" do
+      expect(Email.count).to eq(2)
+    end
+    it "sends a message" do
+      expect(DeliveryRequestService).to have_received(:call).
+        with(email: having_attributes(subject: 'First Subscription',
+                                      address: Email::COURTESY_EMAIL))
+      expect(DeliveryRequestService).to have_received(:call).
+        with(email: having_attributes(subject: 'First Subscription',
+                                      address: "test@example.com"))
+    end
+    it 'unsubscribes all affected subscriptions' do
+      expect(@subscription.reload.ended_at).to_not be_nil
+    end
+  end
+end

--- a/spec/services/unpublish_handler_service_spec.rb
+++ b/spec/services/unpublish_handler_service_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe UnpublishHandlerService do
+  before :each do
+    create(
+      :subscriber,
+      address: Email::COURTESY_EMAIL,
+    )
+    @content_id = SecureRandom.uuid
+  end
+
+  describe '.call' do
+    context 'No subscriber lists are found' do
+      it 'it does not create an email' do
+        expect { described_class.call(@content_id) }.to_not(change { Email.count })
+      end
+      it 'does not send emails' do
+        expect(DeliveryRequestService).to receive(:call).never
+      end
+    end
+
+    context 'there is a taxon_tree subscriber list' do
+      before :each do
+        subscriber = create(
+          :subscriber,
+          address: 'test@example.com',
+          id: 111
+        )
+        @subscriber_list = create(
+          :subscriber_list,
+          links: { taxon_tree: [@content_id] },
+          title: 'First Subscription',
+          )
+        create(
+          :subscription,
+          subscriber: subscriber,
+          subscriber_list: @subscriber_list
+        )
+      end
+      it 'creates an email and a courtesy email' do
+        expect { described_class.call(@content_id) }.to change { Email.count }.by(2)
+      end
+      it 'sends the email and a courtesy email to the DeliverRequestWorker' do
+        expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(subject: 'First Subscription',
+                                        address: 'test@example.com'))
+        expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(subject: 'First Subscription',
+                                       address: Email::COURTESY_EMAIL))
+        described_class.call(@content_id)
+      end
+      it 'unsubscribes all subscribers' do
+        described_class.call(@content_id)
+        expect(@subscriber_list.subscriptions.map(&:ended_at)).to all(be_truthy)
+      end
+      it 'Logs the taxon unpublishing email and the courtesy email' do
+        expect(Rails.logger).to receive(:info).with(include('Created Email', 'First Subscription')).twice
+        described_class.call(@content_id)
+      end
+
+      context 'The subscriber is deactivated' do
+        before :each do
+          @subscriber_list.subscribers.each(&:deactivate!)
+        end
+        it 'it does not create an email' do
+          expect { described_class.call(@content_id) }.to_not(change { Email.count })
+        end
+        it 'does not send emails' do
+          expect(DeliveryRequestService).to receive(:call).never
+        end
+      end
+    end
+
+    context 'there is a non-taxon subscriber list' do
+      before :each do
+        subscriber = create(
+          :subscriber,
+          address: 'test@example.com',
+          id: 111
+        )
+        subscriber_list = create(
+          :subscriber_list,
+          links: { 'world_locations' => [SecureRandom.uuid, SecureRandom.uuid],
+                   'policy_areas' => [@content_id] },
+          title: 'First Subscription',
+        )
+        create(
+          :subscription,
+          subscriber: subscriber,
+          subscriber_list: subscriber_list
+        )
+      end
+
+      it 'Does not create an email' do
+        expect { described_class.call(@content_id) }.to_not(change { Email.count })
+      end
+      it 'does not send emails' do
+        expect(DeliveryRequestService).to receive(:call).never
+      end
+      it 'Logs the non taxon unpublishing event' do
+        expect(Rails.logger).to receive(:info).
+          with(include('Not sending notification', 'First Subscription'))
+        described_class.call(@content_id)
+      end
+    end
+  end
+end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe UnsubscribeService do
 
 
     it 'unsubscribes all subscribers to the list' do
-      expect { subject.subscriber_list!(subscriber_list, :unsubscribed) }
+      expect { subject.subscriber_list!(subscriber_list, 'unsubscribed') }
         .to change { subscriber_list.active_subscriptions_count }
         .by(-5)
     end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -95,4 +95,15 @@ RSpec.describe UnsubscribeService do
         .to("marked_as_spam")
     end
   end
+
+  describe "subscriber_list!" do
+    let!(:subscriber_list) { create(:subscriber_list_with_subscribers, subscriber_count: 5) }
+
+
+    it 'unsubscribes all subscribers to the list' do
+      expect { subject.subscriber_list!(subscriber_list, :unsubscribed) }
+        .to change { subscriber_list.active_subscriptions_count }
+        .by(-5)
+    end
+  end
 end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe SubscriptionContentWorker do
 
   context "with a courtesy subscription" do
     let!(:subscriber) do
-      create(:subscriber, address: "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk")
+      create(:subscriber, address: Email::COURTESY_EMAIL)
     end
 
     it "creates an email for the courtesy email group" do

--- a/spec/workers/unsubscribe_subscriber_list_worker_spec.rb
+++ b/spec/workers/unsubscribe_subscriber_list_worker_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe UnsubscribeSubscriberListWorker do
+  describe '.perform' do
+    it 'calls the unsubscribe service' do
+      list = create(:subscriber_list)
+      expect(UnsubscribeService).to receive(:subscriber_list!).with(list, 'unpublished')
+      UnsubscribeSubscriberListWorker.perform_async(list.id, :unpublished)
+    end
+  end
+end


### PR DESCRIPTION
Now when a message is received by the email-alert-api that a taxon has been unpublished, the users who are subscribed to that taxon will receive an email notifying them that their subscription has ended. 

Currently only taxon's are being processed if they've been unpublished but the plan is to also add this feature for legacy taxons like Policy Areas and Specialist Sectors etc.

(Emails wont actually be sent as is, only logged)

Trello;
https://trello.com/c/fPAplaaV/67-send-notifications-when-unpublishing-taxons