### PR TITLE
Set the Sidekiq timeout to 4 seconds

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,7 @@
 :verbose: true
 :concurrency: 30
 :logfile: ./log/sidekiq.json.log
+:timeout: 4
 :queues:
   - [delivery_immediate_high, 6]
   - [delivery_immediate, 5]


### PR DESCRIPTION
Set the Sidekiq timeout to 4 seconds to try alleviate the inconsistency
between Sidekiq and Upstart's timeouts.

The Sidekiq timeout is the amount of time Sidekiq will give it's workers
to complete when Sidekiq receives a SIGTERM. Upstart's timeout is the
amount of time Upstart will wait between sending a SIGTERM and SIGKILL.

In a recent incident, a long running Sidekiq worker seems to have been
forcibly terminated when a new release of email-alert-api triggered a
restart. Upstart by default will KILL a process after 5 seconds if it
has not responded to a [SIGTERM](http://upstart.ubuntu.com/cookbook/#kill-timeout). 
Sidekiq, on the other hand pauses for 8 seconds to allow it's workers to finish when
it receives a [SIGTERM](https://github.com/mperham/sidekiq/wiki/Signals#term).

Sidekiq itself will terminate workers that do not finish within the 8
second grace period and it will push unfinished jobs back on to the
queue. However, if Sidekiq itself is forcibly terminated with a
SIGKILL in-flight jobs will not be re-enqueud and jobs run the risk of
only being partially completed.