### PR TITLE
Adds 'find latest matching subscription' query

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -63,7 +63,8 @@ class SubscriptionsController < ApplicationController
   end
 
   def latest_matching
-    render json: { todo: true, comment: "Need to check that this method is correctly called!" }, status: ok
+    subscription = Subscription.find(subscription_params.require(:id))
+    render json: { subscription: FindLatestMatchingSubscription.call(subscription) }, status: ok
   end
 
 private

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -64,7 +64,7 @@ class SubscriptionsController < ApplicationController
 
   def latest_matching
     subscription = Subscription.find(subscription_params.require(:id))
-    render json: { subscription: FindLatestMatchingSubscription.call(subscription) }, status: ok
+    render json: { subscription: FindLatestMatchingSubscription.call(subscription) }, status: :ok
   end
 
 private

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -62,6 +62,10 @@ class SubscriptionsController < ApplicationController
     render json: { subscription: subscription }, status: :ok
   end
 
+  def latest_matching
+    render json: { todo: true, comment: "Need to check that this method is correctly called!" }, status: ok
+  end
+
 private
 
   def smoke_test_address?

--- a/app/queries/find_latest_matching_subscription.rb
+++ b/app/queries/find_latest_matching_subscription.rb
@@ -1,9 +1,11 @@
 class FindLatestMatchingSubscription
-  def self.call
-    new.call
-  end
-
-  def call(subscription)
-    # TODO - find the latest subscription that matches the given subscription's subscription_list and email address
+  def self.call(original_subscription)
+    subscriber_list_id = original_subscription.subscriber_list_id
+    subscriber_id = original_subscription.subscriber_id
+    frequency = original_subscription.frequency
+    Subscription.
+      where(subscriber_list_id: subscriber_list_id, subscriber_id: subscriber_id, frequency: frequency).
+      order("created_at DESC")
+      .first
   end
 end

--- a/app/queries/find_latest_matching_subscription.rb
+++ b/app/queries/find_latest_matching_subscription.rb
@@ -1,0 +1,9 @@
+class FindLatestMatchingSubscription
+  def self.call
+    new.call
+  end
+
+  def call(subscription)
+    # TODO - find the latest subscription that matches the given subscription's subscription_list and email address
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
     resources :status_updates, path: "status-updates", only: %i[create]
     resources :subscriptions, only: %i[create show update]
 
+    get "/subscriptions/:id/latest", to: "subscriptions#latest_matching"
+
     patch "/subscribers/:id", to: "subscribers#change_address"
     delete "/subscribers/:id", to: "unsubscribe#unsubscribe_all"
     get "/subscribers/:id/subscriptions", to: "subscribers#subscriptions"

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -60,19 +60,25 @@ RSpec.describe "Subscriptions", type: :request do
 
       it "lets you query the subscription" do
         get "/subscriptions/#{subscription.id}"
+        check_json_is_valid
+      end
+
+      it "lets you query for a more recent subscription" do
+        get "/subscriptions/#{subscription.id}/latest"
+        check_json_is_valid
+      end
+    end
+
+    context "with an existing subscription and an expired matching subscription" do
+      let(:subscriber_list) { create(:subscriber_list) }
+      let(:subscriber) { create(:subscriber, address: "test@example.com") }
+      let!(:old_subscription) { create(:subscription, :ended, subscriber_list: subscriber_list, subscriber: subscriber, created_at: 1000.days.ago) }
+      let!(:new_subscription) { create(:subscription, subscriber_list: subscriber_list, subscriber: subscriber) }
+
+      it "returns a more recent subscription if it exists" do
+        get "/subscriptions/#{old_subscription.id}/latest"
         expect(response.status).to eq(200)
-        expect(data[:subscription].keys).to match_array(%i(
-          id
-          subscriber_list
-          subscriber
-          created_at
-          updated_at
-          ended_at
-          ended_reason
-          ended_email_id
-          frequency
-          source
-        ))
+        expect(data[:subscription][:id]).to eq new_subscription.id
       end
     end
 
@@ -178,4 +184,20 @@ RSpec.describe "Subscriptions", type: :request do
       expect(response.status).to eq(403)
     end
   end
+end
+
+def check_json_is_valid
+  expect(response.status).to eq(200)
+  expect(data[:subscription].keys).to match_array(%i(
+    id
+    subscriber_list
+    subscriber
+    created_at
+    updated_at
+    ended_at
+    ended_reason
+    ended_email_id
+    frequency
+    source
+  ))
 end

--- a/spec/queries/find_latest_matching_subscription_spec.rb
+++ b/spec/queries/find_latest_matching_subscription_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe FindLatestMatchingSubscription do
+  let!(:subscriber) { create(:subscriber) }
+  let!(:subscriber_list) { create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
+  let!(:original_subscription) { create_subscription(:ended, :daily, created_at: 5.days.ago) }
+  # `let` (as opposed to `let!`) is lazy, so value will vary according to other subscriptions
+  # that have been created, therefore we can safely assert against it
+  let(:subject) { described_class.call(original_subscription) }
+
+  context "when only one subscription exists" do
+    it "should return the original subscription" do
+      expect(subject).to eq(original_subscription)
+    end
+  end
+
+  context "when an older subscription exists" do
+    it "should return the original subscription" do
+      create_subscription(:ended, :daily, created_at: 100.days.ago)
+      expect(subject).to eq(original_subscription)
+    end
+  end
+
+  context "when a newer subscription exists" do
+    context "the newer subscription's frequency does not match the given subscription's frequency" do
+      it "should return the original subscription" do
+        create_subscription(:weekly, created_at: Time.now)
+        expect(subject).to eq(original_subscription)
+      end
+    end
+
+    context "the newer subscription's frequency matches the given subscription's frequency" do
+      it "should return the newer subscription" do
+        newer_subscription = create_subscription(:daily, created_at: Time.now)
+        expect(subject).to eq(newer_subscription)
+      end
+
+      it "should return the newer subscription, even if that one has also ended" do
+        newer_subscription = create_subscription(:ended, :daily, created_at: Time.now)
+        expect(subject).to eq(newer_subscription)
+      end
+    end
+  end
+
+  def create_subscription(*traits, options)
+    subscription_args = { subscriber_list: subscriber_list, subscriber: subscriber }.merge(options)
+    create(:subscription, *traits, subscription_args)
+  end
+end


### PR DESCRIPTION
In order to facilitiate Trello card: https://trello.com/c/VlnvU2Dl
Depended on by: https://github.com/alphagov/gds-api-adapters/pull/928

## What

This PR:

-  adds a `/subscriptions/:id/latest` route which calls a new query, `FindLatestMatchingSubscription`. This query fetches the most *recent* subscription that matches the given subscription, i.e. has the same subscriber, subscription list and frequency.
- tests the route
- tests the logic added in `FindLatestMatchingSubscription`

## Why

It's intended to be used to detect unsubscribe requests from old subscription emails that the user may have clicked on, as this is the same subscription conceptually. In most cases this will simply return the original subscription, as a newer one won't exist.

Where there are multiple subscriptions that match the parameters, the query will return the one with the most recent `created_at`. This should be safe given:

- When a user changes their subscription through frequency change
- ...and when a user changes through unsubscribing and resubscribing
- ...a new subscription is created every time, with a more recent 'created_at'.
- In other words, it's not possible for an older record that has become inactive to become active again. It will always be a new subscription.
