### PR TITLE
Add redirect title to unpublishing message

### DIFF
--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -21,9 +21,11 @@ private
     end
   end
 
-  def body(title, address, _)
+  def body(title, address, redirect)
     <<~BODY
       You were subscribed to emails about '#{title}'. This topic no longer exists so you won't get any more emails about it.
+
+      You can subscribe to '#{redirect.title}' instead: (#{redirect.url})
 
       #{presented_manage_subscriptions_links(address)}
     BODY

--- a/app/controllers/unpublish_messages_controller.rb
+++ b/app/controllers/unpublish_messages_controller.rb
@@ -1,8 +1,9 @@
 class UnpublishMessagesController < ApplicationController
   def create
+    redirect_path = unpublishing_params.dig(:redirects, 0, :destination)
     UnpublishHandlerService.call(
-      unpublishing_params[:content_id], unpublishing_params.dig(:redirects, 0, :destination)
-      )
+      unpublishing_params[:content_id], ContentItem.new(redirect_path)
+    )
 
     render json: { message: "Unpublish message queued for sending" }, status: 202
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,0 +1,20 @@
+class ContentItem
+  DEFAULT = ''.freeze
+  attr_reader :path
+
+  def initialize(path)
+    @path = path
+  end
+
+  def title
+    @title ||= begin
+      Services.content_store.content_item(@path).to_h['title'] || DEFAULT
+    rescue GdsApi::HTTPNotFound
+      DEFAULT
+    end
+  end
+
+  def url
+    PublicUrlService.redirect_url(path: @path)
+  end
+end

--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -18,7 +18,7 @@ module PublicUrlService
     end
 
     def redirect_url(path:)
-      "#{website_root}/#{path}"
+      File.join(website_root, path)
     end
 
   private

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -3,13 +3,13 @@ class UnpublishHandlerService
     new.call(*args)
   end
 
-  def call(content_id, redirects)
+  def call(content_id, redirect)
     lists = subscriber_list(content_id)
     taxon_subscriber_lists, other_subscriber_lists = split_subscriber_lists(lists)
 
     taxon_email_parameters = build_emails(taxon_subscriber_lists)
     all_email_parameters = taxon_email_parameters + courtesy_emails(taxon_email_parameters)
-    emails = UnpublishEmailBuilder.call(all_email_parameters, redirects)
+    emails = UnpublishEmailBuilder.call(all_email_parameters, redirect)
 
     queue_delivery_request_workers(emails)
 

--- a/spec/builders/unpublish_email_builder_spec.rb
+++ b/spec/builders/unpublish_email_builder_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe UnpublishEmailBuilder do
         ]
       }
       let(:redirect) {
-        'https://redirect.to/somewhere'
+        double(:redirect, path: '/somewhere', title: 'redirect_title', url: 'https://redirect.to/somewhere')
       }
       it 'Saves an email object' do
         expect { described_class.call(emails, redirect) }.to change { Email.count }.by(1)
@@ -51,9 +51,9 @@ RSpec.describe UnpublishEmailBuilder do
         it 'contains the body for the regular email' do
           expect(@imported_email.body).to include("You were subscribed to emails about")
         end
-        it 'contains the redirect in the body' do
-          pending
-          expect(@imported_email.body).to include(redirect)
+        it 'contains the redirect and title in the body' do
+          expect(@imported_email.body).to include(redirect.url)
+          expect(@imported_email.body).to include(redirect.title)
         end
       end
     end

--- a/spec/integration/unpublish_message_spec.rb
+++ b/spec/integration/unpublish_message_spec.rb
@@ -1,4 +1,8 @@
+require 'gds_api/test_helpers/content_store'
+
 RSpec.describe "Sending an unpublish message", type: :request do
+  include ::GdsApi::TestHelpers::ContentStore
+
   context "with authentication and authorisation" do
     before :each do
       content_id = SecureRandom.uuid
@@ -27,6 +31,13 @@ RSpec.describe "Sending an unpublish message", type: :request do
 
       @request_params = { content_id: content_id,
                           redirects: [{ path: '/source/path', destination: '/redirected/path' }] }.to_json
+
+      content_store_has_item(
+        '/redirected/path',
+        {
+          'title' => 'redirected title'
+        }.to_json
+      )
     end
 
     before do
@@ -49,9 +60,8 @@ RSpec.describe "Sending an unpublish message", type: :request do
                                       address: "test@example.com"))
     end
     it "the message contains the redirect URL" do
-      pending
       expect(DeliveryRequestService).to have_received(:call).
-        with(email: having_attributes(body: include('/redirected/path'))).twice
+        with(email: having_attributes(body: include('/redirected/path', 'redirected title'))).twice
     end
     it 'unsubscribes all affected subscriptions' do
       expect(@subscription.reload.ended_at).to_not be_nil

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe ContentItem do
+  include ::GdsApi::TestHelpers::ContentStore
+
+  describe 'title' do
+    it 'gets the title from the content store' do
+      content_store_has_item(
+        'redirected/path',
+        {
+          'title' => 'redirected title'
+        }.to_json
+      )
+      expect(ContentItem.new('redirected/path').title).to eq('redirected title')
+    end
+    it 'returns a default value as the title if the base path does not exist' do
+      content_store_does_not_have_item('redirected/path')
+      expect(ContentItem.new('redirected/path').title).to eq(ContentItem::DEFAULT)
+    end
+    it 'returns  a default value as the title if the title does not exist' do
+      content_store_has_item(
+        'redirected/path',
+        {
+          'title' => nil
+        }.to_json
+      )
+      expect(ContentItem.new('redirected/path').title).to eq(ContentItem::DEFAULT)
+    end
+  end
+  describe 'url' do
+    it 'returns the full URL' do
+      expect(ContentItem.new('redirected/path').url).to eq("http://www.dev.gov.uk/redirected/path")
+    end
+  end
+end

--- a/spec/services/public_url_service_spec.rb
+++ b/spec/services/public_url_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe PublicUrlService do
   describe ".redirect_url" do
     it "returns the GOV.UK Url for a redirected page" do
       expect(subject.redirect_url(path: 'redirect/to/path')).to eq("http://www.dev.gov.uk/redirect/to/path")
+      expect(subject.redirect_url(path: '/redirect/to/path')).to eq("http://www.dev.gov.uk/redirect/to/path")
     end
   end
 end


### PR DESCRIPTION
When unpublishing a Taxon, we need to display the title of the redirect included in the 
unpublishing message.  The unpublishing message has been updated to use the title.

Trello: https://trello.com/c/gPSdi81i/59-xl-write-email-template-to-notify-users-that-an-email-subscription-has-ended-because-a-taxon-has-been-unpublished