### PR TITLE
Remove the foreign key between subscriptions and emails

### DIFF
--- a/db/migrate/20180917150259_remove_ended_email_id_foreign_key_from_subscriptions.rb
+++ b/db/migrate/20180917150259_remove_ended_email_id_foreign_key_from_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveEndedEmailIdForeignKeyFromSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :subscriptions, :emails
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_10_095917) do
+ActiveRecord::Schema.define(version: 2018_09_17_150259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,7 +182,6 @@ ActiveRecord::Schema.define(version: 2018_09_10_095917) do
   add_foreign_key "subscription_contents", "digest_run_subscribers", on_delete: :cascade
   add_foreign_key "subscription_contents", "emails", on_delete: :cascade
   add_foreign_key "subscription_contents", "subscriptions", on_delete: :restrict
-  add_foreign_key "subscriptions", "emails", column: "ended_email_id"
   add_foreign_key "subscriptions", "subscriber_lists", on_delete: :restrict
   add_foreign_key "subscriptions", "subscribers", on_delete: :restrict
 end


### PR DESCRIPTION
While the subscriptions table does reference the emails table, entries
in the emails table are archived and deleted, so it doesn't make sense
to have this foreign key.

This is causing issues with the scheduled email deletion task.