### PR TITLE
Change title for new business subscription

### DIFF
--- a/db/migrate/20190320125556_rename_business_subscription_title.rb
+++ b/db/migrate/20190320125556_rename_business_subscription_title.rb
@@ -1,0 +1,10 @@
+class RenameBusinessSubscriptionTitle < ActiveRecord::Migration[5.2]
+  def change
+    subscriber_list = SubscriberList.find_by(slug: "find-eu-exit-guidance-for-your-business-appear-in-find-eu-exit-guidance-business-finder")
+
+    if subscriber_list
+      subscriber_list.title = "EU Exit guidance for your business or organisation"
+      subscriber_list.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_13_155146) do
+ActiveRecord::Schema.define(version: 2019_03_20_125556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Due to the override we're doing for the EU Exit business finder email subscriptions, the default title is "Find EU Exit guidance for your business appear in find eu exit guidance business finder".

This migration renames the title to "EU Exit guidance for your business or organisation"

**This has been tested on integration. The title is successfully renamed and the new title appears in the signup process. I couldn't get emails sent to me to access the manage interface, but I assume this will be changed there too."