### PR TITLE
Removes frequency from FindLatestMatchingSubscription query

### DIFF
--- a/app/queries/find_latest_matching_subscription.rb
+++ b/app/queries/find_latest_matching_subscription.rb
@@ -2,10 +2,9 @@ class FindLatestMatchingSubscription
   def self.call(original_subscription)
     subscriber_list_id = original_subscription.subscriber_list_id
     subscriber_id = original_subscription.subscriber_id
-    frequency = original_subscription.frequency
-    Subscription.
-      where(subscriber_list_id: subscriber_list_id, subscriber_id: subscriber_id, frequency: frequency).
-      order("created_at DESC")
+    Subscription
+      .where(subscriber_list_id: subscriber_list_id, subscriber_id: subscriber_id)
+      .order("created_at DESC")
       .first
   end
 end

--- a/spec/queries/find_latest_matching_subscription_spec.rb
+++ b/spec/queries/find_latest_matching_subscription_spec.rb
@@ -20,23 +20,19 @@ RSpec.describe FindLatestMatchingSubscription do
   end
 
   context "when a newer subscription exists" do
-    context "the newer subscription's frequency does not match the given subscription's frequency" do
-      it "should return the original subscription" do
-        create_subscription(:weekly, created_at: Time.now)
-        expect(subject).to eq(original_subscription)
-      end
+    it "should return the newer subscription" do
+      newer_subscription = create_subscription(:daily, created_at: Time.now)
+      expect(subject).to eq(newer_subscription)
     end
 
-    context "the newer subscription's frequency matches the given subscription's frequency" do
-      it "should return the newer subscription" do
-        newer_subscription = create_subscription(:daily, created_at: Time.now)
-        expect(subject).to eq(newer_subscription)
-      end
+    it "should return the newer subscription, even if the frequency is different" do
+      newer_subscription = create_subscription(:weekly, created_at: Time.now)
+      expect(subject).to eq(newer_subscription)
+    end
 
-      it "should return the newer subscription, even if that one has also ended" do
-        newer_subscription = create_subscription(:ended, :daily, created_at: Time.now)
-        expect(subject).to eq(newer_subscription)
-      end
+    it "should return the newer subscription, even if that one has also ended" do
+      newer_subscription = create_subscription(:daily, :ended, created_at: Time.now)
+      expect(subject).to eq(newer_subscription)
     end
   end
 


### PR DESCRIPTION
Fixes a logic error introduced in #856.
Depended on by https://github.com/alphagov/email-alert-frontend/pull/474
See Trello https://trello.com/c/VlnvU2Dl. 

## What

Removes frequency from the `FindLatestMatchingSubscription` check, and updates the tests to describe the behaviour we now expect.

## Why

We always need this to retrieve the _latest_ subscription, regardless of frequency, otherwise we're limited in what we can offer the user.

For example, a user who changes frequency from Daily to Weekly and then clicks Unsubscribe from an old Daily email would continue to see "You're already unsubscribed", as `/latest` would currently return the expired Daily subscription rather than the active Weekly subscription.

In this case, what we would actually like to do is redirect the user to manage their subscriptions, rather than display a potentially confusing message. This is not possible without removing frequency from the query here.

We can then implement the logic we want here: https://github.com/alphagov/email-alert-frontend/pull/474
