### PR TITLE
Add an index on the status column in emails table

### DIFF
--- a/db/migrate/20181213113655_add_index_to_email_status.rb
+++ b/db/migrate/20181213113655_add_index_to_email_status.rb
@@ -1,0 +1,5 @@
+class AddIndexToEmailStatus < ActiveRecord::Migration[5.2]
+  def change
+    add_index :emails, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_19_131532) do
+ActiveRecord::Schema.define(version: 2018_12_13_113655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2018_11_19_131532) do
     t.index ["created_at"], name: "index_emails_on_created_at"
     t.index ["failure_reason"], name: "index_emails_on_failure_reason"
     t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
+    t.index ["status"], name: "index_emails_on_status"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|


### PR DESCRIPTION
Trying to resend just the failed emails is painfully slow as the where query on the status column takes an age to process.  Adding an index to speed this up.