### PR TITLE
[do-not-merge] Add migration to add type field to subscriber_lists

### DIFF
--- a/db/migrate/20190522114020_add_type_to_subscriber_list.rb
+++ b/db/migrate/20190522114020_add_type_to_subscriber_list.rb
@@ -1,0 +1,5 @@
+class AddTypeToSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_03_114015) do
+ActiveRecord::Schema.define(version: 2019_05_22_114020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 2019_05_03_114015) do
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
+    t.string "type"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"


### PR DESCRIPTION
So we can use Single Type inheritance for subscriber_lists

Trello: https://trello.com/c/y6ZhETsr/130-implement-a-joined-subscriber-list-model-in-email-alert-api-recommended-%F0%9F%8D%90

Joint effort with @AgaDufrat 