### PR TITLE
Add missing policies links to policy subscriber lists

### DIFF
--- a/db/migrate/20180828153412_add_missing_policies_links_to_policy_subscriber_lists.rb
+++ b/db/migrate/20180828153412_add_missing_policies_links_to_policy_subscriber_lists.rb
@@ -1,0 +1,20 @@
+class AddMissingPoliciesLinksToPolicySubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    SubscriberList.all.each do |subscriber_list|
+      next unless subscriber_list.tags.key? :policies
+
+      if subscriber_list.links.empty?
+        policy_slug = subscriber_list.tags[:policies].first
+        content_id = Services
+                       .content_store
+                       .content_item("/government/policies/#{policy_slug}")
+                       .to_h
+                       .fetch('content_id')
+
+        subscriber_list.update!(links: { 'policies' => [content_id] })
+
+        puts "updated: #{policy_slug} with content_id #{content_id}"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_27_115914) do
+ActiveRecord::Schema.define(version: 2018_08_28_153412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Recent Policies seem to be missing the relevant links. I'm not sure
what effect this is having, or why they are really missing, but as
we're working on retiring Policies, I've just been looking at fixing
this data, so that these policies can be retired.

This migration adds the missing links.