### PR TITLE
Add Rake task to resend failed emails

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -22,6 +22,14 @@ This task changes a subscriber's email address.
 $ bundle exec rake manage:change_email_address[<old_email_address>, <new_email_address>]
 ```
 
+## Resend emails
+
+This task takes an array of email ids and re-sends them.
+
+```bash
+bundle exec rake deliver:resend_failed_emails[<email_one_id>, <email_two_id>]
+```
+
 ## Manually unsubscribe subscribers
 
 This task unsubscribes one or more subscribers from everything they

--- a/lib/tasks/deliver.rake
+++ b/lib/tasks/deliver.rake
@@ -20,4 +20,14 @@ namespace :deliver do
     email = test_email(args[:test_email_address])
     DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
   end
+
+  desc "Re-send failed emails by email ids"
+  task resend_failed_emails: [:environment] do |_, args|
+    failed_email_ids = Email.where(id: args.to_a, status: 'failed').pluck(:id)
+
+    failed_email_ids.each do |email_id|
+      puts "Resending email: #{email_id}"
+      DeliveryRequestWorker.perform_async_in_queue(email_id, queue: :delivery_immediate)
+    end
+  end
 end


### PR DESCRIPTION
Given an Array of email ids, the new Rake task
`bundle exec rake deliver:resend_failed_emails[<email_one_id>,<email_two_id>...]`
will check if each email has a failed status and, if so, attempt to resend it.