### PR TITLE
Add appropriate facet group links subscriber lists

### DIFF
--- a/db/migrate/20190412121520_add_facet_group_link_to_eu_exit_subscriber_lists.rb
+++ b/db/migrate/20190412121520_add_facet_group_link_to_eu_exit_subscriber_lists.rb
@@ -1,0 +1,8 @@
+class AddFacetGroupLinkToEuExitSubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    SubscriberList.where("slug LIKE 'find-eu-exit-guidance-for-your-business%'").each do |list|
+      list.links = list.links.merge(facet_groups: { any: %W(52435175-82ed-4a04-adef-74c0199d0f46) })
+      list.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_13_155146) do
+ActiveRecord::Schema.define(version: 2019_04_12_121520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/V25E2P7o/43-migrate-email-subscriptions

Subscribers to lists for the EU Exit business readiness finder also need to have
facet group links for when we switch over from legacy finder behaviour to
facet group driven behaviour, this should ensure users receive emails for the finder.