### PR TITLE
Subscriber list validations

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -1,11 +1,10 @@
 class SubscriberList < ApplicationRecord
   include SymbolizeJSON
-
-  TAGS_BLACKLIST = %i(organisations people world_locations part_of_taxonomy_tree).freeze
+  include ActiveModel::Validations
 
   self.include_root_in_json = true
 
-  validate :tag_values_are_valid
+  validates :tags, tags: true
   validate :link_values_are_valid
 
   validates :title, presence: true
@@ -57,21 +56,7 @@ class SubscriberList < ApplicationRecord
     self[:tags].fetch("format", []).include?("medical_safety_alert")
   end
 
-  def invalid_tags
-    TAGS_BLACKLIST & self.tags.keys
-  end
-
 private
-
-  def tag_values_are_valid
-    unless valid_subscriber_criteria(:tags)
-      self.errors.add(:tags, "All tag values must be sent as Arrays")
-    end
-
-    if invalid_tags?
-      self.errors.add(:tags, "#{invalid_tags.to_sentence} are not valid tags. Should they be links?")
-    end
-  end
 
   def link_values_are_valid
     unless valid_subscriber_criteria(:links)
@@ -85,9 +70,5 @@ private
         %i[all any].include?(operator) && values.is_a?(Array)
       end
     end
-  end
-
-  def invalid_tags?
-    invalid_tags.any?
   end
 end

--- a/app/validators/tags_validator.rb
+++ b/app/validators/tags_validator.rb
@@ -1,0 +1,25 @@
+class TagsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, tags)
+    unless tag_values_are_arrays(tags)
+      record.errors.add(attribute, "All tag values must be sent as Arrays")
+    end
+
+    if invalid_tags(tags).any?
+      record.errors.add(attribute, "#{invalid_tags(tags).to_sentence} are not valid tags.")
+    end
+  end
+
+private
+
+  def invalid_tags(tags)
+    tags.keys - ValidTags::ALLOWED_TAGS
+  end
+
+  def tag_values_are_arrays(tags)
+    tags.values.all? do |hash|
+      hash.all? do |operator, values|
+        %i[all any].include?(operator) && values.is_a?(Array)
+      end
+    end
+  end
+end

--- a/doc/fields.md
+++ b/doc/fields.md
@@ -1,0 +1,14 @@
+Email Alert API Field Reference
+===============================
+
+## Subscriber Lists
+
+Subscriber Lists in Email Alert API can have tags or links. When a document is
+is changed, the API does a search for the document's attributes in the API to
+find a matching subscriber list.
+
+### Tags
+
+The API has a whitelist of available tags that a user can subscribe to.
+
+You can find a list of permitted tags in [`lib/valid_tags.rb`](https://github.com/alphagov/email-alert-api/blob/3e0018510ea85f5d561e2865ad149832b94688a1/lib/valid_tags.rb).

--- a/lib/clean/invalid_subscriber_lists.rb
+++ b/lib/clean/invalid_subscriber_lists.rb
@@ -110,7 +110,7 @@ module Clean
       tags.each_with_object({}) do |(key, value), links|
         if key == :part_of_taxonomy_tree
           links[:taxon_tree] = value
-        elsif SubscriberList::TAGS_BLACKLIST.include? key
+        elsif ValidTags::ALLOWED_TAGS.exclude? key
           value.keys.each { |any_or_all|
             links[key] ||= {}
             links[key][any_or_all] = tag_slugs_to_ids(key, value[any_or_all])

--- a/lib/valid_tags.rb
+++ b/lib/valid_tags.rb
@@ -1,7 +1,79 @@
 class ValidTags
-  ALLOWED_TAGS = %i(vessel_type format case_type sector_business_area business_activity
-                    employ_eu_citizens personal_data intellectual_property public_sector_procurement
-                    location eu_uk_government_funding alert_type tribunal_decision_category policies
-                    topics content_store_document_type content_purpose_supergroup railway_type
-                    aircraft_category content_purpose_subgroup appear_in_find_eu_exit_guidance_business_finder).freeze
+  ALLOWED_TAGS = %i(
+    aircraft_category
+    aircraft_type
+    alert_type
+    appear_in_find_eu_exit_guidance_business_finder
+    assessment_date
+    business_activity
+    business_sizes
+    business_stages
+    case_state
+    case_type
+    certificate_status
+    closed_date
+    closing_date
+    commodity_type
+    content_purpose_subgroup
+    content_purpose_supergroup
+    content_store_document_type
+    continuation_link
+    country
+    date_of_occurrence
+    destination_country
+    development_sector
+    dfid_authors
+    dfid_document_type
+    dfid_review_status
+    dfid_theme
+    eligible_entities
+    employ_eu_citizens
+    eu_uk_government_funding
+    first_published_at
+    format
+    fund_state
+    fund_type
+    funding_amount
+    funding_source
+    grant_type
+    hidden_indexable_content
+    industries
+    intellectual_property
+    issued_date
+    laid_date
+    land_use
+    location
+    market_sector
+    medical_specialism
+    opened_date
+    outcome_type
+    personal_data
+    policies
+    public_sector_procurement
+    railway_type
+    regions
+    registration
+    report_type
+    sector_business_area
+    sift_end_date
+    sifting_status
+    subject
+    therapeutic_area
+    tiers_or_standalone_items
+    topics
+    tribunal_decision_categories
+    tribunal_decision_category
+    tribunal_decision_country
+    tribunal_decision_decision_date
+    tribunal_decision_judges
+    tribunal_decision_landmark
+    tribunal_decision_reference_number
+    tribunal_decision_sub_categories
+    tribunal_decision_sub_category
+    types_of_support
+    value_of_funding
+    vessel_type
+    will_continue_on
+    withdrawn_date
+  ).freeze
 end

--- a/lib/valid_tags.rb
+++ b/lib/valid_tags.rb
@@ -1,0 +1,7 @@
+class ValidTags
+  ALLOWED_TAGS = %i(vessel_type format case_type sector_business_area business_activity
+                    employ_eu_citizens personal_data intellectual_property public_sector_procurement
+                    location eu_uk_government_funding alert_type tribunal_decision_category policies
+                    topics content_store_document_type content_purpose_supergroup railway_type
+                    aircraft_category content_purpose_subgroup appear_in_find_eu_exit_guidance_business_finder).freeze
+end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
     it "creates a subscriber_list" do
       create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
-                                     taxon_tree: { all: %w[taxon1 taxon2] } })
+                                     location: { all: %w[france germany] } })
 
       expect(SubscriberList.count).to eq(1)
     end
 
     it "returns a 201" do
       create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
-                                     taxon_tree: { all: %w[taxon1 taxon2] } })
+                                     location: { all: %w[france germany] } })
 
       expect(response.status).to eq(201)
     end
@@ -132,7 +132,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
       it "sets the document_type on the subscriber list" do
         create_subscriber_list(
-          tags: { countries: { any: %w[andorra] } },
+          tags: { location: { any: %w[andorra] } },
           document_type: "travel_advice"
         )
 
@@ -141,23 +141,23 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
-    describe "creating a subscriber list with content_purpose_subgroups" do
+    describe "creating a subscriber list with content_purpose_subgroup" do
       it "returns a 201" do
-        create_subscriber_list(tags: { content_purpose_subgroups: { any: %w[news] } })
+        create_subscriber_list(tags: { content_purpose_subgroup: { any: %w[news] } })
 
         expect(response.status).to eq(201)
       end
 
-      it "sets content_purpose_subgroups on the subscriber list" do
+      it "sets content_purpose_subgroup on the subscriber list" do
         create_subscriber_list(
           tags: {
-            countries: { any: %w[andorra] },
-            content_purpose_subgroups: { any: %w[news] }
+            location: { any: %w[andorra] },
+            content_purpose_subgroup: { any: %w[news] }
           }
         )
 
         subscriber_list = SubscriberList.last
-        expect(subscriber_list.tags[:content_purpose_subgroups]).to eq(any: %w[news])
+        expect(subscriber_list.tags[:content_purpose_subgroup]).to eq(any: %w[news])
       end
     end
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -17,18 +17,18 @@ RSpec.describe SubscriberList, type: :model do
     end
 
     it "is valid when tags 'hash' has 'any' values that are arrays" do
-      subject.tags = { foo: { any: %w[bar] } }
+      subject.tags = { topics: { any: %w[bar] } }
 
       expect(subject).to be_valid
     end
 
     it "is valid when tags 'hash' has 'all' values that are arrays" do
-      subject.tags = { foo: { all: %w[bar] } }
+      subject.tags = { topics: { all: %w[bar] } }
 
       expect(subject).to be_valid
     end
 
-    it "is invalid when tags 'hash' has values that are blacklisted" do
+    it "is invalid when tags 'hash' has values that are not whitelisted" do
       subject.tags = {
         foo: { any: %w[bar] },
         dogs: { all: %w[bark] },
@@ -38,11 +38,11 @@ RSpec.describe SubscriberList, type: :model do
       }
 
       expect(subject).to be_invalid
-      expect(subject.errors[:tags]).to include("organisations, people, and world_locations are not valid tags. Should they be links?")
+      expect(subject.errors[:tags]).to include("foo, dogs, organisations, people, and world_locations are not valid tags.")
     end
 
     it "is invalid when tags 'hash' has values that are not arrays" do
-      subject.tags = { foo: { any: "bar" } }
+      subject.tags = { topics: { any: "bar" } }
 
       expect(subject).to be_invalid
       expect(subject.errors[:tags]).to include("All tag values must be sent as Arrays")

--- a/spec/queries/find_exact_match_spec.rb
+++ b/spec/queries/find_exact_match_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FindExactMatch do
       :subscriber_list,
       tags: {
         topics: { all: ["oil-and-gas/licensing", 'something/else'] },
-        taxon_tree: { all: %w[ship-crew-health-and-safety mental-health-service-reform], any: %w[product-safety] }
+        policies: { all: %w[ship-crew-health-and-safety mental-health-service-reform], any: %w[product-safety] }
       },
       links: {
         topics: { all: %w[uuid-888 uuid-999], any: %w[uuid-777] },
@@ -67,7 +67,7 @@ RSpec.describe FindExactMatch do
     it "requires and and any operators to be correctly set" do
       found_lists = described_class.new(query_field: :tags)
                       .call(topics: { all: ["oil-and-gas/licensing", 'something/else'] },
-                            taxon_tree: { all: %w[ship-crew-health-and-safety mental-health-service-reform], any: %w[product-safety] })
+                            policies: { all: %w[ship-crew-health-and-safety mental-health-service-reform], any: %w[product-safety] })
       expect(found_lists).to eq([list_with_all_and_any])
     end
 

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -51,18 +51,18 @@ RSpec.describe FindExactQuery do
   context "when tags are in the query" do
     it "matched when subscriber tags has the same tags" do
       query = build_query(tags: { policies: { any: %w[beer] },
-                                  taxon_tree: { all: %w[taxon] } })
+                                  topics: { all: %w[taxon] } })
       subscriber_list = create_subscriber_list(tags: { policies: { any: %w[beer] },
-                                                       taxon_tree: { all: %w[taxon] } })
+                                                       topics: { all: %w[taxon] } })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber list has the same tags and matching document_type" do
       query = build_query(tags: { policies: { any: %w[beer] },
-                                  taxon_tree: { all: %w[taxon] } },
+                                  topics: { all: %w[taxon] } },
                           document_type: 'document_type')
       subscriber_list = create_subscriber_list(tags: { policies: { any: %w[beer] },
-                                                      taxon_tree: { all: %w[taxon] } },
+                                                      topics: { all: %w[taxon] } },
                                                document_type: 'document_type')
       expect(query.exact_match).to eq(subscriber_list)
     end

--- a/spec/validators/tags_validator_spec.rb
+++ b/spec/validators/tags_validator_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe TagsValidator do
+  class TagsValidatable
+    include ActiveModel::Validations
+    include ActiveModel::Model
+
+    attr_accessor :tags
+    validates :tags, tags: true
+  end
+
+  subject(:model) { TagsValidatable.new }
+
+  context "when valid tags are provided" do
+    before { model.tags = { topics: { any: %w(dogs cats), all: %w(horses) } } }
+    it { is_expected.to be_valid }
+  end
+
+  context "when invalid tags are provided" do
+    before {
+      model.tags = {
+        organisations: { any: %w(dogs cats) },
+        topics: { any: %w(dogs cats) },
+        foo: { any: %w(dogs cats) },
+        people: { any: %w(dogs cats) },
+        world_locations: { any: "dogs" },
+      }
+    }
+
+    it "has an error" do
+      expect(model.valid?).to be false
+      expect(model.errors[:tags]).to match([
+        "All tag values must be sent as Arrays",
+        "organisations, foo, people, and world_locations are not valid tags."
+      ])
+    end
+  end
+end


### PR DESCRIPTION
This adds a validator for tags, to ensure that only permitted tags can be used in subscriber lists.

The tags I've added to the list are those already in use, or that I found through an audit of the tags that could be used but aren't in use yet.

Trello: https://trello.com/c/3JqVLHZX/393