### PR TITLE
Remove a newline from the unpublish message template

### DIFF
--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -137,8 +137,7 @@ private
 
       Because of this, you will not get email updates about '<%= subject %>' anymore.
 
-      If you want to continue receiving updates relating to this topic, you can
-      [subscribe to the new '<%= redirect.title %>' page](<%= add_utm(redirect.url) %>).
+      If you want to continue receiving updates relating to this topic, you can [subscribe to the new '<%= redirect.title %>' page](<%= add_utm(redirect.url) %>).
 
       <%=presented_manage_subscriptions_links(address)%>
     BODY


### PR DESCRIPTION
This gets converted to a <br> in the HTML version of the email, which
makes the text wrap oddly. Hopefully removing it will be better.