### PR TITLE
Add missing tests for any/all behaviour in email alerts

### DIFF
--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -59,15 +59,31 @@ RSpec.describe MatchedForNotification do
       expect(lists).to include(@list5)
     end
 
+    it 'does not find subscriber list for all topics when not all topics present' do
+      lists = execute_query(field: :links, query_hash: { topics: ["uuid-234", "other2"] })
+      expect(lists).not_to include(@list5)
+    end
+
     it 'finds subscriber lists matching any and all topics' do
       lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-678", "uuid-456"] })
       expect(lists).to include(@list6)
+    end
+
+    it 'does not find subscriber list for mixture of all and any topics when not all topics present' do
+      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-678"] })
+      expect(lists).not_to include(@list6)
     end
 
     it 'finds subscriber lists matching a mix of all topics and policies' do
       lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456", "other1"],
                                                          policies: ["uuid-567", "uuid-678", "other2"] })
       expect(lists).to include(@list7)
+    end
+
+    it 'does not find subscriber list for mix of all topics and policies when not all policies present' do
+      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456", "other1"],
+                                                         policies: ["uuid-678", "other2"] })
+      expect(lists).not_to include(@list7)
     end
 
     context "there are other, non-matching link types in the query hash" do

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe MatchedForNotification do
                                                    {
                                                      all: ["uuid-567", "uuid-678"]
                                                    } })
+
+      @list8 = create(:subscriber_list, links: { topics:
+                                                   {
+                                                     all: ["uuid-345", "uuid-456"]
+                                                   },
+                                                  policies:
+                                                   {
+                                                     any: ["uuid-567", "uuid-678"]
+                                                   } })
     end
 
     def execute_query(field:, query_hash:)
@@ -84,6 +93,18 @@ RSpec.describe MatchedForNotification do
       lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456", "other1"],
                                                          policies: ["uuid-678", "other2"] })
       expect(lists).not_to include(@list7)
+    end
+
+    it 'finds subscriber lists matching a mix of all topics and any policies' do
+      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456"],
+                                                         policies: ["uuid-567", "uuid-678", "other2"] })
+      expect(lists).to include(@list8)
+    end
+
+    it 'does not find subscriber list for mix of all topics and any policies when not all topics present' do
+      lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "other1"],
+                                                         policies: ["uuid-678"] })
+      expect(lists).not_to include(@list8)
     end
 
     context "there are other, non-matching link types in the query hash" do

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe MatchedForNotification do
       expect(lists).to include(@list6)
     end
 
-    it 'finds subscriber lists matching a mix of any and all topics and policies' do
+    it 'finds subscriber lists matching a mix of all topics and policies' do
       lists = execute_query(field: :links, query_hash: { topics: ["uuid-345", "uuid-456", "other1"],
                                                          policies: ["uuid-567", "uuid-678", "other2"] })
       expect(lists).to include(@list7)


### PR DESCRIPTION
Before implementing the `OrJoinedSubscriberList` model, we need to be confident that tests are in place to ensure the new queries do not affect queries for the existing `SubscriberList`.

This adds additional tests where the `all` behaviour was not properly being tested.  We only ensured that the `SubscriberList` was found when all values were present.  There was no test for ensuring the `SubscriberList` was not found when not all the topics are present, therefore `all` could have been implemented as `any` and the tests would still have passed.  This PR adds those tests.

Additionally, this is adding a test where `all`/`any` is combined across multiple tags, which not previously tested.

Trello card: https://trello.com/c/Qt6sEJ2o/129-implement-review-baseline-tests-for-finder-email-alerts-recommended-%F0%9F%8D%9