### PR TITLE
Increase concurrency of sidekiq workers

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: true
-:concurrency: 25
+:concurrency: 30
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:


### PR DESCRIPTION
In b81bf715651bf498bc7d9f6fdd9afc7569632c60 we reduced the concurrency
as a short term fix while our email provider upgraded. They have
completed the upgrade so we can increase our concurrency setting again.