### PR TITLE
Use a different campaign for the unpublish emails

### DIFF
--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -73,7 +73,7 @@ private
           utm_parameters: {
               'utm_source' => subscriber_list.title,
               'utm_medium' => 'email',
-              'utm_campaign' => 'govuk-notification'
+              'utm_campaign' => 'govuk-subscription-ended'
           }
         )
       end


### PR DESCRIPTION
To make it different from the campaign for the general notifications.