### PR TITLE
Add document types to links in ContentChanges

### DIFF
--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -28,8 +28,8 @@ private
       change_note: params[:change_note],
       description: params[:description],
       base_path: params[:base_path],
-      links: params[:links],
-      tags: content_change_tags,
+      links: with_content_change_supertypes(params[:links]),
+      tags: with_content_change_supertypes(params[:tags]),
       public_updated_at: Time.parse(params[:public_updated_at]),
       email_document_supertype: params[:email_document_supertype],
       government_document_supertype: params[:government_document_supertype],
@@ -42,11 +42,8 @@ private
     }
   end
 
-  def content_change_tags
-    content_change_supertypes.merge(params[:tags])
-  end
-
-  def content_change_supertypes
-    GovukDocumentTypes.supertypes(document_type: params[:document_type])
+  def with_content_change_supertypes(hash)
+    content_change_supertypes = GovukDocumentTypes.supertypes(document_type: params[:document_type])
+    content_change_supertypes.merge(hash)
   end
 end

--- a/spec/services/notification_handler_service_spec.rb
+++ b/spec/services/notification_handler_service_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe NotificationHandlerService do
     create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
   end
 
+  let(:document_type_hash) do
+    {
+        navigation_document_supertype: "other",
+        content_purpose_document_supertype: "news",
+        user_journey_document_supertype: "thing",
+        search_user_need_document_supertype: "government",
+        email_document_supertype: "other",
+        government_document_supertype: "other",
+        content_purpose_subgroup: "news",
+        content_purpose_supergroup: "news_and_communications",
+    }
+  end
+
   describe ".call" do
     it "creates a ContentChange" do
       expect { described_class.call(params: params) }
@@ -65,25 +78,18 @@ RSpec.describe NotificationHandlerService do
         base_path: "/government/things",
         change_note: "This is a change note",
         description: "This is a description",
-        links: {
-          organisations: {
-            any: ["c380ea42-5d91-41cc-b3cd-0a4cfe439461"]
-          },
-          taxon_tree: {
-            all: ["6416e4e0-c0c1-457a-8337-4bf8ed9d5f80"]
-          }
-        },
-        tags: {
-          navigation_document_supertype: "other",
-          content_purpose_document_supertype: "news",
-          user_journey_document_supertype: "thing",
-          search_user_need_document_supertype: "government",
-          email_document_supertype: "other",
-          government_document_supertype: "other",
-          content_purpose_subgroup: "news",
-          content_purpose_supergroup: "news_and_communications",
+        links:
+          hash_including(
+            organisations: {
+              any: ["c380ea42-5d91-41cc-b3cd-0a4cfe439461"]
+            },
+            taxon_tree: {
+              all: ["6416e4e0-c0c1-457a-8337-4bf8ed9d5f80"]
+            }
+),
+        tags: hash_including(
           topics: ["oil-and-gas/licensing"],
-        },
+        ),
         email_document_supertype: "email document supertype",
         government_document_supertype: "government document supertype",
         govuk_request_id: "request-id",
@@ -94,6 +100,16 @@ RSpec.describe NotificationHandlerService do
         signon_user_uid: nil,
         footnote: ""
       )
+    end
+
+    it "adds GovukDocumentTypes to the content_change links" do
+      described_class.call(params: params)
+      expect(ContentChange.last.links).to include(document_type_hash)
+    end
+
+    it "adds GovukDocumentTypes to the content_change tags" do
+      described_class.call(params: params)
+      expect(ContentChange.last.tags).to include(document_type_hash)
     end
 
     it "enqueues the content change to be processed by the subscription content worker" do


### PR DESCRIPTION
Currently document types from GovukDocumentTypes are all added
to the tags attribute to be able to match them

This PR adds them to links as well so the same functionality
will be provided for both.

Trello: https://trello.com/c/JinK1IxW/868-fix-email-bug-in-new-finders