### PR TITLE
Add GovukDocumentTypes to content_change tags

### DIFF
--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -29,7 +29,7 @@ private
       description: params[:description],
       base_path: params[:base_path],
       links: params[:links],
-      tags: params[:tags],
+      tags: content_change_tags,
       public_updated_at: Time.parse(params[:public_updated_at]),
       email_document_supertype: params[:email_document_supertype],
       government_document_supertype: params[:government_document_supertype],
@@ -39,10 +39,16 @@ private
       priority: params.fetch(:priority, "normal").to_sym,
       signon_user_uid: user&.uid,
       footnote: params.fetch(:footnote, ""),
-    }.tap do |content_change|
-      content_change[:tags] = Services.business_readiness.inject(
-        content_change[:base_path], content_change[:tags]
-      )
-    end
+    }
+  end
+
+  def content_change_tags
+    tags = Services.business_readiness.inject(params[:base_path], params[:tags])
+
+    content_change_supertypes.merge(tags)
+  end
+
+  def content_change_supertypes
+    GovukDocumentTypes.supertypes(document_type: params[:document_type])
   end
 end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -166,6 +166,26 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
+    describe "creating a subscriber list with content_purpose_subgroups" do
+      it "returns a 201" do
+        create_subscriber_list(tags: { content_purpose_subgroups: { any: %w[news] } })
+
+        expect(response.status).to eq(201)
+      end
+
+      it "sets content_purpose_subgroups on the subscriber list" do
+        create_subscriber_list(
+          tags: {
+            countries: { any: %w[andorra] },
+            content_purpose_subgroups: { any: %w[news] }
+          }
+        )
+
+        subscriber_list = SubscriberList.last
+        expect(subscriber_list.tags[:content_purpose_subgroups]).to eq(any: %w[news])
+      end
+    end
+
     context "when creating a subscriber list with no tags or links" do
       context "and a document_type is provided" do
         it "returns a 201" do

--- a/spec/integration/get_subscriber_list_spec.rb
+++ b/spec/integration/get_subscriber_list_spec.rb
@@ -212,6 +212,33 @@ RSpec.describe "Getting a subscriber list", type: :request do
         expect(subscriber_list.fetch("id")).to eq(beta.id)
       end
     end
+
+    context "when passing in content_purpose_subgroup" do
+      it "does not find a subscriber list if the content_purpose_subgroup does not match" do
+        get_subscriber_list(
+          tags: {
+            topics: { any: ["vat-rates"] },
+            content_purpose_subgroup: { any: %w(news) }
+          },
+          document_type: "tax",
+        )
+        expect(response.status).to eq(404)
+      end
+
+      it "finds the subscriber list if the content_purpose_subgroup matches" do
+        _alpha = create(:subscriber_list, tags: { topics: { any: ["vat-rates"] }, content_purpose_subgroup: { any: %w(updates_and_alerts) } })
+        beta = create(:subscriber_list, tags: { topics: { any: ["vat-rates"] }, content_purpose_subgroup: { any: %w(news) } })
+        _gamma = create(:subscriber_list, tags: { topics: { any: ["vat-rates"] }, content_purpose_subgroup: { any: %w() } })
+
+        get_subscriber_list(
+          tags: { topics: { any: ["vat-rates"] }, content_purpose_subgroup: { any: %w(news) } }
+        )
+        expect(response.status).to eq(200)
+
+        subscriber_list = JSON.parse(response.body).fetch("subscriber_list")
+        expect(subscriber_list.fetch("id")).to eq(beta.id)
+      end
+    end
   end
 
   context "without authentication" do

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -130,6 +130,24 @@ RSpec.describe SubscriberListQuery do
     end
   end
 
+  context 'when a content_purpose_subgroup is provided' do
+    query_params = { tags: { content_purpose_subgroup: %w[updates_and_alerts] } }
+    list_params = { tags: { content_purpose_subgroup: { any: %w[updates_and_alerts] } } }
+
+    it "includes subscriber lists where the content_purpose_subgroup is set to the desired value" do
+      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
+      query = described_class.new(defaults.merge(query_params))
+      expect(query.lists).to include(subscriber_list)
+    end
+
+    it "excludes subscriber lists where the content_purpose_subgroup is set to a different value" do
+      list_params = { tags: { content_purpose_subgroup: { any: %w[speeches_and_statements] } } }
+      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
+      query = described_class.new(defaults.merge(query_params))
+      expect(query.lists).not_to include(subscriber_list)
+    end
+  end
+
   def create_subscriber_list(options)
     create(:subscriber_list, options)
   end

--- a/spec/services/notification_handler_service_spec.rb
+++ b/spec/services/notification_handler_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotificationHandlerService do
       public_updated_at: Time.now.to_s,
       email_document_supertype: "email document supertype",
       government_document_supertype: "government document supertype",
-      document_type: "document type",
+      document_type: "news_article",
       publishing_app: "publishing app",
       govuk_request_id: "request-id",
     }
@@ -56,6 +56,45 @@ RSpec.describe NotificationHandlerService do
     end
 
     let(:content_change) { create(:content_change) }
+
+    it "adds GovukDocumentTypes to the content_change tags" do
+      described_class.call(params: params)
+
+      expect(ContentChange.last).to have_attributes(
+        title: "Travel advice",
+        base_path: "/government/things",
+        change_note: "This is a change note",
+        description: "This is a description",
+        links: {
+          organisations: {
+            any: ["c380ea42-5d91-41cc-b3cd-0a4cfe439461"]
+          },
+          taxon_tree: {
+            all: ["6416e4e0-c0c1-457a-8337-4bf8ed9d5f80"]
+          }
+        },
+        tags: {
+          navigation_document_supertype: "other",
+          content_purpose_document_supertype: "news",
+          user_journey_document_supertype: "thing",
+          search_user_need_document_supertype: "government",
+          email_document_supertype: "other",
+          government_document_supertype: "other",
+          content_purpose_subgroup: "news",
+          content_purpose_supergroup: "news_and_communications",
+          topics: ["oil-and-gas/licensing"],
+        },
+        email_document_supertype: "email document supertype",
+        government_document_supertype: "government document supertype",
+        govuk_request_id: "request-id",
+        document_type: "news_article",
+        publishing_app: "publishing app",
+        processed_at: nil,
+        priority: "normal",
+        signon_user_uid: nil,
+        footnote: ""
+      )
+    end
 
     it "enqueues the content change to be processed by the subscription content worker" do
       allow(ContentChange).to receive(:create!).and_return(content_change)


### PR DESCRIPTION
Ticket: https://trello.com/c/IUEMbTEA

This will add attributes like content_purpose_subgroup to
a content_change's tags. This will make it possible to
subscribe to groups of documents defined in the GovukDocumentTypes gem.

A previous way to make it possible to subscribe to these attributes was to add
a new column `content_purpose_supergroup` to the `subscriber_lists`
relation and then filter using that field. This can be removed. I'll do this in
a followup commit as we'll also need to a migration for the existing subscriptions using that field.