### PR TITLE
Read facet configuration from a shared definition

### DIFF
--- a/lib/business_readiness/loader.rb
+++ b/lib/business_readiness/loader.rb
@@ -3,7 +3,7 @@ require "csv"
 module BusinessReadiness
   class Loader
     def initialize(filename, facets_filename)
-      @rows = CSV.read(filename)
+      @rows = CSV.read(filename, converters: lambda { |v| v || "" })
       @facets = {}
 
       if File.exist?(facets_filename)

--- a/lib/business_readiness/loader.rb
+++ b/lib/business_readiness/loader.rb
@@ -2,8 +2,14 @@ require "csv"
 
 module BusinessReadiness
   class Loader
-    def initialize(filename)
+    def initialize(filename, facets_filename)
       @rows = CSV.read(filename)
+      @facets = {}
+
+      if File.exist?(facets_filename)
+        facet_config = YAML.load_file(facets_filename)
+        @facets = facet_config["details"]["facets"]
+      end
     end
 
     def base_paths_with_tags
@@ -19,7 +25,7 @@ module BusinessReadiness
 
   private
 
-    attr_reader :rows
+    attr_reader :facets, :rows
 
     def tags_for_row(row)
       if row[1] == "yes"
@@ -30,142 +36,21 @@ module BusinessReadiness
     end
 
     def create_all_tags
-      {
-        "sector_business_area" => all_sector_business_area,
-        "employ_eu_citizens" => all_employ_eu_citizens,
-        "doing_business_in_the_eu" => all_doing_business_in_the_eu,
-        "regulations_and_standards" => all_regulations_and_standards,
-        "personal_data" => all_personal_data,
-        "intellectual_property" => all_intellectual_property,
-        "receiving_eu_funding" => all_receiving_eu_funding,
-        "public_sector_procurement" => all_public_sector_procurement
-      }
-    end
-
-    def specific_tags(row)
-      {
-        "sector_business_area" => row.fetch(2, "").split(","),
-        "employ_eu_citizens" => row.fetch(3, "").split(","),
-        "doing_business_in_the_eu" => row.fetch(4, "").split(","),
-        "regulations_and_standards" => row.fetch(5, "").split(","),
-        "personal_data" => row.fetch(6, "").split(","),
-        "intellectual_property" => row.fetch(7, "").split(","),
-        "receiving_eu_funding" => row.fetch(8, "").split(","),
-        "public_sector_procurement" => row.fetch(9, "").split(",")
-      }.reject do |_, value|
-        value == []
+      facets.each_with_object({}) do |facet, tags|
+        tags[facet["key"]] = facet["allowed_values"].map { |f| f["value"] }
       end
     end
 
-    def all_sector_business_area
-      [
-        "accommodation-restaurants-and-catering-services",
-        "aerospace",
-        "agriculture",
-        "air-transport-aviation",
-        "ancillary-services",
-        "animal-health",
-        "automotive",
-        "banking-market-infrastructure",
-        "broadcasting",
-        "chemicals",
-        "computer-services",
-        "construction-contracting",
-        "education",
-        "electricity",
-        "electronics",
-        "environmental-services",
-        "fisheries",
-        "food-and-drink",
-        "furniture-and-other-manufacturing",
-        "gas-markets",
-        "goods-sectors-each-0-4-of-gva",
-        "imports",
-        "imputed-rent",
-        "insurance",
-        "land-transport-excl-rail",
-        "medical-services",
-        "motor-trades",
-        "network-industries-0-3-of-gva",
-        "oil-and-gas-production",
-        "other-personal-services",
-        "parts-and-machinery",
-        "pharmaceuticals",
-        "post",
-        "professional-and-business-services",
-        "public-administration-and-defence",
-        "rail",
-        "real-estate-excl-imputed-rent",
-        "retail",
-        "service-sectors-each-1-of-gva",
-        "social-work",
-        "steel-and-other-metals-commodities",
-        "telecoms",
-        "textiles-and-clothing",
-        "top-ten-trade-partners-by-value",
-        "warehousing-and-support-for-transportation",
-        "water-transport-maritime-ports",
-        "wholesale-excl-motor-vehicles"
-      ]
-    end
+    def specific_tags(row)
+      tags = {}
+      facets.each_with_index do |facet, index|
+        row_index = index + 2
+        tags[facet["key"]] = row.fetch(row_index, "").split(",")
+      end
 
-    def all_employ_eu_citizens
-      %w(yes no dont-know)
-    end
-
-    def all_doing_business_in_the_eu
-      [
-        "do-business-in-the-eu",
-        "buying",
-        "selling",
-        "transporting",
-        "other-eu",
-        "other-rest-of-the-world"
-      ]
-    end
-
-    def all_regulations_and_standards
-      %w(products-or-goods)
-    end
-
-    def all_personal_data
-      [
-        "processing-personal-data",
-        "interacting-with-eea-website",
-        "digital-service-provider"
-      ]
-    end
-
-    def all_intellectual_property
-      [
-        "have-intellectual-property",
-        "copyright",
-        "trademarks",
-        "designs",
-        "patents",
-        "exhaustion-of-rights"
-      ]
-    end
-
-    def all_receiving_eu_funding
-      [
-        "horizon-2020",
-        "cosme",
-        "european-investment-bank-eib",
-        "european-structural-fund-esf",
-        "eurdf",
-        "etcf",
-        "esc",
-        "ecp",
-        "etf"
-      ]
-    end
-
-    def all_public_sector_procurement
-      [
-        "civil-government-contracts",
-        "defence-contracts"
-      ]
+      tags.reject do |_, value|
+        value == []
+      end
     end
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -10,7 +10,8 @@ module Services
   def self.business_readiness
     @business_readiness ||= begin
       path = File.join(Rails.root, "config", "business_readiness.csv")
-      base_paths_with_tags = BusinessReadiness::Loader.new(path).base_paths_with_tags
+      facets_path = File.join(Rails.root, "config", "find-eu-exit-guidance-business.yml")
+      base_paths_with_tags = BusinessReadiness::Loader.new(path, facets_path).base_paths_with_tags
       BusinessReadiness::ContentChangeInjector.new(base_paths_with_tags)
     end
   end

--- a/spec/lib/business_readiness/examples/facet_config.yml
+++ b/spec/lib/business_readiness/examples/facet_config.yml
@@ -1,0 +1,213 @@
+---
+details:
+  facets:
+  - allowed_values:
+    - label: Accommodation, restaurants and catering services
+      value: accommodation-restaurants-and-catering-services
+    - label: Aerospace
+      value: aerospace
+    - label: Agriculture
+      value: agriculture
+    - label: Air transport (Aviation
+      value: air-transport-aviation
+    - label: Ancillary Services
+      value: ancillary-services
+    - label: Animal Health
+      value: animal-health
+    - label: Automotive
+      value: automotive
+    - label: Banking, market infrastructure
+      value: banking-market-infrastructure
+    - label: Broadcasting
+      value: broadcasting
+    - label: Chemicals
+      value: chemicals
+    - label: Computer Services
+      value: computer-services
+    - label: Construction Contracting
+      value: construction-contracting
+    - label: Education
+      value: education
+    - label: Electricity
+      value: electricity
+    - label: Electronics
+      value: electronics
+    - label: Environmental Services
+      value: environmental-services
+    - label: Fisheries
+      value: fisheries
+    - label: Food and Drink
+      value: food-and-drink
+    - label: Furniture and other manufacturing
+      value: furniture-and-other-manufacturing
+    - label: Gas markets
+      value: gas-markets
+    - label: Goods sectors each <0.4% of GVA
+      value: goods-sectors-each-0-4-of-gva
+    - label: Imports
+      value: imports
+    - label: Imputed Rent
+      value: imputed-rent
+    - label: Insurance
+      value: insurance
+    - label: Land transport (excl. rail)
+      value: land-transport-excl-rail
+    - label: Medical services
+      value: medical-services
+    - label: Motor Trades
+      value: motor-trades
+    - label: Network Industries <0.3% of GVA
+      value: network-industries-0-3-of-gva
+    - label: Oil and gas production
+      value: oil-and-gas-production
+    - label: Other personal services
+      value: other-personal-services
+    - label: Parts and machinery
+      value: parts-and-machinery
+    - label: Pharmaceuticals
+      value: pharmaceuticals
+    - label: Post
+      value: post
+    - label: Professional and Business services
+      value: professional-and-business-services
+    - label: Public Administration and Defence
+      value: public-administration-and-defence
+    - label: Rail
+      value: rail
+    - label: Real Estate (excl. Imputed Rent)
+      value: real-estate-excl-imputed-rent
+    - label: Retail
+      value: retail
+    - label: Service sectors each <1% of GVA
+      value: service-sectors-each-1-of-gva
+    - label: Social Work
+      value: social-work
+    - label: Steel and other metals/commodities
+      value: steel-and-other-metals-commodities
+    - label: Telecoms
+      value: telecoms
+    - label: Textiles and clothing
+      value: textiles-and-clothing
+    - label: Top Ten Trade Partners by Value
+      value: top-ten-trade-partners-by-value
+    - label: Warehousing and support for transportation
+      value: warehousing-and-support-for-transportation
+    - label: Water Transport (Maritime/ports)
+      value: water-transport-maritime-ports
+    - label: Wholesale (excl. Motor Vehicles)
+      value: wholesale-excl-motor-vehicles
+    display_as_result_metadata: false
+    filterable: true
+    key: sector_business_area
+    name: Sector / Business Area
+    preposition: for businesses in
+    type: text
+  - allowed_values:
+    - label: "Yes"
+      value: "yes"
+    - label: "No"
+      value: "no"
+    - label: Don't know
+      value: dont-know
+    display_as_result_metadata: false
+    filterable: true
+    key: employ_eu_citizens
+    name: Employ EU citizens
+    preposition: for businesses that
+    type: text
+  - allowed_values:
+    - label: Do business in the EU
+      value: do-business-in-the-eu
+    - label: Buying
+      value: buying
+    - label: Selling
+      value: selling
+    - label: Transporting
+      value: transporting
+    - label: Other - EU
+      value: other-eu
+    - label: Other - Rest of the world
+      value: other-rest-of-the-world
+    display_as_result_metadata: false
+    filterable: true
+    key: doing_business_in_the_eu
+    name: Doing business in the EU
+    preposition: for businesses that
+    type: text
+  - allowed_values:
+    - label: Products or goods
+      value: products-or-goods
+    display_as_result_metadata: false
+    filterable: true
+    key: regulations_and_standards
+    name: Regulations and standards
+    preposition: for businesses that sell
+    type: text
+  - allowed_values:
+    - label: Processing personal data
+      value: processing-personal-data
+    - label: Interacting with EEA website
+      value: interacting-with-eea-website
+    - label: Digital service provide
+      value: digital-service-provider
+    display_as_result_metadata: false
+    filterable: true
+    key: personal_data
+    name: Personal data (EEA)
+    preposition: for businesses involved in
+    type: text
+  - allowed_values:
+    - label: Have intellectual property
+      value: have-intellectual-property
+    - label: Copyright
+      value: copyright
+    - label: Trademarks
+      value: trademarks
+    - label: Designs
+      value: designs
+    - label: Patents
+      value: patents
+    - label: Exhaustion of rights
+      value: exhaustion-of-rights
+    display_as_result_metadata: false
+    filterable: true
+    key: intellectual_property
+    name: Intellectual property
+    preposition: for businesses working with
+    type: text
+  - allowed_values:
+    - label: Horizon 2020
+      value: horizon-2020
+    - label: COSME
+      value: cosme
+    - label: European Investment Bank (EIB)
+      value: european-investment-bank-eib
+    - label: European Structural Fund (ESF)
+      value: european-structural-fund-esf
+    - label: EURDF
+      value: eurdf
+    - label: ETCF
+      value: etcf
+    - label: ESC
+      value: esc
+    - label: ECP
+      value: ecp
+    - label: ETF
+      value: etf
+    display_as_result_metadata: false
+    filterable: true
+    key: receiving_eu_funding
+    name: Receiving EU funding
+    preposition: for businesses that receive funding from
+    type: text
+  - allowed_values:
+    - label: Civil government contracts
+      value: civil-government-contracts
+    - label: Defence contracts
+      value: defence-contracts
+    display_as_result_metadata: false
+    filterable: true
+    key: public_sector_procurement
+    name: Public sector procurement
+    preposition: businesses that work with
+    type: text

--- a/spec/lib/business_readiness/loader_spec.rb
+++ b/spec/lib/business_readiness/loader_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe BusinessReadiness::Loader do
   subject do
     path = File.join(File.dirname(__FILE__), "/examples/#{fixture}.csv")
-    described_class.new(path).base_paths_with_tags
+    facets_path = File.join(File.dirname(__FILE__), "/examples/facet_config.yml")
+    described_class.new(path, facets_path).base_paths_with_tags
   end
 
   context "with all tags" do


### PR DESCRIPTION
https://trello.com/c/UhV3PPfO/87-metadata-tagger-should-use-finder-facet-definitions

Updates to facet names and values is shared between dependent applications (temporarily these are Rummager and Email Alert API) until a central process for assigning metadata is in place.
Use a shared facet definition from file to save hardcoding facet names and values, this DRYs up the update process.
