### PR TITLE
Add a unpublishing report task

### DIFF
--- a/lib/tasks/unpublishing_report.rake
+++ b/lib/tasks/unpublishing_report.rake
@@ -1,0 +1,7 @@
+namespace :unpublishing do
+  desc "Produce a report on the unpublishing activity between two dates.
+        E.g [2018\06/17, 2018\06/18]"
+  task :report, %i[start_date end_date] => :environment do |_t, args|
+    UnpublishingReport.call(args[:start_date], args[:end_date])
+  end
+end

--- a/lib/unpublishing_report.rb
+++ b/lib/unpublishing_report.rb
@@ -1,0 +1,45 @@
+class UnpublishingReport
+  def initialize(start_date, end_date)
+    @start_date = Time.parse(start_date)
+    @end_date = Time.parse(end_date)
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    puts "Unpublishing activity between #{start_date} and #{end_date}"
+
+    subscriptions_info = subscriber_lists_with_subscribers(unpublished_subscriptions)
+    subscription_count_per_subscriber_list(subscriptions_info)
+  end
+
+private
+
+  attr_reader :start_date, :end_date
+
+  def unpublished_subscriptions
+    Subscription.where(ended_reason: "unpublished")
+                .where(ended_at: start_date..end_date)
+  end
+
+  def subscriber_lists_with_subscribers(unpublished_subscriptions)
+    hash_array = Hash.new do |hash, key|
+      hash[key] = []
+    end
+
+    unpublished_subscriptions
+      .pluck(:subscriber_list_id, :subscriber_id)
+      .each_with_object(hash_array) { |(key, value), result| result[key] << value }
+  end
+
+  def subscription_count_per_subscriber_list(subscriptions_info)
+    subscriptions_info.each do |subscriber_list_id, subscription_ids|
+      title = SubscriberList.find(subscriber_list_id).title
+      subscriptions_count = subscription_ids.count
+
+      puts "'#{title}' has been unpublished ending #{subscriptions_count} subscriptions"
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -143,6 +143,10 @@ FactoryBot.define do
       ended_at { Time.now }
       ended_reason { :unsubscribed }
     end
+
+    trait :unpublished do
+      ended_reason { 'unpublished' }
+    end
   end
 
   factory :subscription_content do

--- a/spec/lib/unpublishing_report_spec.rb
+++ b/spec/lib/unpublishing_report_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe UnpublishingReport do
+  before do
+    create(:subscription, :unpublished, ended_at: '2018-08-29 13:04:03')
+  end
+
+  context 'generates report' do
+    it "generates report if there has been unpublishing within time frame" do
+      expect { described_class.call('2018/08/28', '2018/08/30') }.to output(
+        "Unpublishing activity between 2018-08-28 00:00:00 +0000 and 2018-08-30 00:00:00 +0000\n'#{SubscriberList.last.title}' has been unpublished ending 1 subscriptions\n"
+      ).to_stdout
+    end
+
+    it "doesn't generate any results as nothing has been unpublished in the time frame" do
+      expect { described_class.call('2018/08/10', '2018/08/11') }.to output(
+        "Unpublishing activity between 2018-08-10 00:00:00 +0000 and 2018-08-11 00:00:00 +0000\n"
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Produces a unpublishing report within a given timeframe. The report returns what content has been unpublished and how many subscriptions this has ended.

Trello:
https://trello.com/c/lfrup387/181-l-add-a-subscriber-list-unpublishing-reporting-rake-task-to-the-email-alert-api