### PR TITLE
Update subscription count docs for clarity

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,6 +12,10 @@ class Subscription < ApplicationRecord
 
   scope :active, -> { where(ended_at: nil) }
   scope :ended, -> { where.not(ended_at: nil) }
+  scope :active_on, ->(date) do
+    where("created_at <= ?", date)
+      .where("ended_at IS NULL OR ended_at > ?", date)
+  end
 
   def as_json(options = {})
     options[:except] ||= %i(signon_user_uid subscriber_list_id subscriber_id)

--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -28,14 +28,16 @@ endpoints or rake tasks.
 
 Here are some example queries to pull out particular insights.
 
-### How many subscribers does a list have at a particular point in time
+### How many subscribers does a list have
 
 ```ruby
-Subscription.where(
-    "created_at > ? AND (ended_at IS NULL OR ended_at <= ?)",
-    "2018-06-01",
-    "2018-07-01"
-  ).where(subscriber_list_id: 4194).count
+SubscriberList.find(4194).active_subscriptions_count
+```
+
+### How many subscribers did a list have at a particular point in time
+
+```ruby
+Subscription.active_on("2018-06-01").where(subscriber_list_id: 4194).count
 ```
 
 ### Lists with most new subscriptions in a time frame

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
+  describe ".active_on" do
+    before do
+      create(:subscription, created_at: "2018-01-01", ended_at: "2019-01-01")
+    end
+
+    it "returns subscriptions active on a valid date" do
+      expect(Subscription.active_on("2018-06-01").count).to eq(1)
+    end
+
+    it "returns no subscriptions active on an invalid date" do
+      expect(Subscription.active_on("2019-02-01").count).to eq(0)
+    end
+  end
+
   describe ".ended" do
     it "returns subscriptions with ended_at nil" do
       create(:subscription, :ended)


### PR DESCRIPTION
The queries weren't clear on what they were returning and developers were using them incorrectly. They should now be more accurate.

[Trello Card](https://trello.com/c/bCMwB74D/912-email-rake-task-returns-suspicious-subscriber-numbers)