### PR TITLE
Amend the unpublishing message

### DIFF
--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -21,17 +21,11 @@ private
     end
   end
 
-  def body(title, address, redirect)
-    redirect_url = PublicUrlService.redirect_url(path: redirect)
+  def body(title, address, _)
     <<~BODY
-      Your subscription to ‘#{title}’ no longer exists, as a result you will no longer receive emails
-      about this subject.
+      You were subscribed to emails about '#{title}'. This topic no longer exists so you won't get any more emails about it.
 
       #{presented_manage_subscriptions_links(address)}
-      [Redirect to this taxon](#{redirect_url})
-      &nbsp;
-
-      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
     BODY
   end
 

--- a/spec/builders/unpublish_email_builder_spec.rb
+++ b/spec/builders/unpublish_email_builder_spec.rb
@@ -49,9 +49,10 @@ RSpec.describe UnpublishEmailBuilder do
           expect(@imported_email.address).to eq("address@test.com")
         end
         it 'contains the body for the regular email' do
-          expect(@imported_email.body).to include("Your subscription to ‘subject_test’ no longer exists, as a result you will no longer receive emails")
+          expect(@imported_email.body).to include("You were subscribed to emails about")
         end
         it 'contains the redirect in the body' do
+          pending
           expect(@imported_email.body).to include(redirect)
         end
       end

--- a/spec/integration/unpublish_message_spec.rb
+++ b/spec/integration/unpublish_message_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Sending an unpublish message", type: :request do
                                       address: "test@example.com"))
     end
     it "the message contains the redirect URL" do
+      pending
       expect(DeliveryRequestService).to have_received(:call).
         with(email: having_attributes(body: include('/redirected/path'))).twice
     end

--- a/spec/services/unpublish_handler_service_spec.rb
+++ b/spec/services/unpublish_handler_service_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe UnpublishHandlerService do
         expect { described_class.call(@content_id, @redirect_url) }.to change { Email.count }.by(2)
       end
       it 'uses the redirection url in the body of the email' do
+        pending
         expect(DeliveryRequestService).to receive(:call).
           with(email: having_attributes(body: include(@redirect_url))).twice
         described_class.call(@content_id, @redirect_url)


### PR DESCRIPTION
The message sent when taxons are unpublished has been amended.

The redirection URL has been omitted for now, because we also
require a title for the redirection to be added, which will
be implemented in another PR.

trello: https://trello.com/c/gPSdi81i/63-write-the-email-template-to-be-used-when-notifying-users-that-a-email-subscription-has-ended-as-a-taxon-has-been-unpublished