### PR TITLE
Add Rake task to present failed email ids and reasons for content change

### DIFF
--- a/lib/reports/content_change_email_failures.rb
+++ b/lib/reports/content_change_email_failures.rb
@@ -1,0 +1,42 @@
+module Reports
+  class ContentChangeEmailFailures
+    def initialize(content_change)
+      @content_change = content_change
+      @failed_emails = failed_emails
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def call
+      puts <<~HEADING
+        #{@failed_emails.count} Email failures for Content Change #{@content_change.id}
+        -------------------------------------------
+
+      HEADING
+
+      @failed_emails.each do |email|
+        puts <<~EMAIL
+          Email Id:       #{email.id}
+          Failure Reason: #{email.failure_reason}
+
+          -------------------------------------------
+
+        EMAIL
+      end
+    end
+
+  private
+
+    def failed_emails
+      subscription_contents_ids = @content_change
+                                  .subscription_contents
+                                  .pluck(:id)
+      email_ids = SubscriptionContent
+                  .where(id: subscription_contents_ids)
+                  .pluck(:email_id)
+      Email.where(id: email_ids, status: 'failed')
+    end
+  end
+end

--- a/lib/tasks/content_change_email.rake
+++ b/lib/tasks/content_change_email.rake
@@ -1,7 +1,13 @@
 namespace :report do
-  desc "Produce a report on sent and failed emails for a given content change"
+  desc "Produce a report on sent, pending and failed emails for a given content change"
   task :content_change_email_status_count, [:id] => :environment do |_t, args|
     content_change = ContentChange.find(args[:id])
     Reports::ContentChangeEmailStatusCount.call(content_change)
+  end
+
+  desc "Produce a report on failed emails for a given content change"
+  task :content_change_failed_emails, [:id] => :environment do |_t, args|
+    content_change = ContentChange.find(args[:id])
+    Reports::ContentChangeEmailFailures.call(content_change)
   end
 end

--- a/spec/lib/reports/content_change_email_failures_spec.rb
+++ b/spec/lib/reports/content_change_email_failures_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe Reports::ContentChangeEmailFailures do
+  before do
+    failure_reasons = %w[permanent_failure retries_exhausted_failure]
+
+    3.times { create(:email, status: 'sent') }
+    3.times do
+      create(:email,
+             status: 'failed',
+             failure_reason: failure_reasons.sample)
+    end
+  end
+
+  context 'generate report' do
+    let(:content_change) { create(:content_change) }
+
+    let(:sent)    { Email.where(status: 'sent') }
+    let(:failed)  { Email.where(status: 'failed') }
+
+    let(:failure_one)   { failed[0] }
+    let(:failure_two)   { failed[1] }
+    let(:failure_three) { failed[2] }
+
+    let(:emails) { [sent, failed].flatten }
+
+    let!(:subscription_contents) do
+      emails.each do |email|
+        create(:subscription_content,
+               email: email,
+               content_change: content_change)
+      end
+    end
+
+    it 'produces a count of emails statuses for a given content change' do
+      described_class.call(content_change)
+      expect { described_class.call(content_change) }
+        .to output(
+          <<~TEXT
+            #{failed.count} Email failures for Content Change #{content_change.id}
+            -------------------------------------------
+
+            Email Id:       #{failure_one.id}
+            Failure Reason: #{failure_one.failure_reason}
+
+            -------------------------------------------
+
+            Email Id:       #{failure_two.id}
+            Failure Reason: #{failure_two.failure_reason}
+
+            -------------------------------------------
+
+            Email Id:       #{failure_three.id}
+            Failure Reason: #{failure_three.failure_reason}
+
+            -------------------------------------------
+
+          TEXT
+        ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Given a Content Change ID, the new Rake Task
report:content_change_email_failures[':ID']
will print a short report with of failed emails

```
-------------------------------------------
3 Email failures for Content Change 583be894-1230-4651-bdcc-8a2e03d2af23
-------------------------------------------

Email Id:            f25eca68-3128-4e59-8cc7-18e2f63c6927
Failure Reason: retries_exhausted_failure

-------------------------------------------

Email Id:            a794994c-1734-4cd1-9d65-07aafcae2935
Failure Reason: permanent_failure

-------------------------------------------

Email Id:            5a2f56ba-a3ca-4dc7-9ee0-f50615c9db12
Failure Reason: permanent_failure

-------------------------------------------
```