### PR TITLE
Improve healthcheck around scheduled publishing times

### DIFF
--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -86,6 +86,7 @@ module Healthcheck
 
     SCHEDULED_PUBLISHING_TIMES = [
       [Time.zone.parse("09:30"), Time.zone.parse("10:30")],
-    ]
+      [Time.zone.parse("12:30"), Time.zone.parse("13:30")],
+    ].freeze
   end
 end

--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -68,11 +68,11 @@ module Healthcheck
     end
 
     def critical_latency
-      is_scheduled_publishing_time? ? 20.minutes : 10.minutes
+      is_scheduled_publishing_time? ? 30.minutes : 15.minutes
     end
 
     def warning_latency
-      is_scheduled_publishing_time? ? 15.minutes : 5.minutes
+      is_scheduled_publishing_time? ? 20.minutes : 10.minutes
     end
 
     # There's a lot of scheduled publishing at 09:30 UK time, so we

--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -80,10 +80,12 @@ module Healthcheck
     def is_scheduled_publishing_time?
       @is_scheduled_publishing_time ||= begin
         now = Time.zone.now
-        begun = Time.zone.parse("09:30") <= now
-        ended = Time.zone.parse("10:30") <= now
-        begun && !ended
+        SCHEDULED_PUBLISHING_TIMES.any? { |min, max| now.between?(min, max) }
       end
     end
+
+    SCHEDULED_PUBLISHING_TIMES = [
+      [Time.zone.parse("09:30"), Time.zone.parse("10:30")],
+    ]
   end
 end

--- a/spec/models/healthcheck/subscription_contents_spec.rb
+++ b/spec/models/healthcheck/subscription_contents_spec.rb
@@ -2,17 +2,17 @@ RSpec.describe Healthcheck::SubscriptionContents do
   context "between 09:30 and 10:30" do
     shared_examples "an ok healthcheck" do
       specify { expect(subject.status).to eq(:ok) }
-      specify { expect(subject.message).to match(/0 created over 1200 seconds ago/) }
+      specify { expect(subject.message).to match(/0 created over 1800 seconds ago/) }
     end
 
     shared_examples "a warning healthcheck" do
       specify { expect(subject.status).to eq(:warning) }
-      specify { expect(subject.message).to match(/1 created over 900 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 1200 seconds ago/) }
     end
 
     shared_examples "a critical healthcheck" do
       specify { expect(subject.status).to eq(:critical) }
-      specify { expect(subject.message).to match(/1 created over 1200 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 1800 seconds ago/) }
     end
 
     around do |example|
@@ -21,23 +21,23 @@ RSpec.describe Healthcheck::SubscriptionContents do
 
     context "when a subscription content was created 10 minutes ago" do
       before do
-        create(:subscription_content, created_at: 10.minutes.ago)
+        create(:subscription_content, created_at: 20.minutes.ago)
       end
 
       it_behaves_like "an ok healthcheck"
     end
 
-    context "when a subscription content was created over 15 minutes ago" do
+    context "when a subscription content was created over 20 minutes ago" do
       before do
-        create(:subscription_content, created_at: 16.minutes.ago)
+        create(:subscription_content, created_at: 21.minutes.ago)
       end
 
       it_behaves_like "a warning healthcheck"
     end
 
-    context "when a subscription content was created over 20 minutes ago" do
+    context "when a subscription content was created over 30 minutes ago" do
       before do
-        create(:subscription_content, created_at: 21.minutes.ago)
+        create(:subscription_content, created_at: 31.minutes.ago)
       end
 
       it_behaves_like "a critical healthcheck"
@@ -47,17 +47,17 @@ RSpec.describe Healthcheck::SubscriptionContents do
   context "when not scheduled publishing time" do
     shared_examples "an ok healthcheck" do
       specify { expect(subject.status).to eq(:ok) }
-      specify { expect(subject.message).to match(/0 created over 600 seconds ago/) }
+      specify { expect(subject.message).to match(/0 created over 900 seconds ago/) }
     end
 
     shared_examples "a warning healthcheck" do
       specify { expect(subject.status).to eq(:warning) }
-      specify { expect(subject.message).to match(/1 created over 300 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 600 seconds ago/) }
     end
 
     shared_examples "a critical healthcheck" do
       specify { expect(subject.status).to eq(:critical) }
-      specify { expect(subject.message).to match(/1 created over 600 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 900 seconds ago/) }
     end
 
     around do |example|
@@ -72,17 +72,17 @@ RSpec.describe Healthcheck::SubscriptionContents do
       it_behaves_like "an ok healthcheck"
     end
 
-    context "when a subscription content was created over 5 minutes ago" do
+    context "when a subscription content was created over 10 minutes ago" do
       before do
-        create(:subscription_content, created_at: 6.minutes.ago)
+        create(:subscription_content, created_at: 11.minutes.ago)
       end
 
       it_behaves_like "a warning healthcheck"
     end
 
-    context "when a subscription content was created over 10 minutes ago" do
+    context "when a subscription content was created over 20 minutes ago" do
       before do
-        create(:subscription_content, created_at: 11.minutes.ago)
+        create(:subscription_content, created_at: 21.minutes.ago)
       end
 
       it_behaves_like "a critical healthcheck"


### PR DESCRIPTION
This adds 12:30-13:30 as a scheduled publishing time to the subscription contents endpoint (meaning that the thresholds are higher) and it also increases the thresholds in general so we don't alert when lots of emails are being sent out.

[Trello Card](https://trello.com/c/sSkC9sNO/1147-quieten-email-alert-api-healthcheck-during-peak-times)