### PR TITLE
Move subscriptions to new subscriber lists

### DIFF
--- a/app/services/remove_cps_service.rb
+++ b/app/services/remove_cps_service.rb
@@ -1,0 +1,85 @@
+class RemoveCpsService
+  def delete_subscriber_lists
+    subscriber_lists = fetch_subscriber_lists
+
+    subscriptions = Subscription.where(subscriptions: { subscriber_list: subscriber_lists })
+    raise "Can't have any subscribers left" unless subscriptions.empty?
+
+    count = subscriber_lists.count
+    subscriber_lists.each_with_index do |subscriber_list, index|
+      SubscriberList.transaction do
+        matching_list = matching_subscriber_list(subscriber_list)
+        move_matched_content_changes(subscriber_list, matching_list)
+        subscriber_list.destroy
+      end
+      puts "Done #{index} out of #{count} subscriber lists"
+    end
+  end
+
+  def deactivate_subscriber_lists
+    subscriber_lists = fetch_subscriber_lists
+    count = subscriber_lists.count
+    subscriber_lists.each_with_index do |subscriber_list, index|
+      SubscriberList.transaction do
+        matching_list = matching_subscriber_list(subscriber_list)
+        if matching_list.nil?
+          content_purpose_supergroup_to_tags(subscriber_list)
+        else
+          move_subscriptions(subscriber_list, matching_list)
+        end
+      end
+      puts "Done #{index} out of #{count} subscriber lists"
+    end
+  end
+
+private
+
+  def fetch_subscriber_lists
+    SubscriberList.where('content_purpose_supergroup IS NOT NULL')
+  end
+
+  def active_subscribers(subscriber_list)
+    Subscriber.joins(:subscriptions).where(subscriptions: { subscriber_list: subscriber_list, ended_at: nil })
+  end
+
+  def move_subscriptions(from_subscriber_list, to_subscriber_list)
+    subscriptions = from_subscriber_list.subscriptions
+    subscribers = active_subscribers(to_subscriber_list)
+    subscriptions.each do |subscription|
+      if subscription.active? && subscribers.include?(subscription.subscriber)
+        subscription.end(reason: 'subscriber_list_changed')
+      end
+      subscription.update_attribute(:subscriber_list, to_subscriber_list)
+    end
+  end
+
+  def move_matched_content_changes(from_subscriber_list, to_subscriber_list)
+    to_ids = to_subscriber_list.matched_content_changes.pluck(:content_change_id)
+
+    duplicates = MatchedContentChange.where(subscriber_list: from_subscriber_list, content_change_id: to_ids)
+    non_duplicates = MatchedContentChange.where(subscriber_list: from_subscriber_list).where.not(content_change_id: to_ids)
+    non_duplicates.each do |matched_content_change|
+      matched_content_change.update(subscriber_list: to_subscriber_list)
+    end
+    duplicates.try(:first).try(:delete)
+  end
+
+  def content_purpose_supergroup_to_tags(subscriber_list)
+    subscriber_list.update(tags: updated_tags(subscriber_list),
+                           content_purpose_supergroup: nil)
+  end
+
+  def matching_subscriber_list(subscriber_list)
+    FindExactQuery.new(tags: updated_tags(subscriber_list),
+                       links: {},
+                       document_type: subscriber_list.document_type,
+                       email_document_supertype: subscriber_list.email_document_supertype,
+                       government_document_supertype: subscriber_list.government_document_supertype,
+                       slug: nil,
+                       content_purpose_supergroup: nil).exact_match
+  end
+
+  def updated_tags(subscriber_list)
+    subscriber_list.tags.merge(content_purpose_supergroup: { any: [subscriber_list.content_purpose_supergroup] })
+  end
+end

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -95,6 +95,16 @@ namespace :manage do
     end
   end
 
+  desc "Deactivated legacy subscriber lists"
+  task deactivate_legacy_subscriber_lists: :environment do
+    RemoveCpsService.new.deactivate_subscriber_lists
+  end
+
+  desc "Remove legacy subscriber lists"
+  task delete_subscriber_lists: :environment do
+    RemoveCpsService.new.delete_subscriber_lists
+  end
+
   desc "Change the email address of a subscriber"
   task :change_email_address, %i[old_email_address new_email_address] => :environment do |_t, args|
     change_email_address(old_email_address: args[:old_email_address], new_email_address: args[:new_email_address])

--- a/spec/services/remove_cps_service_spec.rb
+++ b/spec/services/remove_cps_service_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe RemoveCpsService do
+  let(:tags) { { a: { any: %w[b] } } }
+  let(:content_purpose_supergroup) { 'news_and_communications' }
+  let(:updated_tags) { tags.merge(content_purpose_supergroup: { any: [content_purpose_supergroup] }) }
+
+  describe '#deactivate_subscriber_lists' do
+    it 'does not create a new SubscriberList because it does not contain a CPS' do
+      subscriber_list = FactoryBot.create(:subscriber_list)
+      expect { RemoveCpsService.new.deactivate_subscriber_lists }.to_not(change { subscriber_list.reload.attributes })
+    end
+    it 'removes the CPS from the subscriber list' do
+      subscriber_list = FactoryBot.create(:subscriber_list, content_purpose_supergroup: content_purpose_supergroup)
+      RemoveCpsService.new.deactivate_subscriber_lists
+      subscriber_list.reload
+      expect(subscriber_list.content_purpose_supergroup).to be nil
+    end
+    it 'adds the content purpose supergroup to the tags' do
+      subscriber_list = FactoryBot.create(:subscriber_list, tags: tags, content_purpose_supergroup: content_purpose_supergroup)
+      RemoveCpsService.new.deactivate_subscriber_lists
+      subscriber_list.reload
+      expect(subscriber_list.tags).to include(content_purpose_supergroup: { any: [content_purpose_supergroup] })
+      expect(subscriber_list.tags).to include(tags)
+    end
+    context 'A duplicate subscriber list exists' do
+      before :each do
+        @subscriber_list = FactoryBot.create(:subscriber_list_with_subscribers,
+                                             tags: tags,
+                                             content_purpose_supergroup: content_purpose_supergroup,
+                                             subscriber_count: 2)
+        @duplicate_subscriber_list = FactoryBot.create(:subscriber_list, tags: updated_tags, content_purpose_supergroup: nil)
+      end
+      it 'adds the subscriptions to the duplicate' do
+        expect { RemoveCpsService.new.deactivate_subscriber_lists }.to change {
+          @duplicate_subscriber_list.reload.subscribers.count
+        }.from(0).to(2)
+      end
+
+      it 'moves deactivated subscriptions' do
+        @subscription = FactoryBot.create(:subscription, :ended, subscriber_list: @subscriber_list)
+        expect { RemoveCpsService.new.deactivate_subscriber_lists }.to change {
+          @duplicate_subscriber_list.reload.subscribers.count
+        }.from(0).to(3)
+      end
+
+      context 'there are duplicate subscribers' do
+        before :each do
+          duplicate_subscriber = FactoryBot.create(:subscriber)
+          @subscription = FactoryBot.create(:subscription, subscriber_list: @subscriber_list, subscriber: duplicate_subscriber)
+          @duplicate_subscription = FactoryBot.create(:subscription, subscriber_list: @duplicate_subscriber_list, subscriber: duplicate_subscriber)
+        end
+        it 'deactivates the subscription that is moved' do
+          RemoveCpsService.new.deactivate_subscriber_lists
+          expect(@subscription.reload.active?).to be false
+        end
+      end
+    end
+  end
+
+  describe '#delete_subscriber_lists' do
+    context 'there are subscriptions attached to a subscriber list' do
+      before :each do
+        @subscriber_list = FactoryBot.create(:subscriber_list_with_subscribers,
+                                             tags: tags,
+                                             content_purpose_supergroup: content_purpose_supergroup,
+                                             subscriber_count: 2)
+      end
+      it 'raises an error' do
+        expect {
+          RemoveCpsService.new.delete_subscriber_lists
+        }.to raise_error(StandardError)
+      end
+    end
+    context 'A duplicate subscriber list exists' do
+      before :each do
+        @subscriber_list = FactoryBot.create(:subscriber_list,
+                                             tags: tags,
+                                             content_purpose_supergroup: content_purpose_supergroup)
+        @duplicate_subscriber_list = FactoryBot.create(:subscriber_list, tags: updated_tags, content_purpose_supergroup: nil)
+      end
+      it 'deletes the list' do
+        subscriber_list_id = @subscriber_list.id
+        RemoveCpsService.new.delete_subscriber_lists
+        expect(SubscriberList.exists?(subscriber_list_id)).to be false
+      end
+      describe 'Move MatchedContentChanges' do
+        before :each do
+          @content_changes = FactoryBot.create_list(:matched_content_change, 5, subscriber_list: @subscriber_list)
+        end
+        it 'moves the matched content change to the duplicate list' do
+          RemoveCpsService.new.delete_subscriber_lists
+          @content_changes.each(&:reload)
+          expect(@content_changes.map(&:subscriber_list)).to all eq(@duplicate_subscriber_list)
+        end
+        context 'there is a duplicate content change' do
+          before :each do
+            duplicated_content_change = @content_changes.first
+            @duplicated_content_change_id = @content_changes.first.id
+
+            FactoryBot.create(:matched_content_change,
+                            subscriber_list: @duplicate_subscriber_list,
+                            content_change_id: duplicated_content_change.content_change_id)
+          end
+          it 'does not raise an error' do
+            expect { RemoveCpsService.new.delete_subscriber_lists }.to_not raise_error
+          end
+          it 'destroys the duplicate' do
+            RemoveCpsService.new.delete_subscriber_lists
+            expect(MatchedContentChange.exists?(@duplicate_content_change_id)).to be false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We will soon remove the 'content_purpose_supergroup' field in
the SubscriberLists. The content_purpose_supergroup is now
embedded in the 'tags' field.

This commit introduces rake tasks to get rid of any subscriber
lists with a value set in content_purpose_supergroup field.

This process is split into two tasks. The first moves all subscriptions
from the 'legacy' subscriber_lists to the new lists. The second removes
the now unused subscriber lists and moves all matched_content_changes
to their new counterparts. This is done so we avoid most
synchronisation issues that may arise.

trello: https://trello.com/c/NPTRaB1e/618-remove-supergroup-attribute-from-subscriber-lists-in-email-alert-api