### PR TITLE
Refactor email templates and implement text improvements

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -1,4 +1,5 @@
 class DigestEmailBuilder
+  include EmailBuilderHelper
   def initialize(subscriber:, digest_run:, subscription_content_change_results:)
     @subscriber = subscriber
     @digest_run = digest_run
@@ -25,8 +26,9 @@ private
   attr_reader :subscriber, :digest_run, :results
 
   def body
-    presented_results.concat("\n")
-      .concat(subscription_link).concat("\n")
+    presented_results.concat("\n\n&nbsp;\n\n---\n\n")
+      .concat(permission_reminder).concat("\n")
+      .concat(presented_manage_subscriptions_links).concat("\n\n&nbsp;\n\n")
       .concat(feedback_link)
   end
 
@@ -45,38 +47,6 @@ private
     RESULT
   end
 
-  def subscription_link
-    <<~BODY
-
-      &nbsp;
-
-      ---
-
-      You’re getting this email because you subscribed to GOV.UK email alerts.
-      #{presented_manage_subscriptions_links}
-    BODY
-  end
-
-  def feedback_link
-    <<~BODY
-      &nbsp;
-
-      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
-
-      &nbsp;
-
-      ^Do not reply to this email. Feedback? Visit #{Plek.new.website_root}/contact
-    BODY
-  end
-
-  def subject
-    if digest_run.daily?
-      "GOV.UK: your daily update"
-    else
-      "GOV.UK: your weekly update"
-    end
-  end
-
   def deduplicate_and_present(content_changes)
     presented_content_changes(
       deduplicated_content_changes(content_changes)
@@ -89,7 +59,6 @@ private
 
   def presented_content_changes(content_changes)
     changes = content_changes.map do |content_change|
-      frequency = digest_run.daily? ? "daily" : "weekly"
       ContentChangePresenter.call(content_change, frequency: frequency)
     end
 

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -37,6 +37,7 @@ private
       ---
 
       #{permission_reminder}
+
       #{presented_manage_subscriptions_links(address)}
 
       &nbsp;

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -28,6 +28,8 @@ private
 
   def body
     <<~BODY
+      #{opening_line}
+
       #{presented_results}
 
       &nbsp;

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -31,11 +31,6 @@ private
       #{opening_line}
 
       #{presented_results}
-
-      &nbsp;
-
-      ---
-
       #{permission_reminder}
 
       #{presented_manage_subscriptions_links(address)}

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -40,8 +40,6 @@ private
 
       #{presented_manage_subscriptions_links(address)}
 
-      &nbsp;
-
       #{feedback_link.strip}
     BODY
   end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -36,12 +36,16 @@ private
   def body(content_change, subscriptions, address)
     if Array(subscriptions).empty?
       <<~BODY
+        #{opening_line}
+
         #{presented_content_change(content_change)}
         ---
         #{feedback_link.strip}
       BODY
     else
       <<~BODY
+        #{opening_line}
+
         #{presented_content_change(content_change)}
         ---
         #{permission_reminder(subscriptions.first.subscriber_list.title)}

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -52,8 +52,6 @@ private
 
         #{presented_manage_subscriptions_links(address)}
 
-        &nbsp;
-
         #{feedback_link.strip}
       BODY
     end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -1,4 +1,5 @@
 class ImmediateEmailBuilder
+  include EmailBuilderHelper
   def initialize(recipients_and_content)
     @recipients_and_content = recipients_and_content
   end
@@ -32,10 +33,6 @@ private
     %i(address subject body subscriber_id)
   end
 
-  def subject(content_change)
-    "GOV.UK update – #{content_change.title}"
-  end
-
   def body(content_change, subscriptions, address)
     if Array(subscriptions).empty?
       <<~BODY
@@ -47,7 +44,7 @@ private
       <<~BODY
         #{presented_content_change(content_change)}
         ---
-        You’re getting this email because you subscribed to GOV.UK email alerts about ‘#{subscriptions.first.subscriber_list.title}’.
+        #{permission_reminder(subscriptions.first.subscriber_list.title)}
 
         #{presented_unsubscribe_links(subscriptions)}
         #{presented_manage_subscriptions_links(address)}
@@ -59,18 +56,8 @@ private
     end
   end
 
-  def feedback_link
-    <<~BODY
-      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
-
-      &nbsp;
-
-      ^Do not reply to this email. Feedback? Visit #{Plek.new.website_root}/contact
-    BODY
-  end
-
   def presented_content_change(content_change)
-    ContentChangePresenter.call(content_change, frequency: "immediate")
+    ContentChangePresenter.call(content_change, frequency: frequency)
   end
 
   def presented_manage_subscriptions_links(address)

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -38,6 +38,7 @@ private
       <<~BODY
         #{opening_line}
 
+        ---
         #{presented_content_change(content_change)}
         ---
         #{feedback_link.strip}
@@ -46,6 +47,7 @@ private
       <<~BODY
         #{opening_line}
 
+        ---
         #{presented_content_change(content_change)}
         ---
         #{permission_reminder(subscriptions.first.subscriber_list.title)}

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -56,20 +56,9 @@ private
     end
   end
 
-  def presented_content_change(content_change)
-    ContentChangePresenter.call(content_change, frequency: frequency)
-  end
-
-  def presented_manage_subscriptions_links(address)
-    ManageSubscriptionsLinkPresenter.call(address: address)
-  end
-
   def presented_unsubscribe_links(subscriptions)
     links_array = subscriptions.map do |subscription|
-      UnsubscribeLinkPresenter.call(
-        id: subscription.id,
-        title: subscription.subscriber_list.title,
-      )
+      presented_unsubscribe_link(subscription.id, subscription.subscriber_list.title)
     end
 
     links_array.join("\n")

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -50,7 +50,6 @@ private
         ---
         #{permission_reminder(subscriptions.first.subscriber_list.title)}
 
-        #{presented_unsubscribe_links(subscriptions)}
         #{presented_manage_subscriptions_links(address)}
 
         &nbsp;
@@ -58,13 +57,5 @@ private
         #{feedback_link.strip}
       BODY
     end
-  end
-
-  def presented_unsubscribe_links(subscriptions)
-    links_array = subscriptions.map do |subscription|
-      presented_unsubscribe_link(subscription.id, subscription.subscriber_list.title)
-    end
-
-    links_array.join("\n")
   end
 end

--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -13,7 +13,7 @@ private
     email_parameters.map do |email|
       {
         address: email.subscriber.address,
-        subject: "GOV.UK update – #{email.subject}",
+        subject: "Update from GOV.UK – #{email.subject}",
         body: ERB.new(template).result(
           EmailTemplateContext.new(
             email.template_data

--- a/app/helpers/email_builder_helper.rb
+++ b/app/helpers/email_builder_helper.rb
@@ -3,6 +3,10 @@ module EmailBuilderHelper
     I18n.t("frequencies.#{frequency}.subject", title: content_change&.title)
   end
 
+  def opening_line
+    I18n.t("frequencies.#{frequency}.opening_line")
+  end
+
   def permission_reminder(*subscription_title)
     title = I18n.t("frequencies.#{frequency}.permission_reminder_topic", :missing, default: "", title: subscription_title.first)
     I18n.t("permission_reminder", title: title)

--- a/app/helpers/email_builder_helper.rb
+++ b/app/helpers/email_builder_helper.rb
@@ -1,0 +1,19 @@
+module EmailBuilderHelper
+  def subject(content_change = nil)
+    I18n.t("frequencies.#{frequency}.subject", title: content_change&.title)
+  end
+
+  def permission_reminder(*subscription_title)
+    title = I18n.t("frequencies.#{frequency}.permission_reminder_topic", :missing, default: "", title: subscription_title.first)
+    I18n.t("permission_reminder", title: title)
+  end
+
+  def feedback_link
+    survey_link = I18n.t("frequencies.#{frequency}.survey_link")
+    I18n.t("feedback_link", survey_link: survey_link, feedback_link: "#{Plek.new.website_root}/contact")
+  end
+
+  def frequency
+    defined?(digest_run).nil? ? "immediately" : digest_run.range
+  end
+end

--- a/app/helpers/email_builder_helper.rb
+++ b/app/helpers/email_builder_helper.rb
@@ -8,8 +8,8 @@ module EmailBuilderHelper
   end
 
   def permission_reminder(*subscription_title)
-    title = I18n.t("frequencies.#{frequency}.permission_reminder_topic", :missing, default: "", title: subscription_title.first)
-    I18n.t("permission_reminder", title: title)
+    permission_reminder_topic = I18n.t("frequencies.#{frequency}.permission_reminder_topic", title: subscription_title&.first)
+    I18n.t("permission_reminder", frequency: frequency, permission_reminder_topic: permission_reminder_topic)
   end
 
   def feedback_link
@@ -18,7 +18,7 @@ module EmailBuilderHelper
   end
 
   def frequency
-    defined?(digest_run).nil? ? "immediately" : digest_run.range
+    defined?(digest_run).nil? ? "immediate" : digest_run.range
   end
 
   def presented_content_change(content_change)

--- a/app/helpers/email_builder_helper.rb
+++ b/app/helpers/email_builder_helper.rb
@@ -16,4 +16,19 @@ module EmailBuilderHelper
   def frequency
     defined?(digest_run).nil? ? "immediately" : digest_run.range
   end
+
+  def presented_content_change(content_change)
+    ContentChangePresenter.call(content_change, frequency: frequency)
+  end
+
+  def presented_unsubscribe_link(subscription_id, subscriber_list_title)
+    UnsubscribeLinkPresenter.call(
+      id: subscription_id,
+      title: subscriber_list_title
+    )
+  end
+
+  def presented_manage_subscriptions_links(address)
+    ManageSubscriptionsLinkPresenter.call(address: address)
+  end
 end

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -16,7 +16,7 @@ class ContentChangePresenter
     [
       title_markdown,
       description_markdown,
-      change_note_markdown,
+      change_note_markdown.rstrip,
       footnote_markdown,
     ].compact.join("\n\n") + "\n"
   end
@@ -38,8 +38,12 @@ private
     PublicUrlService.url_for(base_path: base_path)
   end
 
+  def public_updated_at_header
+    I18n.t("public_updated_at_header")
+  end
+
   def public_updated_at
-    content_change.public_updated_at.strftime(EMAIL_DATE_FORMAT)
+    content_change.public_updated_at.strftime(EMAIL_DATE_FORMAT).strip
   end
 
   def strip_markdown(string)
@@ -54,14 +58,28 @@ private
     "[#{title}](#{content_url})"
   end
 
+  def description_header
+    I18n.t("description_header")
+  end
+
   def description_markdown
     return nil if description.blank?
 
-    strip_markdown(description)
+    description_header.concat("\n").concat(strip_markdown(description))
+  end
+
+  def change_note_header
+    I18n.t("change_note_header")
   end
 
   def change_note_markdown
-    "#{public_updated_at}: #{strip_markdown(change_note)}"
+    <<~CHANGE_NOTE
+      #{change_note_header}
+      #{strip_markdown(change_note)}
+
+      #{public_updated_at_header}
+      #{public_updated_at}
+    CHANGE_NOTE
   end
 
   def footnote_markdown

--- a/app/presenters/manage_subscriptions_link_presenter.rb
+++ b/app/presenters/manage_subscriptions_link_presenter.rb
@@ -8,7 +8,7 @@ class ManageSubscriptionsLinkPresenter
   end
 
   def call
-    "[View and manage your subscriptions](#{url})"
+    "[View, unsubscribe or change the frequency of your subscriptions](#{url})"
   end
 
   private_class_method :new

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -67,9 +67,10 @@ private
 
   def create_email(digest_run_subscriber, content_changes)
     DigestEmailBuilder.call(
-      subscriber: digest_run_subscriber.subscriber,
+      address: digest_run_subscriber.subscriber.address,
+      subscription_content_changes: content_changes,
       digest_run: digest_run_subscriber.digest_run,
-      subscription_content_change_results: content_changes,
+      subscriber_id: digest_run_subscriber.subscriber.id
     )
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,14 +32,17 @@
 en:
   frequencies:
     immediately:
-      subject: "GOV.UK update – %{title}"
+      subject: "Update from GOV.UK – %{title}"
+      opening_line: Update on GOV.UK.
       permission_reminder_topic: " about ‘%{title}’"
       survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate
     daily:
-      subject: "GOV.UK: your daily update"
+      subject: "Daily update from GOV.UK"
+      opening_line: Daily update from GOV.UK.
       survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
     weekly:
-      subject: "GOV.UK: your weekly update"
+      subject: "Weekly update from GOV.UK"
+      opening_line: Updates on GOV.UK this week.
       survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
   description_header: "Page summary"
   change_note_header: "Change made"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,23 +31,25 @@
 
 en:
   frequencies:
-    immediately:
+    immediate:
       subject: "Update from GOV.UK – %{title}"
       opening_line: Update on GOV.UK.
-      permission_reminder_topic: " about ‘%{title}’"
+      permission_reminder_topic: to ‘%{title}’
       survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate
     daily:
       subject: "Daily update from GOV.UK"
       opening_line: Daily update from GOV.UK.
+      permission_reminder_topic: on these topics
       survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
     weekly:
       subject: "Weekly update from GOV.UK"
       opening_line: Updates on GOV.UK this week.
+      permission_reminder_topic: on these topics
       survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
   description_header: "Page summary"
   change_note_header: "Change made"
   public_updated_at_header: "Time updated"
-  permission_reminder: "You’re getting this email because you subscribed to GOV.UK email alerts%{title}."
+  permission_reminder: "^You’re getting this email because you subscribed to %{frequency} updates %{permission_reminder_topic} on GOV.UK."
   feedback_link: |
         ^Is this email useful? [Answer some questions to tell us more](%{survey_link}).
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,21 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  frequencies:
+    immediately:
+      subject: "GOV.UK update – %{title}"
+      permission_reminder_topic: " about ‘%{title}’"
+      survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate
+    daily:
+      subject: "GOV.UK: your daily update"
+      survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
+    weekly:
+      subject: "GOV.UK: your weekly update"
+      survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
+  permission_reminder: "You’re getting this email because you subscribed to GOV.UK email alerts%{title}."
+  feedback_link: |
+        ^Is this email useful? [Answer some questions to tell us more](%{survey_link}).
+
+        &nbsp;
+
+        ^Do not reply to this email. Feedback? Visit %{feedback_link}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,9 @@ en:
     weekly:
       subject: "GOV.UK: your weekly update"
       survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
+  description_header: "Page summary"
+  change_note_header: "Change made"
+  public_updated_at_header: "Time updated"
   permission_reminder: "You’re getting this email because you subscribed to GOV.UK email alerts%{title}."
   feedback_link: |
         ^Is this email useful? [Answer some questions to tell us more](%{survey_link}).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,9 +50,4 @@ en:
   change_note_header: "Change made"
   public_updated_at_header: "Time updated"
   permission_reminder: "^You’re getting this email because you subscribed to %{frequency} updates %{permission_reminder_topic} on GOV.UK."
-  feedback_link: |
-        ^Is this email useful? [Answer some questions to tell us more](%{survey_link}).
-
-        &nbsp;
-
-        ^Do not reply to this email. Feedback? Visit %{feedback_link}
+  feedback_link: "Is this email useful? [Answer some questions to tell us more](%{survey_link})."

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe DigestEmailBuilder do
-  let(:digest_run) { double(daily?: true) }
+  let(:digest_run) { double(range: "daily") }
   let(:subscriber) { build(:subscriber) }
   let(:subscription_content_change_results) {
     [
@@ -133,7 +133,7 @@ RSpec.describe DigestEmailBuilder do
   end
 
   context "weekly" do
-    let(:digest_run) { double(daily?: false) }
+    let(:digest_run) { double(range: "weekly") }
     it "sets the subject" do
       expect(email.subject).to eq("GOV.UK: your weekly update")
     end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -79,6 +79,8 @@ RSpec.describe DigestEmailBuilder do
 
     expect(email.body).to eq(
       <<~BODY
+        Daily update from GOV.UK.
+
         #Test title 1&nbsp;
 
         presented_content_change
@@ -131,14 +133,14 @@ RSpec.describe DigestEmailBuilder do
 
   context "daily" do
     it "sets the subject" do
-      expect(email.subject).to eq("GOV.UK: your daily update")
+      expect(email.subject).to eq("Daily update from GOV.UK")
     end
   end
 
   context "weekly" do
     let(:digest_run) { double(range: "weekly") }
     it "sets the subject" do
-      expect(email.subject).to eq("GOV.UK: your weekly update")
+      expect(email.subject).to eq("Weekly update from GOV.UK")
     end
   end
 end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -116,13 +116,7 @@ RSpec.describe DigestEmailBuilder do
 
         [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
-        &nbsp;
-
-        ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
-
-        &nbsp;
-
-        ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
+        Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
       BODY
     )
   end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -107,11 +107,6 @@ RSpec.describe DigestEmailBuilder do
 
         unsubscribe_link_2
 
-
-        &nbsp;
-
-        ---
-
         ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
         [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -112,7 +112,8 @@ RSpec.describe DigestEmailBuilder do
 
         ---
 
-        You’re getting this email because you subscribed to GOV.UK email alerts.
+        ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
+
         [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
         &nbsp;

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe DigestEmailBuilder do
   let(:digest_run) { double(range: "daily") }
   let(:subscriber) { build(:subscriber) }
-  let(:subscription_content_change_results) {
+  let(:address) { subscriber.address }
+  let(:subscriber_id) { subscriber.id }
+  let(:subscription_content_changes) {
     [
       double(
         subscription_id: "ABC1",
@@ -26,9 +28,10 @@ RSpec.describe DigestEmailBuilder do
 
   let(:email) {
     described_class.call(
-      subscriber: subscriber,
+      address: address,
+      subscription_content_changes: subscription_content_changes,
       digest_run: digest_run,
-      subscription_content_change_results: subscription_content_change_results,
+      subscriber_id: subscriber_id
     )
   }
 
@@ -41,7 +44,7 @@ RSpec.describe DigestEmailBuilder do
   end
 
   it "sets the subscriber id on the email" do
-    expect(email.subscriber_id).to eq(subscriber.id)
+    expect(email.subscriber_id).to eq(subscriber_id)
   end
 
   it "adds an entry to body for each content change" do
@@ -55,11 +58,11 @@ RSpec.describe DigestEmailBuilder do
       title: "Test title 2"
     ).and_return("unsubscribe_link_2")
 
-    first_content_changes = subscription_content_change_results
+    first_content_changes = subscription_content_changes
       .first
       .content_changes
 
-    second_content_changes = subscription_content_change_results
+    second_content_changes = subscription_content_changes
       .second
       .content_changes
 

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe DigestEmailBuilder do
         ---
 
         You’re getting this email because you subscribed to GOV.UK email alerts.
-        [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+        [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
         &nbsp;
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe ImmediateEmailBuilder do
         <<~BODY
           Update on GOV.UK.
 
+          ---
           presented_content_change
 
           ---
@@ -110,6 +111,7 @@ RSpec.describe ImmediateEmailBuilder do
           <<~BODY
             Update on GOV.UK.
 
+            ---
             presented_content_change
 
             ---

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ImmediateEmailBuilder do
             presented_content_change
 
             ---
-            You’re getting this email because you subscribed to GOV.UK email alerts about ‘#{subscriptions.first.subscriber_list.title}’.
+            ^You’re getting this email because you subscribed to immediate updates to ‘#{subscriptions.first.subscriber_list.title}’ on GOV.UK.
 
             [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -71,11 +71,7 @@ RSpec.describe ImmediateEmailBuilder do
           presented_content_change
 
           ---
-          ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
-
-          &nbsp;
-
-          ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
+          Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
         BODY
       )
     end
@@ -121,13 +117,7 @@ RSpec.describe ImmediateEmailBuilder do
 
             [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
 
-            &nbsp;
-
-            ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
-
-            &nbsp;
-
-            ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
+            Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
           BODY
         )
       end

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ImmediateEmailBuilder do
     end
 
     it "sets the subject" do
-      expect(email.subject).to eq("GOV.UK update – Title")
+      expect(email.subject).to eq("Update from GOV.UK – Title")
     end
 
     it "sets the body and unsubscribe links" do
@@ -66,6 +66,8 @@ RSpec.describe ImmediateEmailBuilder do
 
       expect(email.body).to eq(
         <<~BODY
+          Update on GOV.UK.
+
           presented_content_change
 
           ---
@@ -115,6 +117,8 @@ RSpec.describe ImmediateEmailBuilder do
 
         expect(email.body).to eq(
           <<~BODY
+            Update on GOV.UK.
+
             presented_content_change
 
             ---

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -104,12 +104,7 @@ RSpec.describe ImmediateEmailBuilder do
 
       let(:email) { Email.find(email_import.ids.first) }
 
-      it "sets the body and unsubscribe links" do
-        expect(UnsubscribeLinkPresenter).to receive(:call).with(
-          id: "bef9b608-05ba-46ce-abb7-8567f4180a25",
-          title: "First Subscription"
-        ).and_return("unsubscribe_link")
-
+      it "sets the body" do
         expect(ContentChangePresenter).to receive(:call)
           .and_return("presented_content_change\n")
 
@@ -124,8 +119,7 @@ RSpec.describe ImmediateEmailBuilder do
             ---
             You’re getting this email because you subscribed to GOV.UK email alerts about ‘#{subscriptions.first.subscriber_list.title}’.
 
-            unsubscribe_link
-            [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
+            [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
 
             &nbsp;
 

--- a/spec/builders/unpublish_email_builder_spec.rb
+++ b/spec/builders/unpublish_email_builder_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe UnpublishEmailBuilder do
       describe 'return one email' do
         it 'sets the subject' do
           imported_email = Email.find(described_class.call(emails, 'body').first)
-          expect(imported_email.subject).to eq('GOV.UK update – subject_test')
+          expect(imported_email.subject).to eq('Update from GOV.UK – subject_test')
         end
         it 'contains the subscriber id' do
           imported_email = Email.find(described_class.call(emails, 'body').first)

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -14,23 +14,37 @@ RSpec.describe "creating and delivering digests", type: :request do
     Timecop.return
   end
 
+  def base_path
+    "http://www.dev.gov.uk/base-path?"
+  end
+
   def first_expected_daily_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four, subscriber)
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'daily')})
+      [Title one](#{base_path}#{utm_params(content_change_one.id, 'daily')})
 
+      Page summary
       Description one
 
-      10:00am, 1 January 2017: Change note one
+      Change made
+      Change note one
+
+      Time updated
+      10:00am, 1 January 2017
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'daily')})
+      [Title two](#{base_path}#{utm_params(content_change_two.id, 'daily')})
 
+      Page summary
       Description two
 
-       9:00am, 1 January 2017: Change note two
+      Change made
+      Change note two
+
+      Time updated
+      9:00am, 1 January 2017
 
       ---
 
@@ -40,19 +54,29 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       #Subscriber list two&nbsp;
 
-      [Title four](http://www.dev.gov.uk/base-path?#{utm_params(content_change_four.id, 'daily')})
+      [Title four](#{base_path}#{utm_params(content_change_four.id, 'daily')})
 
+      Page summary
       Description four
 
-       9:30am, 1 January 2017: Change note four
+      Change made
+      Change note four
+
+      Time updated
+      9:30am, 1 January 2017
 
       ---
 
-      [Title three](http://www.dev.gov.uk/base-path?#{utm_params(content_change_three.id, 'daily')})
+      [Title three](#{base_path}#{utm_params(content_change_three.id, 'daily')})
 
+      Page summary
       Description three
 
-       9:00am, 1 January 2017: Change note three
+      Change made
+      Change note three
+
+      Time updated
+      9:00am, 1 January 2017
 
       ---
 
@@ -80,19 +104,29 @@ RSpec.describe "creating and delivering digests", type: :request do
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'daily')})
+      [Title one](#{base_path}#{utm_params(content_change_one.id, 'daily')})
 
+      Page summary
       Description one
 
-      10:00am, 1 January 2017: Change note one
+      Change made
+      Change note one
+
+      Time updated
+      10:00am, 1 January 2017
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'daily')})
+      [Title two](#{base_path}#{utm_params(content_change_two.id, 'daily')})
 
+      Page summary
       Description two
 
-       9:00am, 1 January 2017: Change note two
+      Change made
+      Change note two
+
+      Time updated
+      9:00am, 1 January 2017
 
       ---
 
@@ -256,19 +290,29 @@ RSpec.describe "creating and delivering digests", type: :request do
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'weekly')})
+      [Title one](#{base_path}#{utm_params(content_change_one.id, 'weekly')})
 
+      Page summary
       Description one
 
-      10:00am, 28 December 2016: Change note one
+      Change made
+      Change note one
+
+      Time updated
+      10:00am, 28 December 2016
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'weekly')})
+      [Title two](#{base_path}#{utm_params(content_change_two.id, 'weekly')})
 
+      Page summary
       Description two
 
-       9:00am, 27 December 2016: Change note two
+      Change made
+      Change note two
+
+      Time updated
+      9:00am, 27 December 2016
 
       ---
 
@@ -278,19 +322,29 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       #Subscriber list two&nbsp;
 
-      [Title four](http://www.dev.gov.uk/base-path?#{utm_params(content_change_four.id, 'weekly')})
+      [Title four](#{base_path}#{utm_params(content_change_four.id, 'weekly')})
 
+      Page summary
       Description four
 
-       9:30am, 1 January 2017: Change note four
+      Change made
+      Change note four
+
+      Time updated
+      9:30am, 1 January 2017
 
       ---
 
-      [Title three](http://www.dev.gov.uk/base-path?#{utm_params(content_change_three.id, 'weekly')})
+      [Title three](#{base_path}#{utm_params(content_change_three.id, 'weekly')})
 
+      Page summary
       Description three
 
-       9:00am, 30 December 2016: Change note three
+      Change made
+      Change note three
+
+      Time updated
+      9:00am, 30 December 2016
 
       ---
 
@@ -318,19 +372,29 @@ RSpec.describe "creating and delivering digests", type: :request do
     <<~BODY
       #Subscriber list one&nbsp;
 
-      [Title one](http://www.dev.gov.uk/base-path?#{utm_params(content_change_one.id, 'weekly')})
+      [Title one](#{base_path}#{utm_params(content_change_one.id, 'weekly')})
 
+      Page summary
       Description one
 
-      10:00am, 28 December 2016: Change note one
+      Change made
+      Change note one
+
+      Time updated
+      10:00am, 28 December 2016
 
       ---
 
-      [Title two](http://www.dev.gov.uk/base-path?#{utm_params(content_change_two.id, 'weekly')})
+      [Title two](#{base_path}#{utm_params(content_change_two.id, 'weekly')})
 
+      Page summary
       Description two
 
-       9:00am, 27 December 2016: Change note two
+      Change made
+      Change note two
+
+      Time updated
+      9:00am, 27 December 2016
 
       ---
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      You’re getting this email because you subscribed to GOV.UK email alerts.
+      ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
+
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
@@ -141,7 +142,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      You’re getting this email because you subscribed to GOV.UK email alerts.
+      ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
+
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
@@ -361,7 +363,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      You’re getting this email because you subscribed to GOV.UK email alerts.
+      ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
+
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
@@ -413,7 +416,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      You’re getting this email because you subscribed to GOV.UK email alerts.
+      ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
+
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -84,11 +84,6 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
-
-      &nbsp;
-
-      ---
-
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
@@ -130,11 +125,6 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
-
-
-      &nbsp;
-
-      ---
 
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
@@ -346,11 +336,6 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
 
-
-      &nbsp;
-
-      ---
-
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
@@ -392,11 +377,6 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
-
-
-      &nbsp;
-
-      ---
 
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       You’re getting this email because you subscribed to GOV.UK email alerts.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 
@@ -142,7 +142,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       You’re getting this email because you subscribed to GOV.UK email alerts.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 
@@ -362,7 +362,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       You’re getting this email because you subscribed to GOV.UK email alerts.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 
@@ -414,7 +414,7 @@ RSpec.describe "creating and delivering digests", type: :request do
       ---
 
       You’re getting this email because you subscribed to GOV.UK email alerts.
-      [View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       &nbsp;
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def first_expected_daily_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four, subscriber)
     <<~BODY
+      Daily update from GOV.UK.
+
       #Subscriber list one&nbsp;
 
       [Title one](#{base_path}#{utm_params(content_change_one.id, 'daily')})
@@ -102,6 +104,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def second_expected_daily_email_body(subscription, content_change_one, content_change_two, subscriber)
     <<~BODY
+      Daily update from GOV.UK.
+
       #Subscriber list one&nbsp;
 
       [Title one](#{base_path}#{utm_params(content_change_one.id, 'daily')})
@@ -257,7 +261,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your daily update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "Daily update from GOV.UK")))
       .with(
         body: hash_including(
           personalisation: hash_including(
@@ -269,7 +273,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     second_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-two@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your daily update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "Daily update from GOV.UK")))
       .with(
         body: hash_including(
           personalisation: hash_including(
@@ -288,6 +292,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def first_expected_weekly_email_body(subscription_one, subscription_two, content_change_one, content_change_two, content_change_three, content_change_four, subscriber)
     <<~BODY
+      Updates on GOV.UK this week.
+
       #Subscriber list one&nbsp;
 
       [Title one](#{base_path}#{utm_params(content_change_one.id, 'weekly')})
@@ -370,6 +376,8 @@ RSpec.describe "creating and delivering digests", type: :request do
 
   def second_expected_weekly_email_body(subscription, content_change_one, content_change_two, subscriber)
     <<~BODY
+      Updates on GOV.UK this week.
+
       #Subscriber list one&nbsp;
 
       [Title one](#{base_path}#{utm_params(content_change_one.id, 'weekly')})
@@ -528,7 +536,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     first_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-one@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your weekly update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "Weekly update from GOV.UK")))
       .with(
         body: hash_including(
           personalisation: hash_including(
@@ -540,7 +548,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
     second_digest_stub = stub_request(:post, "http://fake-notify.com/v2/notifications/email")
       .with(body: hash_including(email_address: "test-two@example.com"))
-      .with(body: hash_including(personalisation: hash_including("subject" => "GOV.UK: your weekly update")))
+      .with(body: hash_including(personalisation: hash_including("subject" => "Weekly update from GOV.UK")))
       .with(
         body: hash_including(
           personalisation: hash_including(

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -93,13 +93,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
-      &nbsp;
-
-      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
-
-      &nbsp;
-
-      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
+      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -146,13 +140,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
-      &nbsp;
-
-      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
-
-      &nbsp;
-
-      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
+      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -367,13 +355,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
-      &nbsp;
-
-      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
-
-      &nbsp;
-
-      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
+      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -420,13 +402,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
-      &nbsp;
-
-      ^Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
-
-      &nbsp;
-
-      ^Do not reply to this email. Feedback? Visit http://www.dev.gov.uk/contact
+      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
   scenario "weekly digest run" do

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe "Sending an email", type: :request do
 
     expect(body).to include("Description")
     expect(body).to include("gov.uk/base-path")
-    expect(body).to include("12:00am, 1 January 2017: Change note")
+    expect(body).to include("Change note")
+    expect(body).to include("12:00am, 1 January 2017")
     expect(body).to include("[Unsubscribe from ‘Example’]")
     expect(body).to include("gov.uk/email/unsubscribe/")
   end

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Sending an email", type: :request do
     body = email_data.dig(:personalisation, :body)
 
     expect(address).to eq("test@test.com")
-    expect(subject).to eq("GOV.UK update – Title")
+    expect(subject).to eq("Update from GOV.UK – Title")
 
     expect(body).to include("Description")
     expect(body).to include("gov.uk/base-path")

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Sending an email", type: :request do
     expect(body).to include("gov.uk/base-path")
     expect(body).to include("Change note")
     expect(body).to include("12:00am, 1 January 2017")
-    expect(body).to include("[Unsubscribe from ‘Example’]")
-    expect(body).to include("gov.uk/email/unsubscribe/")
+    expect(body).to include("View, unsubscribe or change the frequency of your subscriptions")
+    expect(body).to include("gov.uk/email/authenticate?address=")
   end
 end

--- a/spec/features/unsubscribing_spec.rb
+++ b/spec/features/unsubscribing_spec.rb
@@ -4,22 +4,37 @@ RSpec.describe "Unsubscribing from a subscriber_list", type: :request do
   end
 
   scenario "unsubscribing from an email uuid, then no longer receiving emails" do
-    login_with_internal_app
+    Timecop.freeze "2019-06-26 10:00" do
+      login_with_internal_app
 
-    subscriber_list_id = create_subscriber_list
-    subscribe_to_subscriber_list(subscriber_list_id)
-    create_content_change
-    email_data = expect_an_email_was_sent
+      subscriber_list_id = create_subscriber_list
+      subscribe_to_subscriber_list(subscriber_list_id, frequency: "daily")
 
-    id = extract_unsubscribe_id(email_data)
-    unsubscribe_from_subscriber_list(id, expected_status: 204)
+      Timecop.freeze "2019-06-25 09:30:00" do
+        create_content_change(public_updated_at: "2019-06-25 10:00:00")
+      end
 
-    clear_any_requests_that_have_been_recorded!
+      DailyDigestInitiatorWorker.new.perform
+      Sidekiq::Worker.drain_all
 
-    create_content_change
-    expect_an_email_was_not_sent
+      email_data = expect_an_email_was_sent
 
-    unsubscribe_from_subscriber_list(id, expected_status: 404)
-    unsubscribe_from_subscriber_list("missing", expected_status: 404)
+      id = extract_unsubscribe_id(email_data)
+      unsubscribe_from_subscriber_list(id, expected_status: 204)
+
+      clear_any_requests_that_have_been_recorded!
+
+      Timecop.freeze "2019-06-25 09:30:01" do
+        create_content_change(public_updated_at: "2019-06-25 10:00:00")
+      end
+
+      DailyDigestInitiatorWorker.new.perform
+      Sidekiq::Worker.drain_all
+
+      expect_an_email_was_not_sent
+
+      unsubscribe_from_subscriber_list(id, expected_status: 404)
+      unsubscribe_from_subscriber_list("missing", expected_status: 404)
+    end
   end
 end

--- a/spec/integration/anonymise_email_addresses_spec.rb
+++ b/spec/integration/anonymise_email_addresses_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Anonymising email addresses" do
         You’re getting this email because you subscribed to ‘Thailand  - travel advice’ updates on GOV.UK.
 
         [Unsubscribe from ‘Thailand  - travel advice’](https://www.gov.uk/email/unsubscribe/8697f282-21f5-474f-a69f-abc3f70b18a8)
-        [View and manage your subscriptions](https://www.gov.uk/email/authenticate?address=foo@example.com)
+        [View, unsubscribe or change the frequency of your subscriptions](https://www.gov.uk/email/authenticate?address=foo@example.com)
       HDOC
     )
 
@@ -78,7 +78,7 @@ RSpec.describe "Anonymising email addresses" do
     expect(email.body).not_to match(/foo@example.com/)
     expect(email.subject).to eq("Email for anonymous-1@example.com")
     expect(email.body).to match(
-      /#{Regexp.escape("[View and manage your subscriptions](https://www.gov.uk/email/authenticate?address=anonymous-1@example.com)")}/
+      /#{Regexp.escape("[View, unsubscribe or change the frequency of your subscriptions](https://www.gov.uk/email/authenticate?address=anonymous-1@example.com)")}/
     )
   end
 

--- a/spec/integration/unpublish_message_spec.rb
+++ b/spec/integration/unpublish_message_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe "Sending an unpublish message", type: :request do
     end
     it "sends a message" do
       expect(DeliveryRequestService).to have_received(:call).
-        with(email: having_attributes(subject: 'GOV.UK update – First Subscription',
+        with(email: having_attributes(subject: 'Update from GOV.UK – First Subscription',
                                       address: Email::COURTESY_EMAIL))
       expect(DeliveryRequestService).to have_received(:call).
-        with(email: having_attributes(subject: 'GOV.UK update – First Subscription',
+        with(email: having_attributes(subject: 'Update from GOV.UK – First Subscription',
                                       address: "test@example.com"))
     end
     it "the message contains the redirect URL" do

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -16,9 +16,14 @@ RSpec.describe ContentChangePresenter do
       expected = <<~CONTENT_CHANGE
         [Change title](http://www.dev.gov.uk/government/test-slug?#{utm_params(content_change.id, 'immediate')})
 
+        Page summary
         Test description
 
-        11:00am, 28 March 2018: Test change note
+        Change made
+        Test change note
+
+        Time updated
+        11:00am, 28 March 2018
       CONTENT_CHANGE
 
       expect(described_class.call(content_change)).to eq(expected)
@@ -39,9 +44,14 @@ RSpec.describe ContentChangePresenter do
         expected = <<~CONTENT_CHANGE
           [Change title](http://www.dev.gov.uk/government/test-slug?#{utm_params(content_change.id, 'immediate')})
 
+          Page summary
           more markdown
 
-          10:30am, 28 March 2018: Test change note markdown test (https://gov.uk)
+          Change made
+          Test change note markdown test (https://gov.uk)
+
+          Time updated
+          10:30am, 28 March 2018
         CONTENT_CHANGE
 
         expect(described_class.call(content_change)).to eq(expected)
@@ -60,7 +70,11 @@ RSpec.describe ContentChangePresenter do
         expected = <<~CONTENT_CHANGE
           [title](http://www.dev.gov.uk/government/base_path?#{utm_params(content_change.id, 'immediate')})
 
-          10:00am, 1 January 2018: change note
+          Change made
+          change note
+
+          Time updated
+          10:00am, 1 January 2018
         CONTENT_CHANGE
 
         expect(described_class.call(content_change)).to eq(expected)
@@ -79,9 +93,14 @@ RSpec.describe ContentChangePresenter do
         expected = <<~CONTENT_CHANGE
           [title](http://www.dev.gov.uk/government/base_path?#{utm_params(content_change.id, 'immediate')})
 
+          Page summary
           description
 
-          10:00am, 1 January 2018: change note
+          Change made
+          change note
+
+          Time updated
+          10:00am, 1 January 2018
 
           footnote
         CONTENT_CHANGE

--- a/spec/presenters/manage_subscriptions_link_presenter_spec.rb
+++ b/spec/presenters/manage_subscriptions_link_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ManageSubscriptionsLinkPresenter do
   describe ".call" do
     it "returns a manage subscriptions link" do
-      expected = "[View and manage your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-email%40test.com)"
+      expected = "[View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-email%40test.com)"
       expect(described_class.call(address: 'test-email@test.com')).to eq(expected)
     end
   end

--- a/spec/services/unpublish_handler_service_spec.rb
+++ b/spec/services/unpublish_handler_service_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe UnpublishHandlerService do
     end
     it 'sends the email and a courtesy email to the DeliverRequestWorker' do
       expect(DeliveryRequestService).to receive(:call).
-          with(email: having_attributes(subject: 'GOV.UK update – First Subscription',
+          with(email: having_attributes(subject: 'Update from GOV.UK – First Subscription',
                                         address: 'test@example.com'))
       expect(DeliveryRequestService).to receive(:call).
-          with(email: having_attributes(subject: 'GOV.UK update – First Subscription',
+          with(email: having_attributes(subject: 'Update from GOV.UK – First Subscription',
                                         address: Email::COURTESY_EMAIL))
       described_class.call(@content_id, @redirect)
     end


### PR DESCRIPTION
**What**
Improve Email Builders to centralise email template terminology using i18n as well as avoid duplication and make it easier to change (more details in the commit message).

Update our email templates with the changes suggested by our content designers:
- Add headers for page description, change note and time updated at
- Change email subject 
- Add opening line to the body
- Reorder parts of the footer (to avoid inconsistent placement of manage and unsubscribe links)
- Remove unsubscribe link from immediate emails
- Update text for manage your subscriptions link
- Update permission reminder text and formatting
- Remove ‘do not reply’ and update feedback part formatting
- Remove line between content changes and footer

**Why**
These changes will make email-alert-api easier to maintain and reduce the amount of developer effort needed when future changes are required. It should also stop email for different frequencies getting out of sync with each other.

Our user research showed some points of confusion in the understanding of content within email.
These pattern-wide fixes we can make to improve email alerts across GOV.UK.

**Immediate update template before**
<img width="427" alt="before-immediate" src="https://user-images.githubusercontent.com/38078064/60329181-bfdbd280-9987-11e9-8f95-039817c83ed8.png">


**NEW immediate update template**
<img width="455" alt="new-immediate" src="https://user-images.githubusercontent.com/38078064/60329191-c5391d00-9987-11e9-8e98-290a52c42735.png">


---

**Digest update template before**
<img width="427" alt="before-daily" src="https://user-images.githubusercontent.com/38078064/60328738-ccabf680-9986-11e9-9b57-e5407a8158f7.png">

**NEW digest update template**
![new-weekly](https://user-images.githubusercontent.com/38078064/60329223-d97d1a00-9987-11e9-8e76-1f0661e3a265.png)


[Trello card: Refactor templates in email-alert-api](https://trello.com/c/XfyyP9ry/159-refactor-templates-in-email-alert-api)
[Trello card: Make text improvements to GOV.UK email templates](https://trello.com/c/rVMddkis/164-make-text-improvements-to-govuk-email-templates)
