### PR TITLE
Generate report on successful delivery attempts

### DIFF
--- a/lib/reports/email_delivery_attempts.rb
+++ b/lib/reports/email_delivery_attempts.rb
@@ -1,0 +1,60 @@
+require 'csv'
+
+module Reports
+  class EmailDeliveryAttempts
+    def initialize(start_date, end_date)
+      @start_date = parse_date(start_date)
+      @end_date = parse_date(end_date)
+    end
+
+    def report
+      date_range = @start_date...@end_date
+
+      puts "Searching for all sucessful delivery attempts between #{start_date} and #{end_date}"
+
+      delivery_attempts = get_email_delivery_attempts(date_range)
+
+      raise RuntimeError.new('No data for dates provided') if delivery_attempts.empty?
+
+      path = "#{Rails.root}/tmp/delivery_attempt_time_#{@start_date}_to_#{@end_date}.csv".delete(' ')
+      csv_headers = ["created_at", "updated_at", "time delay(s)"]
+      times = []
+
+      CSV.open(path, 'wb', headers: csv_headers, write_headers: true) do |csv|
+        puts 'Calculating delivery attempt times...'
+
+        delivery_attempts.each do |delivery_attempt|
+          time_delay = delivery_attempt.updated_at - delivery_attempt.created_at
+          times << time_delay
+
+          csv << [
+            delivery_attempt.updated_at,
+            delivery_attempt.created_at,
+            time_delay
+          ]
+        end
+      end
+
+      average_time = times.sum / times.length
+      puts "Finished! Average delivery attempt time between #{start_date} and #{end_date} is #{average_time}s"
+      puts "Report available at #{path}"
+    end
+
+  private
+
+    attr_reader :start_date, :end_date
+
+    def parse_date(date)
+      raise ArgumentError, 'Date(s) entered need to be of date/time format' unless Time.zone.parse(date)
+
+      Time.zone.parse(date)
+    end
+
+    def get_email_delivery_attempts(date_range)
+      DeliveryAttempt
+        .where(status: 1)
+        .where('sent_at IS NOT NULL')
+        .where(created_at: date_range)
+    end
+  end
+end

--- a/lib/tasks/delivery_attempt_report.rake
+++ b/lib/tasks/delivery_attempt_report.rake
@@ -1,0 +1,8 @@
+namespace :report do
+  desc "Find successful delivery attempts between two dates/times and calculate average (seconds)"
+  task :find_delivery_attempts, %i[start_date end_date] => :environment do |_t, args|
+    raise ArgumentError.new("Missing start_date or end_date") unless args[:start_date].present? && args[:end_date].present?
+
+    Reports::EmailDeliveryAttempts.new(args[:start_date], args[:end_date]).report
+  end
+end

--- a/spec/lib/reports/email_delivery_attempts_spec.rb
+++ b/spec/lib/reports/email_delivery_attempts_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Reports::EmailDeliveryAttempts do
+  before do
+    2.times {
+      create(
+        :delivery_attempt,
+        status: 'delivered',
+        created_at: Time.zone.parse('2019-03-21T15:04:22.000000Z'),
+        updated_at: Time.zone.parse('2019-03-22T06:10:44.000000Z'),
+        sent_at: Time.zone.parse('2019-03-21T15:04:22.000000Z')
+      )
+    }
+
+    create(
+      :delivery_attempt,
+      status: 'delivered',
+      created_at: Time.zone.parse('2019-03-21T11:08:33.000000Z'),
+      updated_at: Time.zone.parse('2019-03-22T016:22:43.000000Z'),
+      sent_at: Time.zone.parse('2019-03-21T11:08:33.000000Z')
+    )
+
+    create(:delivery_attempt, status: 'sending')
+    create(:delivery_attempt, status: 'temporary_failure')
+  end
+
+  context 'delivery attempt report' do
+    let(:start_date) { '2019-03-21' }
+    let(:end_date) { '2019-03-23' }
+
+    it 'throws an error if invalid date is used' do
+      expect { described_class.new('xyz', end_date).report }.to raise_error(ArgumentError, "Date(s) entered need to be of date/time format")
+    end
+
+    it 'outputs the average time between created_at and updated_at' do
+      expect { described_class.new(start_date, end_date).report }.to output(
+        <<~TEXT
+          Searching for all sucessful delivery attempts between 2019-03-21 00:00:00 +0000 and 2019-03-23 00:00:00 +0000
+          Calculating delivery attempt times...
+          Finished! Average delivery attempt time between 2019-03-21 00:00:00 +0000 and 2019-03-23 00:00:00 +0000 is 71338.0s
+          Report available at #{Rails.root}/tmp/delivery_attempt_time_2019-03-2100:00:00+0000_to_2019-03-2300:00:00+0000.csv
+        TEXT
+      ).to_stdout
+    end
+
+    it 'does not output the average time if there are no delivery attempts within date range' do
+      expect { described_class.new('2019-02-02', '2019-02-01').report }.to raise_error(RuntimeError, "No data for dates provided")
+    end
+  end
+end


### PR DESCRIPTION
We want to monitor how long it takes for an email to be delivered
successfully by comparing the `created_at` and `updated_at` fields.

This script gets all successful delivery attempts within the given
dates and compares the two fields, writing the time difference to a
csv. It also outputs the average of these values to the terminal.

It's worth noting that emails and their delivery attempts are archived
after 24 hours of an email reaching it's final state (sent/failed) so
this script can only be run for the past day.

More information: https://github.com/alphagov/email-alert-api/blob/master/doc/arch/adr-003-data-retention.md

Leaving the rake task to accept dates (rather than fix it for the past
24 hours) should we need to modify it.

Trello card: https://trello.com/c/omh8AtzA/880-investigate-email-status-update-health