### PR TITLE
Strip spaces from business readiness csv values

### DIFF
--- a/lib/business_readiness/loader.rb
+++ b/lib/business_readiness/loader.rb
@@ -28,7 +28,7 @@ module BusinessReadiness
     attr_reader :facets, :rows
 
     def tags_for_row(row)
-      if row[1] == "yes"
+      if row[1].strip == "yes"
         create_all_tags
       else
         specific_tags(row)
@@ -45,7 +45,7 @@ module BusinessReadiness
       tags = {}
       facets.each_with_index do |facet, index|
         row_index = index + 2
-        tags[facet["key"]] = row.fetch(row_index, "").split(",")
+        tags[facet["key"]] = row.fetch(row_index, "").split(",").map(&:strip)
       end
 
       tags.reject do |_, value|

--- a/spec/lib/business_readiness/examples/all.csv
+++ b/spec/lib/business_readiness/examples/all.csv
@@ -1,1 +1,1 @@
-/all,yes
+/all, yes ,

--- a/spec/lib/business_readiness/examples/specific.csv
+++ b/spec/lib/business_readiness/examples/specific.csv
@@ -1,1 +1,1 @@
-/specific,,"aerospace,agriculture",yes
+/specific,," aerospace,agriculture ", yes


### PR DESCRIPTION
CSV file can present with leading and trailing spaces. We should strip
these before using them in the business readiness loader. Apply
String#strip to facet values and also introduce some leading and
trailing space to the test fixtures.

Related [Rummager PR](https://github.com/alphagov/rummager/pull/1349)
[Trello](https://trello.com/c/BhQuSYao/92-strip-spaces-from-csv-values)