### PR TITLE
Add rake task for removing sub lists with no subs

### DIFF
--- a/lib/clean/empty_subscriber_lists.rb
+++ b/lib/clean/empty_subscriber_lists.rb
@@ -1,0 +1,12 @@
+module Clean
+  class EmptySubscriberLists
+    def lists
+      @lists ||= SubscriberList.all.select { |l| l.subscriptions.count.zero? }
+    end
+
+    def remove_empty_subscriberlists(dry_run: true)
+      lists.each(&:destroy) unless dry_run
+      puts "Found #{dry_run ? '' : 'and removed '}#{lists.count} #{'lists'.pluralize(lists.count)} that had no subscribers"
+    end
+  end
+end

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -37,6 +37,13 @@ namespace :clean do
     cleaner.deactivate_invalid_subscriptions(dry_run: dry_run)
   end
 
+  desc "Remove SubscriberLists with no subscriptions"
+  task remove_empty_subscriberlists: :environment do
+    dry_run = is_dry_run?
+    cleaner = Clean::EmptySubscriberLists.new
+    cleaner.remove_empty_subscriberlists(dry_run: dry_run)
+  end
+
   def is_dry_run?
     dry = ENV["DRY_RUN"] != 'no'
     puts "Warning: Running in DRY_RUN mode. Use DRY_RUN=no to run live." if dry

--- a/spec/lib/clean/empty_subscriber_lists_spec.rb
+++ b/spec/lib/clean/empty_subscriber_lists_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe Clean::EmptySubscriberLists do
         expect(subject.lists).to include(list)
       end
     end
+
+    context "during a dry run" do
+      it "wont remove the list" do
+        expect { subject.remove_empty_subscriberlists }.not_to(change { SubscriberList.count })
+      end
+    end
+
+    it "removes the list" do
+      expect { subject.remove_empty_subscriberlists(dry_run: false) }.to(change { SubscriberList.count })
+    end
   end
 
   context "when there are lists with subscribers" do

--- a/spec/lib/clean/empty_subscriber_lists_spec.rb
+++ b/spec/lib/clean/empty_subscriber_lists_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Clean::EmptySubscriberLists do
+  let(:subject) { described_class.new }
+
+  context "when there are empty lists" do
+    let!(:list) { create(:subscriber_list) }
+
+    describe "#lists" do
+      it "returns one subscriber list" do
+        expect(subject.lists.count).to eq(1)
+        expect(subject.lists).to include(list)
+      end
+    end
+  end
+
+  context "when there are lists with subscribers" do
+    let!(:list) { create(:subscriber_list_with_subscribers) }
+
+    describe "#lists" do
+      it "returns zero subscriber lists" do
+        expect(subject.lists.count).to eq(0)
+        expect(subject.lists).to_not include(list)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/TcWzthQL/880-clean-subscriber-lists-created-by-finder-frontend