### PR TITLE
Add a feedback line to the bottom of every email

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -25,7 +25,9 @@ private
   attr_reader :subscriber, :digest_run, :results
 
   def body
-    presented_results.concat("\n").concat(spam_prevention_survey_links)
+    presented_results.concat("\n")
+      .concat(subscription_link).concat("\n")
+      .concat(feedback_link)
   end
 
   def presented_results
@@ -43,14 +45,22 @@ private
     RESULT
   end
 
-  def spam_prevention_survey_links
+  def subscription_link
     <<~BODY
       You’re getting this email because you subscribed to these topic updates on GOV.UK.
       #{presented_manage_subscriptions_links}
+    BODY
+  end
 
+  def feedback_link
+    <<~BODY
       &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
+
+      &nbsp;
+
+      ^Do not reply to this email. Feedback? Visit #{Plek.new.website_root}/contact
     BODY
   end
 

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -38,7 +38,11 @@ private
 
   def body(content_change, subscriptions, address)
     if Array(subscriptions).empty?
-      presented_content_change(content_change)
+      <<~BODY
+        #{presented_content_change(content_change)}
+        ---
+        #{feedback_link.strip}
+      BODY
     else
       <<~BODY
         #{presented_content_change(content_change)}
@@ -50,9 +54,19 @@ private
 
         &nbsp;
 
-        ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
+        #{feedback_link.strip}
       BODY
     end
+  end
+
+  def feedback_link
+    <<~BODY
+      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
+
+      &nbsp;
+
+      ^Do not reply to this email. Feedback? Visit #{Plek.new.website_root}/contact
+    BODY
   end
 
   def presented_content_change(content_change)

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -108,6 +108,10 @@ RSpec.describe DigestEmailBuilder do
         &nbsp;
 
         ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
+
+        &nbsp;
+
+        ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
       BODY
     )
   end

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe ImmediateEmailBuilder do
       expect(email.body).to eq(
         <<~BODY
           presented_content_change
+
+          ---
+          ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
+
+          &nbsp;
+
+          ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
         BODY
       )
     end
@@ -119,6 +126,10 @@ RSpec.describe ImmediateEmailBuilder do
             &nbsp;
 
             ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
+
+            &nbsp;
+
+            ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
           BODY
         )
       end

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe "creating and delivering digests", type: :request do
       &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
+
+      &nbsp;
+
+      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
     BODY
   end
 
@@ -95,6 +99,10 @@ RSpec.describe "creating and delivering digests", type: :request do
       &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
+
+      &nbsp;
+
+      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
     BODY
   end
 
@@ -284,6 +292,10 @@ RSpec.describe "creating and delivering digests", type: :request do
       &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
+
+      &nbsp;
+
+      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
     BODY
   end
 
@@ -315,6 +327,10 @@ RSpec.describe "creating and delivering digests", type: :request do
       &nbsp;
 
       ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
+
+      &nbsp;
+
+      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
     BODY
   end
   scenario "weekly digest run" do


### PR DESCRIPTION
We're going to be change the emails so that replying to them no longer sends feedback to us. This line has been written by the content designers who previously worked on the email team and will tell users to go through our normal contact form to ask for help.

[Trello Card](https://trello.com/c/xsvN7oWp/896-change-the-email-address-that-govuk-email-notifications-are-sent-from-to-a-no-reply-address-and-update-the-template)