### PR TITLE
Introduce new internal_failure status

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -5,7 +5,7 @@ class DeliveryAttempt < ApplicationRecord
 
   FINAL_STATUSES = %i[delivered permanent_failure].freeze
 
-  enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4 }
+  enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4, internal_failure: 5 }
   enum provider: { pseudo: 0, notify: 1 }
 
   def has_final_status?

--- a/app/models/healthcheck/delivery_status.rb
+++ b/app/models/healthcheck/delivery_status.rb
@@ -1,0 +1,46 @@
+module Healthcheck
+  class DeliveryStatus < GovukHealthcheck::ThresholdCheck
+    def value
+      return 0 if total.zero?
+
+      total_failing.to_f / total.to_f
+    end
+
+    def critical_threshold
+      0.1
+    end
+
+    def warning_threshold
+      0.05
+    end
+
+    def enabled?
+      EmailAlertAPI.config.email_service.fetch(:expect_status_update_callbacks)
+    end
+
+    def delivery_status
+      raise "This method must be overridden to be the status value."
+    end
+
+  private
+
+    def totals
+      @totals ||= DeliveryAttempt
+        .where("created_at > ?", 1.hour.ago)
+        .group("CASE WHEN status = #{ActiveRecord::Base.connection.quote(delivery_status)} THEN 'failing' ELSE 'other' END")
+        .count
+    end
+
+    def total_failing
+      totals.fetch("failing", 0)
+    end
+
+    def total_other
+      totals.fetch("other", 0)
+    end
+
+    def total
+      total_failing + total_other
+    end
+  end
+end

--- a/app/models/healthcheck/internal_failures.rb
+++ b/app/models/healthcheck/internal_failures.rb
@@ -1,0 +1,11 @@
+module Healthcheck
+  class InternalFailures < DeliveryStatus
+    def name
+      :internal_failures
+    end
+
+    def delivery_status
+      5
+    end
+  end
+end

--- a/app/models/healthcheck/technical_failures.rb
+++ b/app/models/healthcheck/technical_failures.rb
@@ -1,46 +1,11 @@
 module Healthcheck
-  class TechnicalFailures < GovukHealthcheck::ThresholdCheck
+  class TechnicalFailures < DeliveryStatus
     def name
       :technical_failures
     end
 
-    def value
-      return 0 if total.zero?
-
-      total_failing.to_f / total.to_f
-    end
-
-    def critical_threshold
-      0.1
-    end
-
-    def warning_threshold
-      0.05
-    end
-
-    def enabled?
-      EmailAlertAPI.config.email_service.fetch(:expect_status_update_callbacks)
-    end
-
-  private
-
-    def totals
-      @totals ||= DeliveryAttempt
-        .where("created_at > ?", 1.hour.ago)
-        .group("CASE WHEN status = 4 THEN 'failing' ELSE 'other' END")
-        .count
-    end
-
-    def total_failing
-      totals.fetch("failing", 0)
-    end
-
-    def total_other
-      totals.fetch("other", 0)
-    end
-
-    def total
-      total_failing + total_other
+    def delivery_status
+      4
     end
   end
 end

--- a/app/providers/notify_provider.rb
+++ b/app/providers/notify_provider.rb
@@ -21,7 +21,7 @@ class NotifyProvider
 
     MetricsService.sent_to_notify_successfully
     :sending
-  rescue StandardError => e
+  rescue Notifications::Client::RequestError => e
     MetricsService.failed_to_send_to_notify
     GovukError.notify(e, tags: { provider: "notify" })
     :technical_failure

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       Healthcheck::StatusUpdates,
       Healthcheck::SubscriptionContents,
       Healthcheck::TechnicalFailures,
+      Healthcheck::InternalFailures,
     )
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -43,6 +43,12 @@ FactoryBot.define do
       sent_at { nil }
       completed_at { Time.zone.now }
     end
+
+    factory :internal_failure_delivery_attempt do
+      status { :internal_failure }
+      sent_at { nil }
+      completed_at { Time.zone.now }
+    end
   end
 
   factory :digest_run do

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Healthcheck", type: :request do
       status_updates:        hash_including(status: "ok", total: 0),
       subscription_contents: hash_including(status: "ok", critical: 0, warning: 0),
       technical_failures:    hash_including(status: "ok", value: 0),
+      internal_failures:     hash_including(status: "ok", value: 0),
     )
   end
 end

--- a/spec/models/healthcheck/internal_failures_spec.rb
+++ b/spec/models/healthcheck/internal_failures_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Healthcheck::InternalFailures do
+  def create_delivery_attempt(status, created, email = create(:email))
+    create(:delivery_attempt, status: status, created_at: created, email: email)
+  end
+
+  context "when there are no provider failures" do
+    before { create_delivery_attempt(:delivered, 1.minute.ago) }
+    specify { expect(subject.status).to eq(:ok) }
+  end
+
+  context "when a proportion of delivery attempts are provider failures" do
+    context "at 2%" do
+      before do
+        1.times { create_delivery_attempt(:internal_failure, 15.minutes.ago) }
+        49.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
+      end
+      specify { expect(subject.status).to eq(:ok) }
+    end
+
+    context "at 5%" do
+      before do
+        1.times { create_delivery_attempt(:internal_failure, 15.minutes.ago) }
+        19.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
+      end
+      specify { expect(subject.status).to eq(:warning) }
+    end
+
+    context "at 10%" do
+      before do
+        1.times { create_delivery_attempt(:internal_failure, 15.minutes.ago) }
+        9.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
+      end
+      specify { expect(subject.status).to eq(:critical) }
+    end
+  end
+
+  describe "#details" do
+    before do
+      2.times { create_delivery_attempt(:internal_failure, 15.minutes.ago) }
+      4.times { create_delivery_attempt(:delivered, 15.minutes.ago) }
+      4.times { create_delivery_attempt(:sending, 15.minutes.ago) }
+    end
+
+    it "shows the value" do
+      expect(subject.details.fetch(:value)).to eq(0.2)
+    end
+  end
+end

--- a/spec/providers/notify_provider_spec.rb
+++ b/spec/providers/notify_provider_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe NotifyProvider do
 
     context "when an error occurs" do
       before do
+        error_response = double(code: 404, body: '{"errors": "an error"}')
         allow_any_instance_of(Notifications::Client).to receive(:send_email)
-          .and_raise("Sending Failed")
+          .and_raise(Notifications::Client::RequestError.new(error_response))
       end
 
       it "returns a status of technical_failure" do

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe DeliveryRequestService do
       expect(attempted).to be true
     end
 
+    context "when the provider raises an exception" do
+      before do
+        expect(subject.provider).to receive(:call).and_raise("Unknown error!")
+      end
+
+      it "sets the status to internal_failure" do
+        subject.call(email: email)
+        expect(DeliveryAttempt.last.status).to eq("internal_failure")
+      end
+    end
+
     context "when the email address is overridden" do
       let(:subject) do
         described_class.new(config: config.merge(email_address_override: address))


### PR DESCRIPTION
This is used to allow us to make a distinction between two kinds of `technical_failure`s. Right now `technical_failure` covers any kind of unrecoverable/unknown error we experience while sending an email.

With this change, we have the following meanings:

- **`technical_failure`** is a valid status response from our provider (Notify) when it's unable to send an email for an unspecified reason. It's also the response we use when Notify gives us back some sort of error response such as HTTP error code `500`.

- **`internal_failure`** is set when we receive an exception from our provider or in our code that wasn't handled - implying that the failure condition was unexpected. This is likely to tell us about problems in our code rather than in a failure with Notify. This was the case in a recent incident where we were unable to start a connection to Notify but we were reporting this failure as `technical_failure` whereas now it would return a `internal_failure`.

[Trello Card](https://trello.com/c/x7qVo3IM/1051-improve-email-alert-api-code-to-differentiate-between-notify-errors-and-errors-in-our-code) · [Incident Report](https://docs.google.com/document/d/1NyxVSFzQnBSOAlVbeRagVW1SjXdkJHjrKz2xnWYhwR0/edit#)