### PR TITLE
Unsubscribing subscriberlists with ended subscription now works.

### DIFF
--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -25,7 +25,7 @@ module UnsubscribeService
 
     def subscriber_list!(list, reason)
       ActiveRecord::Base.transaction do
-        subscriptions = list.subscriptions
+        subscriptions = list.subscriptions.active
         unsubscribe_subscriptions!(subscriptions, reason)
         Subscriber.where(subscriptions: subscriptions).each do |subscriber|
           unsubscribe_subscriber!(subscriber)

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -105,5 +105,20 @@ RSpec.describe UnsubscribeService do
         .to change { subscriber_list.active_subscriptions_count }
         .by(-5)
     end
+
+    it 'does not throw an error if there are already unsubscribed subscriptions' do
+      subscriber = create(
+        :subscriber,
+        address: 'unsubscribed@example.com',
+        id: 222
+      )
+      create(
+        :subscription,
+        :ended,
+        subscriber: subscriber,
+        subscriber_list: subscriber_list,
+        )
+      expect { subject.subscriber_list!(subscriber_list, 'unsubscribed') }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Previously unsubscribing subscriberlists with subscriptions that
had been ended would raise an error.