### PR TITLE
Remove reject_content_purpose_supergroup field from subscriber lists

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -57,7 +57,6 @@ private
       email_document_supertype: permitted_params.fetch(:email_document_supertype, ""),
       government_document_supertype: permitted_params.fetch(:government_document_supertype, ""),
       content_purpose_supergroup: permitted_params.fetch(:content_purpose_supergroup, nil),
-      reject_content_purpose_supergroup: permitted_params.fetch(:reject_content_purpose_supergroup, nil),
       slug: params[:gov_delivery_id],
     }
   end

--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -20,7 +20,8 @@ class ContentChange < ApplicationRecord
 
   def content_purpose_supergroup
     @content_purpose_supergroup ||= begin
-      GovukDocumentTypes.supertypes(document_type: document_type)['content_purpose_supergroup']
+      group = GovukDocumentTypes.supertypes(document_type: document_type)['content_purpose_supergroup']
+      group == 'other' ? nil : group
     end
   end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -6,7 +6,6 @@ class SubscriberList < ApplicationRecord
   validate :tag_values_are_valid
   validate :link_values_are_valid
   validate :content_purpose_supergroup_is_valid
-  validate :reject_content_purpose_supergroup_is_valid
 
   validates :title, presence: true
   validates_uniqueness_of :slug
@@ -75,20 +74,12 @@ private
     GovukDocumentTypes.supergroup_document_types supergroup
   end
 
-  def validate_supergroup_field(supergroup, field)
-    valid = supergroup.nil? || supergroup_document_types(supergroup).any? || supergroup == 'other'
+  def content_purpose_supergroup_is_valid
+    valid = content_purpose_supergroup.nil? || supergroup_document_types(content_purpose_supergroup).any?
 
     unless valid
-      self.errors.add(field, "Invalid supergroup '#{supergroup}'")
+      self.errors.add(:content_purpose_supergroup, "Invalid supergroup '#{content_purpose_supergroup}'")
     end
-  end
-
-  def content_purpose_supergroup_is_valid
-    validate_supergroup_field(content_purpose_supergroup, :content_purpose_supergroup)
-  end
-
-  def reject_content_purpose_supergroup_is_valid
-    validate_supergroup_field(reject_content_purpose_supergroup, :reject_content_purpose_supergroup)
   end
 
   def valid_subscriber_criteria(link_or_tags)

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -8,8 +8,7 @@ class FindExactQuery
     email_document_supertype:,
     government_document_supertype:,
     slug: nil,
-    content_purpose_supergroup:,
-    reject_content_purpose_supergroup:
+    content_purpose_supergroup:
   )
     @tags = tags.deep_symbolize_keys
     @links = links.deep_symbolize_keys
@@ -17,7 +16,6 @@ class FindExactQuery
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
     @content_purpose_supergroup = content_purpose_supergroup
-    @reject_content_purpose_supergroup = reject_content_purpose_supergroup
     @slug = slug
   end
 
@@ -37,7 +35,6 @@ private
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)
         .where(content_purpose_supergroup: @content_purpose_supergroup)
-        .where(reject_content_purpose_supergroup: @reject_content_purpose_supergroup)
       scope = scope.where(slug: @slug) if @slug.present?
       scope
     end

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -36,6 +36,5 @@ private
       .where(email_document_supertype: ['', @email_document_supertype])
       .where(government_document_supertype: ['', @government_document_supertype])
       .where(content_purpose_supergroup: [nil, @content_purpose_supergroup])
-      .where("reject_content_purpose_supergroup <> '#{@content_purpose_supergroup}' OR reject_content_purpose_supergroup IS NULL")
   end
 end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe "Creating a subscriber list", type: :request do
           email_document_supertype
           government_document_supertype
           active_subscriptions_count
-          content_purpose_supergroup
           reject_content_purpose_supergroup
+          content_purpose_supergroup
         }.to_set.sort
       )
 

--- a/spec/models/content_change_spec.rb
+++ b/spec/models/content_change_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe ContentChange do
       expect(content_item.content_purpose_supergroup).to be(supertypes.fetch('content_purpose_supergroup'))
     end
 
-    it "is other when it is part of the default supergroup" do
-      expect(content_item_with_other_supergroup.content_purpose_supergroup).to eq('other')
+    it "is nil when it is part of the 'other' supergroup" do
+      expect(content_item_with_other_supergroup.content_purpose_supergroup).to be(nil)
     end
   end
 end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -65,24 +65,6 @@ RSpec.describe SubscriberList, type: :model do
       expect(subject).to be_valid
     end
 
-    it "is valid with a correct reject_content_purpose_supergroup" do
-      subject.reject_content_purpose_supergroup = 'news_and_communications'
-
-      expect(subject).to be_valid
-    end
-
-    it "is invalid with an incorrect reject_content_purpose_supergroup" do
-      subject.reject_content_purpose_supergroup = 'blah_blah'
-
-      expect(subject).to be_invalid
-    end
-
-    it "is valid with a nil reject_content_purpose_supergroup" do
-      subject.reject_content_purpose_supergroup = nil
-
-      expect(subject).to be_valid
-    end
-
     it "is invalid when links 'hash' has 'any' values that are not arrays" do
       subject.links = { foo: { any: "bar" } }
 

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -122,18 +122,6 @@ RSpec.describe FindExactQuery do
     expect(query.exact_match).to be_nil
   end
 
-  it "matched on reject_content_purpose_supergroup" do
-    query = build_query(reject_content_purpose_supergroup: 'other')
-    subscriber_list = create_subscriber_list(reject_content_purpose_supergroup: 'other')
-    expect(query.exact_match).to eq(subscriber_list)
-  end
-
-  it "matched on reject_content_purpose_supergroup and content_purpose_supergroup" do
-    query = build_query(reject_content_purpose_supergroup: 'other', content_purpose_supergroup: 'news_and_communications')
-    subscriber_list = create_subscriber_list(reject_content_purpose_supergroup: 'other', content_purpose_supergroup: 'news_and_communications')
-    expect(query.exact_match).to eq(subscriber_list)
-  end
-
   def build_query(params = {})
     defaults = {
       tags: {},
@@ -142,7 +130,6 @@ RSpec.describe FindExactQuery do
       email_document_supertype: '',
       government_document_supertype: '',
       content_purpose_supergroup: nil,
-      reject_content_purpose_supergroup: nil,
     }
 
     described_class.new(defaults.merge(params))

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -128,22 +128,6 @@ RSpec.describe SubscriberListQuery do
       query = described_class.new(defaults.merge(query_params))
       expect(query.lists).not_to include(subscriber_list)
     end
-
-    it "excludes subscriber lists where reject_content_purpose_supergroup is set to the document's content_purpose_supergroup value" do
-      list_params = { reject_content_purpose_supergroup: 'guidance_and_regulation' }
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(query_params)
-      expect(query.lists).not_to include(subscriber_list)
-    end
-
-    it "includes subscriber lists where reject_content_purpose_supergroup is different to the document's content_purpose_supergroup value" do
-      # this is equivalent to the /all-content finder
-      list_params = { reject_content_purpose_supergroup: 'other' }
-
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(query_params)
-      expect(query.lists).to include(subscriber_list)
-    end
   end
 
   def create_subscriber_list(options)


### PR DESCRIPTION
This field was used to filter out / reject specified supergroups.
The field is no longer needed (introduced in https://github.com/alphagov/email-alert-api/pull/784),
so this removes it.

It looks like just one active subscription used this (it wasnt
seen by the public), so can be removed without issues.

https://trello.com/c/45eoS6mj/491-remove-rejectcontentpurposesupergroup-functionality-from-email-alert-api-m-%F0%9F%98%AD

I've added a db migration to remove this column from the subscriber list here: https://github.com/alphagov/email-alert-api/compare/RemoveRejectContentPurposeSupergroupFromSubscriberList?expand=1