### PR TITLE
Count number of subscriptions for each business sector

### DIFF
--- a/config/find-eu-exit-guidance-business.yml
+++ b/config/find-eu-exit-guidance-business.yml
@@ -1,0 +1,219 @@
+---
+base_path: "/find-eu-exit-guidance-business"
+content_id: 42ce66de-04f3-4192-bf31-8394538e0734
+signup_content_id: 2818d67a-029a-4899-a438-a543d5c6a20d
+title: Find EU Exit guidance for your business
+description: 'This is the information that has been published so far for your business to prepare for EU exit. You can change what information you get using the checkboxes. Come back to this page regularly or sign up to receive emails when new information is published.'
+name: 'Find EU Exit guidance for your business'
+locale: en
+public_updated_at: '2018-11-23T09:00:00.000+00:00'
+publishing_app: rummager
+rendering_app: finder-frontend
+details:
+  beta: false
+  document_noun: publication
+  subscription_list_title_prefix: 'Find EU Exit guidance for your business '
+  summary: 'This is the information that has been published so far for your business to prepare for EU exit. You can change what information you get using the checkboxes. Come back to this page regularly or sign up to receive emails when new information is published.'
+  canonical_link: true
+  sort:
+    - name: Most relevant
+      key: -public_timestamp
+      default: true
+    - name: Most viewed
+      key: -popularity
+    - name: Most recent
+      key: -public_timestamp
+    - name: A to Z
+      key: title
+  filter:
+    appear_in_find_eu_exit_guidance_business_finder: "yes"
+  facets:
+  - allowed_values:
+    - label: Accommodation, restaurants and catering services
+      value: accommodation-restaurants-and-catering-services
+    - label: Aerospace
+      value: aerospace
+    - label: Agriculture
+      value: agriculture
+    - label: Air transport (aviation)
+      value: air-transport-aviation
+    - label: Ancillary services
+      value: ancillary-services
+    - label: Animal health
+      value: animal-health
+    - label: Automotive
+      value: automotive
+    - label: Banking, markets and infrastructure
+      value: banking-market-infrastructure
+    - label: Broadcasting
+      value: broadcasting
+    - label: Chemicals
+      value: chemicals
+    - label: Computer services
+      value: computer-services
+    - label: Construction and contracting
+      value: construction-contracting
+    - label: Education
+      value: education
+    - label: Electricity
+      value: electricity
+    - label: Electronics
+      value: electronics
+    - label: Environmental services
+      value: environmental-services
+    - label: Fisheries
+      value: fisheries
+    - label: Food and drink
+      value: food-and-drink
+    - label: Furniture and other manufacturing
+      value: furniture-and-other-manufacturing
+    - label: Gas markets
+      value: gas-markets
+    - label: Imports
+      value: imports
+    - label: Imputed rent
+      value: imputed-rent
+    - label: Insurance
+      value: insurance
+    - label: Land transport (excluding rail)
+      value: land-transport-excl-rail
+    - label: Medical services
+      value: medical-services
+    - label: Motor trades
+      value: motor-trades
+    - label: Oil and gas production
+      value: oil-and-gas-production
+    - label: Other personal services
+      value: other-personal-services
+    - label: Parts and machinery
+      value: parts-and-machinery
+    - label: Pharmaceuticals
+      value: pharmaceuticals
+    - label: Post
+      value: post
+    - label: Professional and business services
+      value: professional-and-business-services
+    - label: Public administration and defence
+      value: public-administration-and-defence
+    - label: Rail
+      value: rail
+    - label: Real estate (excluding imputed rent)
+      value: real-estate-excl-imputed-rent
+    - label: Retail
+      value: retail
+    - label: Social work
+      value: social-work
+    - label: Steel and other metals or commodities
+      value: steel-and-other-metals-commodities
+    - label: Telecoms
+      value: telecoms
+    - label: Textiles and clothing
+      value: textiles-and-clothing
+    - label: Warehousing and support for transportation
+      value: warehousing-and-support-for-transportation
+    - label: Water transport including maritime and ports
+      value: water-transport-maritime-ports
+    - label: Wholesale (excluding motor vehicles)
+      value: wholesale-excl-motor-vehicles
+    display_as_result_metadata: false
+    filterable: true
+    combine_mode: and
+    key: sector_business_area
+    name: Sector / Business Area
+    preposition: your business is in
+    type: text
+  - allowed_values:
+    - label: Sell products or goods in the UK
+      value: products-or-goods
+    - label: Buy products or goods from abroad
+      value: buying
+    - label: Sell products or goods abroad
+      value: selling
+    - label: Do other types of business in the EU
+      value: other-eu
+    - label: Transport goods abroad
+      value: transporting
+    display_as_result_metadata: false
+    filterable: true
+    combine_mode: and
+    key: business_activity
+    name: Business activity
+    preposition: you
+    type: text
+  - allowed_values:
+    - label: "EU citizens"
+      value: "yes"
+    - label: "No EU citizens"
+      value: "no"
+    display_as_result_metadata: false
+    filterable: true
+    combine_mode: or
+    key: employ_eu_citizens
+    name: Who you employ
+    preposition: you employ
+    type: text
+  - allowed_values:
+    - label: Processing personal data from Europe
+      value: processing-personal-data
+    - label: Using websites or services hosted in Europe
+      value: interacting-with-eea-website
+    - label: Providing digital services available to Europe
+      value: digital-service-provider
+    display_as_result_metadata: false
+    filterable: true
+    combine_mode: or
+    key: personal_data
+    name: Personal data
+    preposition: you exchange personal data by
+    type: text
+  - allowed_values:
+    - label: Copyright
+      value: copyright
+    - label: Trade marks
+      value: trademarks
+    - label: Designs
+      value: designs
+    - label: Patents
+      value: patents
+    - label: Exhaustion of rights
+      value: exhaustion-of-rights
+    display_as_result_metadata: false
+    filterable: true
+    combine_mode: or
+    key: intellectual_property
+    name: Intellectual property
+    preposition: you use or rely on
+    type: text
+  - allowed_values:
+    - label: EU funding
+      value: receiving-eu-funding
+    - label: UK government funding
+      value: receiving-uk-government-funding
+    display_as_result_metadata: false
+    filterable: true
+    combine_mode: or
+    key: eu_uk_government_funding
+    name: EU or UK government funding
+    preposition: you get
+    type: text
+  - allowed_values:
+    - label: Civil government contracts
+      value: civil-government-contracts
+    - label: Defence contracts
+      value: defence-contracts
+    display_as_result_metadata: false
+    filterable: true
+    combine_mode: or
+    key: public_sector_procurement
+    name: Public sector procurement
+    preposition: you apply for
+    type: text
+routes:
+- path: "/find-eu-exit-guidance-business"
+  type: exact
+- path: "/find-eu-exit-guidance-business.atom"
+  type: exact
+- path: "/find-eu-exit-guidance-business.json"
+  type: exact
+document_type: finder
+schema_name: finder

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -23,4 +23,9 @@ namespace :export do
   task csv_from_living_in_europe: :environment do
     DataExporter.new.export_csv_from_living_in_europe
   end
+
+  desc "Export the number of subscriptions for each sector in the Business Readiness finder"
+  task csv_from_sectors_in_business_readiness: :environment do
+    DataExporter.new.export_csv_from_sectors_in_business_readiness
+  end
 end

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -52,4 +52,24 @@ RSpec.describe DataExporter do
       expect { subject }.to output("id,title,count\n1,Foo,1\n2,Bar,1\n").to_stdout
     end
   end
+
+  describe "#export_csv_from_sectors_in_business_readiness" do
+    let(:subscriber_list_foo) { create(:subscriber_list, id: 1, title: "Foo", slug: DataExporter::BUSINESS_READINESS_FINDER_SLUG_PREFIX + "-foo") }
+    let(:subscriber_list_bar) { create(:subscriber_list, id: 2, title: "Foo and Bar", slug: DataExporter::BUSINESS_READINESS_FINDER_SLUG_PREFIX + "-foo-and-bar") }
+
+    before do
+      create(:subscription, subscriber_list: subscriber_list_foo)
+      create(:subscription, subscriber_list: subscriber_list_bar)
+    end
+
+    subject { DataExporter.new }
+
+    it "exports subscriber lists by business readiness sectors" do
+      allow(subject).to receive(:business_sectors).and_return([
+        { "label" => "Foo", "value" => "foo" },
+        { "label" => "Bar", "value" => "bar" }
+      ])
+      expect { subject.export_csv_from_sectors_in_business_readiness }.to output("title,count\nFoo,2\nBar,1\n").to_stdout
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/Hde9OCFa

Creates a new rake task to count the number of subscriptions to each sector in the business readiness finder.

```
bundle exec rake export:csv_from_sectors_in_business_readiness
```

### Example output

The results are sent to STDOUT in csv format:

```
title,count
"Accommodation, restaurants and catering services",63
Aerospace,47
Agriculture,60
Air transport (aviation),54
Ancillary services,35
Animal health,39
Automotive,67
"Banking, markets and infrastructure",0
Broadcasting,34
Chemicals,57
Computer services,71
Construction and contracting,0
Education,61
Electricity,42
Electronics,86
Environmental services,40
Fisheries,35
Food and drink,92
Furniture and other manufacturing,79
Gas markets,35
Imports,102
Imputed rent,42
Insurance,34
Land transport (excluding rail),0
Medical services,56
Motor trades,44
Oil and gas production,39
Other personal services,40
Parts and machinery,106
Pharmaceuticals,57
Post,35
Professional and business services,131
Public administration and defence,32
Rail,93
Real estate (excluding imputed rent),0
Retail,137
Social work,37
Steel and other metals or commodities,0
Telecoms,34
Textiles and clothing,55
Warehousing and support for transportation,70
Water transport including maritime and ports,0
Wholesale (excluding motor vehicles),0
```