### PR TITLE
Add rake task to update business finder subscriptions

### DIFF
--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -95,6 +95,48 @@ namespace :manage do
     end
   end
 
+  def update_business_finder_subscriptions
+    facet_group_content_id = "52435175-82ed-4a04-adef-74c0199d0f46".freeze
+
+    Subscription.transaction do
+      primary_business_finder_subscriber_list = SubscriberList.where(title: "EU Exit guidance for your business or organisation")
+      primary_business_finder_subscriber_list_id = primary_business_finder_subscriber_list.ids[0]
+
+      other_business_finder_subscriber_lists = SubscriberList.find_by_links_value(facet_group_content_id) - primary_business_finder_subscriber_list
+      other_business_finder_subscriber_list_ids = other_business_finder_subscriber_lists.map(&:id)
+
+      business_finder_subscriptions = Subscription.where(subscriber_list_id: other_business_finder_subscriber_list_ids)
+      subscriber_ids_that_moved_to_primary_subscriber_list = Subscription.where(subscriber_id: business_finder_subscriptions.map(&:subscriber_id)).where(subscriber_list_id: primary_business_finder_subscriber_list_id).map(&:subscriber_id)
+      subscriptions_to_move = business_finder_subscriptions.where.not(subscriber_id: subscriber_ids_that_moved_to_primary_subscriber_list)
+
+      subscriber_lists_to_change = SubscriberList.where(id: subscriptions_to_move.map(&:subscriber_list_id)).map(&:id)
+
+      subscriptions_to_move.each do |subscription|
+        old_subscriber_list = subscription.subscriber_list_id
+        subscription.subscriber_list_id = primary_business_finder_subscriber_list_id
+        subscription.save!
+        puts "Moved subscription #{subscription.id} from Subscriber List #{old_subscriber_list} to #{subscription.subscriber_list_id}"
+      end
+
+      # If Subscriber already moved to the primary, old Subscriptions remain under that Subscriber List and cannot be deleted
+      # Delete Subscriber Lists that have no Subscriptions
+      subscriber_lists_to_delete = []
+      subscriber_lists_to_change.each { |id|
+        subscriber_lists_to_delete << id if Subscription.where(subscriber_list_id: id) == []
+      }
+      SubscriberList.destroy(subscriber_lists_to_delete)
+
+      # If Subscriber List cannot be deleted, remove the links
+      subscriber_lists_to_remove_links = other_business_finder_subscriber_lists - subscriber_lists_to_delete
+
+      subscriber_lists_to_remove_links.each do |list|
+        list.links = {}
+        list.save!
+        puts "Removed facet_group links from Subscriber List #{list.id}"
+      end
+    end
+  end
+
   desc "Change the email address of a subscriber"
   task :change_email_address, %i[old_email_address new_email_address] => :environment do |_t, args|
     change_email_address(old_email_address: args[:old_email_address], new_email_address: args[:new_email_address])
@@ -155,5 +197,10 @@ namespace :manage do
   desc "Update subscriber list title and slug"
   task :update_subscriber_list, %i[slug new_title new_slug] => :environment do |_t, args|
     update_subscriber_list(slug: args[:slug], new_title: args[:new_title], new_slug: args[:new_slug])
+  end
+
+  desc "Update business finder subscriptions"
+  task update_business_finder_subscriptions: :environment do |_t|
+    update_business_finder_subscriptions
   end
 end


### PR DESCRIPTION
Since rolling out changes to subscribing users to business finder updates
(https://github.com/alphagov/finder-frontend/commit/bac5bf269ea30070af929ce4fd9c48a3c7fff80a),
the title for new subscriptions has become a long string, rather than "EU Exit
guidance for your business or organisation".

The rake task:
- moves Business Finder subscriptions to point to the primary SubscriberLists (id 18160)
- removes the Business Finder SubscriberLists which now don't have any Subscriptions
- removes `{"facet_groups"=>{"any"=>["52435175-82ed-4a04-adef-74c0199d0f46"]}}` from links of the SubscriberLists that still have Subscriptions. The Subscriptions cannot be deleted because we want to keep a record of subscription history

To run the rake task `bundle exec rake manage:update_business_finder_subscriptions`

[Trello card](https://trello.com/c/vueh4v07/98-fix-bug-in-business-finder-email-signup)