### PR TITLE
Add db migration to remove reject_content_purpose_supergroup from subscriber list

### DIFF
--- a/db/migrate/20190313155146_remove_reject_content_purpose_supergroup_from_subscriber_list.rb
+++ b/db/migrate/20190313155146_remove_reject_content_purpose_supergroup_from_subscriber_list.rb
@@ -1,0 +1,5 @@
+class RemoveRejectContentPurposeSupergroupFromSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :subscriber_lists, :reject_content_purpose_supergroup, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_06_130316) do
+ActiveRecord::Schema.define(version: 2019_03_13_155146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,7 +116,6 @@ ActiveRecord::Schema.define(version: 2019_02_06_130316) do
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
     t.string "content_purpose_supergroup", limit: 100
-    t.string "reject_content_purpose_supergroup", limit: 100
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
           email_document_supertype
           government_document_supertype
           active_subscriptions_count
-          reject_content_purpose_supergroup
           content_purpose_supergroup
         }.to_set.sort
       )


### PR DESCRIPTION
This follows https://github.com/alphagov/email-alert-api/pull/809 and removes the column from the subscriber_lists table. I will merge this in once #809 has been deployed.

Trello: https://trello.com/c/45eoS6mj/491-remove-rejectcontentpurposesupergroup-functionality-from-email-alert-api-m