### PR TITLE
Deduplicate esfa subscriber lists

### DIFF
--- a/db/migrate/20181019072511_deduplicate_esfa_subscriber_list.rb
+++ b/db/migrate/20181019072511_deduplicate_esfa_subscriber_list.rb
@@ -1,0 +1,30 @@
+class DeduplicateEsfaSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    old_list = SubscriberList.find_by(
+      slug: "education-and-education-and-skills-funding-agency"
+    )
+    new_list = SubscriberList.find_by(
+      slug: "education-and-skills-funding-agency"
+    )
+
+    if old_list && new_list
+      puts "#{old_list.subscriptions.count} subscriptions for '#{old_list.title}'"
+      puts "#{new_list.subscriptions.count} subscriptions for '#{new_list.title}'"
+      puts "#{(old_list.subscribers & new_list.subscribers).count} subscribers exist in both lists"
+
+      scope = Subscription
+        .where(subscriber_list: old_list)
+        .where.not(subscriber: new_list.subscribers)
+
+      puts "#{scope.count} subscriptions to migrate from '#{old_list.title}' to '#{new_list.title}'"
+
+      updated = scope.update_all(subscriber_list_id: new_list.id)
+
+      puts "Added #{updated} subscriptions to '#{new_list.title}'"
+
+      if Subscription.where(subscriber_list: old_list).destroy_all && old_list.destroy
+        puts "Deleted '#{old_list.title}' with remaining subscriptions"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_17_150259) do
+ActiveRecord::Schema.define(version: 2018_10_19_072511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/qqw5RbKb/556-change-this-email-signup-from-education-and-education-and-skills-funding-agency-to-education-and-skills-funding-agency

Two subscriber lists: 
`Education and Education and Skills Funding Agency` and 
`Education and Skills Funding Agency`
contain around 2000 subscriptions each with some subscribers on both lists.
We only want the latter so migrate subscriptions to this list and remove the `Education and Education and Skills Funding Agency` list.