### PR TITLE
Add UTM parameters to the redirect URLs in the unpublishing emails.

### DIFF
--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -15,20 +15,26 @@ private
       {
         address: email.fetch(:address),
         subject: email.fetch(:subject),
-        body: body(email.fetch(:subject), email.fetch(:address), email.fetch(:redirect)),
+        body: body(email.fetch(:subject), email.fetch(:address), email.fetch(:redirect), email.fetch(:utm_parameters)),
         subscriber_id: email.fetch(:subscriber_id)
       }
     end
   end
 
-  def body(title, address, redirect)
+  def body(title, address, redirect, utm_parameters)
     <<~BODY
       Your subscription to email updates about '#{title}' has ended because this topic no longer exists on GOV.UK.
 
-      You might want to subscribe to updates about '#{redirect.title}' instead: #{redirect.url}
+      You might want to subscribe to updates about '#{redirect.title}' instead: #{add_query_params(redirect.url, utm_parameters)}
 
       #{presented_manage_subscriptions_links(address)}
     BODY
+  end
+
+  def add_query_params(redirect_url, query_params)
+    uri = URI.parse(redirect_url)
+    uri.query = [uri.query, *query_params.map { |k| k.join('=') }].compact.join('&')
+    uri.to_s
   end
 
   def presented_manage_subscriptions_links(address)

--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -3,19 +3,19 @@ class UnpublishEmailBuilder
     new.call(*args)
   end
 
-  def call(emails, redirect)
-    ids = Email.import!(email_records(emails, redirect)).ids
+  def call(emails)
+    ids = Email.import!(email_records(emails)).ids
     Email.where(id: ids)
   end
 
 private
 
-  def email_records(emails, redirect)
+  def email_records(emails)
     emails.map do |email|
       {
         address: email.fetch(:address),
         subject: email.fetch(:subject),
-        body: body(email.fetch(:subject), email.fetch(:address), redirect),
+        body: body(email.fetch(:subject), email.fetch(:address), email.fetch(:redirect)),
         subscriber_id: email.fetch(:subscriber_id)
       }
     end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -15,6 +15,6 @@ class ContentItem
   end
 
   def url
-    PublicUrlService.redirect_url(path: @path)
+    @url ||= PublicUrlService.redirect_url(path: @path)
   end
 end

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -7,9 +7,9 @@ class UnpublishHandlerService
     lists = subscriber_list(content_id)
     taxon_subscriber_lists, other_subscriber_lists = split_subscriber_lists(lists)
 
-    taxon_email_parameters = build_emails(taxon_subscriber_lists)
+    taxon_email_parameters = build_emails(taxon_subscriber_lists, redirect)
     all_email_parameters = taxon_email_parameters + courtesy_emails(taxon_email_parameters)
-    emails = UnpublishEmailBuilder.call(all_email_parameters, redirect)
+    emails = UnpublishEmailBuilder.call(all_email_parameters)
 
     queue_delivery_request_workers(emails)
 
@@ -50,13 +50,14 @@ private
       .includes(:subscribers)
   end
 
-  def build_emails(subscriber_lists)
+  def build_emails(subscriber_lists, redirect)
     subscriber_lists.flat_map do |subscriber_list|
       subscriber_list.subscribers.activated.map do |subscriber|
         {
           subject: subscriber_list.title,
           address: subscriber.address,
-          subscriber_id: subscriber.id
+          subscriber_id: subscriber.id,
+          redirect: redirect
         }
       end
     end
@@ -68,7 +69,8 @@ private
       {
         subject: taxon_emails.first.fetch(:subject),
         address: subscriber.address,
-        subscriber_id: subscriber.id
+        subscriber_id: subscriber.id,
+        redirect: taxon_emails.first.fetch(:redirect),
       }
     end
   end

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -57,7 +57,12 @@ private
           subject: subscriber_list.title,
           address: subscriber.address,
           subscriber_id: subscriber.id,
-          redirect: redirect
+          redirect: redirect,
+          utm_parameters: {
+              'utm_source' => subscriber_list.title,
+              'utm_medium' => 'email',
+              'utm_campaign' => 'govuk-notification'
+          }
         }
       end
     end
@@ -71,6 +76,7 @@ private
         address: subscriber.address,
         subscriber_id: subscriber.id,
         redirect: taxon_emails.first.fetch(:redirect),
+        utm_parameters: {}
       }
     end
   end

--- a/spec/builders/unpublish_email_builder_spec.rb
+++ b/spec/builders/unpublish_email_builder_spec.rb
@@ -60,6 +60,9 @@ RSpec.describe UnpublishEmailBuilder do
           expect(@imported_email.body).to include(redirect.url)
           expect(@imported_email.body).to include(redirect.title)
         end
+        it 'contains the UTM parameters in the body' do
+          expect(@imported_email.body).to include("utm_source=mysource", "utm_content=mycontent")
+        end
       end
     end
   end

--- a/spec/builders/unpublish_email_builder_spec.rb
+++ b/spec/builders/unpublish_email_builder_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe UnpublishEmailBuilder do
   describe ".call" do
     describe 'No emails sent' do
       it 'does not return any emails' do
-        expect(described_class.call([], nil)).to be_empty
+        expect(described_class.call([])).to be_empty
       end
       it 'does not save and email objects' do
-        expect { described_class.call([], nil) }.to_not(change { Email.count })
+        expect { described_class.call([]) }.to_not(change { Email.count })
       end
     end
 
@@ -23,6 +23,11 @@ RSpec.describe UnpublishEmailBuilder do
             address: "address@test.com",
             subject: "subject_test",
             subscriber_id: 123,
+            redirect: redirect,
+            utm_parameters: {
+                "utm_source" => "mysource",
+                "utm_content" => "mycontent"
+            }
           }
         ]
       }
@@ -30,11 +35,11 @@ RSpec.describe UnpublishEmailBuilder do
         double(:redirect, path: '/somewhere', title: 'redirect_title', url: 'https://redirect.to/somewhere')
       }
       it 'Saves an email object' do
-        expect { described_class.call(emails, redirect) }.to change { Email.count }.by(1)
+        expect { described_class.call(emails) }.to change { Email.count }.by(1)
       end
       describe 'return one email' do
         before :each do
-          @imported_email = described_class.call(emails, redirect).first
+          @imported_email = described_class.call(emails).first
         end
         it 'sets the subject' do
           expect(@imported_email.subject).to eq("subject_test")


### PR DESCRIPTION
Add UTM parameters to the redirect URLs in the unpublishing emails.

We need to add Google Analytics data when users use the redirect
link in the Taxon unpublishing email.

Trello: https://trello.com/c/gPSdi81i/59-xl-write-email-template-to-notify-users-that-an-email-subscription-has-ended-because-a-taxon-has-been-unpublished