### PR TITLE
Rake task for counting subscribers

### DIFF
--- a/lib/tasks/count_subscribers.rake
+++ b/lib/tasks/count_subscribers.rake
@@ -1,0 +1,16 @@
+namespace :query do
+  desc "Query how many active subscribers there are to the given subscription slug"
+  task :count_subscribers, %i[subscription_list_slug] => :environment do |_t, args|
+    slug = args[:subscription_list_slug]
+    subscription_lists = SubscriberList.where(slug: slug)
+    raise "There is no SubscriberList called '#{slug}'" unless subscription_lists.count == 1
+
+    active_subscriptions = subscription_lists.first.subscriptions.where(ended_at: nil)
+    puts """
+      The SubscriberList '#{slug}' has #{active_subscriptions.count} active subscriptions, of which:
+        - #{active_subscriptions.where(frequency: 0).count} are signed up for Immediate updates
+        - #{active_subscriptions.where(frequency: 1).count} are signed up for Daily updates
+        - #{active_subscriptions.where(frequency: 2).count} are signed up for Weekly updates
+    """
+  end
+end


### PR DESCRIPTION
This work was originally prompted by Zendesk ticket 3707659.
It has come up again in Zendesk ticket 3771545.

Creates a rake task you can run on Jenkins, e.g.

> `query:count_subscribers['vietnam-travel-advice']`

The output is as follows:

```
The SubscriberList 'vietnam-travel-advice' has 7992 active subscriptions, of which:
  - 7837 are signed up for Immediate updates
  - 54 are signed up for Daily updates
  - 101 are signed up for Weekly updates
```

(See https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/74948/console)

