### PR TITLE
Correctly count the number of subscribers to business sector

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -113,6 +113,10 @@ FactoryBot.define do
       tags { { format: %w[medical_safety_alert], alert_type: %w(devices drugs field-safety-notices company-led-drugs) } }
     end
 
+    trait :business_sectors do
+      tags { { sector_business_area: { any: %w[foo bar] } } }
+    end
+
     factory :subscriber_list_with_subscribers do
       transient do
         subscriber_count { 5 }

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe DataExporter do
   end
 
   describe "#export_csv_from_sectors_in_business_readiness" do
-    let(:subscriber_list_foo) { create(:subscriber_list, id: 1, title: "Foo", slug: DataExporter::BUSINESS_READINESS_FINDER_SLUG_PREFIX + "-foo") }
-    let(:subscriber_list_bar) { create(:subscriber_list, id: 2, title: "Foo and Bar", slug: DataExporter::BUSINESS_READINESS_FINDER_SLUG_PREFIX + "-foo-and-bar") }
+    let(:subscriber_list_foo) { create(:subscriber_list, :business_sectors, id: 1, title: "Item One", slug: DataExporter::BUSINESS_READINESS_FINDER_SLUG_PREFIX + "-one") }
+    let(:subscriber_list_bar) { create(:subscriber_list, :business_sectors, id: 2, title: "Item Two", slug: DataExporter::BUSINESS_READINESS_FINDER_SLUG_PREFIX + "-two") }
 
     before do
       create(:subscription, subscriber_list: subscriber_list_foo)
@@ -69,7 +69,7 @@ RSpec.describe DataExporter do
         { "label" => "Foo", "value" => "foo" },
         { "label" => "Bar", "value" => "bar" }
       ])
-      expect { subject.export_csv_from_sectors_in_business_readiness }.to output("title,count\nFoo,2\nBar,1\n").to_stdout
+      expect { subject.export_csv_from_sectors_in_business_readiness }.to output("title,count\nFoo,2\nBar,2\n").to_stdout
     end
   end
 end


### PR DESCRIPTION
Subscriber lists are only unique in terms of their slug. The list is created by the first subscriber, but other subscribers can subscribe to the same list.

Also changed the query to search by the sector the content item is tagged to as mentioned here:
https://github.com/alphagov/email-alert-api/commit/d46d5c0e665acff0550031c1a38208d228f22b83