### PR TITLE
Add validation for subscriber list tags

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -57,10 +57,6 @@ class SubscriberList < ApplicationRecord
     self[:tags].fetch("format", []).include?("medical_safety_alert")
   end
 
-  def invalid_tags?
-    invalid_tags.any?
-  end
-
   def invalid_tags
     TAGS_BLACKLIST & self.tags.keys
   end
@@ -70,6 +66,10 @@ private
   def tag_values_are_valid
     unless valid_subscriber_criteria(:tags)
       self.errors.add(:tags, "All tag values must be sent as Arrays")
+    end
+
+    if invalid_tags?
+      self.errors.add(:tags, "#{invalid_tags.to_sentence} are not valid tags. Should they be links?")
     end
   end
 
@@ -85,5 +85,9 @@ private
         %i[all any].include?(operator) && values.is_a?(Array)
       end
     end
+  end
+
+  def invalid_tags?
+    invalid_tags.any?
   end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -11,7 +11,7 @@ class SubscriberList < ApplicationRecord
   validates :title, presence: true
   validates_uniqueness_of :slug
 
-  has_many :subscriptions
+  has_many :subscriptions, dependent: :destroy
   has_many :subscribers, through: :subscriptions
   has_many :matched_content_changes
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,7 +2,7 @@ class Subscription < ApplicationRecord
   belongs_to :subscriber
   belongs_to :subscriber_list
 
-  has_many :subscription_contents
+  has_many :subscription_contents, dependent: :destroy
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
   enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2, subscriber_list_changed: 3 }, _prefix: true

--- a/lib/clean/invalid_subscriber_lists.rb
+++ b/lib/clean/invalid_subscriber_lists.rb
@@ -3,13 +3,13 @@ module Clean
   # with invalid tags.
   class InvalidSubscriberLists
     def lists
-      SubscriberList.select(&:invalid_tags?)
+      SubscriberList.select(&:invalid?)
     end
 
     def valid_list(invalid_list, dry_run: true)
       return unless subscriber_lists?([invalid_list])
 
-      return unless invalid_list.invalid_tags?
+      return unless invalid_list.invalid?
 
       unless invalid_list.subscribers.activated.any?
         puts "NoSubscribersError: Did not create a new subscriber list for invalid list #{invalid_list.id}: #{invalid_list.slug}, as there were no active subscribers"

--- a/lib/clean/invalid_subscriber_lists.rb
+++ b/lib/clean/invalid_subscriber_lists.rb
@@ -91,6 +91,19 @@ module Clean
       end
     end
 
+    def destroy_invalid_subscriber_lists(dry_run: true)
+      count = 0
+      lists.each do |list|
+        next if list.subscriptions.active.any?
+
+        count += 1
+        puts "#{dry_run ? '[DRY RUN]' : ''} Deleting subscriber_list #{list.slug}"
+        list.destroy unless dry_run
+      end
+      dry_msg = dry_run ? "[DRY RUN] Would have deleted" : "Deleted"
+      puts "#{dry_msg} #{count} subscriber lists"
+    end
+
   private
 
     def tags_to_links(tags)

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -44,6 +44,13 @@ namespace :clean do
     cleaner.remove_empty_subscriberlists(dry_run: dry_run)
   end
 
+  desc "Destroys SubscriberLists that don't pass validations and don't have active subscriptions"
+  task delete_invalid_subscriber_lists: :environment do
+    dry_run = is_dry_run?
+    cleaner = Clean::InvalidSubscriberLists.new
+    cleaner.destroy_invalid_subscriber_lists(dry_run: dry_run)
+  end
+
   def is_dry_run?
     dry = ENV["DRY_RUN"] != 'no'
     puts "Warning: Running in DRY_RUN mode. Use DRY_RUN=no to run live." if dry

--- a/spec/lib/clean/invalid_subscriber_lists_spec.rb
+++ b/spec/lib/clean/invalid_subscriber_lists_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Clean::InvalidSubscriberLists do
         new_list = subject.valid_list(invalid_list, dry_run: false)
         expect(SubscriberList.count).to eq(3)
         expect(new_list).to be_instance_of(SubscriberList)
-        expect(new_list.invalid_tags?).to be false
+        expect(new_list.invalid?).to be false
         expect(new_list.tags).to eq({})
         expect(new_list.links).to eq(
           organisations: { any: %w[silly-walks-id sillier-walks-walks-id] },

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe SubscriberList, type: :model do
       expect(subject).to be_valid
     end
 
+    it "is invalid when tags 'hash' has values that are blacklisted" do
+      subject.tags = {
+        foo: { any: %w[bar] },
+        dogs: { all: %w[bark] },
+        organisations: { any: %w[bar] },
+        people: { any: %w[bar] },
+        world_locations: { all: %w[bar] },
+      }
+
+      expect(subject).to be_invalid
+      expect(subject.errors[:tags]).to include("organisations, people, and world_locations are not valid tags. Should they be links?")
+    end
+
     it "is invalid when tags 'hash' has values that are not arrays" do
       subject.tags = { foo: { any: "bar" } }
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -83,6 +83,33 @@ RSpec.describe SubscriberList, type: :model do
     end
   end
 
+  context "when a subscriber_list is deleted" do
+    subject { create(:subscriber_list_with_invalid_tags, :skip_validation) }
+    let!(:a_sanity_check_list) { build(:subscriber_list) }
+    let!(:subscriber) { create(:subscriber) }
+    let!(:subscriber2) { create(:subscriber) }
+    let!(:subscription1) { create(:subscription, subscriber: subscriber, subscriber_list: subject) }
+    let!(:subscription2) { create(:subscription, subscriber: subscriber2, subscriber_list: subject) }
+    let!(:subscription3) { create(:subscription, subscriber: subscriber, subscriber_list: a_sanity_check_list) }
+
+    it "will delete all dependent subscriptions" do
+      expect { subject.destroy! }.to(change { subscriber.subscriptions.count }.by(-1))
+    end
+
+    it "will not delete subscribers" do
+      expect { subject.destroy! }.not_to(change { Subscriber.count })
+    end
+
+    it "will not delete non-dependent subscriptions" do
+      expect { subject.destroy! }.to(change { SubscriberList.count }.by(-1))
+    end
+
+    it "will not delete other subscriptions" do
+      subject.destroy!
+      expect(subscription3.reload.active?).to be true
+    end
+  end
+
   context "with a subscription" do
     subject { create(:subscriber_list) }
 
@@ -90,12 +117,6 @@ RSpec.describe SubscriberList, type: :model do
 
     it "can access the subscribers" do
       expect(subject.subscribers.size).to eq(1)
-    end
-
-    it "cannot be deleted" do
-      expect {
-        subject.destroy
-      }.to raise_error(ActiveRecord::InvalidForeignKey)
     end
   end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -78,4 +78,15 @@ RSpec.describe Subscription, type: :model do
       expect(Subscription.ended.count).to eq(0)
     end
   end
+
+  describe "when it is deleted" do
+    subject { create(:subscription) }
+    let!(:subscription_content) { create(:subscription_content, subscription: subject) }
+
+    it "deletes associated subscription_contents" do
+      expect { subject.destroy }.to(change {
+        SubscriptionContent.count
+      }.by(-1))
+    end
+  end
 end


### PR DESCRIPTION
This will prevent the creation of subscriber lists that will not send emails to subscribers.

Trello: https://trello.com/c/9bVKz2EP/896