### PR TITLE
Make email footers more consistent

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -47,7 +47,12 @@ private
 
   def subscription_link
     <<~BODY
-      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+      &nbsp;
+
+      ---
+
+      You’re getting this email because you subscribed to GOV.UK email alerts.
       #{presented_manage_subscriptions_links}
     BODY
   end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -47,7 +47,7 @@ private
       <<~BODY
         #{presented_content_change(content_change)}
         ---
-        You’re getting this email because you subscribed to ‘#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
+        You’re getting this email because you subscribed to GOV.UK email alerts about ‘#{subscriptions.first.subscriber_list.title}’.
 
         #{presented_unsubscribe_links(subscriptions)}
         #{presented_manage_subscriptions_links(address)}

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -102,7 +102,12 @@ RSpec.describe DigestEmailBuilder do
 
         unsubscribe_link_2
 
-        You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+        &nbsp;
+
+        ---
+
+        You’re getting this email because you subscribed to GOV.UK email alerts.
         [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
         &nbsp;

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe ImmediateEmailBuilder do
             presented_content_change
 
             ---
-            You’re getting this email because you subscribed to ‘#{subscriptions.first.subscriber_list.title}’ updates on GOV.UK.
+            You’re getting this email because you subscribed to GOV.UK email alerts about ‘#{subscriptions.first.subscriber_list.title}’.
 
             unsubscribe_link
             [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -58,7 +58,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
-      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+      &nbsp;
+
+      ---
+
+      You’re getting this email because you subscribed to GOV.UK email alerts.
       [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
@@ -93,7 +98,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
-      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+      &nbsp;
+
+      ---
+
+      You’re getting this email because you subscribed to GOV.UK email alerts.
       [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
@@ -286,7 +296,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
-      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+      &nbsp;
+
+      ---
+
+      You’re getting this email because you subscribed to GOV.UK email alerts.
       [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
@@ -321,7 +336,12 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
 
-      You’re getting this email because you subscribed to these topic updates on GOV.UK.
+
+      &nbsp;
+
+      ---
+
+      You’re getting this email because you subscribed to GOV.UK email alerts.
       [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;


### PR DESCRIPTION
Fixes small inconsistency between footers in immediate and digest
emails.
Small content change to make the purpose of the subscription
management link clearer

Also adds spacing between last content change and subscription link to make it clearer that it is not related to the last content change.

A digest email will now look like this

![new_digest_email](https://user-images.githubusercontent.com/41049800/58960961-1ea29780-87a0-11e9-898b-e41f1aab0bfb.png)


Trello: https://trello.com/c/dxCp3oXw/141-investigate-template-differences-between-immediate-daily-and-weekly-emails