### PR TITLE
Quicken SubscriptionContent healthcheck

### DIFF
--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -7,8 +7,6 @@ module Healthcheck
     def status
       if critical_subscription_contents.positive?
         :critical
-      elsif warning_subscription_contents.positive?
-        :warning
       else
         :ok
       end
@@ -17,14 +15,12 @@ module Healthcheck
     def details
       {
         critical: critical_subscription_contents,
-        warning: warning_subscription_contents,
       }
     end
 
     def message
       <<~MESSAGE
         #{critical_subscription_contents} created over #{critical_latency} seconds ago.
-        #{warning_subscription_contents} created over #{warning_latency} seconds ago.
       MESSAGE
     end
 
@@ -32,10 +28,6 @@ module Healthcheck
 
     def critical_subscription_contents
       @critical_subscription_contents ||= count_subscription_contents(critical_latency)
-    end
-
-    def warning_subscription_contents
-      @warning_subscription_contents ||= count_subscription_contents(warning_latency)
     end
 
     def count_subscription_contents(age)
@@ -55,10 +47,6 @@ module Healthcheck
     end
 
     def critical_latency
-      is_scheduled_publishing_time? ? 20.minutes : 10.minutes
-    end
-
-    def warning_latency
       is_scheduled_publishing_time? ? 15.minutes : 5.minutes
     end
 

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Healthcheck", type: :request do
       sidekiq_queue_size:    hash_including(status: "ok", queues: a_kind_of(Hash)),
       sidekiq_retry_size:    hash_including(status: "ok", value: 0),
       status_updates:        hash_including(status: "ok", total: 0),
-      subscription_contents: hash_including(status: "ok", critical: 0, warning: 0),
+      subscription_contents: hash_including(status: "ok", critical: 0),
       technical_failures:    hash_including(status: "ok", value: 0),
       internal_failures:     hash_including(status: "ok", value: 0),
     )

--- a/spec/models/healthcheck/subscription_contents_spec.rb
+++ b/spec/models/healthcheck/subscription_contents_spec.rb
@@ -2,17 +2,12 @@ RSpec.describe Healthcheck::SubscriptionContents do
   context "between 09:30 and 10:30" do
     shared_examples "an ok healthcheck" do
       specify { expect(subject.status).to eq(:ok) }
-      specify { expect(subject.message).to match(/0 created over 1200 seconds ago/) }
-    end
-
-    shared_examples "a warning healthcheck" do
-      specify { expect(subject.status).to eq(:warning) }
-      specify { expect(subject.message).to match(/1 created over 900 seconds ago/) }
+      specify { expect(subject.message).to match(/0 created over 900 seconds ago/) }
     end
 
     shared_examples "a critical healthcheck" do
       specify { expect(subject.status).to eq(:critical) }
-      specify { expect(subject.message).to match(/1 created over 1200 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 900 seconds ago/) }
     end
 
     around do |example|
@@ -32,14 +27,6 @@ RSpec.describe Healthcheck::SubscriptionContents do
         create(:subscription_content, created_at: 16.minutes.ago)
       end
 
-      it_behaves_like "a warning healthcheck"
-    end
-
-    context "when a subscription content was created over 20 minutes ago" do
-      before do
-        create(:subscription_content, created_at: 21.minutes.ago)
-      end
-
       it_behaves_like "a critical healthcheck"
     end
   end
@@ -47,17 +34,12 @@ RSpec.describe Healthcheck::SubscriptionContents do
   context "when not scheduled publishing time" do
     shared_examples "an ok healthcheck" do
       specify { expect(subject.status).to eq(:ok) }
-      specify { expect(subject.message).to match(/0 created over 600 seconds ago/) }
-    end
-
-    shared_examples "a warning healthcheck" do
-      specify { expect(subject.status).to eq(:warning) }
-      specify { expect(subject.message).to match(/1 created over 300 seconds ago/) }
+      specify { expect(subject.message).to match(/0 created over 300 seconds ago/) }
     end
 
     shared_examples "a critical healthcheck" do
       specify { expect(subject.status).to eq(:critical) }
-      specify { expect(subject.message).to match(/1 created over 600 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 300 seconds ago/) }
     end
 
     around do |example|
@@ -75,14 +57,6 @@ RSpec.describe Healthcheck::SubscriptionContents do
     context "when a subscription content was created over 5 minutes ago" do
       before do
         create(:subscription_content, created_at: 6.minutes.ago)
-      end
-
-      it_behaves_like "a warning healthcheck"
-    end
-
-    context "when a subscription content was created over 10 minutes ago" do
-      before do
-        create(:subscription_content, created_at: 11.minutes.ago)
       end
 
       it_behaves_like "a critical healthcheck"


### PR DESCRIPTION
https://trello.com/c/P9fomge6/646-%E2%9C%89%EF%B8%8F-email-alert-api-app-healthcheck-not-ok

This should reduce the multi-second timings we currently have warnings
for in production...

Previously running this healthcheck involved querying two large tables
twice: SubscriptionContent and Subscription. Since we expect the steps
taken to address the alert to be identical for both a warning and a
critical, this reduces the runtime of the check by just having one
(critical) severity level, but using the parameters for the (deleted)
warning severity level so that the alert will still be timely.