### PR TITLE
Enable users to create subscriptions using supergroups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'foreman', '~> 0.85'
 gem 'gds-api-adapters', '~> 57.1'
 gem 'gds-sso', '~> 14.0'
 gem 'govuk_app_config', '~> 1.11'
+gem 'govuk_document_types', '~> 0.9.0'
 # This is pinned < 2 until gds-sso supports JWT > 2
 gem 'jwt', '~> 2.1'
 gem 'nokogiri', '~> 1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
+    govuk_document_types (0.9.0)
     govuk_sidekiq (3.0.2)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -367,6 +368,7 @@ DEPENDENCIES
   gds-sso (~> 14.0)
   govuk-lint (~> 3.9)
   govuk_app_config (~> 1.11)
+  govuk_document_types (~> 0.9.0)
   govuk_sidekiq (~> 3.0)
   jwt (~> 2.1)
   listen (= 3.1.5)
@@ -386,4 +388,4 @@ DEPENDENCIES
   with_advisory_lock (~> 4.0)
 
 BUNDLED WITH
-   1.16.3
+   1.17.1

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -44,6 +44,7 @@ private
       document_type: permitted_params.fetch(:document_type, ""),
       email_document_supertype: permitted_params.fetch(:email_document_supertype, ""),
       government_document_supertype: permitted_params.fetch(:government_document_supertype, ""),
+      content_purpose_supergroup: permitted_params.fetch(:content_purpose_supergroup, nil),
       slug: params[:gov_delivery_id],
     }
   end

--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -17,4 +17,11 @@ class ContentChange < ApplicationRecord
   def processed?
     processed_at.present?
   end
+
+  def content_purpose_supergroup
+    @content_purpose_supergroup ||= begin
+      group = GovukDocumentTypes.supertypes(document_type: document_type)['content_purpose_supergroup']
+      group == 'other' ? nil : group
+    end
+  end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -5,6 +5,7 @@ class SubscriberList < ApplicationRecord
 
   validate :tag_values_are_valid
   validate :link_values_are_valid
+  validate :content_purpose_supergroup_is_valid
 
   validates :title, presence: true
   validates_uniqueness_of :slug
@@ -66,6 +67,18 @@ private
   def link_values_are_valid
     unless valid_subscriber_criteria(:links)
       self.errors.add(:links, "All link values must be sent as Arrays")
+    end
+  end
+
+  def supergroup_document_types
+    GovukDocumentTypes.supergroup_document_types content_purpose_supergroup
+  end
+
+  def content_purpose_supergroup_is_valid
+    valid = content_purpose_supergroup.nil? || supergroup_document_types.any?
+
+    unless valid
+      self.errors.add(:supergroup, "Invalid supergroup '#{content_purpose_supergroup}'")
     end
   end
 

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -1,12 +1,13 @@
 class FindExactQuery
   class InvalidFindCriteria < StandardError; end
 
-  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:, slug: nil)
+  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:, slug: nil, content_purpose_supergroup:)
     @tags = tags.deep_symbolize_keys
     @links = links.deep_symbolize_keys
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
+    @content_purpose_supergroup = content_purpose_supergroup
     @slug = slug
   end
 
@@ -24,6 +25,7 @@ private
         .where(document_type: @document_type)
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)
+        .where(content_purpose_supergroup: @content_purpose_supergroup)
       scope = scope.where(slug: @slug) if @slug.present?
       scope
     end

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -1,10 +1,11 @@
 class SubscriberListQuery
-  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:)
+  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:, content_purpose_supergroup:)
     @tags = tags.symbolize_keys
     @links = links.symbolize_keys
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
+    @content_purpose_supergroup = content_purpose_supergroup
   end
 
   def lists
@@ -34,5 +35,6 @@ private
       .where(document_type: ['', @document_type])
       .where(email_document_supertype: ['', @email_document_supertype])
       .where(government_document_supertype: ['', @government_document_supertype])
+      .where(content_purpose_supergroup: @content_purpose_supergroup)
   end
 end

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -35,6 +35,7 @@ private
       document_type: content_change.document_type,
       email_document_supertype: content_change.email_document_supertype,
       government_document_supertype: content_change.government_document_supertype,
+      content_purpose_supergroup: content_change.content_purpose_supergroup,
     ).lists
   end
 end

--- a/db/migrate/20190125145045_add_content_purpose_supergroup_to_subscriber_list.rb
+++ b/db/migrate/20190125145045_add_content_purpose_supergroup_to_subscriber_list.rb
@@ -1,0 +1,5 @@
+class AddContentPurposeSupergroupToSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :content_purpose_supergroup, :string, limit: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_19_131532) do
+ActiveRecord::Schema.define(version: 2019_01_25_145045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 2018_11_19_131532) do
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
+    t.string "content_purpose_supergroup", limit: 100
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
@@ -138,6 +139,7 @@ ActiveRecord::Schema.define(version: 2018_11_19_131532) do
     t.uuid "subscription_id", null: false
     t.uuid "content_change_id", null: false
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
+    t.index ["created_at"], name: "index_subscription_contents_on_created_at"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
     t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
       response_hash = JSON.parse(response.body)
       subscriber_list = response_hash["subscriber_list"]
 
-      expect(subscriber_list.keys.to_set).to eq(
+      expect(subscriber_list.keys.to_set.sort).to eq(
         %w{
           id
           title
@@ -59,7 +59,8 @@ RSpec.describe "Creating a subscriber list", type: :request do
           email_document_supertype
           government_document_supertype
           active_subscriptions_count
-        }.to_set
+          content_purpose_supergroup
+        }.to_set.sort
       )
 
       expect(subscriber_list).to include(
@@ -138,6 +139,30 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
         subscriber_list = SubscriberList.last
         expect(subscriber_list.document_type).to eq("travel_advice")
+      end
+    end
+
+    describe "creating a subscriber list with a content_purpose_supergroup" do
+      it "returns a 201" do
+        create_subscriber_list(content_purpose_supergroup: "news_and_communications")
+
+        expect(response.status).to eq(201)
+      end
+
+      it "enforces supergroup types contraint" do
+        create_subscriber_list(content_purpose_supergroup: "invalid_supergroup")
+
+        expect(response.status).to eq(422)
+      end
+
+      it "sets content_purpose_supergroup on the subscriber list" do
+        create_subscriber_list(
+          tags: { countries: { any: %w[andorra] } },
+          content_purpose_supergroup: "services"
+        )
+
+        subscriber_list = SubscriberList.last
+        expect(subscriber_list.content_purpose_supergroup).to eq("services")
       end
     end
 

--- a/spec/integration/get_subscriber_list_spec.rb
+++ b/spec/integration/get_subscriber_list_spec.rb
@@ -186,6 +186,32 @@ RSpec.describe "Getting a subscriber list", type: :request do
         expect(subscriber_list.fetch("id")).to eq(beta.id)
       end
     end
+
+    context "when passing in content_purpose_supergroup" do
+      it "does not find a subscriber list if the content_purpose_supergroup does not match" do
+        get_subscriber_list(
+          tags: { topics: { any: ["vat-rates"] } },
+          document_type: "tax",
+          content_purpose_supergroup: "news_and_communications"
+        )
+        expect(response.status).to eq(404)
+      end
+
+      it "finds the subscriber list if the content_purpose_supergroup matches" do
+        _alpha = create(:subscriber_list, tags: { topics: { any: ["vat-rates"] } }, content_purpose_supergroup: "services")
+        beta = create(:subscriber_list, tags: { topics: { any: ["vat-rates"] } }, content_purpose_supergroup: "news_and_communications")
+        _gamma = create(:subscriber_list, tags: { topics: { any: ["vat-rates"] } }, content_purpose_supergroup: nil)
+
+        get_subscriber_list(
+          tags: { topics: { any: ["vat-rates"] } },
+          content_purpose_supergroup: "news_and_communications"
+        )
+        expect(response.status).to eq(200)
+
+        subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+        expect(subscriber_list.fetch("id")).to eq(beta.id)
+      end
+    end
   end
 
   context "without authentication" do

--- a/spec/models/content_change_spec.rb
+++ b/spec/models/content_change_spec.rb
@@ -11,4 +11,18 @@ RSpec.describe ContentChange do
       end
     end
   end
+
+  describe "#content_purpose_supergroup" do
+    let(:content_item) { create(:content_change, document_type: 'news_story') }
+    let(:content_item_with_other_supergroup) { create(:content_change, document_type: 'edition') }
+
+    it "is a supergroup type" do
+      supertypes = GovukDocumentTypes.supertypes(document_type: 'news_story')
+      expect(content_item.content_purpose_supergroup).to be(supertypes.fetch('content_purpose_supergroup'))
+    end
+
+    it "is nil when it is part of the 'other' supergroup" do
+      expect(content_item_with_other_supergroup.content_purpose_supergroup).to be(nil)
+    end
+  end
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -47,6 +47,24 @@ RSpec.describe SubscriberList, type: :model do
       expect(subject).to be_valid
     end
 
+    it "is valid with a correct content_purpose_supergroup" do
+      subject.content_purpose_supergroup = 'news_and_communications'
+
+      expect(subject).to be_valid
+    end
+
+    it "is invalid with an incorrect content_purpose_supergroup" do
+      subject.content_purpose_supergroup = 'blah_blah'
+
+      expect(subject).to be_invalid
+    end
+
+    it "is valid with a nil content_purpose_supergroup" do
+      subject.content_purpose_supergroup = nil
+
+      expect(subject).to be_valid
+    end
+
     it "is invalid when links 'hash' has 'any' values that are not arrays" do
       subject.links = { foo: { any: "bar" } }
 

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe FindExactQuery do
       document_type: '',
       email_document_supertype: '',
       government_document_supertype: '',
+      content_purpose_supergroup: nil,
     }
 
     described_class.new(defaults.merge(params))
@@ -141,6 +142,7 @@ RSpec.describe FindExactQuery do
       document_type: '',
       email_document_supertype: '',
       government_document_supertype: '',
+      content_purpose_supergroup: nil,
     }
     create(:subscriber_list, defaults.merge(params))
   end

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe SubscriberListQuery do
       links: { policies: %w[11aa], taxon_tree: %w[taxon1 taxon2] },
       document_type: 'travel_advice',
       email_document_supertype: 'publications',
-      government_document_supertype: 'news_stories'
+      government_document_supertype: 'news_stories',
+      content_purpose_supergroup: nil
     )
   end
 
@@ -16,6 +17,8 @@ RSpec.describe SubscriberListQuery do
     it { is_excluded_from_links tags_or_links, email_document_supertype: 'other' }
     it { is_included_in_links tags_or_links, government_document_supertype: 'news_stories' }
     it { is_excluded_from_links tags_or_links, government_document_supertype: 'other' }
+    it { is_included_in_links(tags_or_links, content_purpose_supergroup: nil) }
+    it { is_excluded_from_links(tags_or_links, content_purpose_supergroup: 'news_and_communications') }
 
     it do
       is_included_in_links(
@@ -90,6 +93,7 @@ RSpec.describe SubscriberListQuery do
       document_type: '',
       email_document_supertype: '',
       government_document_supertype: '',
+      content_purpose_supergroup: nil,
     }
   end
 


### PR DESCRIPTION
https://trello.com/c/3FaAtFr8/281-email-alert-api-should-support-supergroups

`email-alert-api` will accept `content_purpose_supergroup` as an optional parameter.

The `content_purpose_supergroup` field on content items is to be deprecated. At runtime we get up-to-date supergroups and their document types via the GovukDocumentTypes gem. 

Reviewing by commit should be easier.