### PR TITLE
Rake task for updating subscriber list facet values & titles

### DIFF
--- a/lib/tasks/eu_exit_business_finder.rake
+++ b/lib/tasks/eu_exit_business_finder.rake
@@ -1,0 +1,83 @@
+namespace :eu_exit_business_finder do
+  task update_subscriber_list_titles_and_facet_values: [:environment] do
+    subscriber_lists = SubscriberList
+      .where("links::text != '{}'")
+      .where("ARRAY(SELECT json_object_keys(links)) <@ Array[:keys]", keys: [:facet_values])
+    update_facet_values(subscriber_lists)
+  end
+
+  # Iterate through the affected subscriber lists and if we encounter any
+  # facet values that need replacing with a newer one, we insert the new one
+  # to the array (inserted 'in place' to retain original order). Then remove
+  # the old facet values in bulk and write only the unique values that remain.
+  def update_facet_values(subscriber_lists)
+    subscriber_lists.each do |list|
+      links = list.links[:facet_values][:any]
+      updated_links = links.map { |original_value|
+        EuExitFacetMigrationConfig::facet_values_to_replace[original_value] || original_value
+      }.flatten
+      updated_links = (updated_links - EuExitFacetMigrationConfig::facet_values_to_remove).uniq
+      list.write_attribute('links', facet_values: { any: updated_links })
+      list.write_attribute('title', title_from_facets(updated_links))
+      list.save
+    end
+  end
+
+  def title_from_facets(facet_values)
+    subscription_title_prefix = "EU Exit guidance for your business in the following #{'category'.pluralize(facet_values.count)}: "
+    titles = facet_values.map do |facet_value|
+      if EuExitFacetMigrationConfig.facet_value_label_overrides[facet_value].present?
+        "'#{EuExitFacetMigrationConfig.facet_value_label_overrides[facet_value]}'"
+      else
+        content_item_title = GdsApi.publishing_api_v2.get_content(facet_value).to_h['title']
+        "'#{content_item_title}'"
+      end
+    end
+    subscription_title_prefix + titles.join(', ')
+  end
+end
+
+module EuExitFacetMigrationConfig
+  def self.facet_values_to_replace
+    {
+      "9f3476e1-8ff0-455d-a14e-003236b2797c" => ["53f9ce4c-7cbb-447f-bdf1-a9b022896d3a"],
+      "b4e507df-f067-4749-9468-3de120775216" => ["24fd50fa-6619-46ca-96cd-8ce90fa076ce"],
+      "356f46a0-17d3-4ba4-8952-8c02244f904" => ["18c3892e-8a0e-4884-906e-5938380eceee"],
+      "356f46a0-17d3-4ba4-8952-8c02244f9045" => ["18c3892e-8a0e-4884-906e-5938380eceee"],
+      # "34a6edd0-46ea-4a76-ae80-8c96709d4f5" is worth noting as
+      # it's the result of a merge between two facets. The
+      # find-and-replace works the same way regardless.
+      "1e3e8abd-135d-4844-afa8-5c51df3d3c57" => ["34a6edd0-46ea-4a76-ae80-8c96709d4f59"],
+      "c1d8057c-76bf-431c-9ac8-6281a4b7b9ca" => ["34a6edd0-46ea-4a76-ae80-8c96709d4f59"],
+      # "94b3cfe2-af89-4744-b8d7-7fc79edcbc85" is a special case
+      # as it's been split into two facets. We should assume the
+      # user wants to remain subscribed to both.
+      "94b3cfe2-af89-4744-b8d7-7fc79edcbc85" => [
+        "9d54c591-f5ca-4d0c-a484-12d5591987cb",
+        "afd45eef-743a-417d-9245-3eab8322116d"
+      ],
+      # to fix a missing character issue introduced in
+      # https://github.com/alphagov/search-api/commit/8fce3db218821dfc7a2b50dbd1b03984b1ec41b1
+      "7620da7a-0427-4b3c-9498-db9dc25209b" => ["7620da7a-0427-4b3c-9498-db9dc25209b0"]
+    }
+  end
+
+  def self.facet_values_to_remove
+    [
+      "7536c0c4-fb41-43f4-a2c4-08f4fa9f5427",
+      "5faa1741-fc55-4110-b342-de92f6324118",
+      "14cf2a68-3297-44d3-ba01-a4426845b1b8",
+      "040649fc-4e2c-4028-b846-77fe3eebd1f7",
+      "94b3cfe2-af89-4744-b8d7-7fc79edcbc85"
+    ]
+  end
+
+  def self.facet_value_label_overrides
+    {
+      "5476f0c7-d029-459b-8a17-196374ae3366" => "Employing EU citizens",
+      "bbdbda71-b1ec-46b8-a5b8-931d933288e9" => "Employing non-EU citizens",
+      "f165dc7c-7cef-446a-bdfd-8a1ca685d091" => "Public sector procurement - civil government contracts",
+      "33fc20d7-6a45-40c9-b31f-e4678f962ff1" => "Public sector procurement - defence contracts"
+    }
+  end
+end

--- a/spec/lib/tasks/eu_exit_business_finder_spec.rb
+++ b/spec/lib/tasks/eu_exit_business_finder_spec.rb
@@ -1,0 +1,179 @@
+require 'rake'
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+RSpec.describe 'eu_exit_business_finder:update_subscriber_list_titles_and_facet_values' do
+  include GdsApi::TestHelpers::PublishingApiV2
+
+  before :each do
+    Rails.application.load_tasks
+  end
+
+  def mock_facet_values_to_remove(values)
+    allow(EuExitFacetMigrationConfig).to receive(:facet_values_to_remove).and_return(values)
+  end
+
+  def mock_facet_values_to_replace(replacements)
+    allow(EuExitFacetMigrationConfig).to receive(:facet_values_to_replace).and_return(replacements)
+  end
+
+  def mock_facet_value_label_overrides(replacements)
+    allow(EuExitFacetMigrationConfig).to receive(:facet_value_label_overrides).and_return(replacements)
+  end
+
+  let(:facet_values) { [] }
+  let(:mock_behaviour!) {}
+  let(:create_list_and_execute_rake!) {
+    create(:subscriber_list, links: {
+      facet_values: {
+        any: facet_values
+      }
+    })
+    Rake::Task['eu_exit_business_finder:update_subscriber_list_titles_and_facet_values'].execute
+  }
+
+  describe "updating the facet values" do
+    subject {
+      stub_publishing_api_has_item("content_id" => "111-new")
+      stub_publishing_api_has_item("content_id" => "222-new")
+      stub_publishing_api_has_item("content_id" => "123-keep-me")
+      mock_behaviour!
+      create_list_and_execute_rake!
+      SubscriberList.last.links[:facet_values][:any]
+    }
+
+    context "given values that should not be removed" do
+      let(:facet_values) { ["123-keep-me"] }
+
+      it { is_expected.to eql ["123-keep-me"] }
+    end
+
+    context "given only values to remove" do
+      let(:facet_values) { ["000-remove-me"] }
+      let(:mock_behaviour!) { mock_facet_values_to_remove(["000-remove-me"]) }
+
+      it { is_expected.to eql [] }
+    end
+
+    context "given a mixture of values to keep and remove" do
+      let(:facet_values) { ["123-keep-me", "000-remove-me"] }
+      let(:mock_behaviour!) { mock_facet_values_to_remove(["000-remove-me"]) }
+
+      it { is_expected.to eql ["123-keep-me"] }
+    end
+
+    context "given values to replace" do
+      let(:facet_values) { ["000-old"] }
+      let(:mock_behaviour!) {
+        mock_facet_values_to_replace("000-old" => ["111-new"])
+      }
+
+      it { is_expected.to eql ["111-new"] }
+    end
+
+    context "given a mixture of values to replace, remove and keep" do
+      let(:facet_values) { ["000-old", "000-remove-me", "123-keep-me"] }
+      let(:mock_behaviour!) {
+        mock_facet_values_to_remove(["000-remove-me", "000-old"])
+        mock_facet_values_to_replace("000-old" => ["111-new"])
+      }
+
+      it { is_expected.to eql ["111-new", "123-keep-me"] }
+    end
+
+    context "given facet replacements which could lead to duplicates" do
+      let(:facet_values) { ["000-old", "001-also-old"] }
+      let(:mock_behaviour!) {
+        mock_facet_values_to_replace(
+          "000-old" => "111-new",
+          "001-also-old" => "111-new",
+        )
+      }
+
+      it { is_expected.to eql ["111-new"] } # `111-new` should only appear once
+    end
+
+    context "given a facet value which has been split into multiple new facets" do
+      let(:facet_values) { ["000-old"] }
+      let(:mock_behaviour!) {
+        mock_facet_values_to_replace(
+          "000-old" => ["111-new", "222-new"]
+        )
+      }
+
+      it { is_expected.to eql ["111-new", "222-new"] }
+    end
+  end
+
+  describe "updating the title" do
+    subject {
+      stub_publishing_api_has_item(
+        "content_id": "000-content-id-of-food-drink-tobacco-facet",
+        "title": "Food, drink and tobacco (retail and wholesale)",
+      )
+      stub_publishing_api_has_item(
+        "content_id": "111-content-id-of-ports-airports",
+        "title": "Ports and airports",
+      )
+      stub_publishing_api_has_item(
+        "content_id": "777-content-id-of-employing-eu-citizens",
+        "title": "EU citizens",
+      )
+      stub_publishing_api_has_item(
+        "content_id": "444-content-id-of-eu-funding",
+        "title": "EU funding",
+      )
+      mock_behaviour!
+      create_list_and_execute_rake!
+      SubscriberList.last.title
+    }
+
+    context "build title from single facet value" do
+      let(:facet_values) { ["000-content-id-of-food-drink-tobacco-facet"] }
+
+      it {
+        is_expected.to eql "EU Exit guidance for your business in the following category: 'Food, drink and tobacco (retail and wholesale)'"
+      }
+    end
+
+    context "build title from multiple facet values" do
+      let(:facet_values) { ["000-content-id-of-food-drink-tobacco-facet", "111-content-id-of-ports-airports"] }
+
+      it {
+        is_expected.to eql "EU Exit guidance for your business in the following categories: 'Food, drink and tobacco (retail and wholesale)', 'Ports and airports'"
+      }
+    end
+
+    context "build title from facet value whose title has been overridden" do
+      let(:facet_values) { ["000-content-id-of-food-drink-tobacco-facet"] }
+      let(:mock_behaviour!) {
+        mock_facet_value_label_overrides(
+          "000-content-id-of-food-drink-tobacco-facet" => "Special category",
+        )
+      }
+
+      it { is_expected.to eql "EU Exit guidance for your business in the following category: 'Special category'" }
+    end
+
+    context "build title from a mixture of facet values and overridden facet titles" do
+      let(:facet_values) {
+        [
+          "000-content-id-of-food-drink-tobacco-facet",
+          "111-content-id-of-ports-airports",
+          "777-content-id-of-employing-eu-citizens",
+          "444-content-id-of-eu-funding",
+        ]
+      }
+      let(:mock_behaviour!) {
+        mock_facet_value_label_overrides(
+          "777-content-id-of-employing-eu-citizens" => "Employing EU citizens",
+          "000-content-id-of-food-drink-tobacco-facet" => "Special category",
+        )
+      }
+
+      it {
+        is_expected.to eql "EU Exit guidance for your business in the following categories: 'Special category', 'Ports and airports', 'Employing EU citizens', 'EU funding'"
+      }
+    end
+  end
+end


### PR DESCRIPTION
We recently split and merged some facet values for the EU Exit Business
Readiness Finder (see [alphagov/content-tagger#941](https://github.com/alphagov/content-tagger/pull/941)). We now need to migrate users who had subscribed to the old facets.

This PR adds a rake task to perform the migration for us, and should be removed once the task has been run. Tests have been written to have confidence that the task will work.

Technical approach:

> Iterate through the affected subscriber lists and replace any facet values
> that need replacing with a newer one. Then remove old facet values and write
> only the unique values that remain. Finally, take those updated facet values
> to update the title.

Trello card: https://trello.com/c/SlZdVUbe/.