### PR TITLE
Fix soon-to-be deprecated use of exists

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -6,6 +6,7 @@ class ContentChange < ApplicationRecord
     :govuk_request_id, :document_type, :publishing_app
 
   has_many :matched_content_changes
+  has_many :subscription_contents
 
   enum priority: { normal: 0, high: 1 }
 

--- a/app/queries/content_changes_for_email_query.rb
+++ b/app/queries/content_changes_for_email_query.rb
@@ -1,9 +1,8 @@
 class ContentChangesForEmailQuery
   def self.call(email)
-    subscription_content = SubscriptionContent
-      .where("subscription_contents.content_change_id = content_changes.id")
-      .where(email: email)
-      .exists
-    ContentChange.where(subscription_content)
+    content_change_ids = SubscriptionContent.
+        where(email: email).
+        select(:content_change_id)
+    ContentChange.where(id: content_change_ids)
   end
 end

--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -4,20 +4,10 @@ class SubscribersForImmediateEmailQuery
   end
 
   def call
-    Subscriber
-      .activated
-      .where(
-        unprocessed_subscription_contents_exist_for_subscribers
-       )
-  end
-
-private
-
-  def unprocessed_subscription_contents_exist_for_subscribers
-    SubscriptionContent
-      .joins(:subscription)
-      .where(email_id: nil)
-      .where("subscriptions.subscriber_id = subscribers.id")
-      .exists
+    subscriber_ids = Subscription.
+        joins(:subscription_contents).
+        where(subscription_contents: { email_id: nil }).
+        select(:subscriber_id)
+    Subscriber.activated.where(id: subscriber_ids)
   end
 end

--- a/spec/queries/content_changes_for_email_query_spec.rb
+++ b/spec/queries/content_changes_for_email_query_spec.rb
@@ -1,23 +1,34 @@
 RSpec.describe ContentChangesForEmailQuery do
   describe ".call" do
     let!(:email) { create(:email) }
+    let!(:content_change) { create(:content_change) }
+
     subject(:content_changes) { described_class.call(email) }
+
+    before :each do
+      create(:subscription_content, email: create(:email), content_change: create(:content_change))
+      create(:subscription_content, email: create(:email), content_change: content_change)
+    end
 
     context "when there are no subscription content associations" do
       it "returns an empty scope" do
-        expect(content_changes.exists?).to be false
+        expect(subject.exists?).to be false
       end
     end
 
     context "when there are multiple subscription content associations" do
-      let(:content_change) { create(:content_change) }
       before do
         create(:subscription_content, email: email, content_change: content_change)
         create(:subscription_content, email: email, content_change: content_change)
       end
 
       it "returns a scope of the unique content changes" do
-        expect(content_changes.count).to eq 1
+        expect(subject).to match_array([content_change])
+      end
+      it "returns a scope with two content changes" do
+        second_content_change = create(:content_change)
+        create(:subscription_content, email: email, content_change: second_content_change)
+        expect(subject).to match_array([content_change, second_content_change])
       end
     end
   end


### PR DESCRIPTION
Using arel 'exists' shows the following message
DEPRECATION WARNING: Delegating exists to arel is deprecated and will be
removed in Rails 6.0.