### PR TITLE
Fixes deprectation warning:

### DIFF
--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -59,7 +59,7 @@ private
   def grouped_subscription_ids_by_subscriber(content_change)
     ContentChangeImmediateSubscriptionQuery.call(content_change: content_change)
       .group(:subscriber_id)
-      .pluck("ARRAY_AGG(subscriptions.id)")
+      .pluck(Arel.sql("ARRAY_AGG(subscriptions.id)"))
   end
 
   def queue_delivery_to_courtesy_subscribers(content_change)


### PR DESCRIPTION
DEPRECATION WARNING: Dangerous query method (method whose arguments are
used as raw SQL) called with non-attribute argument(s):
"ARRAY_AGG(subscriptions.id)".
Non-attribute arguments will be disallowed in Rails 6.0. This method
should not be called with user-provided values, such as request parameters
or model attributes. Known-safe values can be passed by wrapping them in
Arel.sql()