### PR TITLE
Add redirect URL to unpublishing email content

### DIFF
--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -3,31 +3,31 @@ class UnpublishEmailBuilder
     new.call(*args)
   end
 
-  def call(emails)
-    ids = Email.import!(email_records(emails)).ids
+  def call(emails, redirect)
+    ids = Email.import!(email_records(emails, redirect)).ids
     Email.where(id: ids)
   end
 
 private
 
-  def email_records(emails)
+  def email_records(emails, redirect)
     emails.map do |email|
       {
         address: email.fetch(:address),
         subject: email.fetch(:subject),
-        body: body(email.fetch(:subject), email.fetch(:address)),
+        body: body(email.fetch(:subject), email.fetch(:address), redirect),
         subscriber_id: email.fetch(:subscriber_id)
       }
     end
   end
 
-  def body(title, address)
+  def body(title, address, redirect)
     <<~BODY
       Your subscription to ‘#{title}’ no longer exists, as a result you will no longer receive emails
       about this subject.
 
       #{presented_manage_subscriptions_links(address)}
-
+      [Redirect to this taxon](#{redirect})
       &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).

--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -22,12 +22,13 @@ private
   end
 
   def body(title, address, redirect)
+    redirect_url = PublicUrlService.redirect_url(path: redirect)
     <<~BODY
       Your subscription to ‘#{title}’ no longer exists, as a result you will no longer receive emails
       about this subject.
 
       #{presented_manage_subscriptions_links(address)}
-      [Redirect to this taxon](#{redirect})
+      [Redirect to this taxon](#{redirect_url})
       &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).

--- a/app/controllers/unpublish_messages_controller.rb
+++ b/app/controllers/unpublish_messages_controller.rb
@@ -1,8 +1,8 @@
 class UnpublishMessagesController < ApplicationController
   def create
     UnpublishHandlerService.call(
-      unpublishing_params[:content_id]
-    )
+      unpublishing_params[:content_id], unpublishing_params.dig(:redirects, 0, :destination)
+      )
 
     render json: { message: "Unpublish message queued for sending" }, status: 202
   end
@@ -10,7 +10,6 @@ class UnpublishMessagesController < ApplicationController
 private
 
   def unpublishing_params
-    permitted_params = params.permit!.to_h
-    permitted_params.slice(:content_id)
+    @_params ||= params.permit(:content_id, redirects: :destination)
   end
 end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -17,6 +17,10 @@ module PublicUrlService
       "#{website_root}/email/authenticate?#{param('address', address)}"
     end
 
+    def redirect_url(path:)
+      "#{website_root}/#{path}"
+    end
+
   private
 
     def website_root

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -3,12 +3,13 @@ class UnpublishHandlerService
     new.call(*args)
   end
 
-  def call(content_id)
+  def call(content_id, redirects)
     lists = subscriber_list(content_id)
     taxon_subscriber_lists, other_subscriber_lists = split_subscriber_lists(lists)
 
-    taxon_emails = build_emails(taxon_subscriber_lists)
-    emails = UnpublishEmailBuilder.call(taxon_emails + courtesy_emails(taxon_emails))
+    taxon_email_parameters = build_emails(taxon_subscriber_lists)
+    all_email_parameters = taxon_email_parameters + courtesy_emails(taxon_email_parameters)
+    emails = UnpublishEmailBuilder.call(all_email_parameters, redirects)
 
     queue_delivery_request_workers(emails)
 

--- a/spec/builders/unpublish_email_builder_spec.rb
+++ b/spec/builders/unpublish_email_builder_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe UnpublishEmailBuilder do
   describe ".call" do
     describe 'No emails sent' do
       it 'does not return any emails' do
-        expect(described_class.call([])).to be_empty
+        expect(described_class.call([], nil)).to be_empty
       end
       it 'does not save and email objects' do
-        expect { described_class.call([]) }.to_not(change { Email.count })
+        expect { described_class.call([], nil) }.to_not(change { Email.count })
       end
     end
 
@@ -26,12 +26,15 @@ RSpec.describe UnpublishEmailBuilder do
           }
         ]
       }
+      let(:redirect) {
+        'https://redirect.to/somewhere'
+      }
       it 'Saves an email object' do
-        expect { described_class.call(emails) }.to change { Email.count }.by(1)
+        expect { described_class.call(emails, redirect) }.to change { Email.count }.by(1)
       end
       describe 'return one email' do
         before :each do
-          @imported_email = described_class.call(emails).first
+          @imported_email = described_class.call(emails, redirect).first
         end
         it 'sets the subject' do
           expect(@imported_email.subject).to eq("subject_test")
@@ -45,9 +48,11 @@ RSpec.describe UnpublishEmailBuilder do
         it 'sets the addess' do
           expect(@imported_email.address).to eq("address@test.com")
         end
-
         it 'contains the body for the regular email' do
           expect(@imported_email.body).to include("Your subscription to ‘subject_test’ no longer exists, as a result you will no longer receive emails")
+        end
+        it 'contains the redirect in the body' do
+          expect(@imported_email.body).to include(redirect)
         end
       end
     end

--- a/spec/services/public_url_service_spec.rb
+++ b/spec/services/public_url_service_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe PublicUrlService do
       expect(result).to eq("http://www.dev.gov.uk/email/subscriptions/new?topic_id=foo_bar")
     end
   end
+
+  describe ".redirect_url" do
+    it "returns the GOV.UK Url for a redirected page" do
+      expect(subject.redirect_url(path: 'redirect/to/path')).to eq("http://www.dev.gov.uk/redirect/to/path")
+    end
+  end
 end

--- a/spec/services/unpublish_handler_service_spec.rb
+++ b/spec/services/unpublish_handler_service_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe UnpublishHandlerService do
       address: Email::COURTESY_EMAIL,
     )
     @content_id = SecureRandom.uuid
+    @redirect_url = 'http://redirect_to_somewhere'
   end
 
   describe '.call' do
     context 'No subscriber lists are found' do
       it 'it does not create an email' do
-        expect { described_class.call(@content_id) }.to_not(change { Email.count })
+        expect { described_class.call(@content_id, @redirect_url) }.to_not(change { Email.count })
       end
       it 'does not send emails' do
         expect(DeliveryRequestService).to receive(:call).never
@@ -36,7 +37,12 @@ RSpec.describe UnpublishHandlerService do
         )
       end
       it 'creates an email and a courtesy email' do
-        expect { described_class.call(@content_id) }.to change { Email.count }.by(2)
+        expect { described_class.call(@content_id, @redirect_url) }.to change { Email.count }.by(2)
+      end
+      it 'uses the redirection url in the body of the email' do
+        expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: include(@redirect_url))).twice
+        described_class.call(@content_id, @redirect_url)
       end
       it 'sends the email and a courtesy email to the DeliverRequestWorker' do
         expect(DeliveryRequestService).to receive(:call).
@@ -45,15 +51,15 @@ RSpec.describe UnpublishHandlerService do
         expect(DeliveryRequestService).to receive(:call).
           with(email: having_attributes(subject: 'First Subscription',
                                        address: Email::COURTESY_EMAIL))
-        described_class.call(@content_id)
+        described_class.call(@content_id, @redirect_url)
       end
       it 'unsubscribes all subscribers' do
-        described_class.call(@content_id)
+        described_class.call(@content_id, @redirect_url)
         expect(@subscriber_list.subscriptions.map(&:ended_at)).to all(be_truthy)
       end
       it 'Logs the taxon unpublishing email and the courtesy email' do
         expect(Rails.logger).to receive(:info).with(include('Created Email', 'First Subscription')).twice
-        described_class.call(@content_id)
+        described_class.call(@content_id, @redirect_url)
       end
 
       context 'The subscriber is deactivated' do
@@ -61,7 +67,7 @@ RSpec.describe UnpublishHandlerService do
           @subscriber_list.subscribers.each(&:deactivate!)
         end
         it 'it does not create an email' do
-          expect { described_class.call(@content_id) }.to_not(change { Email.count })
+          expect { described_class.call(@content_id, @redirect_url) }.to_not(change { Email.count })
         end
         it 'does not send emails' do
           expect(DeliveryRequestService).to receive(:call).never
@@ -90,7 +96,7 @@ RSpec.describe UnpublishHandlerService do
       end
 
       it 'Does not create an email' do
-        expect { described_class.call(@content_id) }.to_not(change { Email.count })
+        expect { described_class.call(@content_id, @redirect_url) }.to_not(change { Email.count })
       end
       it 'does not send emails' do
         expect(DeliveryRequestService).to receive(:call).never
@@ -98,7 +104,7 @@ RSpec.describe UnpublishHandlerService do
       it 'Logs the non taxon unpublishing event' do
         expect(Rails.logger).to receive(:info).
           with(include('Not sending notification', 'First Subscription'))
-        described_class.call(@content_id)
+        described_class.call(@content_id, @redirect_url)
       end
     end
   end


### PR DESCRIPTION
When a taxon is unpublished, we want to include the redirect URL in the email message.

Trello: https://trello.com/c/gPSdi81i/59-write-the-email-template-to-be-used-when-notifying-users-that-a-email-subscription-has-ended-as-a-taxon-has-been-unpublished