### PR TITLE
Add rake task to get notification report from Notify

### DIFF
--- a/app/providers/notify_provider.rb
+++ b/app/providers/notify_provider.rb
@@ -1,9 +1,6 @@
 class NotifyProvider
-  def initialize(config: EmailAlertAPI.config.notify)
-    api_key = config.fetch(:api_key)
-    base_url = config.fetch(:base_url)
-
-    @client = Notifications::Client.new(api_key, base_url)
+  def initialize(config: EmailAlertAPI.config.notify, notify_client: EmailAlertAPI.config.notify_client)
+    @client = notify_client
     @template_id = config.fetch(:template_id)
   end
 

--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -15,6 +15,12 @@ module EmailAlertAPI
       @notify ||= notify_environment_config.symbolize_keys.freeze
     end
 
+    def notify_client
+      api_key = @notify[:api_key]
+      base_url = @notify[:base_url]
+      Notifications::Client.new(api_key, base_url)
+    end
+
     def email_service
       @email_service ||= email_service_config.symbolize_keys.freeze
     end

--- a/lib/reports/notifications_from_notify.rb
+++ b/lib/reports/notifications_from_notify.rb
@@ -22,7 +22,7 @@ module Reports
       )
 
       if response.is_a?(Notifications::Client::NotificationsCollection)
-        if response.collection.count == 0
+        if response.collection.count.zero?
           puts "No results found, empty collection returned"
         else
           response.collection.each do |notification|

--- a/lib/reports/notifications_from_notify.rb
+++ b/lib/reports/notifications_from_notify.rb
@@ -22,16 +22,22 @@ module Reports
       )
 
       if response.is_a?(Notifications::Client::NotificationsCollection)
-        response.collection.each do |notification|
-          puts <<~TEXT
-            -------------------------------------------
-            Notification ID: #{notification.id}
-            Status: #{notification.status}
-            created_at: #{notification.created_at}
-            sent_at: #{notification.sent_at}
-            completed_at: #{notification.completed_at}
-          TEXT
+        if response.collection.count == 0
+          puts "No results found, empty collection returned"
+        else
+          response.collection.each do |notification|
+            puts <<~TEXT
+              -------------------------------------------
+              Notification ID: #{notification.id}
+              Status: #{notification.status}
+              created_at: #{notification.created_at}
+              sent_at: #{notification.sent_at}
+              completed_at: #{notification.completed_at}
+            TEXT
+          end
         end
+      else
+        puts "No results found"
       end
     rescue Notifications::Client::RequestError => error
       puts "Returns request error #{error.code}, message: #{error.message}"

--- a/lib/reports/notifications_from_notify.rb
+++ b/lib/reports/notifications_from_notify.rb
@@ -33,6 +33,8 @@ module Reports
           TEXT
         end
       end
+    rescue Notifications::Client::RequestError => error
+      puts "Returns request error #{error.code}, message: #{error.message}"
     end
 
   private

--- a/lib/reports/notifications_from_notify.rb
+++ b/lib/reports/notifications_from_notify.rb
@@ -1,10 +1,7 @@
 module Reports
   class NotificationsFromNotify
-    def initialize(config: EmailAlertAPI.config.notify)
-      api_key = config.fetch(:api_key)
-      base_url = config.fetch(:base_url)
-
-      @client = Notifications::Client.new(api_key, base_url)
+    def initialize(config: EmailAlertAPI.config.notify, notify_client: EmailAlertAPI.config.notify_client)
+      @client = notify_client
       @template_id = config.fetch(:template_id)
     end
 

--- a/lib/reports/notifications_from_notify.rb
+++ b/lib/reports/notifications_from_notify.rb
@@ -1,0 +1,42 @@
+module Reports
+  class NotificationsFromNotify
+    def initialize(config: EmailAlertAPI.config.notify)
+      api_key = config.fetch(:api_key)
+      base_url = config.fetch(:base_url)
+
+      @client = Notifications::Client.new(api_key, base_url)
+      @template_id = config.fetch(:template_id)
+    end
+
+    def self.call(*args)
+      new.call(*args)
+    end
+
+    def call(reference)
+      #reference is the DeliveryAttempt.id
+      puts "Query Notify for emails with the reference #{reference}"
+
+      response = @client.get_notifications(
+        template_type: "email",
+        reference: reference
+      )
+
+      if response.is_a?(Notifications::Client::NotificationsCollection)
+        response.collection.each do |notification|
+          puts <<~TEXT
+            -------------------------------------------
+            Notification ID: #{notification.id}
+            Status: #{notification.status}
+            created_at: #{notification.created_at}
+            sent_at: #{notification.sent_at}
+            completed_at: #{notification.completed_at}
+          TEXT
+        end
+      end
+    end
+
+  private
+
+    attr_reader :client, :template_id
+  end
+end

--- a/lib/tasks/notify_report.rake
+++ b/lib/tasks/notify_report.rake
@@ -3,4 +3,17 @@ namespace :report do
   task :get_notifications_from_notify, [:reference] => :environment do |_t, args|
     Reports::NotificationsFromNotify.call(args[:reference])
   end
+
+  desc "Query the Notify API for email(s) by email ID"
+  task :get_notifications_from_notify_by_email_id, [:id] => :environment do |_t, args|
+    delivery_attempts = DeliveryAttempt.where(email_id: args[:id])
+
+    if delivery_attempts.count.zero?
+      puts "No results returned"
+    else
+      delivery_attempts.each do |delivery_attempt|
+        Reports::NotificationsFromNotify.call(delivery_attempt.id)
+      end
+    end
+  end
 end

--- a/lib/tasks/notify_report.rake
+++ b/lib/tasks/notify_report.rake
@@ -1,0 +1,6 @@
+namespace :report do
+  desc "Query the Notify API for email(s) by reference"
+  task :get_notifications_from_notify, [:reference] => :environment do |_t, args|
+    Reports::NotificationsFromNotify.call(args[:reference])
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -223,4 +223,22 @@ FactoryBot.define do
       }
     end
   end
+
+  factory :client_request_error,
+    class: Notifications::Client::RequestError do
+    code '400'
+    body do
+      {
+        'status_code' => 400,
+        'errors' => ['error' => 'ValidationError',
+                      'message' => 'bad status is not one of [created, sending, sent, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure, accepted, received]']
+      }
+    end
+
+    initialize_with do
+      new(
+        OpenStruct.new(code: code, body: body.to_json)
+      )
+    end
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -226,15 +226,15 @@ FactoryBot.define do
 
   factory :empty_client_notifications_collection,
     class: Notifications::Client::NotificationsCollection do
-      initialize_with do
-        new(body)
-      end
-      body do
-        {
-          "links" => {},
-          "notifications" => {}
-        }
-      end
+    initialize_with do
+      new(body)
+    end
+    body do
+      {
+        "links" => {},
+        "notifications" => {}
+      }
+    end
   end
 
   factory :client_request_error,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -175,4 +175,52 @@ FactoryBot.define do
     initialize_with { new(path) }
     skip_create
   end
+
+  factory :client_notification,
+    class: Notifications::Client::Notification do
+    initialize_with do
+      new(body)
+    end
+
+    body do
+      {
+        "id" => "f163deaf-2d3f-4ec6-98fc-f23fa511518f",
+        "reference" => "ref_123",
+        "email_address" => "123@notify.com",
+        "type" => "email",
+        "status" => "delivered",
+        "template" =>
+          {
+            "id" => "cb633abc-6ae6-4843-ae6f-82ca500b6de2",
+            "uri" => "/v2/templates/5e427b42-4e98-46f3-a047-32c4a87d26bb",
+            "version" => 1
+          },
+        "body" => "Body of the message",
+        "subject" => "Changes to this document",
+        "created_at" => "2019-01-29T11:12:30.12354Z",
+        "sent_at" => "2019-01-29T11:12:40.12354Z",
+        "completed_at" => "2019-01-29T11:12:52.12354Z",
+        "created_by_name" => "A. Sender",
+      }
+    end
+  end
+
+  factory :client_notifications_collection,
+    class: Notifications::Client::NotificationsCollection do
+    initialize_with do
+      new(body)
+    end
+
+    body do
+      {
+        "links" => {
+          "current" => "/v2/notifications?page=3&template_type=email&status=delivered",
+          "next" => "/v2/notifications?page=3&template_type=email&status=delivered"
+        },
+        "notifications" => 1.times.map {
+          attributes_for(:client_notification)[:body]
+        }
+      }
+    end
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -224,6 +224,19 @@ FactoryBot.define do
     end
   end
 
+  factory :empty_client_notifications_collection,
+    class: Notifications::Client::NotificationsCollection do
+      initialize_with do
+        new(body)
+      end
+      body do
+        {
+          "links" => {},
+          "notifications" => {}
+        }
+      end
+  end
+
   factory :client_request_error,
     class: Notifications::Client::RequestError do
     code '400'

--- a/spec/lib/reports/notifications_from_notify_spec.rb
+++ b/spec/lib/reports/notifications_from_notify_spec.rb
@@ -1,28 +1,20 @@
 RSpec.describe Reports::NotificationsFromNotify do
   describe "notifications report" do
-    let(:options) {
-      {
-        "template_type" => "email",
-        "reference"     => reference
-      }
-    }
+    context "when passing a reference which is found" do
+      let!(:notifications_collection) { build :client_notifications_collection }
+      let(:reference) { "ref_123" }
 
-    let(:reference) { "ref_123" }
-    let(:request_path) { URI.encode_www_form(options) }
-    let!(:notifications_collection) { build :client_notifications_collection }
-
-    context "when passing a valid reference" do
       before do
         stub_request(
           :get,
-          "http://fake-notify.com/v2/notifications?#{request_path}"
+          "http://fake-notify.com/v2/notifications?template_type=email&reference=#{reference}"
         ).to_return(body: mocked_response.to_json)
       end
 
       let(:mocked_response) {
         attributes_for(
           :client_notifications_collection
-        )[:body].merge(options)
+        )[:body]
       }
 
       it "prints details about one notification" do
@@ -31,6 +23,7 @@ RSpec.describe Reports::NotificationsFromNotify do
         client = instance_double("Notifications::Client")
         notification = notifications_collection.collection.first
         allow(client).to receive(:get_notifications).and_return(notifications_collection)
+
         described_class.call(reference)
 
         expect { described_class.call(reference) }

--- a/spec/lib/reports/notifications_from_notify_spec.rb
+++ b/spec/lib/reports/notifications_from_notify_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Reports::NotificationsFromNotify do
+  describe "notifications report" do
+    let(:options) {
+      {
+        "template_type" => "email",
+        "reference"     => reference
+      }
+    }
+
+    let(:reference) { "ref_123" }
+    let(:request_path) { URI.encode_www_form(options) }
+    let!(:notifications_collection) { build :client_notifications_collection }
+
+    context "when passing a valid reference" do
+      before do
+        stub_request(
+          :get,
+          "http://fake-notify.com/v2/notifications?#{request_path}"
+        ).to_return(body: mocked_response.to_json)
+      end
+
+      let(:mocked_response) {
+        attributes_for(
+          :client_notifications_collection
+        )[:body].merge(options)
+      }
+
+      it "prints details about one notification" do
+        # We generate a unique reference for each email sent so we should only
+        # expect to return one notification within the collection
+        client = instance_double("Notifications::Client")
+        notification = notifications_collection.collection.first
+        allow(client).to receive(:get_notifications).and_return(notifications_collection)
+        described_class.call(reference)
+
+        expect { described_class.call(reference) }
+        .to output(
+          <<~TEXT
+            Query Notify for emails with the reference #{reference}
+            -------------------------------------------
+            Notification ID: #{notification.id}
+            Status: #{notification.status}
+            created_at: #{notification.created_at}
+            sent_at: #{notification.sent_at}
+            completed_at: #{notification.completed_at}
+          TEXT
+        ).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rake task allows us to directly query Notify's API and find
out information about an email's notification, should the callbacks
fail.

It uses Notify's [multiple notifications method](https://docs.notifications.service.gov.uk/ruby.html#get-the-status-of-multiple-messages), using the
`reference` field to query for an email notification.
We are unable to use Notify's [single notification method](https://docs.notifications.service.gov.uk/ruby.html#get-the-status-of-one-message-method) as it
requires the `notification_id`, which we don't store.

The `reference` is the `DeliveryAttempt.id` and is unique to each
email.

Example output when a notification is found:
```
Query Notify for emails with the reference ref_123
-------------------------------------------
Notification ID: f163deaf-2d3f-4ec6-98fc-f23fa511518f
Status: delivered
created_at: 2019-01-29 11:12:30 UTC
sent_at: 2019-01-29 11:12:40 UTC
completed_at: 2019-01-29 11:12:52 UTC
```

Example output when a notification is not found:
```
Query Notify for emails with the reference PPP
No results found, empty collection returned
```

Example output when the request fails:
```
Query Notify for emails with the reference ref_123
Returns request error 400, message: [{"error"=>"ValidationError",
"message"=>"bad status is not one of [created, sending, sent,
delivered, pending, failed, technical-failure, temporary-failure,
permanent-failure, accepted, received]"}]
```

A rework of original branch https://github.com/alphagov/email-alert-api/compare/query-notify-api

Trello card: https://trello.com/c/lUfUspdh/18-easily-query-the-govuk-notify-api-from-email-alert-api-for-specific-emails