### PR TITLE
Reduce concurrency to help Notify

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: true
-:concurrency: 30
+:concurrency: 25
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:


### PR DESCRIPTION
Notify are hitting their database and processing limits. They've asked
us to reduced the load we send to them temporarily so they reduce the
possibility of an outage. They are going to upgrade, but have to
co-ordinate this with quite a few users of their service because it
involves downtime. Once they have upgraded, we can revert this.