### PR TITLE
Add an index on subscriptions ended_at

### DIFF
--- a/db/migrate/20190717121233_add_index_to_subscription_ended_at.rb
+++ b/db/migrate/20190717121233_add_index_to_subscription_ended_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToSubscriptionEndedAt < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscriptions, :ended_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_18_111941) do
+ActiveRecord::Schema.define(version: 2019_07_17_121233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -156,6 +156,7 @@ ActiveRecord::Schema.define(version: 2019_06_18_111941) do
     t.integer "ended_reason"
     t.uuid "ended_email_id"
     t.index ["created_at"], name: "index_subscriptions_on_created_at"
+    t.index ["ended_at"], name: "index_subscriptions_on_ended_at"
     t.index ["subscriber_id", "subscriber_list_id"], name: "index_subscriptions_on_subscriber_id_and_subscriber_list_id", unique: true, where: "(ended_at IS NULL)"
     t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["subscriber_list_id"], name: "index_subscriptions_on_subscriber_list_id"


### PR DESCRIPTION
This field is [used in a query on the healthcheck to find subscription contents for active subscriptions](https://github.com/alphagov/email-alert-api/blob/4c4a9e588aadaa1fbcb038e5c5f0bd72ea4e5121/app/models/healthcheck/subscription_contents.rb#L41-L55).

Before adding this index the query takes about 5 seconds to run: http://tatiyants.com/pev/#/plans/plan_1563365336138

After adding the index, it takes under 100 milliseconds: http://tatiyants.com/pev/#/plans/plan_1563365836649

We often see the healthcheck timing out on 2nd line.