### PR TITLE
Bulk email policy areas

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -13,7 +13,7 @@ class SubscriberList < ApplicationRecord
   has_many :subscribers, through: :subscriptions
   has_many :matched_content_changes
 
-  def self.find_by_links_value(content_id)
+  scope :find_by_links_value, ->(content_id) do
     # For this query to return the content id has to be wrapped in a
     # double quote blame psql 9.
     sql = <<~SQLSTRING
@@ -21,7 +21,7 @@ class SubscriberList < ApplicationRecord
         SELECT json_array_elements((json_each(links)).value)::text
        )
     SQLSTRING
-    SubscriberList.where(sql, id: "\"#{content_id}\"")
+    where(sql, id: "\"#{content_id}\"")
   end
 
   def subscription_url

--- a/app/services/bulk_unsubscribe_service.rb
+++ b/app/services/bulk_unsubscribe_service.rb
@@ -29,21 +29,13 @@ module BulkUnsubscribeService
         people: [], #[{content_id: ..., slug: ....}]
         world_locations: [], #[{content_id: ..., slug: ....}]
         organisations: [], #[{content_id: ..., slug: ....}]
-        policy_area_mappings: [] #[{content_id: ...., policy_area_path:, taxon_path: ....}]
+        policy_area_mappings: [] #[{content_id: ...., policy_area_path: ... taxon_path: ....}]
     )
 
     BulkUnsubscribeService.people = people
     BulkUnsubscribeService.world_locations = world_locations
     BulkUnsubscribeService.organisations = organisations
-    BulkUnsubscribeService.policy_area_mappings = policy_area_mappings.map do |mapping|
-      taxon_title = Services.content_store.content_item(mapping[:taxon_path])['title']
-      policy_area_title = Services.content_store.content_item(mapping[:policy_area_path])['title']
-      { content_id: mapping[:content_id],
-        taxon_path: mapping[:taxon_path],
-        taxon_title: taxon_title,
-        policy_area_title: policy_area_title
-      }
-    end
+    BulkUnsubscribeService.policy_area_mappings = policy_area_mappings
     BulkUnsubscribeService.taxonomy = Taxonomy.new
 
     affected_subscriber_list_ids = policy_area_mappings.flat_map do |mapping|
@@ -68,7 +60,7 @@ module BulkUnsubscribeService
                                 .values
                                 .flatten
         mapping = policy_area_mappings.find { |m| subscription_content_ids.include?(m[:content_id]) }
-        SubscriptionDetails.new(subscription, mapping[:taxon_path])
+        SubscriptionDetails.new(subscription, mapping[:policy_area_path], mapping[:taxon_path])
       end
 
       subscription_details.sort_by!(&:title)

--- a/app/services/bulk_unsubscribe_service.rb
+++ b/app/services/bulk_unsubscribe_service.rb
@@ -29,13 +29,21 @@ module BulkUnsubscribeService
         people: [], #[{content_id: ..., slug: ....}]
         world_locations: [], #[{content_id: ..., slug: ....}]
         organisations: [], #[{content_id: ..., slug: ....}]
-        policy_area_mappings: [] #[{content_id: ...., taxon_path: ....}]
+        policy_area_mappings: [] #[{content_id: ...., policy_area_path:, taxon_path: ....}]
     )
 
     BulkUnsubscribeService.people = people
     BulkUnsubscribeService.world_locations = world_locations
     BulkUnsubscribeService.organisations = organisations
-    BulkUnsubscribeService.policy_area_mappings = policy_area_mappings
+    BulkUnsubscribeService.policy_area_mappings = policy_area_mappings.map do |mapping|
+      taxon_title = Services.content_store.content_item(mapping[:taxon_path])['title']
+      policy_area_title = Services.content_store.content_item(mapping[:policy_area_path])['title']
+      { content_id: mapping[:content_id],
+        taxon_path: mapping[:taxon_path],
+        taxon_title: taxon_title,
+        policy_area_title: policy_area_title
+      }
+    end
     BulkUnsubscribeService.taxonomy = Taxonomy.new
 
     affected_subscriber_list_ids = policy_area_mappings.flat_map do |mapping|

--- a/app/services/bulk_unsubscribe_service.rb
+++ b/app/services/bulk_unsubscribe_service.rb
@@ -138,7 +138,7 @@ module BulkUnsubscribeService
   BULK_POLICY_TEMPLATE = <<~BODY.freeze
     We're changing the way content is organised on GOV.​UK. This affects your email subscriptions.
 
-    You are subscribed to email updates about <%= pluralize(subscription_details.length, 'policy page') %>. You will not receive these updates any more.
+    You are subscribed to email updates about <%= pluralize(subscription_details.length, 'policy area') %>. You will not receive these updates any more.
 
     You can sign up to <%= subscription_details.length == 1 ? 'this topic' : 'these topics' %> to get similar updates:
     <% subscription_details.each do |details| %>

--- a/app/services/bulk_unsubscribe_service.rb
+++ b/app/services/bulk_unsubscribe_service.rb
@@ -117,35 +117,7 @@ module BulkUnsubscribeService
       - [<%= details.replacement_title %>](<%= add_utm(details.replacement_url, utm_parameters) %>)
     <% end %>
   BODY
-
-  class SubscriptionDetails
-
-    def initialize(subscription, replacement)
-      @subscription = subscription
-      @replacement = replacement
-    end
-
-    def subscriber_list
-      @_subscriber_list = @subscription.subscriber_list
-    end
-
-    def title
-      subscriber_list.title
-    end
-
-    def links
-      subscriber_list.links
-    end
-
-    def replacement_title
-      @replacement.title
-    end
-
-    def replacement_url
-      @replacement.url
-    end
-
-  end
+  
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/app/services/bulk_unsubscribe_service.rb
+++ b/app/services/bulk_unsubscribe_service.rb
@@ -1,11 +1,44 @@
 # rubocop:disable Metrics/BlockLength
 
 module BulkUnsubscribeService
+  mattr_accessor :people, :world_locations, :organisations, :policy_area_mappings, :taxonomy
+
+  def self.person_slug(content_id)
+    result = people.find(-> { {} }) { |person| person[:content_id] == content_id }
+    result[:slug]
+  end
+
+  def self.world_location_slug(content_id)
+    result = world_locations.find(-> { {} }) { |world_location| world_location[:content_id] == content_id }
+    result[:slug]
+  end
+
+  def self.organisation_slug(content_id)
+    result = organisations.find(-> { {} }) { |org| org[:content_id] == content_id }
+    result[:slug]
+  end
+
+  def self.taxon_path(policy_area_content_id)
+    result = policy_area_mappings.find(-> { {} }) { |mapping| mapping[:content_id] == policy_area_content_id }
+    result[:taxon_path]
+  end
+
   def self.call(
         content_ids_and_replacements,
         subscriber_limit: 1_000_000,
-        courtesy_emails_every_nth_email: 500
-      )
+        courtesy_emails_every_nth_email: 500,
+        people: [], #[{content_id: ..., slug: ....}]
+        world_locations: [], #[{content_id: ..., slug: ....}]
+        organisations: [], #[{content_id: ..., slug: ....}]
+        policy_area_mappings: [] #[{content_id: ...., taxon_path: ....}]
+    )
+
+    BulkUnsubscribeService.people = people
+    BulkUnsubscribeService.world_locations = world_locations
+    BulkUnsubscribeService.organisations = organisations
+    BulkUnsubscribeService.policy_area_mappings = policy_area_mappings
+    BulkUnsubscribeService.taxonomy = Taxonomy.new
+
     affected_subscriber_list_ids = content_ids_and_replacements
                                      .keys
                                      .flat_map do |content_id|
@@ -117,7 +150,6 @@ module BulkUnsubscribeService
       - [<%= details.replacement_title %>](<%= add_utm(details.replacement_url, utm_parameters) %>)
     <% end %>
   BODY
-  
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/app/services/bulk_unsubscribe_service/subscription_details.rb
+++ b/app/services/bulk_unsubscribe_service/subscription_details.rb
@@ -1,0 +1,30 @@
+module BulkUnsubscribeService
+  class SubscriptionDetails
+
+    def initialize(subscription, replacement)
+      @subscription = subscription
+      @replacement = replacement
+    end
+
+    def subscriber_list
+      @_subscriber_list = @subscription.subscriber_list
+    end
+
+    def title
+      subscriber_list.title
+    end
+
+    def links
+      subscriber_list.links
+    end
+
+    def replacement_title
+      @replacement.title
+    end
+
+    def replacement_url
+      @replacement.url
+    end
+
+  end
+end

--- a/app/services/bulk_unsubscribe_service/subscription_details.rb
+++ b/app/services/bulk_unsubscribe_service/subscription_details.rb
@@ -1,7 +1,8 @@
 module BulkUnsubscribeService
   class SubscriptionDetails
-    def initialize(subscription, taxon_path)
+    def initialize(subscription, policy_area_path, taxon_path)
       @subscription = subscription
+      @policy_area = ContentItem.new(policy_area_path)
       @replacement = ContentItem.new(taxon_path)
     end
 
@@ -18,7 +19,12 @@ module BulkUnsubscribeService
     end
 
     def replacement_title
-      @replacement.title
+      if subscriber_list[:email_document_supertype] == 'announcements' ||
+          subscriber_list[:email_document_supertype] == 'publications'
+        @subscription.subscriber_list.title.gsub(@policy_area.title, @replacement.title)
+      else
+        @replacement.title
+      end
     end
 
     def replacement_url

--- a/app/services/bulk_unsubscribe_service/subscription_details.rb
+++ b/app/services/bulk_unsubscribe_service/subscription_details.rb
@@ -1,8 +1,8 @@
 module BulkUnsubscribeService
   class SubscriptionDetails
-    def initialize(subscription, replacement)
+    def initialize(subscription, taxon_path)
       @subscription = subscription
-      @replacement = replacement
+      @replacement = ContentItem.new(taxon_path)
     end
 
     def subscriber_list

--- a/app/services/bulk_unsubscribe_service/taxonomy.rb
+++ b/app/services/bulk_unsubscribe_service/taxonomy.rb
@@ -1,0 +1,17 @@
+module BulkUnsubscribeService
+  class Taxonomy
+    def initialize
+      @first_level_taxons = JSON.parse(Redis.current.get('topic_taxonomy_taxons'))
+      @second_level_taxons = @first_level_taxons.flat_map { |t| t.dig('links', 'child_taxons') || [] }
+    end
+
+    def get_taxon_content_id(base_path)
+      level_one_base_path = /\/[^\/]*/.match(base_path).to_s
+      @first_level_taxons.find(-> { {} }) { |t| t['base_path'] == level_one_base_path }.fetch('content_id', 'all')
+    end
+
+    def get_subtaxon_content_id(base_path)
+      @second_level_taxons.find(-> { {} }) { |t| t['base_path'] == base_path }.fetch('content_id', 'all')
+    end
+  end
+end

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/BlockLength
+
 require 'csv'
 
 namespace :manage do
@@ -89,8 +91,17 @@ namespace :manage do
   task :unsubscribe_bulk_from_base_paths_csv, %i[csv_file_path subscriber_limit courtesy_emails_every_nth_email] => :environment do |_t, args|
     args.with_defaults(
       subscriber_limit: 1_000_000,
-      courtesy_emails_every_nth_email: 500
+      courtesy_emails_every_nth_email: 500,
+      people_path: 'tmp/people.json', #[{content_id: ..., slug: ....}]
+      world_location_path: 'tmp/world_location.json', #[{content_id: ..., slug: ....}]
+      organisations_path: 'tmp/organisations.json', #[{content_id: ..., slug: ....}]
+      policy_area_mappings_path: 'tmp/policy_area_mappings.json' #[{content_id: ..., taxon_path: ....}]
     )
+
+    people = JSON.parse(File.read(args[:people_path]), symbolize_names: true)
+    world_locations = JSON.parse(File.read(args[:world_location_path]), symbolize_names: true)
+    organisations = JSON.parse(File.read(args[:organisations_path]), symbolize_names: true)
+    policy_area_mappings = JSON.parse(File.read(args[:policy_area_mappings_path]), symbolize_names: true)
 
     content_ids_and_replacements = {}
 
@@ -114,7 +125,12 @@ namespace :manage do
     BulkUnsubscribeService.call(
       content_ids_and_replacements,
       subscriber_limit: args[:subscriber_limit].to_i,
-      courtesy_emails_every_nth_email: args[:courtesy_emails_every_nth_email].to_i
+      courtesy_emails_every_nth_email: args[:courtesy_emails_every_nth_email].to_i,
+      people: people,
+      world_locations: world_locations,
+      organisations: organisations,
+      policy_area_mappings: policy_area_mappings
     )
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -93,7 +93,7 @@ namespace :manage do
       people_path: 'tmp/people.json', #[{content_id: ..., slug: ....}]
       world_location_path: 'tmp/world_locations.json', #[{content_id: ..., slug: ....}]
       organisations_path: 'tmp/organisations.json', #[{content_id: ..., slug: ....}]
-      policy_area_mappings_path: 'tmp/policy_area_mappings.json' #[{content_id: ..., taxon_path: ....}]
+      policy_area_mappings_path: 'tmp/policy_area_mappings.json' #[{content_id: ..., taxon_path: ...., policy_area_path:}]
     )
 
     people = JSON.parse(File.read(args[:people_path]), symbolize_names: true)

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -1,5 +1,3 @@
-# rubocop:disable Metrics/BlockLength
-
 require 'csv'
 
 namespace :manage do
@@ -87,13 +85,13 @@ namespace :manage do
     move_all_subscribers(from_slug: args[:from_slug], to_slug: args[:to_slug])
   end
 
-  desc "Unsubscribe subscribers using a list of base paths"
-  task :unsubscribe_bulk_from_base_paths_csv, %i[csv_file_path subscriber_limit courtesy_emails_every_nth_email] => :environment do |_t, args|
+  desc "Unsubscribe subscribers using a list policy areas to taxons"
+  task :unsubscribe_bulk_policy_areas, %i[subscriber_limit courtesy_emails_every_nth_email people_path world_location_path organisations_path policy_area_mappings_path] => :environment do |_t, args|
     args.with_defaults(
       subscriber_limit: 1_000_000,
       courtesy_emails_every_nth_email: 500,
       people_path: 'tmp/people.json', #[{content_id: ..., slug: ....}]
-      world_location_path: 'tmp/world_location.json', #[{content_id: ..., slug: ....}]
+      world_location_path: 'tmp/world_locations.json', #[{content_id: ..., slug: ....}]
       organisations_path: 'tmp/organisations.json', #[{content_id: ..., slug: ....}]
       policy_area_mappings_path: 'tmp/policy_area_mappings.json' #[{content_id: ..., taxon_path: ....}]
     )
@@ -103,27 +101,10 @@ namespace :manage do
     organisations = JSON.parse(File.read(args[:organisations_path]), symbolize_names: true)
     policy_area_mappings = JSON.parse(File.read(args[:policy_area_mappings_path]), symbolize_names: true)
 
-    content_ids_and_replacements = {}
-
-    CSV.foreach(args[:csv_file_path], headers: true) do |row|
-      content_id = ContentItem.new(row['base_path']).content_id
-      alternative_content_item = ContentItem.new(row['alternative_path'])
-
-      raise "Missing title for #{row['alternative_path']}" \
-        unless alternative_content_item.title.present?
-
-      content_ids_and_replacements[content_id] = alternative_content_item
-    end
-
-    if content_ids_and_replacements.keys.uniq.length != content_ids_and_replacements.size
-      raise "Non-unique content id's detected"
-    end
-
     puts "Processing #{args[:subscriber_limit].to_i} subscribers"
     puts "Sending a courtesy copy every #{args[:courtesy_emails_every_nth_email].to_i} emails"
 
     BulkUnsubscribeService.call(
-      content_ids_and_replacements,
       subscriber_limit: args[:subscriber_limit].to_i,
       courtesy_emails_every_nth_email: args[:courtesy_emails_every_nth_email].to_i,
       people: people,
@@ -133,4 +114,3 @@ namespace :manage do
     )
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/spec/services/bulk_unsubscribe_service_spec.rb
+++ b/spec/services/bulk_unsubscribe_service_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe BulkUnsubscribeService do
 
   describe 'send bulk emails' do
     before :each do
+      Redis.current = double
+      allow(Redis.current).to receive(:get).with('topic_taxonomy_taxons').and_return(JSON.dump([]))
 
       policy_area1_content_id = SecureRandom.uuid
       policy_area2_content_id = SecureRandom.uuid
 
       policy_area1_subscriber_list = create(:subscriber_list, links: { policy_areas: [policy_area1_content_id] })
       policy_area2_subscriber_list = create(:subscriber_list, links: { policy_areas: [policy_area2_content_id] })
-
 
       @content_ids_and_replacements = {
             policy_area1_content_id => create(:content_item, path: '/topic1'),
@@ -60,6 +61,9 @@ RSpec.describe BulkUnsubscribeService do
 
   describe 'redirect to announcements finder' do
     before :each do
+      Redis.current = double
+      allow(Redis.current).to receive(:get).with('topic_taxonomy_taxons').and_return(JSON.dump([]))
+
       @policy_area1_content_id = SecureRandom.uuid
 
       @content_ids_and_replacements = {
@@ -148,7 +152,6 @@ RSpec.describe BulkUnsubscribeService do
                email_document_supertype: 'publications',
                links: { policy_areas: [@policy_area1_content_id] })
 
-        Redis.current = double
         taxonomy = [{
                       content_id: 'level_one_content_id',
                       base_path: '/level_one',
@@ -161,6 +164,7 @@ RSpec.describe BulkUnsubscribeService do
                         ]
                       }
                     }]
+        Redis.current = double
         allow(Redis.current).to receive(:get).with('topic_taxonomy_taxons').and_return(JSON.dump(taxonomy))
       end
       it 'sends the user to a url filtered on taxon and subtaxon' do

--- a/spec/services/bulk_unsubscribe_service_spec.rb
+++ b/spec/services/bulk_unsubscribe_service_spec.rb
@@ -3,60 +3,180 @@ require 'gds_api/test_helpers/content_store'
 RSpec.describe BulkUnsubscribeService do
   include ::GdsApi::TestHelpers::ContentStore
 
-  let(:policy1_content_id) { SecureRandom.uuid }
-  let(:policy2_content_id) { SecureRandom.uuid }
+  describe 'send bulk emails' do
+    before :each do
 
-  let(:policy1_subscriber_list) do
-    create(:subscriber_list, links: { policies: [policy1_content_id] })
-  end
-  let(:policy2_subscriber_list) do
-    create(:subscriber_list, links: { policies: [policy2_content_id] })
-  end
+      policy_area1_content_id = SecureRandom.uuid
+      policy_area2_content_id = SecureRandom.uuid
 
-  let(:content_ids_and_replacements) do
-    {
-      policy1_content_id => create(:content_item, path: '/topic1'),
-      policy2_content_id => create(:content_item, path: '/topic2')
-    }
-  end
+      policy_area1_subscriber_list = create(:subscriber_list, links: { policy_areas: [policy_area1_content_id] })
+      policy_area2_subscriber_list = create(:subscriber_list, links: { policy_areas: [policy_area2_content_id] })
 
-  before :each do
-    double_subscriber = create(
-      :subscription,
-      subscriber_list: policy1_subscriber_list
-    ).subscriber
 
-    create(
-      :subscription,
-      subscriber: double_subscriber,
-      subscriber_list: policy2_subscriber_list
-    )
-    create(
-      :subscription,
-      subscriber_list: policy1_subscriber_list
-    )
+      @content_ids_and_replacements = {
+            policy_area1_content_id => create(:content_item, path: '/topic1'),
+            policy_area2_content_id => create(:content_item, path: '/topic2')
+      }
 
-    create(:subscriber, address: Email::COURTESY_EMAIL)
+      double_subscriber = create(
+        :subscription,
+        subscriber_list: policy_area1_subscriber_list
+      ).subscriber
 
-    content_ids_and_replacements.each do |(_content_id, content_item)|
-      content_store_has_item(
-        content_item.path,
-        {
-          'base_path' => content_item.path,
-          'title' => content_item.path.titleize
-        }.to_json
+      create(
+        :subscription,
+        subscriber: double_subscriber,
+        subscriber_list: policy_area2_subscriber_list
       )
+      create(
+        :subscription,
+        subscriber_list: policy_area1_subscriber_list
+      )
+
+      create(:subscriber, address: Email::COURTESY_EMAIL)
+
+      @content_ids_and_replacements.each do |(_content_id, content_item)|
+        content_store_has_item(
+          content_item.path,
+          {
+            'base_path' => content_item.path,
+            'title' => content_item.path.titleize
+          }.to_json
+        )
+      end
+    end
+
+    describe ".call" do
+      it "sends three emails" do
+        Sidekiq::Testing.fake! do
+          DeliveryRequestWorker.jobs.clear
+          described_class.call(@content_ids_and_replacements)
+        end
+
+        expect(DeliveryRequestWorker.jobs.size).to eq(3)
+      end
     end
   end
 
-  describe ".call" do
-    it "sends three emails" do
-      Sidekiq::Testing.fake! do
-        DeliveryRequestWorker.jobs.clear
-        described_class.call(content_ids_and_replacements)
-      end
+  describe 'redirect to announcements finder' do
+    before :each do
+      @policy_area1_content_id = SecureRandom.uuid
 
-      expect(DeliveryRequestWorker.jobs.size).to eq(3)
+      @content_ids_and_replacements = {
+          @policy_area1_content_id => build(:content_item, path: '/topic1'),
+      }
+      content_store_has_item(
+        '/topic1',
+          {
+              'base_path' => '/topic1',
+              'title' => 'topic1'
+          }.to_json
+      )
+    end
+
+    it 'sends the user to the announcements' do
+      create(:subscriber_list_with_subscribers,
+             subscriber_count: 1,
+             email_document_supertype: 'announcements',
+             links: { policy_areas: [@policy_area1_content_id] })
+
+      expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: include('/government/announcements')))
+      BulkUnsubscribeService.call(@content_ids_and_replacements)
+    end
+
+    it 'sends the user to the publications' do
+      create(:subscriber_list_with_subscribers,
+             subscriber_count: 1,
+             email_document_supertype: 'publications',
+             links: { policy_areas: [@policy_area1_content_id] })
+
+      expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: include('/government/publications')))
+      BulkUnsubscribeService.call(@content_ids_and_replacements)
+    end
+
+    it 'sends the user to a url filtered on people' do
+      person_content_id = SecureRandom.uuid
+
+      create(:subscriber_list_with_subscribers,
+             subscriber_count: 1,
+             email_document_supertype: 'announcements',
+             links: { policy_areas: [@policy_area1_content_id], people: [person_content_id] })
+
+      expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: include('people%5B%5D=person-slug')))
+
+      BulkUnsubscribeService.call(@content_ids_and_replacements,
+                                  people: [{ content_id: person_content_id, slug: 'person-slug' }])
+    end
+
+    it 'sends the user to a url filtered on world location' do
+      world_location_id = SecureRandom.uuid
+
+      create(:subscriber_list_with_subscribers,
+             subscriber_count: 1,
+             email_document_supertype: 'announcements',
+             links: { policy_areas: [@policy_area1_content_id], world_locations: [world_location_id] })
+
+      expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: include('world_locations%5B%5D=world_location_slug')))
+
+      BulkUnsubscribeService.call(@content_ids_and_replacements,
+                                  world_locations: [{ content_id: world_location_id, slug: 'world_location_slug' }])
+    end
+
+    it 'sends the user to a url filtered on department (organisation)' do
+      organisations_id = SecureRandom.uuid
+
+      create(:subscriber_list_with_subscribers,
+             subscriber_count: 1,
+             email_document_supertype: 'publications',
+             links: { policy_areas: [@policy_area1_content_id], organisations: [organisations_id] })
+
+      expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: include('departments%5B%5D=organisation_slug')))
+
+      BulkUnsubscribeService.call(@content_ids_and_replacements,
+                                  organisations: [{ content_id: organisations_id, slug: 'organisation_slug' }])
+    end
+
+    describe 'taxon and subtaxon' do
+      before :each do
+        create(:subscriber_list_with_subscribers,
+               subscriber_count: 1,
+               email_document_supertype: 'publications',
+               links: { policy_areas: [@policy_area1_content_id] })
+
+        Redis.current = double
+        taxonomy = [{
+                      content_id: 'level_one_content_id',
+                      base_path: '/level_one',
+                      links: {
+                        child_taxons: [
+                          {
+                            content_id: 'level_two_content_id',
+                            base_path: '/level_one/level_two'
+                          }
+                        ]
+                      }
+                    }]
+        allow(Redis.current).to receive(:get).with('topic_taxonomy_taxons').and_return(JSON.dump(taxonomy))
+      end
+      it 'sends the user to a url filtered on taxon and subtaxon' do
+        expect(DeliveryRequestService).to receive(:call).
+            with(email: having_attributes(body: include('taxons%5B%5D=level_one_content_id', 'subtaxons%5B%5D=level_two_content_id')))
+
+        BulkUnsubscribeService.call(@content_ids_and_replacements,
+                                    policy_area_mappings: [{ content_id: @policy_area1_content_id, taxon_path: '/level_one/level_two' }])
+      end
+      it 'sends the user to a url filtered on taxon; the subtaxon is set to "all"' do
+        expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: include('taxons%5B%5D=level_one_content_id', 'subtaxons%5B%5D=all')))
+
+        BulkUnsubscribeService.call(@content_ids_and_replacements,
+                                    policy_area_mappings: [{ content_id: @policy_area1_content_id, taxon_path: '/level_one' }])
+      end
     end
   end
 end


### PR DESCRIPTION
Code to send emails to people that subscribed to policy areas telling them the policy areas they subscribed to have been retired.

This overwrites the code that was used to send emails to unpublish policies - it is assumed that is not needed anymore after all policies have been retired.

The rake task requires a number of static mapping files to handle the conversion of slugs and content_ids.

tmp/people.json - [{content_id: ..., slug: ....}]*
tmp/world_location.json - [{content_id: ..., slug: ....}]*
tmp/organisations.json - [{content_id: ..., slug: ....}]*
tmp/policy_area_mappings.json - [{content_id: ..., taxon_path: ...., policy_area_path: ...}]*

These can be obtained by collecting data from the relevant models in Whitehall.

The policy_area_mappings can be retrieved from: https://docs.google.com/spreadsheets/d/1_LTHKhXvORCAhT9AuW2MGosYw-6OelJC6D8Ddvu_XeE/edit#gid=1779149617