### PR TITLE
All subscriber list now work with a taxon_tree key instead of taxons

### DIFF
--- a/lib/tasks/move_taxons_to_taxon_tree.rake
+++ b/lib/tasks/move_taxons_to_taxon_tree.rake
@@ -1,0 +1,26 @@
+desc "Move all non-duplicated lists with the key :taxons in the link to an equivalent or new list containing :taxon_tree"
+task move_taxons_to_taxon_tree: :environment do
+  taxons_lists = SubscriberList.all.select { |list| list.links.key?(:taxons) }
+
+  lists_without_matches = taxons_lists.select { |list| FindExactQuery.new(new_params(list)).exact_match.nil? }
+
+  lists_without_matches.each do |from_list|
+    from_list.links = updated_links(from_list)
+    from_list.save!
+    puts "Updated: #{from_list.slug}"
+  end
+end
+
+def updated_links(list)
+  list.links.transform_keys { |key| key == :taxons ? :taxon_tree : key }
+end
+
+def new_params(list)
+  {
+    tags: {},
+    links: updated_links(list),
+    document_type: list.document_type,
+    email_document_supertype: list.email_document_supertype,
+    government_document_supertype: list.government_document_supertype
+  }
+end


### PR DESCRIPTION
By mistake we used the 'taxons' key when creating subscriber lists
in the finders in Whitehall (announcements etc)

This PR fixes this issue. It tests that there are no equivalent
subscriber lists already present, which ought to be the case and
then fixes all existing lists by updating the links attribute
to the correct key.

See also: https://github.com/alphagov/whitehall/pull/4489