### PR TITLE
Change confirmation and contact us text in email

### DIFF
--- a/app/builders/auth_email_builder.rb
+++ b/app/builders/auth_email_builder.rb
@@ -34,13 +34,13 @@ private
 
       ^ [Confirm your email address](#{link})
 
-      We need to check that #{subscriber.address} is your email address so that you can manage your GOV.UK email subscriptions. This link will stop working in 7 days.
+      You need to do this to manage your GOV.UK email subscriptions. The link will stop working in 7 days.
 
       # Didn’t request this email?
 
       Ignore or delete this email if you didn’t request it. Your subscriptions won’t be changed.
 
-      [Contact us](https://www.gov.uk/contact/govuk) if you have problems with your GOV.UK email subscription.
+      [Contact GOV.UK](https://www.gov.uk/contact/govuk) if you have any problems with your email subscriptions.
     BODY
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/RO9xS4wS
Related to: https://github.com/alphagov/email-alert-frontend/pull/502

## Motivation

From our research we know that  the 'Manage your subscriptions' flow is causing confusion for users trying to change their email frequency.

We should clarify the content design of emails to make clearer why the user is being asked to confirm their email address, and that this will enable them to change their email frequency.

## Expected changes
![screenshot-www notifications service gov uk-2019 06 10-14-27-55](https://user-images.githubusercontent.com/5793815/59198626-11b0ea00-8b8c-11e9-9ccf-809b3850242d.png)
