### PR TITLE
Bump govuk_app_config to v1.16.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.16.2)
+    govuk_app_config (1.16.3)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)


### PR DESCRIPTION
A new version of `govuk_app_config` has been released: https://github.com/alphagov/govuk_app_config/pull/93