### PR TITLE
Allow nil for content_purpose supergroup

### DIFF
--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -35,6 +35,6 @@ private
       .where(document_type: ['', @document_type])
       .where(email_document_supertype: ['', @email_document_supertype])
       .where(government_document_supertype: ['', @government_document_supertype])
-      .where(content_purpose_supergroup: @content_purpose_supergroup)
+      .where(content_purpose_supergroup: [nil, @content_purpose_supergroup])
   end
 end


### PR DESCRIPTION
This will enable the SubscriberListQuery's base_scope to
check for a content_purpose_supergroup while not
affecting the delivery of other content changes to
subscriber lists.