### PR TITLE
Adds or joined facet subscriber list

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -39,7 +39,13 @@ private
       title: title,
       slug: slug,
       signon_user_uid: current_user.uid,
+      type: type
     )
+  end
+
+  def type
+    combine_mode = params[:combine_mode].present? && params[:combine_mode] == "or"
+    combine_mode ? 'OrJoinedFacetSubscriberList' : ''
   end
 
   def convert_legacy_params(link_or_tags)

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -39,7 +39,6 @@ private
       title: title,
       slug: slug,
       signon_user_uid: current_user.uid,
-      type: type
     )
   end
 
@@ -56,7 +55,7 @@ private
 
   def find_exact_query_params
     permitted_params = params.permit!.to_h
-    {
+    exact_query_params = {
       tags: convert_legacy_params(permitted_params.fetch(:tags, {})),
       links: convert_legacy_params(permitted_params.fetch(:links, {})),
       document_type: permitted_params.fetch(:document_type, ""),
@@ -64,6 +63,8 @@ private
       government_document_supertype: permitted_params.fetch(:government_document_supertype, ""),
       slug: params[:gov_delivery_id],
     }
+    exact_query_params[:type] = type if params[:combine_mode].present?
+    exact_query_params
   end
 
   def slugify(title)

--- a/app/models/or_joined_facet_subscriber_list.rb
+++ b/app/models/or_joined_facet_subscriber_list.rb
@@ -1,0 +1,2 @@
+class OrJoinedFacetSubscriberList < SubscriberList
+end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -44,7 +44,7 @@ class SubscriberList < ApplicationRecord
   def to_json(options = {})
     options[:except] ||= %i{signon_user_uid}
     options[:methods] ||= %i{subscription_url gov_delivery_id active_subscriptions_count}
-    super(options)
+    convert_to_subscriber_list_json(as_json(options))
   end
 
   def is_travel_advice?
@@ -75,5 +75,17 @@ private
         %i[all any].include?(operator) && values.is_a?(Array)
       end
     end
+  end
+
+  def convert_to_subscriber_list_json(subscriber_list_hash)
+    # If it is already correct, just return
+    return ActiveSupport::JSON.encode(subscriber_list_hash) if subscriber_list_hash.has_key?("subscriber_list")
+
+    # to_json and as_json will return a hash with the root key as
+    # or_joined_facet_subscriber_list, for that type which
+    # will make breaking changes.
+    # Instead, just change the root key to 'subscriber_list'
+    result_with_super_table_type = { "subscriber_list" => subscriber_list_hash.delete(type.underscore) }
+    ActiveSupport::JSON.encode(result_with_super_table_type)
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -18,7 +18,7 @@ class Subscription < ApplicationRecord
   end
 
   def as_json(options = {})
-    options[:except] ||= %i(signon_user_uid subscriber_list_id subscriber_id)
+    options[:except] ||= %i(signon_user_uid subscriber_list_id or_joined_subscriber_list_id subscriber_id)
     options[:include] ||= %i(subscriber_list subscriber)
     super(options)
   end

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -7,7 +7,8 @@ class FindExactQuery
     document_type:,
     email_document_supertype:,
     government_document_supertype:,
-    slug: nil
+    slug: nil,
+    type: nil
   )
     @tags = tags.deep_symbolize_keys
     @links = links.deep_symbolize_keys
@@ -15,6 +16,7 @@ class FindExactQuery
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
     @slug = slug
+    @type = type
   end
 
   def exact_match
@@ -33,6 +35,7 @@ private
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)
       scope = scope.where(slug: @slug) if @slug.present?
+      scope = scope.where(type: @type) if @type.present?
       scope
     end
   end

--- a/app/queries/matched_for_notification.rb
+++ b/app/queries/matched_for_notification.rb
@@ -7,46 +7,70 @@ class MatchedForNotification
   end
 
   # Filter out subscriber lists:
-  # - where the keys from the supplied hash are a superset of the keys in the specified query_field AND
+  # - where the keys from the supplied hash:
+  #   - Have a superset of the keys in the specified query_field for subscriber_lists
+  #   - Have an overlap with  the keys in the specified query_field for or_joined_facet_subscriber_lists
+  # - AND
   # - If the operator is 'any':
   #     the key values in the subscriber list have at least one corresponding match in the supplied hash.
   # - If the operator is 'all'
   #   all key values in the subscriber list have corresponding matches in the supplied hash.
-  # Note that this means that not all keys from the the supplied hash are required to be matched.
   def call(content_item_tags_or_links)
     return [] unless content_item_tags_or_links.present?
 
     content_item_tags_or_links = content_item_tags_or_links.deep_symbolize_keys
 
     only_contains_keys(content_item_tags_or_links.keys).select do |subscriber_list|
-      subscriber_list_tags_or_links = subscriber_list.send(@query_field) # send ensures the keys are symbols
-
-      subscriber_list_tags_or_links.keys.all? do |key|
-        content_item_values = Array(content_item_tags_or_links[key])
-        any_values = subscriber_list_tags_or_links[key].fetch(:any, [])
-        all_values = subscriber_list_tags_or_links[key].fetch(:all, [])
-
-        (all_values - content_item_values).empty? &&
-          (any_values.empty? || (any_values & content_item_values).any?)
-      end
+      filter_tags_or_links(subscriber_list, content_item_tags_or_links)
     end
   end
 
 private
 
-  # Return all SubscriberLists which have a subset of keys from those requested.
+  def filter_tags_or_links(subscriber_list, content_item_tags_or_links)
+    operator = subscriber_list.type == 'OrJoinedFacetSubscriberList' ? :any? : :all?
+    subscriber_list_tags_or_links = subscriber_list.send(@query_field) # send ensures the keys are symbols
+    subscriber_list_tags_or_links.keys.send(operator) do |key|
+      content_item_values = Array(content_item_tags_or_links[key])
+      any_values = subscriber_list_tags_or_links[key].fetch(:any, [])
+      all_values = subscriber_list_tags_or_links[key].fetch(:all, [])
+
+      (all_values - content_item_values).empty? &&
+        (any_values.empty? || (any_values & content_item_values).any?)
+    end
+  end
+
+  # Returns:
+  #
+  # all SubscriberLists which have a subset of keys from those requested.
   # For example, if `links` is:
   #
   #     {"topics": [...], "organisations": [...]}
   #
   # then this returns all lists which have only "topics" and/or "organisations"
   # links, but not those with "topics" and "policies"
+  #
+  # all OrJoinedFacetSubscriberLists which has an intersection of keys from those requested
+  # For example, if `links` is:
+  #
+  #     {"topics": [...], "organisations": [...]}
+  #
+  # then this returns all lists which have "topics" and/or "organisations"
+  # or "topics" and "policies"
   def only_contains_keys(keys)
     # This uses the <@` array operator, which returns true if the all the items in the left
     # side array are contained in the right side array
     @scope
+      .where(type: ["", nil])
       .where("#{@query_field}::text != '{}'")
       .where("ARRAY(SELECT json_object_keys(#{@query_field})) <@ Array[:keys]",
-             keys: keys,)
+             keys: keys,) +
+    # This uses the &&` array operator, which returns true if there is an intersection between
+    # the items in the left side array and those contained in the right side array
+      @scope
+          .where(type: "OrJoinedFacetSubscriberList")
+          .where("#{@query_field}::text != '{}'")
+          .where("ARRAY(SELECT json_object_keys(#{@query_field})) && Array[:keys]",
+                 keys: keys,)
   end
 end

--- a/db/migrate/20190522114020_add_type_to_subscriber_list.rb
+++ b/db/migrate/20190522114020_add_type_to_subscriber_list.rb
@@ -1,0 +1,5 @@
+class AddTypeToSubscriberList < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_03_114015) do
+ActiveRecord::Schema.define(version: 2019_05_22_114020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 2019_05_03_114015) do
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
+    t.string "type"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -124,6 +124,21 @@ FactoryBot.define do
     end
   end
 
+  factory :or_joined_facet_subscriber_list do
+    sequence(:title) { |n| "or joined title #{n}" }
+    sequence(:slug) { |n| "or-joined-title-#{n}" }
+    tags { { topics: { any: ["motoring/road_rage"] } } }
+    created_at { 1.year.ago }
+
+    trait :travel_advice do
+      links { { countries: { any: [SecureRandom.uuid] } } }
+    end
+
+    trait :medical_safety_alert do
+      tags { { format: %w[medical_safety_alert], alert_type: %w(devices drugs field-safety-notices company-led-drugs) } }
+    end
+  end
+
   factory :subscription do
     subscriber
     subscriber_list

--- a/spec/features/creating_subscriber_list_spec.rb
+++ b/spec/features/creating_subscriber_list_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Creating subscriber lists", type: :request do
   scenario "creating and looking up subscriber lists where the facets are joined with or" do
     login_with(%w(internal_app status_updates))
 
-    params = { title: "Example", tags: {}, links: { person: { any: ["test-123"] } } }
+    params = { title: "Example", tags: {}, links: { person: { any: ["test-123"] } }, combine_mode: "or" }
 
     lookup_subscriber_list_by_slug("example", expected_status: 404)
     lookup_subscriber_list(params, expected_status: 404)
@@ -30,13 +30,49 @@ RSpec.describe "Creating subscriber lists", type: :request do
     create_or_joined_facet_subscriber_list(links: { person: { any: ["test-123"] } })
 
     lookup_subscriber_list_by_slug("example", expected_status: 200)
-    expect(data.fetch(:subscriber_list)).to include(params)
+    expect(data.fetch(:subscriber_list)).to include(params.except(:combine_mode))
 
     lookup_subscriber_list(params, expected_status: 200)
-    expect(data.fetch(:subscriber_list)).to include(params)
+    expect(data.fetch(:subscriber_list)).to include(params.except(:combine_mode))
 
     gov_delivery_id = data.dig(:subscriber_list, :gov_delivery_id)
     expect(gov_delivery_id).to eq("example")
+  end
+
+  scenario "creating and looking up subscriber_list and or_joined_facet_subscriber_list with same facets" do
+    login_with(%w(internal_app status_updates))
+    links_params = { person: { any: ["test-123"] } }
+    facets = { title: "Example", tags: {}, links: links_params }
+
+    subscriber_list_params = facets.merge(combine_mode: "")
+    or_joined_facet_subscriber_list_params = facets.merge(combine_mode: "or")
+
+    lookup_subscriber_list(subscriber_list_params, expected_status: 404)
+    lookup_subscriber_list(or_joined_facet_subscriber_list_params, expected_status: 404)
+
+    create_subscriber_list(links: links_params)
+
+    lookup_subscriber_list(subscriber_list_params, expected_status: 200)
+    lookup_subscriber_list(or_joined_facet_subscriber_list_params, expected_status: 404)
+
+    create_or_joined_facet_subscriber_list(links: links_params)
+
+    lookup_subscriber_list(subscriber_list_params, expected_status: 200)
+    lookup_subscriber_list(or_joined_facet_subscriber_list_params, expected_status: 200)
+  end
+
+  scenario "creating and looking up subscriber_list and or_joined_facet_subscriber_list with the same params without combine_mode param" do
+    # It will simply return the first subscriber_list of any type, in this case, the or_joined_facet_subscriber_list
+    login_with(%w(internal_app status_updates))
+    params = { title: "Example", tags: {}, links: { person: { any: ["test-123"] } } }
+
+    lookup_subscriber_list(params, expected_status: 404)
+
+    create_subscriber_list(links: { person: { any: ["test-123"] } })
+    or_joined_facet_subscriber_list_id = create_or_joined_facet_subscriber_list(links: { person: { any: ["test-123"] } })
+
+    lookup_subscriber_list(params, expected_status: 200)
+    assert_equal or_joined_facet_subscriber_list_id, data[:subscriber_list][:id]
   end
 
   scenario "creating and looking up legacy subscriber lists" do

--- a/spec/features/creating_subscriber_list_spec.rb
+++ b/spec/features/creating_subscriber_list_spec.rb
@@ -19,6 +19,26 @@ RSpec.describe "Creating subscriber lists", type: :request do
     expect(gov_delivery_id).to eq("example")
   end
 
+  scenario "creating and looking up subscriber lists where the facets are joined with or" do
+    login_with(%w(internal_app status_updates))
+
+    params = { title: "Example", tags: {}, links: { person: { any: ["test-123"] } } }
+
+    lookup_subscriber_list_by_slug("example", expected_status: 404)
+    lookup_subscriber_list(params, expected_status: 404)
+
+    create_or_joined_facet_subscriber_list(links: { person: { any: ["test-123"] } })
+
+    lookup_subscriber_list_by_slug("example", expected_status: 200)
+    expect(data.fetch(:subscriber_list)).to include(params)
+
+    lookup_subscriber_list(params, expected_status: 200)
+    expect(data.fetch(:subscriber_list)).to include(params)
+
+    gov_delivery_id = data.dig(:subscriber_list, :gov_delivery_id)
+    expect(gov_delivery_id).to eq("example")
+  end
+
   scenario "creating and looking up legacy subscriber lists" do
     login_with(%w(internal_app status_updates))
 

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -24,4 +24,33 @@ RSpec.describe "Sending an email", type: :request do
     expect(body).to include("[Unsubscribe from ‘Example’]")
     expect(body).to include("gov.uk/email/unsubscribe/")
   end
+
+  scenario "sending an email for a subscription to an or_joined_facet_subscriber_list" do
+    login_with_internal_app
+    facets = {
+        links: {
+            topics: { all: %w(topic_one) },
+            organisations: { all: %w(organisation_1) }
+        }
+    }
+    and_joined_subscriber_list_id = create_subscriber_list(facets.merge(title: "And joined list"))
+    or_joined_subscriber_list_id = create_or_joined_facet_subscriber_list(facets.merge(title: "Or joined list"))
+    subscribe_to_subscriber_list(or_joined_subscriber_list_id)
+    subscribe_to_subscriber_list(and_joined_subscriber_list_id)
+    create_content_change(links: { topics: %w(topic_one) })
+    email_data = expect_an_email_was_sent
+
+    address = email_data.dig(:email_address)
+    subject = email_data.dig(:personalisation, :subject)
+    body = email_data.dig(:personalisation, :body)
+
+    expect(address).to eq("test@test.com")
+    expect(subject).to eq("GOV.UK update – Title")
+
+    expect(body).to include("Description")
+    expect(body).to include("gov.uk/base-path")
+    expect(body).to include("12:00am, 1 January 2017: Change note")
+    expect(body).to include("[Unsubscribe from ‘Or joined list’]")
+    expect(body).to include("gov.uk/email/unsubscribe/")
+  end
 end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(SubscriberList.count).to eq(1)
     end
 
+    it "creates an or_joined_subscriber_list" do
+      create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
+                                     taxon_tree: { all: %w[taxon1 taxon2] } },
+                             combine_mode: "or")
+
+      expect(OrJoinedFacetSubscriberList.count).to eq(1)
+    end
+
     it "returns a 201" do
       create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
                                      taxon_tree: { all: %w[taxon1 taxon2] } })

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -120,4 +120,44 @@ RSpec.describe SubscriberList, type: :model do
       )
     end
   end
+
+  describe "#to_json for a record without a type" do
+    subject { SubscriberList.new }
+
+    it "returns a hash as a subscriber list" do
+      assert subject.to_json.is_a?(String)
+      parsed_json = JSON.parse(subject.to_json)
+      assert parsed_json.has_key?("subscriber_list")
+      assert_equal expected_subscriber_list_keys,
+                   parsed_json["subscriber_list"].keys
+    end
+  end
+
+  describe "#to_json for an OrJoinedFacetSubscriberList" do
+    subject { OrJoinedFacetSubscriberList.new }
+
+    it "returns a hash as a subscriber list" do
+      assert subject.to_json.is_a?(String)
+      parsed_json = JSON.parse(subject.to_json)
+      assert parsed_json.has_key?("subscriber_list")
+      assert_equal expected_subscriber_list_keys,
+                   parsed_json["subscriber_list"].keys
+    end
+  end
+
+  def expected_subscriber_list_keys
+    %w(id
+       title
+       created_at
+       updated_at
+       document_type
+       tags
+       links
+       email_document_supertype
+       government_document_supertype
+       slug
+       subscription_url
+       gov_delivery_id
+       active_subscriptions_count)
+  end
 end

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -81,20 +81,52 @@ RSpec.describe MatchedForNotification do
         lists = execute_query(topics: %w(vat tax licensing))
         expect(lists).to eq([@all_topics_tax_vat_any_topics_licensing_paye])
       end
+
+      it "does not find subscriber list for mixture of all and any topics when not all topics present" do
+        lists = execute_query(field: :links, query_hash: { topics: %w(vat licensing) })
+        expect(lists).not_to include(@all_topics_tax_vat_any_topics_licensing_paye)
+      end
     end
 
-    context "matches on all of both topics and organisations" do
+    context "matches on all topics and any policies" do
       before do
-        @all_topics_tax_vat_all_orgs_defra_hmrc = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax) }, organisations: { all: %w(defra hmrc) })
-        @all_topics_vat_organisations_defra_hmrc = create_subscriber_list_with_tags_facets(topics: { all: %w(paye schools) }, organisations: { all: %w(defra dfe) })
+        @all_topics_tax_vat_any_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax) }, policies: { any: %w(economy industry) })
+        @all_topics_vat_any_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w(paye schools) }, policies: { any: %w(economy industry) })
       end
 
-      it "finds subscriber lists matching a mix of all topics and organisations" do
-        lists = execute_query(topics: %w(vat tax licensing), organisations: %w(defra hmrc oft))
-        expect(lists).to eq([@all_topics_tax_vat_all_orgs_defra_hmrc])
+      it "finds subscriber lists matching a mix of all topics and any policies" do
+        lists = execute_query(topics: %w(vat tax), policies: %w(economy industry))
+        expect(lists).to eq([@all_topics_tax_vat_any_policies_economy_industry])
+      end
+
+      it "does not find subscriber list for mix of all topics and any policies when not all topics present" do
+        lists = execute_query(field: :links, query_hash: { topics: %w(vat), policies: %w(economy) })
+        expect(lists).not_to include(@all_topics_tax_vat_any_policies_economy_industry)
       end
     end
 
+    context "matches on all topics and all policies" do
+      before do
+        @all_topics_tax_vat = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax) })
+        @all_topics_tax_vat_all_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax) }, policies: { all: %w(economy industry) })
+        @all_topics_vat_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w(paye schools) }, policies: { all: %w(economy broadband) })
+      end
+
+      it "finds subscriber lists matching a mix of all topics and policies" do
+        lists = execute_query(topics: %w(vat tax licensing), policies: %w(economy industry))
+        expect(lists).to include(@all_topics_tax_vat_all_policies_economy_industry)
+      end
+
+      it "does not find subscriber list for all topics when not all topics present" do
+        lists = execute_query(topics: %w(vat schools))
+        expect(lists).not_to include(@all_topics_tax_vat)
+      end
+
+      it "does not find subscriber list for mix of all topics and policies when not all policies present" do
+        lists = execute_query(topics: %w(vat tax ufos), policies: %w(economy acceptable_footwear))
+        expect(lists).to_not include(@all_topics_tax_vat_all_policies_economy_schools)
+      end
+    end
 
     context "or_joined_subscriber_lists match on tag and links keys" do
       before do
@@ -206,7 +238,6 @@ RSpec.describe MatchedForNotification do
         end
       end
     end
-
 
     context "can return subscriber_lists and or_joined_facet_subscriber_lists" do
       before do

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -1,162 +1,266 @@
 RSpec.describe MatchedForNotification do
   describe "#call" do
     before do
-      @list1 = create(:subscriber_list, tags: {
-        topics: { any: ["oil-and-gas/licensing"] }, organisations: { any: ["environment-agency", "hm-revenue-customs"] }
+      @subscriber_list_that_should_never_match = create(:subscriber_list, tags: {
+        topics: { any: ["Badical Turbo Radness"] }, organisations: { any: ["Sirius Cybernetics Corporation"] }
       })
-
-      @list2 = create(:subscriber_list, tags: {
-        topics: { any: ["business-tax/vat", "oil-and-gas/licensing"] }
-      })
-
-      @list3 = create(:subscriber_list, links: { topics: { any: ["uuid-123"] }, policies: { any: ["uuid-888"] } })
-
-      @list4 = create(:subscriber_list,
-                      links: { topics: { any: ["uuid-123"] } },
-                      tags: {
-                        topics: { any: ["environmental-management/boating"] },
-                      })
-
-      @list5 = create(:subscriber_list, links: { topics: { all: ["uuid-123", "uuid-234"] } })
-
-      @list6 = create(:subscriber_list, links: { topics: { all: ["uuid-345", "uuid-456"], any: ["uuid-567", "uuid-678"] } })
-
-      @list7 = create(:subscriber_list, links: { topics:
-                                                   {
-                                                     all: ["uuid-345", "uuid-456"]
-                                                   },
-                                                  policies:
-                                                   {
-                                                     all: ["uuid-567", "uuid-678"]
-                                                   } })
-
-      @list8 = create(:subscriber_list, links: { topics:
-                                                   {
-                                                     all: ["uuid-345", "uuid-456"]
-                                                   },
-                                                  policies:
-                                                   {
-                                                     any: ["uuid-567", "uuid-678"]
-                                                   } })
     end
 
-    def execute_query(field:, query_hash:)
+    def create_subscriber_list_with_tags_facets(facets)
+      create(:subscriber_list, tags: facets)
+    end
+
+    def create_subscriber_list_with_links_facets(facets)
+      create(:subscriber_list, links: facets)
+    end
+
+    def create_or_joined_facet_subscriber_list_with_tags_facets(facets)
+      create(:or_joined_facet_subscriber_list, tags: facets)
+    end
+
+    def create_or_joined_facet_subscriber_list_with_links_facets(facets)
+      create(:or_joined_facet_subscriber_list, links: facets)
+    end
+
+    def execute_query(query_hash, field: :tags)
       described_class.new(query_field: field).call(query_hash)
     end
 
-    it "finds subscriber lists where at least one value of each link in the subscription is present in the query_hash" do
-      lists = execute_query(field: :tags, query_hash: { topics: ["oil-and-gas/licensing"] })
-      expect(lists).to eq([@list2])
+    context "subscriber_lists match on tag and links keys" do
+      before do
+        @lists = {
+          tags:
+            {
+              any_topic_paye_any_org_defra_hmrc: create_subscriber_list_with_tags_facets(topics: { any: %w(paye) }, organisations: { any: %w(defra hmrc) }),
+              any_topic_vat_licensing: create_subscriber_list_with_tags_facets(topics: { any: %w(vat licensing) }),
+            },
+          links:
+            {
+              any_topic_paye_any_org_defra_hmrc: create_subscriber_list_with_links_facets(topics: { any: %w(paye) }, organisations: { any: %w(defra hmrc) }),
+              any_topic_vat_licensing: create_subscriber_list_with_links_facets(topics: { any: %w(vat licensing) }),
+            }
+        }
+      end
 
-      lists = execute_query(field: :tags, query_hash: { topics: ["business-tax/vat"] })
-      expect(lists).to eq([@list2])
+      %i(links tags).each do |key|
+        it "finds subscriber lists where at least one value of each #{key} in the subscription is present in the query_hash" do
+          lists = execute_query({ topics: %w(paye), organisations: %w(defra) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_paye_any_org_defra_hmrc]])
 
-      lists = execute_query(field: :tags, query_hash: {
-        topics: ["oil-and-gas/licensing"], organisations: ["environment-agency"]
-      })
-      expect(lists).to eq([@list1, @list2])
+          lists = execute_query({ topics: %w(paye), organisations: %w(hmrc) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_paye_any_org_defra_hmrc]])
 
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-123"], policies: ["uuid-888"] })
-      expect(lists).to eq([@list3, @list4])
+          lists = execute_query({ topics: %w(vat) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_vat_licensing]])
 
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-123"] })
-      expect(lists).to eq([@list4])
+          lists = execute_query({ topics: %w(licensing) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_vat_licensing]])
+        end
+      end
     end
 
-    it 'finds subscriber lists matching all topics' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-234", "uuid-123"] })
-      expect(lists).to include(@list5)
+    context "matches on all topics" do
+      before do
+        @all_topics_tax_vat = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax) })
+        @all_topics_tax_vat_licensing = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax licensing) })
+      end
+
+      it "finds subscriber lists matching all topics" do
+        lists = execute_query(topics: %w(vat tax))
+        expect(lists).to eq([@all_topics_tax_vat])
+      end
     end
 
-    it 'does not find subscriber list for all topics when not all topics present' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-234", "other2"] })
-      expect(lists).not_to include(@list5)
+    context "matches on any and all topics" do
+      before do
+        @all_topics_tax_vat_any_topics_licensing_paye = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax), any: %w(licensing paye) })
+        @all_topics_tax_vat_licensing_any_topics_paye = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax schools), any: %w(paye) })
+      end
+
+      it "finds subscriber lists matching on both of all and one of any topics" do
+        lists = execute_query(topics: %w(vat tax licensing))
+        expect(lists).to eq([@all_topics_tax_vat_any_topics_licensing_paye])
+      end
     end
 
-    it 'finds subscriber lists matching any and all topics' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-678", "uuid-456"] })
-      expect(lists).to include(@list6)
+    context "matches on all of both topics and organisations" do
+      before do
+        @all_topics_tax_vat_all_orgs_defra_hmrc = create_subscriber_list_with_tags_facets(topics: { all: %w(vat tax) }, organisations: { all: %w(defra hmrc) })
+        @all_topics_vat_organisations_defra_hmrc = create_subscriber_list_with_tags_facets(topics: { all: %w(paye schools) }, organisations: { all: %w(defra dfe) })
+      end
+
+      it "finds subscriber lists matching a mix of all topics and organisations" do
+        lists = execute_query(topics: %w(vat tax licensing), organisations: %w(defra hmrc oft))
+        expect(lists).to eq([@all_topics_tax_vat_all_orgs_defra_hmrc])
+      end
     end
 
-    it 'does not find subscriber list for mixture of all and any topics when not all topics present' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-678"] })
-      expect(lists).not_to include(@list6)
+
+    context "or_joined_subscriber_lists match on tag and links keys" do
+      before do
+        @lists = {
+          tags:
+            {
+              any_topic_paye_any_org_defra_hmrc: create_or_joined_facet_subscriber_list_with_tags_facets(topics: { any: %w(paye) }, organisations: { any: %w(defra hmrc) }),
+              any_topic_vat_licensing: create_or_joined_facet_subscriber_list_with_tags_facets(topics: { any: %w(vat licensing) }),
+            },
+          links:
+            {
+              any_topic_paye_any_org_defra_hmrc: create_or_joined_facet_subscriber_list_with_links_facets(topics: { any: %w(paye) }, organisations: { any: %w(defra hmrc) }),
+              any_topic_vat_licensing: create_or_joined_facet_subscriber_list_with_links_facets(topics: { any: %w(vat licensing) }),
+            }
+        }
+      end
+
+      %i(links tags).each do |key|
+        it "finds subscriber lists where at least one value of each #{key} in the subscription is present in the query_hash" do
+          lists = execute_query({ topics: %w(paye), organisations: %w(defra) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_paye_any_org_defra_hmrc]])
+
+          lists = execute_query({ topics: %w(paye), organisations: %w(hmrc) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_paye_any_org_defra_hmrc]])
+
+          lists = execute_query({ topics: %w(vat) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_vat_licensing]])
+
+          lists = execute_query({ topics: %w(licensing) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_vat_licensing]])
+        end
+      end
     end
 
-    it 'finds subscriber lists matching a mix of all topics and policies' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456", "other1"],
-                                                         policies: ["uuid-567", "uuid-678", "other2"] })
-      expect(lists).to include(@list7)
+    context "finds or_joined_subscription lists for the right query hash for 'any' facets" do
+      before do
+        @lists = {
+          tags: {
+            or_joined_topics_vat_organisations_hrmc_defra: create_or_joined_facet_subscriber_list_with_tags_facets(topics: { any: %w(vat) }, organisations: { any: %w(hmrc defra) }),
+          },
+          links: {
+            or_joined_topics_vat_organisations_hrmc_defra: create_or_joined_facet_subscriber_list_with_links_facets(topics: { any: %w(vat) }, organisations: { any: %w(hmrc defra) }),
+          }
+        }
+      end
+
+      %i(links tags).each do |key|
+        it "will match an or_joined_facet_subscriber_list with multiple facets where there is only one matching facet for #{key}" do
+          lists = execute_query({ topics: %w(paye), organisations: %w(defra) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+
+          lists = execute_query({ topics: %w(paye), organisations: %w(hmrc) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+
+          lists = execute_query({ topics: %w(vat) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+        end
+
+        it "will match an or_joined_facet_subscriber_list with multiple facets where all facets has at least one match for #{key}" do
+          lists = execute_query({ topics: %w(vat), organisations: %w(hmrc) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+        end
+
+        it "will not match an or_joined_facet_subscriber_list with multiple facets where no facets match for #{key}" do
+          lists = execute_query({ topics: %w(licensing) }, field: key)
+          expect(lists).to eq([])
+        end
+      end
     end
 
-    it 'does not find subscriber list for mix of all topics and policies when not all policies present' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456", "other1"],
-                                                         policies: ["uuid-678", "other2"] })
-      expect(lists).not_to include(@list7)
+    context "finds or_joined_subscription lists for the right query hash for 'all' facets" do
+      before do
+        @lists = {
+          tags: {
+            or_joined_topics_vat_organisations_hrmc_defra: create_or_joined_facet_subscriber_list_with_tags_facets(topics: { all: %w(vat) }, organisations: { all: %w(hmrc defra) }),
+          },
+          links: {
+            or_joined_topics_vat_organisations_hrmc_defra: create_or_joined_facet_subscriber_list_with_links_facets(topics: { all: %w(vat) }, organisations: { all: %w(hmrc defra) }),
+          }
+        }
+      end
+
+      %i(links tags).each do |key|
+        it "will match an or_joined_facet_subscriber_list with multiple facets where there is one facet completely matches for #{key}" do
+          lists = execute_query({ topics: %w(vat) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+
+          lists = execute_query({ topics: %w(vat), organisations: %w(dfe) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+
+          lists = execute_query({ topics: %w(paye), organisations: %w(hmrc defra) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+        end
+
+        it "will match an or_joined_facet_subscriber_list with multiple facets where all facets completely match for #{key}" do
+          lists = execute_query({ topics: %w(vat), organisations: %w(hmrc defra) }, field: key)
+          expect(lists).to eq([@lists[key][:or_joined_topics_vat_organisations_hrmc_defra]])
+        end
+
+        it "will not match an or_joined_facet_subscriber_list with multiple facets where no facets match for #{key}" do
+          lists = execute_query({ topics: %w(paye) }, field: key)
+          expect(lists).to eq([])
+
+          lists = execute_query({ organisations: %w(hmrc) }, field: key)
+          expect(lists).to eq([])
+
+          lists = execute_query({ topics: %w(paye), organisations: %w(hmrc) }, field: key)
+          expect(lists).to eq([])
+        end
+      end
     end
 
-    it 'finds subscriber lists matching a mix of all topics and any policies' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456"],
-                                                         policies: ["uuid-567", "uuid-678", "other2"] })
-      expect(lists).to include(@list8)
-    end
 
-    it 'does not find subscriber list for mix of all topics and any policies when not all topics present' do
-      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "other1"],
-                                                         policies: ["uuid-678"] })
-      expect(lists).not_to include(@list8)
+    context "can return subscriber_lists and or_joined_facet_subscriber_lists" do
+      before do
+        @or_joined_topics_vat_paye = create_or_joined_facet_subscriber_list_with_tags_facets(topics: { any: %w(vat paye) })
+        @topics_vat_paye = create_subscriber_list_with_tags_facets(topics: { any: %w(vat paye) })
+      end
+
+      it "will return an or_joined_facet_subscriber_list and an subscriber_list if it matches both" do
+        lists = execute_query(topics: %w(vat))
+        expect(lists).to eq([@topics_vat_paye, @or_joined_topics_vat_paye])
+      end
     end
 
     context "there are other, non-matching link types in the query hash" do
-      let(:lists) do
-        execute_query(field: :tags, query_hash: {
-          topics: ["oil-and-gas/licensing"],
-          another_link_thats_not_part_of_the_subscription: %w[elephants],
-        })
+      before do
+        @topics_any_licensing = create_subscriber_list_with_tags_facets(topics: { any: %w(licensing) })
       end
 
       it "finds lists where all the link types in the subscription have a value present" do
-        expect(lists).to eq([@list2])
+        lists = execute_query(topics: %w(licensing), another_link_thats_not_part_of_the_subscription: %w(elephants))
+        expect(lists).to eq([@topics_any_licensing])
       end
     end
 
     context "there are non-matching values in the query_hash" do
-      let(:lists) {
-        execute_query(field: :tags, query_hash: {
-          topics: ["oil-and-gas/licensing", "elephants"],
-        })
-      }
+      before do
+        @topics_any_licensing = create_subscriber_list_with_tags_facets(topics: { any: %w(licensing) })
+      end
 
       it "finds lists where all the link types in the subscription have a value present" do
-        expect(lists).to eq([@list2])
-      end
-    end
-
-    context "Specialist publisher edge case" do
-      let!(:subscriber_list) { create(:subscriber_list, tags: { format: { any: %w[employment_tribunal_decision] } }) }
-
-      it "finds the list when the criteria values is a string that is present in the subscriber list values for the field" do
-        lists = execute_query(field: :tags, query_hash: {
-          format: "employment_tribunal_decision",
-        })
-
-        expect(lists).to eq([subscriber_list])
+        lists = execute_query(topics: %w(licensing elephants))
+        expect(lists).to eq([@topics_any_licensing])
       end
 
-      it "does not find the list when the criteria values is a string that is not present in the subscriber list values for the field" do
-        lists = execute_query(field: :tags, query_hash: {
-          format: "drug_safety_update",
-        })
-
+      it "doesn't return lists which have no tag types present in the document" do
+        lists = execute_query(another_tag_thats_not_part_of_any_subscription: %w(elephants))
         expect(lists).to eq([])
       end
     end
 
-    it "doesn't return lists which have no tag types present in the document" do
-      lists = execute_query(field: :tags, query_hash: {
-        another_tag_thats_not_part_of_any_subscription: %w[elephants],
-      })
-      expect(lists).to eq([])
+    context "Specialist publisher edge case in format tag" do
+      before do
+        @subscriber_list = create_subscriber_list_with_tags_facets(format: { any: %w[employment_tribunal_decision] })
+      end
+
+      it "finds the list when the criteria values is a string that is present in the subscriber list values for the field" do
+        lists = execute_query(format: "employment_tribunal_decision")
+        expect(lists).to eq([@subscriber_list])
+      end
+
+      it "does not find the list when the criteria values is a string that is not present in the subscriber list values for the field" do
+        lists = execute_query(format: "drug_safety_update")
+        expect(lists).to eq([])
+      end
     end
   end
 end

--- a/spec/services/matched_content_change_generation_service_spec.rb
+++ b/spec/services/matched_content_change_generation_service_spec.rb
@@ -3,14 +3,24 @@ RSpec.describe MatchedContentChangeGenerationService do
     create(:content_change, tags: { topics: ["oil-and-gas/licensing"] })
   end
 
+  let(:another_content_change) do
+    create(:content_change, tags: { organisation: ["oil-and-gas/licensing"], format: %w[employment_tribunal_decision] })
+  end
+
   before do
     create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
+    create(:or_joined_facet_subscriber_list, tags: { organisation: { any: ["oil-and-gas/licensing"] } })
   end
 
   describe ".call" do
-    it "creates a MatchedContentChange" do
+    it "creates a MatchedContentChange for an SubscriberList" do
       expect { described_class.call(content_change: content_change) }
         .to change { MatchedContentChange.count }.by(1)
+    end
+
+    it "creates a MatchedContentChange for an OrJoinedFacetSubscriberList" do
+      expect { described_class.call(content_change: another_content_change) }
+          .to change { MatchedContentChange.count }.by(1)
     end
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -19,6 +19,13 @@ module FeatureHelpers
     data.dig(:subscriber_list, :id)
   end
 
+  def create_or_joined_facet_subscriber_list(overrides = {})
+    params = { title: "Example", tags: {}, links: {}, combine_mode: "or" }.merge(overrides)
+    post "/subscriber-lists", params: params.to_json, headers: JSON_HEADERS
+    expect(response.status).to eq(201)
+    data.dig(:subscriber_list, :id)
+  end
+
   def lookup_subscriber_list_by_slug(slug, expected_status: 200)
     get "/subscriber-lists/#{slug}"
     expect(response.status).to eq(expected_status)


### PR DESCRIPTION
Will match a content change against this type of subscriber list
when at least one facet matches.
Adds in new parameter for subscriber_lists#create 'join_facets_with'
which defaults to and (if not included) but if a value of 'or' is
supplied it will create an OrJoinedFacetSubscriberList and will
match the resulting subscriber list with an or join on the facets

Trello: https://trello.com/c/y6ZhETsr/130-implement-a-joined-subscriber-list-model-in-email-alert-api-recommended-%F0%9F%8D%90

Joint effort with @AgaDufrat 