### PR TITLE
Create new subscription only if old one is active

### DIFF
--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -39,7 +39,9 @@ namespace :manage do
           subscriber_list: source_subscriber_list
         )
 
-        existing_subscription.end(reason: :subscriber_list_changed) if existing_subscription
+        next unless existing_subscription
+
+        existing_subscription.end(reason: :subscriber_list_changed)
 
         subscribed_to_destination_subscriber_list = Subscription.find_by(
           subscriber: subscriber,


### PR DESCRIPTION
This PR fixes https://sentry.io/govuk/app-email-alert-api/issues/660322303/

In this rake task we "move" all subscribers from a subscription list to
another. In order to do this, we consider all subscribers but only the
"active" subscriptions. This can create a problem when creating a new
subscription for a subscriber that has a "non-active" subscription.
In that case, `existing_subscription` would be nil and calling #frequency
on it gives us a NoMethodError:
https://sentry.io/govuk/app-email-alert-api/issues/660322303/

One solution could be to remove the `active` scope from
`existing_subscription` and recreate also all the non-active ones,
adding the `ended_reason` and `ended_at` attributes to the creation.

As I don't think it's useful to recreate ended subscriptions I went for
a different solution and decided to run the creation only if an
existing_subscription is present.