### PR TITLE
Update factories to get rid of deprecation warning

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,58 +1,58 @@
 FactoryBot.define do
   factory :content_change do
     content_id { SecureRandom.uuid }
-    title "title"
-    base_path "government/base_path"
-    change_note "change note"
-    description "description"
-    links Hash.new
-    tags Hash.new
+    title { "title" }
+    base_path { "government/base_path" }
+    change_note { "change note" }
+    description { "description" }
+    links { Hash.new }
+    tags { Hash.new }
     public_updated_at { Time.now.to_s }
-    email_document_supertype "email document supertype"
-    government_document_supertype "government document supertype"
+    email_document_supertype { "email document supertype" }
+    government_document_supertype { "government document supertype" }
     sequence(:govuk_request_id) { |i| "request-id-#{i}" }
-    document_type "document type"
-    publishing_app "publishing app"
+    document_type { "document type" }
+    publishing_app { "publishing app" }
   end
 
   factory :delivery_attempt, aliases: [:sending_delivery_attempt] do
     email
-    status :sending
-    provider :notify
+    status { :sending }
+    provider { :notify }
 
     factory :delivered_delivery_attempt do
-      status :delivered
+      status { :delivered }
       sent_at { Time.zone.now }
       completed_at { Time.zone.now }
     end
 
     factory :temporary_failure_delivery_attempt do
-      status :temporary_failure
-      sent_at nil
+      status { :temporary_failure }
+      sent_at { nil }
       completed_at { Time.zone.now }
     end
 
     factory :permanent_failure_delivery_attempt do
-      status :permanent_failure
-      sent_at nil
+      status { :permanent_failure }
+      sent_at { nil }
       completed_at { Time.zone.now }
     end
 
     factory :technical_failure_delivery_attempt do
-      status :technical_failure
-      sent_at nil
+      status { :technical_failure }
+      sent_at { nil }
       completed_at { Time.zone.now }
     end
   end
 
   factory :digest_run do
     date { 1.day.ago }
-    range Frequency::DAILY
+    range { Frequency::DAILY }
 
     trait :daily
 
     trait :weekly do
-      range Frequency::WEEKLY
+      range { Frequency::WEEKLY }
     end
   end
 
@@ -62,23 +62,23 @@ FactoryBot.define do
   end
 
   factory :email, aliases: %i[unarchivable_email pending_email] do
-    address "test@example.com"
-    subject "subject"
-    body "body"
+    address { "test@example.com" }
+    subject { "subject" }
+    body { "body" }
 
     factory :archivable_email do
-      status :sent
+      status { :sent }
       finished_sending_at { 2.days.ago }
     end
 
     factory :archived_email do
-      status :sent
+      status { :sent }
       finished_sending_at { 2.days.ago }
       archived_at { 1.day.ago }
     end
 
     factory :deleteable_email do
-      status :sent
+      status { :sent }
       finished_sending_at { 15.days.ago }
       archived_at { 14.days.ago }
     end
@@ -94,7 +94,7 @@ FactoryBot.define do
     end
 
     trait :nullified do
-      address nil
+      address { nil }
       deactivated_at { Time.now }
     end
   end
@@ -102,20 +102,20 @@ FactoryBot.define do
   factory :subscriber_list do
     sequence(:title) { |n| "title #{n}" }
     sequence(:slug) { |n| "title-#{n}" }
-    tags(topics: ["motoring/road_rage"])
+    tags { { topics: ["motoring/road_rage"] } }
     created_at { 1.year.ago }
 
     trait :travel_advice do
-      links countries: [SecureRandom.uuid]
+      links { { countries: [SecureRandom.uuid] } }
     end
 
     trait :medical_safety_alert do
-      tags format: ["medical_safety_alert"], alert_type: %w(devices drugs field-safety-notices company-led-drugs)
+      tags { { format: ["medical_safety_alert"], alert_type: %w(devices drugs field-safety-notices company-led-drugs) } }
     end
 
     factory :subscriber_list_with_subscribers do
       transient do
-        subscriber_count 5
+        subscriber_count { 5 }
       end
 
       after(:create) do |list, evaluator|
@@ -127,21 +127,21 @@ FactoryBot.define do
   factory :subscription do
     subscriber
     subscriber_list
-    frequency Frequency::IMMEDIATELY
+    frequency { Frequency::IMMEDIATELY }
 
     trait :immediately
 
     trait :daily do
-      frequency Frequency::DAILY
+      frequency { Frequency::DAILY }
     end
 
     trait :weekly do
-      frequency Frequency::WEEKLY
+      frequency { Frequency::WEEKLY }
     end
 
     trait :ended do
       ended_at { Time.now }
-      ended_reason :unsubscribed
+      ended_reason { :unsubscribed }
     end
   end
 


### PR DESCRIPTION
fixes: 
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block: