### PR TITLE
Increase subscription contents healthcheck thresholds around 09:30

### DIFF
--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -55,11 +55,22 @@ module Healthcheck
     end
 
     def critical_latency
-      10.minutes
+      is_scheduled_publishing_time? ? 20.minutes : 10.minutes
     end
 
     def warning_latency
-      5.minutes
+      is_scheduled_publishing_time? ? 15.minutes : 5.minutes
+    end
+
+    # There's a lot of scheduled publishing at 09:30 UK time, so we
+    # want larger thresholds around then.
+    def is_scheduled_publishing_time?
+      @is_scheduled_publishing_time ||= begin
+        now = Time.zone.now
+        begun = Time.zone.parse("09:30") <= now
+        ended = Time.zone.parse("10:30") <= now
+        begun && !ended
+      end
     end
   end
 end

--- a/spec/models/healthcheck/subscription_contents_spec.rb
+++ b/spec/models/healthcheck/subscription_contents_spec.rb
@@ -1,40 +1,91 @@
 RSpec.describe Healthcheck::SubscriptionContents do
-  shared_examples "an ok healthcheck" do
-    specify { expect(subject.status).to eq(:ok) }
-    specify { expect(subject.message).to match(/0 created over 600 seconds ago/) }
-  end
-
-  shared_examples "a warning healthcheck" do
-    specify { expect(subject.status).to eq(:warning) }
-    specify { expect(subject.message).to match(/1 created over 300 seconds ago/) }
-  end
-
-  shared_examples "a critical healthcheck" do
-    specify { expect(subject.status).to eq(:critical) }
-    specify { expect(subject.message).to match(/1 created over 600 seconds ago/) }
-  end
-
-  context "when a subscription content was created 10 second ago" do
-    before do
-      create(:subscription_content, created_at: 10.seconds.ago)
+  context "between 09:30 and 10:30" do
+    shared_examples "an ok healthcheck" do
+      specify { expect(subject.status).to eq(:ok) }
+      specify { expect(subject.message).to match(/0 created over 1200 seconds ago/) }
     end
 
-    it_behaves_like "an ok healthcheck"
-  end
-
-  context "when a subscription content was created 5 minutes ago" do
-    before do
-      create(:subscription_content, created_at: 5.minutes.ago)
+    shared_examples "a warning healthcheck" do
+      specify { expect(subject.status).to eq(:warning) }
+      specify { expect(subject.message).to match(/1 created over 900 seconds ago/) }
     end
 
-    it_behaves_like "a warning healthcheck"
-  end
-
-  context "when a subscription content was created 10 minutes ago" do
-    before do
-      create(:subscription_content, created_at: 10.minutes.ago)
+    shared_examples "a critical healthcheck" do
+      specify { expect(subject.status).to eq(:critical) }
+      specify { expect(subject.message).to match(/1 created over 1200 seconds ago/) }
     end
 
-    it_behaves_like "a critical healthcheck"
+    around do |example|
+      Timecop.freeze("10:00") { example.run }
+    end
+
+    context "when a subscription content was created 10 minutes ago" do
+      before do
+        create(:subscription_content, created_at: 10.minutes.ago)
+      end
+
+      it_behaves_like "an ok healthcheck"
+    end
+
+    context "when a subscription content was created over 15 minutes ago" do
+      before do
+        create(:subscription_content, created_at: 16.minutes.ago)
+      end
+
+      it_behaves_like "a warning healthcheck"
+    end
+
+    context "when a subscription content was created over 20 minutes ago" do
+      before do
+        create(:subscription_content, created_at: 21.minutes.ago)
+      end
+
+      it_behaves_like "a critical healthcheck"
+    end
+  end
+
+  context "when not scheduled publishing time" do
+    shared_examples "an ok healthcheck" do
+      specify { expect(subject.status).to eq(:ok) }
+      specify { expect(subject.message).to match(/0 created over 600 seconds ago/) }
+    end
+
+    shared_examples "a warning healthcheck" do
+      specify { expect(subject.status).to eq(:warning) }
+      specify { expect(subject.message).to match(/1 created over 300 seconds ago/) }
+    end
+
+    shared_examples "a critical healthcheck" do
+      specify { expect(subject.status).to eq(:critical) }
+      specify { expect(subject.message).to match(/1 created over 600 seconds ago/) }
+    end
+
+    around do |example|
+      Timecop.freeze("12:00") { example.run }
+    end
+
+    context "when a subscription content was created 10 seconds ago" do
+      before do
+        create(:subscription_content, created_at: 10.seconds.ago)
+      end
+
+      it_behaves_like "an ok healthcheck"
+    end
+
+    context "when a subscription content was created over 5 minutes ago" do
+      before do
+        create(:subscription_content, created_at: 6.minutes.ago)
+      end
+
+      it_behaves_like "a warning healthcheck"
+    end
+
+    context "when a subscription content was created over 10 minutes ago" do
+      before do
+        create(:subscription_content, created_at: 11.minutes.ago)
+      end
+
+      it_behaves_like "a critical healthcheck"
+    end
   end
 end


### PR DESCRIPTION
We frequently see this healthcheck go critical in the morning, because there's a lot of scheduled publishing at 09:30.  Rather than increase the thresholds unconditionally, we can just relax them around this time.

---

[Trello card](https://trello.com/c/fxDUVoSk/401-stop-email-alert-api-going-critical-every-morning)