### PR TITLE
Rename education and skill funding agency subscriber list

### DIFF
--- a/db/migrate/20181019072511_rename_esfa_subscriber_list.rb
+++ b/db/migrate/20181019072511_rename_esfa_subscriber_list.rb
@@ -1,0 +1,10 @@
+class RenameEsfaSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    SubscriberList.find_by(
+      slug: "education-and-education-and-skills-funding-agency"
+    ).update_attributes!(
+      slug: "education-and-skills-funding-agency",
+      title: "Education and Skills Funding Agency"
+    )
+  end
+end


### PR DESCRIPTION
https://trello.com/c/qqw5RbKb/556-change-this-email-signup-from-education-and-education-and-skills-funding-agency-to-education-and-skills-funding-agency

@rubenarakelyan could you advise please? Not sure if this is the correct approach, it seems better to have the slug and title in sync but we could just update the title according to the trello story.