### PR TITLE
Include content_store_document_type in content change tags and links

### DIFF
--- a/app/services/notification_handler_service.rb
+++ b/app/services/notification_handler_service.rb
@@ -44,6 +44,7 @@ private
 
   def with_content_change_supertypes(hash)
     content_change_supertypes = GovukDocumentTypes.supertypes(document_type: params[:document_type])
-    content_change_supertypes.merge(hash)
+    content_store_document_type = { content_store_document_type: params[:document_type] }
+    content_change_supertypes.merge(hash).merge(content_store_document_type)
   end
 end

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -147,6 +147,16 @@ RSpec.describe MatchedForNotification do
       end
     end
 
+    context "matches on content_store_document_type" do
+      let!(:list1) { create(:subscriber_list, links: { content_store_document_type: { any: %w[news_article] } }) }
+      let!(:list2) { create(:subscriber_list, links: { content_store_document_type: { any: %w[other_type] } }) }
+
+      it "finds subscriber lists matching content_store_document_type" do
+        lists = execute_query({ content_store_document_type: 'news_article' }, field: :links)
+        expect(lists).to eq([list1])
+      end
+    end
+
     context "Specialist publisher edge case in format tag" do
       before do
         @subscriber_list = create_subscriber_list_with_tags_facets(format: { any: %w[employment_tribunal_decision] })

--- a/spec/services/notification_handler_service_spec.rb
+++ b/spec/services/notification_handler_service_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe NotificationHandlerService do
         government_document_supertype: "other",
         content_purpose_subgroup: "news",
         content_purpose_supergroup: "news_and_communications",
+        content_store_document_type: "news_article",
     }
   end
 
@@ -83,12 +84,14 @@ RSpec.describe NotificationHandlerService do
             organisations: {
               any: ["c380ea42-5d91-41cc-b3cd-0a4cfe439461"]
             },
+            content_store_document_type: "news_article",
             taxon_tree: {
               all: ["6416e4e0-c0c1-457a-8337-4bf8ed9d5f80"]
             }
 ),
         tags: hash_including(
           topics: ["oil-and-gas/licensing"],
+          content_store_document_type: "news_article",
         ),
         email_document_supertype: "email document supertype",
         government_document_supertype: "government document supertype",


### PR DESCRIPTION
This will ensure that content changes with `document_type` of news_article will be delivered to subscriber lists with tags or links of e.g. `content_store_document_type: { any: [news_article news] } }`

Trello: https://trello.com/c/kNl6PISW/898