### PR TITLE
Retrieve first id for EU Exit finder subscription list

### DIFF
--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -96,7 +96,7 @@ namespace :manage do
   end
 
   def update_business_finder_subscriptions
-    primary_business_finder_subscriber_list_id = SubscriberList.find_by(title: "EU Exit guidance for your business or organisation").pluck(:id)
+    primary_business_finder_subscriber_list_id = SubscriberList.where(title: "EU Exit guidance for your business or organisation").pluck(:id).first
 
     other_business_finder_subscriber_lists = SubscriberList
       .where.not(id: primary_business_finder_subscriber_list_id)


### PR DESCRIPTION
Fixes error introduced in https://github.com/alphagov/email-alert-api/pull/860 when finding the primary EU Exit subscription list.