### PR TITLE
Clean email lists

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -1,6 +1,8 @@
 class SubscriberList < ApplicationRecord
   include SymbolizeJSON
 
+  TAGS_BLACKLIST = %i(organisations people world_locations part_of_taxonomy_tree).freeze
+
   self.include_root_in_json = true
 
   validate :tag_values_are_valid
@@ -53,6 +55,14 @@ class SubscriberList < ApplicationRecord
 
   def is_medical_safety_alert?
     self[:tags].fetch("format", []).include?("medical_safety_alert")
+  end
+
+  def invalid_tags?
+    invalid_tags.any?
+  end
+
+  def invalid_tags
+    TAGS_BLACKLIST & self.tags.keys
   end
 
 private

--- a/lib/clean/invalid_subscriber_lists.rb
+++ b/lib/clean/invalid_subscriber_lists.rb
@@ -77,6 +77,20 @@ module Clean
       puts "#{dry} #{moved} of #{total_subscribers} subscribers from list #{from_list.slug} to #{to_list.slug}"
     end
 
+    def deactivate_invalid_subscriptions(dry_run: true)
+      dry_msg = dry_run ? "[DRY RUN] Would have deactivated" : "Deactivated"
+      lists.each do |list|
+        SubscriberList.transaction do
+          subscriptions = list.subscriptions.active
+          count = subscriptions.count
+          subscriptions.each do |subscription|
+            subscription.end(reason: :subscriber_list_changed) unless dry_run
+          end
+          puts "#{dry_msg} #{count} subscription(s) on subscriber list #{list.slug}"
+        end
+      end
+    end
+
   private
 
     def tags_to_links(tags)

--- a/lib/clean/invalid_subscriber_lists.rb
+++ b/lib/clean/invalid_subscriber_lists.rb
@@ -1,0 +1,150 @@
+module Clean
+  # InvalidSubscriberLists enables us to find and correct subscriber lists
+  # with invalid tags.
+  class InvalidSubscriberLists
+    def lists
+      SubscriberList.select(&:invalid_tags?)
+    end
+
+    def valid_list(invalid_list, dry_run: true)
+      return unless subscriber_lists?([invalid_list])
+
+      return unless invalid_list.invalid_tags?
+
+      unless invalid_list.subscribers.activated.any?
+        puts "NoSubscribersError: Did not create a new subscriber list for invalid list #{invalid_list.id}: #{invalid_list.slug}, as there were no active subscribers"
+        return
+      end
+
+      slug = invalid_list.slug + '-untagged'
+      list = SubscriberList.find_by(slug: slug)
+      return list unless list.nil?
+
+      new_list = SubscriberList.new(
+        document_type: invalid_list.document_type,
+        email_document_supertype: invalid_list.email_document_supertype,
+        government_document_supertype: invalid_list.government_document_supertype,
+        links: tags_to_links(invalid_list.tags),
+        slug: slug,
+        title: invalid_list.title,
+      )
+
+      new_list.save! unless dry_run
+
+      new_list
+    rescue StandardError => e
+      puts "InvalidTagValueError: Could not create subscriber list from an invalid list. invalid_id: #{invalid_list.id}
+      invalid_slug: #{invalid_list.slug} as we couldn't create a valid subscriber list: #{e.message}"
+    end
+
+    def copy_subscribers(from_list, to_list, dry_run: true)
+      return unless subscriber_lists?([from_list, to_list])
+
+      subscribers = from_list.subscribers.activated
+      total_subscribers = subscribers.count
+      moved = 0
+      subscribers.each do |subscriber|
+        Subscription.transaction do
+          existing_subscription = Subscription.active.find_by(
+            subscriber: subscriber,
+            subscriber_list: from_list,
+          )
+
+          next unless existing_subscription
+
+          # Check if they have already subscribed
+          subscribed_to_destination_subscriber_list = Subscription.find_by(
+            subscriber: subscriber,
+            subscriber_list: to_list
+          )
+
+          # Subscribed them if they haven't already been subscribed
+          if subscribed_to_destination_subscriber_list.nil?
+            moved += 1
+            unless dry_run
+              Subscription.create!(
+                subscriber: subscriber,
+                subscriber_list: to_list,
+                frequency: existing_subscription.frequency,
+                source: :subscriber_list_changed
+              )
+            end
+          end
+        end
+      end
+
+      dry = dry_run ? '[DRY RUN] Would have copied' : 'copied'
+      puts "#{dry} #{moved} of #{total_subscribers} subscribers from list #{from_list.slug} to #{to_list.slug}"
+    end
+
+  private
+
+    def tags_to_links(tags)
+      tags.each_with_object({}) do |(key, value), links|
+        if key == :part_of_taxonomy_tree
+          links[:taxon_tree] = value
+        elsif SubscriberList::TAGS_BLACKLIST.include? key
+          value.keys.each { |any_or_all|
+            links[key] ||= {}
+            links[key][any_or_all] = tag_slugs_to_ids(key, value[any_or_all])
+          }
+        else
+          links[key] = value
+        end
+      end
+    end
+
+    def tag_slugs_to_ids(key, values)
+      case key
+      when :people
+        values.map { |slug| people_content_id(slug) }
+      when :organisations
+        values.map { |slug| organisation_content_id(slug) }
+      when :world_locations
+        values.map { |slug| world_location_content_id(slug) }
+      end
+    end
+
+    def organisation_content_id(slug)
+      slug = CGI::escape(slug)
+      @organisations ||= {}
+      cached = @organisations[slug]
+      return cached unless cached.nil?
+
+      path = "/government/organisations/#{slug}"
+      item = Services.content_store.content_item(path).to_h
+      id = item['content_id']
+
+      @organisations[slug] = id
+    end
+
+    def people_content_id(slug)
+      slug = CGI::escape(slug)
+      @people ||= {}
+      cached = @people[slug]
+      return cached unless cached.nil?
+
+      path = "/government/people/#{slug}"
+      item = Services.content_store.content_item(path).to_h
+      id = item['content_id']
+
+      @people[slug] = id
+    end
+
+    def world_location_content_id(slug)
+      slug = CGI::escape(slug)
+      @world_locations ||= begin
+        locations = GdsApi.worldwide.world_locations.with_subsequent_pages.to_a
+        locations.each_with_object({}) { |location, result_hash|
+          result_hash[location.dig('details', 'slug')] = location.dig('content_id')
+        }
+      end
+
+      @world_locations[slug]
+    end
+
+    def subscriber_lists?(objects)
+      objects.all? { |obj| obj.instance_of? SubscriberList }
+    end
+  end
+end

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -30,6 +30,13 @@ namespace :clean do
     }
   end
 
+  desc "Deactivate subcriptions to invalid SubscriberLists"
+  task :deactivate_invalid_subscriptions, [:id] => :environment do |_t, _args|
+    dry_run = is_dry_run?
+    cleaner = Clean::InvalidSubscriberLists.new
+    cleaner.deactivate_invalid_subscriptions(dry_run: dry_run)
+  end
+
   def is_dry_run?
     dry = ENV["DRY_RUN"] != 'no'
     puts "Warning: Running in DRY_RUN mode. Use DRY_RUN=no to run live." if dry

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -1,0 +1,38 @@
+namespace :clean do
+  desc "List invalid SubscriberLists that will not deliver emails"
+  task :report_invalid_subscriber_lists, [:id] => :environment do |_t, _args|
+    lists = Clean::InvalidSubscriberLists.new.lists
+    num_lists = lists.count
+    puts "Found #{num_lists} #{'lists'.pluralize(num_lists)} that are invalid"
+  end
+
+  desc "
+    Subscribe people that have subscriptions to invalid lists to valid lists
+
+    * Looks up all invalid SubscriberLists
+    * For each invalid SubscriberList, creates a valid list
+    * Subscribes subscribers of invalid list to the valid list
+    * Does not delete any bad lists or subscriptions
+
+    By default, this will not create anything. If you would like it to, use
+    DRY_RUN=no. E.g. `DRY_RUN=no bundle exec rake clean:migrate_subscriptions_to_valid_lists`
+  "
+  task :migrate_subscriptions_to_valid_lists, [:id] => :environment do |_t, _args|
+    dry_run = is_dry_run?
+    cleaner = Clean::InvalidSubscriberLists.new
+    lists = cleaner.lists
+    num_lists = lists.count
+    puts "Found #{num_lists} #{'lists'.pluralize(num_lists)} that are invalid"
+
+    lists.each { |from_list|
+      new_list = cleaner.valid_list(from_list, dry_run: dry_run)
+      cleaner.copy_subscribers(from_list, new_list, dry_run: dry_run)
+    }
+  end
+
+  def is_dry_run?
+    dry = ENV["DRY_RUN"] != 'no'
+    puts "Warning: Running in DRY_RUN mode. Use DRY_RUN=no to run live." if dry
+    dry
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
     publishing_app { "publishing app" }
   end
 
+  trait :skip_validation do
+    to_create { |instance| instance.save!(validate: false) }
+  end
+
   factory :delivery_attempt, aliases: [:sending_delivery_attempt] do
     email
     status { :sending }
@@ -126,6 +130,25 @@ FactoryBot.define do
 
       after(:create) do |list, evaluator|
         create_list(:subscriber, evaluator.subscriber_count, subscriber_lists: [list])
+      end
+    end
+
+    factory :subscriber_list_with_invalid_tags do
+      tags {
+        {
+          organisations: { any: %w[bar] },
+          people: { all: %w[bar] },
+          world_locations: { all: %w[bar] },
+        }
+      }
+
+      transient do
+        subscriber_count { 5 }
+      end
+
+      after(:create) do |list, evaluator|
+        list = build_list(:subscriber, evaluator.subscriber_count, subscriber_lists: [list])
+        list.each { |item| item.save!(validate: false) }
       end
     end
   end

--- a/spec/lib/clean/invalid_subscriber_lists_spec.rb
+++ b/spec/lib/clean/invalid_subscriber_lists_spec.rb
@@ -1,0 +1,170 @@
+require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/worldwide'
+
+RSpec.describe Clean::InvalidSubscriberLists do
+  include ::GdsApi::TestHelpers::Worldwide
+  include ::GdsApi::TestHelpers::ContentStore
+
+  let(:subject) { described_class.new }
+
+  context "when there are invalid lists" do
+    let!(:list) { create(:subscriber_list_with_invalid_tags, :skip_validation) }
+
+    describe "#lists" do
+      it "returns all subscriber_lists that are invalid" do
+        expect(subject.lists.count).to eq(1)
+        expect(subject.lists).to include(list)
+      end
+    end
+  end
+
+  context "when there are no invalid lists" do
+    let!(:list) { create(:subscriber_list) }
+
+    describe "#lists" do
+      it "returns zero subscriber lists" do
+        expect(subject.lists.count).to eq(0)
+        expect(subject.lists).to_not include(list)
+      end
+    end
+  end
+
+  describe "#valid_list" do
+    let(:tags) {
+      {
+        organisations: { any: %w[ministry-of-silly-walks ministry-of-sillier-walks] },
+        people: { all: %w[harry-potter] },
+        world_locations: { all: %w[france iceland malta], any: %w[australia] },
+        content_store_document_type: { any: %w[news_and_communications] },
+        part_of_taxonomy_tree: { any: %w[taxon], all: %w[another-taxon] },
+      }
+    }
+    let!(:valid_list) { create(:subscriber_list) }
+    let!(:invalid_list) { create(:subscriber_list_with_invalid_tags, :skip_validation, tags: tags) }
+
+    it "returns nil when given a valid list" do
+      expect(subject.valid_list(valid_list)).to be nil
+    end
+
+    context "when given an invalid list" do
+      before :each do
+        content_store_has_organisations
+        content_store_has_people
+        stub_worldwide_api_has_selection_of_locations
+      end
+
+      context "during a dry run" do
+        it "wont create a new list" do
+          expect { subject.valid_list(invalid_list) }.not_to(change { SubscriberList.count })
+        end
+      end
+
+      it "returns a new valid list" do
+        expect(SubscriberList.count).to eq(2)
+        new_list = subject.valid_list(invalid_list, dry_run: false)
+        expect(SubscriberList.count).to eq(3)
+        expect(new_list).to be_instance_of(SubscriberList)
+        expect(new_list.invalid_tags?).to be false
+        expect(new_list.tags).to eq({})
+        expect(new_list.links).to eq(
+          organisations: { any: %w[silly-walks-id sillier-walks-walks-id] },
+          people: { all: %w[harry-potter-id] },
+          world_locations: {
+            all: %w[content_id_for_france content_id_for_iceland content_id_for_malta],
+            any: %w[content_id_for_australia]
+          },
+          content_store_document_type: { any: %w[news_and_communications] },
+          taxon_tree: { any: %w[taxon], all: %w[another-taxon] },
+        )
+      end
+    end
+
+    context "when given a list with invalid value" do
+      let(:tags) {
+        {
+          people: { all: %w[harry-potter non-existant-person] },
+        }
+      }
+
+      before :each do
+        content_store_has_people
+      end
+
+      it "wont create a new list" do
+        expect {
+          subject.valid_list(invalid_list)
+        }.not_to(change { SubscriberList.count })
+      end
+    end
+  end
+
+  describe "#copy_subscribers" do
+    let!(:from_list) { create(:subscriber_list_with_subscribers) }
+    let!(:to_list) { create(:subscriber_list) }
+    let!(:subscriber) { create(:subscriber) }
+    let!(:subscription1) { create(:subscription, subscriber: subscriber, subscriber_list: from_list) }
+    let!(:subscription2) { create(:subscription, subscriber: subscriber, subscriber_list: to_list) }
+
+    it "creates new subscriptions to the to_list for the subscribers to the for_list" do
+      expect {
+        subject.copy_subscribers(from_list, to_list, dry_run: false)
+      }.to(change { to_list.subscribers.count }.by(5))
+    end
+
+    it "does not change the subscriptions to the from_list" do
+      expect {
+        subject.copy_subscribers(from_list, to_list, dry_run: false)
+      }.not_to(change { from_list.subscribers.count })
+    end
+
+    context "when it is a dry run, which is the default" do
+      it "does not create any new subscriptions" do
+        expect {
+          subject.copy_subscribers(from_list, to_list)
+        }.not_to(change { to_list.subscribers.count })
+        expect {
+          subject.copy_subscribers(from_list, to_list)
+        }.not_to(change { from_list.subscribers.count })
+      end
+    end
+
+    context "when not given subscriber lists" do
+      it "does nothing" do
+        expect {
+          subject.copy_subscribers(nil, nil)
+        }.not_to(change { Subscription.count })
+      end
+    end
+  end
+
+  def content_store_has_organisations
+    content_store_has_item(
+      '/government/organisations/ministry-of-silly-walks',
+      {
+        'base_path' => '/government/organisations/ministry-of-silly-walks',
+        'content_id' => 'silly-walks-id',
+      }.to_json
+    )
+
+    content_store_has_item(
+      '/government/organisations/ministry-of-sillier-walks',
+      {
+        'base_path' => '/government/organisations/ministry-of-sillier-walks',
+        'content_id' => 'sillier-walks-walks-id',
+      }.to_json
+    )
+  end
+
+  def content_store_has_people
+    content_store_has_item(
+      '/government/people/harry-potter',
+      {
+        'base_path' => '/government/people/harry-potter',
+        'content_id' => 'harry-potter-id',
+      }.to_json
+    )
+    stub_content_store_does_not_have_item(
+      '/government/people/non-existant-person'
+    )
+  end
+end

--- a/spec/queries/find_exact_match_spec.rb
+++ b/spec/queries/find_exact_match_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FindExactMatch do
       :subscriber_list,
       tags: {
         topics: { any: ["oil-and-gas/licensing"] },
-        organisations: { any: ["environment-agency", "hm-revenue-customs"] }
+        format: { any: %w[guide news_story] }
       },
       links: {
         topics: { any: ["uuid-888"] },
@@ -38,7 +38,7 @@ RSpec.describe FindExactMatch do
     it "not matched when query contains more keys than the subscriber_list" do
       found_lists = described_class.new(query_field: :tags)
         .call(topics:  { any: ["oil-and-gas/licensing"] },
-          organisations:  { any: ["environment-agency", "hm-revenue-customs"] },
+          format: { any: %w[guide news_story] },
           foo:  { any: %w[bar] })
       expect(found_lists).to eq([])
     end
@@ -46,21 +46,21 @@ RSpec.describe FindExactMatch do
     it "not matched when matching keys, but different values for each key" do
       found_lists = described_class.new(query_field: :tags)
         .call(topics:  { any: ["oil-and-gas/conservation"] },
-          organisations:  { any: ["environment-agency", "hm-revenue-customs"] })
+          format: { any: %w[guide news_story] })
       expect(found_lists).to eq([])
     end
 
     it "matched when matching keys with matching values" do
       found_lists = described_class.new(query_field: :tags)
         .call(topics: { any: ["oil-and-gas/licensing"] },
-          organisations:  { any: ["environment-agency", "hm-revenue-customs"] })
+          format: { any: %w[guide news_story] })
       expect(found_lists).to eq([list_with_tags])
     end
 
     it "order of values for keys does not affect matching" do
       found_lists = described_class.new(query_field: :tags)
         .call(topics:  { any: ["oil-and-gas/licensing"] },
-          organisations:  { any: ["hm-revenue-customs", "environment-agency"] })
+          format: { any: %w[news_story guide] })
       expect(found_lists).to eq([list_with_tags])
     end
 

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MatchedForNotification do
   describe "#call" do
     before do
       @subscriber_list_that_should_never_match = create(:subscriber_list, tags: {
-        topics: { any: ["Badical Turbo Radness"] }, organisations: { any: ["Sirius Cybernetics Corporation"] }
+        topics: { any: ["Badical Turbo Radness"] }, format: { any: %w[news_story] }
       })
     end
 
@@ -23,12 +23,12 @@ RSpec.describe MatchedForNotification do
         @lists = {
           tags:
             {
-              any_topic_paye_any_org_defra_hmrc: create_subscriber_list_with_tags_facets(topics: { any: %w(paye) }, organisations: { any: %w(defra hmrc) }),
+              any_topic_paye_any_format_guides: create_subscriber_list_with_tags_facets(topics: { any: %w(paye) }, format: { any: %w(policy guide) }),
               any_topic_vat_licensing: create_subscriber_list_with_tags_facets(topics: { any: %w(vat licensing) }),
             },
           links:
             {
-              any_topic_paye_any_org_defra_hmrc: create_subscriber_list_with_links_facets(topics: { any: %w(paye) }, organisations: { any: %w(defra hmrc) }),
+              any_topic_paye_any_format_guides: create_subscriber_list_with_links_facets(topics: { any: %w(paye) }, format: { any: %w(policy guide) }),
               any_topic_vat_licensing: create_subscriber_list_with_links_facets(topics: { any: %w(vat licensing) }),
             }
         }
@@ -36,11 +36,11 @@ RSpec.describe MatchedForNotification do
 
       %i(links tags).each do |key|
         it "finds subscriber lists where at least one value of each #{key} in the subscription is present in the query_hash" do
-          lists = execute_query({ topics: %w(paye), organisations: %w(defra) }, field: key)
-          expect(lists).to eq([@lists[key][:any_topic_paye_any_org_defra_hmrc]])
+          lists = execute_query({ topics: %w(paye), format: %w(guide) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_paye_any_format_guides]])
 
-          lists = execute_query({ topics: %w(paye), organisations: %w(hmrc) }, field: key)
-          expect(lists).to eq([@lists[key][:any_topic_paye_any_org_defra_hmrc]])
+          lists = execute_query({ topics: %w(paye), format: %w(guide) }, field: key)
+          expect(lists).to eq([@lists[key][:any_topic_paye_any_format_guides]])
 
           lists = execute_query({ topics: %w(vat) }, field: key)
           expect(lists).to eq([@lists[key][:any_topic_vat_licensing]])


### PR DESCRIPTION
This adds `Clean::InvalidSubscriberLists` that will be called via the rake task `clean:migrate_subscriptions_to_valid_lists`.

This will enable us to find and fix situations where a user is subscribed to an email list which has invalid tags.

By default the tasks will be run in `dry_run` mode, so nothing will be modified unless you use `DRY_RUN=no.`

If it's not a dry run, then `clean:migrate_subscriptions_to_valid_lists` will find all the invalid subscriber lists and create a new valid subscriber list. It'll then create new subscriptions for the users on the invalid list.

Later on we can clean up the old data (invalid subscriber lists and their subscriptions) and add some validations against these invalid tags.

Trello: https://trello.com/c/rTXOLY1z/878.

