### PR TITLE
Increase slug and title length

### DIFF
--- a/db/migrate/20181119131532_update_slug_and_title_limit.rb
+++ b/db/migrate/20181119131532_update_slug_and_title_limit.rb
@@ -1,0 +1,6 @@
+class UpdateSlugAndTitleLimit < ActiveRecord::Migration[5.2]
+  def change
+    change_column :subscriber_lists, :title, :string, limit: 10000
+    change_column :subscriber_lists, :slug, :string, limit: 10000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_17_150259) do
+ActiveRecord::Schema.define(version: 2018_11_19_131532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 2018_09_17_150259) do
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
-    t.string "title", limit: 1000, null: false
+    t.string "title", limit: 10000, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false
@@ -114,7 +114,7 @@ ActiveRecord::Schema.define(version: 2018_09_17_150259) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
-    t.string "slug", limit: 1000, null: false
+    t.string "slug", limit: 10000, null: false
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"


### PR DESCRIPTION
We're likely to start seeing slugs and titles longer than 1000 characters so we should prepare for this by increasing the limit available to them.