### PR TITLE
Update subscriber lists from `EU Exit` to `Brexit`

### DIFF
--- a/lib/tasks/change_subscription_titles.rake
+++ b/lib/tasks/change_subscription_titles.rake
@@ -26,4 +26,35 @@ namespace :subscriber_list do
 
     puts " All done now!"
   end
+
+  desc "Update business readiness titles containing `EU Exit` to `Brexit`"
+  task change_business_readiness_titles: :environment do
+    title = "Find EU Exit guidance for your business"
+
+    subscriber_lists = SubscriberList.where("title ILIKE ?", "%#{title}%")
+
+    raise "Cannot find any subscriber lists with title containing `#{title}`" if subscriber_lists.nil?
+
+    puts "============================="
+
+    puts "Found #{subscriber_lists.count} subscriber lists containing '#{title}'"
+
+    subscriber_lists.each do |subscriber_list|
+      puts "============================="
+      puts "Original title: '#{subscriber_list.title}'"
+      puts "Original slug: '#{subscriber_list.slug}'"
+
+      new_title = subscriber_list.title.gsub("Find EU Exit guidance", "Find Brexit guidance")
+      new_slug = subscriber_list.slug.gsub("find-eu-exit-guidance", "find-brexit-guidance")
+
+      subscriber_list.title = new_title
+      subscriber_list.slug = new_slug
+
+      if subscriber_list.save!
+        puts "Subscriber list updated with title: '#{new_title}' and slug: '#{new_slug}'"
+      else
+        puts "Error updating subscriber list with title: '#{new_title}' and slug: '#{new_slug}'"
+      end
+    end
+  end
 end


### PR DESCRIPTION
We are changing all instances of `EU Exit` to `Brexit` across
GOV.UK.

This rake task finds all subscriber lists that come from the business
readiness finder that contain `EU Exit` in the title and slug, and is
replaced with `Brexit`. The changes will be reflected in the affected
email templates.

Before:
<img width="659" alt="Screen Shot 2019-08-02 at 11 04 03" src="https://user-images.githubusercontent.com/19667619/62364470-7861dc80-b519-11e9-8828-4ffbe5e60a4b.png">

After:
<img width="664" alt="Screen Shot 2019-08-02 at 11 33 06" src="https://user-images.githubusercontent.com/19667619/62364489-80ba1780-b519-11e9-80e9-a9c972563268.png">

Trello card: https://trello.com/c/GnNdTWi9/1160-change-email-template-eu-exit-to-brexit