### PR TITLE
Increase status updates healthcheck thresholds

### DIFF
--- a/app/models/healthcheck/status_updates.rb
+++ b/app/models/healthcheck/status_updates.rb
@@ -11,11 +11,11 @@ module Healthcheck
     end
 
     def critical_threshold
-      0.2
+      0.25
     end
 
     def warning_threshold
-      0.1
+      0.166
     end
 
     def enabled?

--- a/spec/models/healthcheck/status_updates_spec.rb
+++ b/spec/models/healthcheck/status_updates_spec.rb
@@ -12,18 +12,19 @@ RSpec.describe Healthcheck::StatusUpdates do
       specify { expect(subject.status).to eq(:ok) }
     end
 
-    context "at 10%" do
+    context "at 16.6%" do
       before do
         create_delivery_attempt(:sending, 15.minutes.ago)
-        9.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
+        5.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
       end
+
       specify { expect(subject.status).to eq(:warning) }
     end
 
-    context "at 20%" do
+    context "at 25%" do
       before do
         create_delivery_attempt(:sending, 15.minutes.ago)
-        4.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
+        3.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
       end
       specify { expect(subject.status).to eq(:critical) }
     end


### PR DESCRIPTION
We have generally noticed an increase in the number of emails being
sent out. Increasing the `warning` and `critical` thresholds to better
monitor the rate of delivery attempts that haven't been delivered
 within the past 15 minutes.

`warning` - 16.6% (1 in 6 has not been `delivered`)
`critical` - 25% (1 in 4 has not been `delivered`)

Trello card: https://trello.com/c/omh8AtzA/880-investigate-email-status-update-health