### PR TITLE
Enable rejection of a content_purpose_supergroup

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -45,6 +45,7 @@ private
       email_document_supertype: permitted_params.fetch(:email_document_supertype, ""),
       government_document_supertype: permitted_params.fetch(:government_document_supertype, ""),
       content_purpose_supergroup: permitted_params.fetch(:content_purpose_supergroup, nil),
+      reject_content_purpose_supergroup: permitted_params.fetch(:reject_content_purpose_supergroup, nil),
       slug: params[:gov_delivery_id],
     }
   end

--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -20,8 +20,7 @@ class ContentChange < ApplicationRecord
 
   def content_purpose_supergroup
     @content_purpose_supergroup ||= begin
-      group = GovukDocumentTypes.supertypes(document_type: document_type)['content_purpose_supergroup']
-      group == 'other' ? nil : group
+      GovukDocumentTypes.supertypes(document_type: document_type)['content_purpose_supergroup']
     end
   end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -6,6 +6,7 @@ class SubscriberList < ApplicationRecord
   validate :tag_values_are_valid
   validate :link_values_are_valid
   validate :content_purpose_supergroup_is_valid
+  validate :reject_content_purpose_supergroup_is_valid
 
   validates :title, presence: true
   validates_uniqueness_of :slug
@@ -70,16 +71,24 @@ private
     end
   end
 
-  def supergroup_document_types
-    GovukDocumentTypes.supergroup_document_types content_purpose_supergroup
+  def supergroup_document_types(supergroup)
+    GovukDocumentTypes.supergroup_document_types supergroup
+  end
+
+  def validate_supergroup_field(supergroup, field)
+    valid = supergroup.nil? || supergroup_document_types(supergroup).any? || supergroup == 'other'
+
+    unless valid
+      self.errors.add(field, "Invalid supergroup '#{supergroup}'")
+    end
   end
 
   def content_purpose_supergroup_is_valid
-    valid = content_purpose_supergroup.nil? || supergroup_document_types.any?
+    validate_supergroup_field(content_purpose_supergroup, :content_purpose_supergroup)
+  end
 
-    unless valid
-      self.errors.add(:supergroup, "Invalid supergroup '#{content_purpose_supergroup}'")
-    end
+  def reject_content_purpose_supergroup_is_valid
+    validate_supergroup_field(reject_content_purpose_supergroup, :reject_content_purpose_supergroup)
   end
 
   def valid_subscriber_criteria(link_or_tags)

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -1,13 +1,23 @@
 class FindExactQuery
   class InvalidFindCriteria < StandardError; end
 
-  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:, slug: nil, content_purpose_supergroup:)
+  def initialize(
+    tags:,
+    links:,
+    document_type:,
+    email_document_supertype:,
+    government_document_supertype:,
+    slug: nil,
+    content_purpose_supergroup:,
+    reject_content_purpose_supergroup:
+  )
     @tags = tags.deep_symbolize_keys
     @links = links.deep_symbolize_keys
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
     @content_purpose_supergroup = content_purpose_supergroup
+    @reject_content_purpose_supergroup = reject_content_purpose_supergroup
     @slug = slug
   end
 
@@ -26,6 +36,7 @@ private
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)
         .where(content_purpose_supergroup: @content_purpose_supergroup)
+        .where(reject_content_purpose_supergroup: @reject_content_purpose_supergroup)
       scope = scope.where(slug: @slug) if @slug.present?
       scope
     end

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -36,5 +36,6 @@ private
       .where(email_document_supertype: ['', @email_document_supertype])
       .where(government_document_supertype: ['', @government_document_supertype])
       .where(content_purpose_supergroup: [nil, @content_purpose_supergroup])
+      .where("reject_content_purpose_supergroup <> '#{@content_purpose_supergroup}' OR reject_content_purpose_supergroup IS NULL")
   end
 end

--- a/db/migrate/20190206130316_add_reject_content_purpose_supergroup_to_subscriber_list.rb
+++ b/db/migrate/20190206130316_add_reject_content_purpose_supergroup_to_subscriber_list.rb
@@ -1,0 +1,5 @@
+class AddRejectContentPurposeSupergroupToSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :reject_content_purpose_supergroup, :string, limit: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_25_145045) do
+ActiveRecord::Schema.define(version: 2019_02_06_130316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 2019_01_25_145045) do
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
     t.string "content_purpose_supergroup", limit: 100
+    t.string "reject_content_purpose_supergroup", limit: 100
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
@@ -139,7 +140,6 @@ ActiveRecord::Schema.define(version: 2019_01_25_145045) do
     t.uuid "subscription_id", null: false
     t.uuid "content_change_id", null: false
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
-    t.index ["created_at"], name: "index_subscription_contents_on_created_at"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
     t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true
@@ -151,8 +151,8 @@ ActiveRecord::Schema.define(version: 2019_01_25_145045) do
     t.bigint "subscriber_list_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "signon_user_uid"
     t.integer "frequency", default: 0, null: false
+    t.string "signon_user_uid"
     t.integer "source", default: 0, null: false
     t.datetime "ended_at"
     t.integer "ended_reason"

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
           government_document_supertype
           active_subscriptions_count
           content_purpose_supergroup
+          reject_content_purpose_supergroup
         }.to_set.sort
       )
 

--- a/spec/models/content_change_spec.rb
+++ b/spec/models/content_change_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe ContentChange do
       expect(content_item.content_purpose_supergroup).to be(supertypes.fetch('content_purpose_supergroup'))
     end
 
-    it "is nil when it is part of the 'other' supergroup" do
-      expect(content_item_with_other_supergroup.content_purpose_supergroup).to be(nil)
+    it "is other when it is part of the default supergroup" do
+      expect(content_item_with_other_supergroup.content_purpose_supergroup).to eq('other')
     end
   end
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -65,6 +65,24 @@ RSpec.describe SubscriberList, type: :model do
       expect(subject).to be_valid
     end
 
+    it "is valid with a correct reject_content_purpose_supergroup" do
+      subject.reject_content_purpose_supergroup = 'news_and_communications'
+
+      expect(subject).to be_valid
+    end
+
+    it "is invalid with an incorrect reject_content_purpose_supergroup" do
+      subject.reject_content_purpose_supergroup = 'blah_blah'
+
+      expect(subject).to be_invalid
+    end
+
+    it "is valid with a nil reject_content_purpose_supergroup" do
+      subject.reject_content_purpose_supergroup = nil
+
+      expect(subject).to be_valid
+    end
+
     it "is invalid when links 'hash' has 'any' values that are not arrays" do
       subject.links = { foo: { any: "bar" } }
 

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -122,6 +122,18 @@ RSpec.describe FindExactQuery do
     expect(query.exact_match).to be_nil
   end
 
+  it "matched on reject_content_purpose_supergroup" do
+    query = build_query(reject_content_purpose_supergroup: 'other')
+    subscriber_list = create_subscriber_list(reject_content_purpose_supergroup: 'other')
+    expect(query.exact_match).to eq(subscriber_list)
+  end
+
+  it "matched on reject_content_purpose_supergroup and content_purpose_supergroup" do
+    query = build_query(reject_content_purpose_supergroup: 'other', content_purpose_supergroup: 'news_and_communications')
+    subscriber_list = create_subscriber_list(reject_content_purpose_supergroup: 'other', content_purpose_supergroup: 'news_and_communications')
+    expect(query.exact_match).to eq(subscriber_list)
+  end
+
   def build_query(params = {})
     defaults = {
       tags: {},
@@ -130,6 +142,7 @@ RSpec.describe FindExactQuery do
       email_document_supertype: '',
       government_document_supertype: '',
       content_purpose_supergroup: nil,
+      reject_content_purpose_supergroup: nil,
     }
 
     described_class.new(defaults.merge(params))

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -128,6 +128,22 @@ RSpec.describe SubscriberListQuery do
       query = described_class.new(defaults.merge(query_params))
       expect(query.lists).not_to include(subscriber_list)
     end
+
+    it "excludes subscriber lists where reject_content_purpose_supergroup is set to the document's content_purpose_supergroup value" do
+      list_params = { reject_content_purpose_supergroup: 'guidance_and_regulation' }
+      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
+      query = described_class.new(query_params)
+      expect(query.lists).not_to include(subscriber_list)
+    end
+
+    it "includes subscriber lists where reject_content_purpose_supergroup is different to the document's content_purpose_supergroup value" do
+      # this is equivalent to the /all-content finder
+      list_params = { reject_content_purpose_supergroup: 'other' }
+
+      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
+      query = described_class.new(query_params)
+      expect(query.lists).to include(subscriber_list)
+    end
   end
 
   def create_subscriber_list(options)


### PR DESCRIPTION
https://trello.com/c/ylw7DDQa/329-enable-email-alert-api-to-reject-a-content-purpose-supergroup

This lets one set reject_content_purpose_supergroup as a parameter when creating and looking up subscriber lists.

This parameter, if set, will enable an email subscription to not receive emails when documents in certain supergroups are changed.

The main use case for this is the ability to subscribe to all content that isn't 'other' content. 

We need to update gds api adapters for this to have an effect.

*Tangential:*

The intent is for email subscriptions to be able to provide alerts when anything that would appear in a search query is changed. Adding a new column here is easy to understand, but is a little crude. It might be worth creating an RFC for a longer term solution. I expect a nice solution would be to use rummager for matching documents to subscriber lists. Perhaps we could store subscriber lists in rummager, and query rummager for subscriber lists using a content change. It would be similar to the current behaviour but might enable us to have a one-to-one match between email subscriptions and the search queries they are intended to mimic.