### PR TITLE
Remove remove_content_purpose_supergroup_from_subscriber_list migration

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -29,6 +29,11 @@ class SubscriberList < ApplicationRecord
     where(sql, id: "\"#{content_id}\"")
   end
 
+  #TODO Remove this once migration has been run
+  def self.columns
+    super.reject { |c| c.name == "content_purpose_supergroup" }
+  end
+
   def subscription_url
     PublicUrlService.subscription_url(slug: slug)
   end

--- a/db/migrate/20190503114015_remove_content_purpose_supergroup_from_subscriber_list.rb
+++ b/db/migrate/20190503114015_remove_content_purpose_supergroup_from_subscriber_list.rb
@@ -1,5 +1,0 @@
-class RemoveContentPurposeSupergroupFromSubscriberList < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :subscriber_lists, :content_purpose_supergroup, :string, limit: 100
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_03_114015) do
+ActiveRecord::Schema.define(version: 2019_04_12_121520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 2019_05_03_114015) do
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
+    t.string "content_purpose_supergroup", limit: 100
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"


### PR DESCRIPTION
This migration cannot be simply deployed in production because
Rails caches these columns and accessing them will cause errors
when hot-deploying.

