### PR TITLE
Document rake task & make more robust

### DIFF
--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -34,6 +34,11 @@ Here are some example queries to pull out particular insights.
 SubscriberList.find(4194).active_subscriptions_count
 ```
 
+There is a [rake task][rake-count-subscribers] that does this for you, and
+includes a breakdown of subscriptions that are Immediate, Daily or Weekly:
+
+`query:count_subscribers['subscriber-list-slug']`
+
 ### How many subscribers did a list have at a particular point in time
 
 ```ruby
@@ -185,8 +190,9 @@ ORDER BY count DESC
 LIMIT 10;
 ```
 
-[console-instructions]: https://docs.publishing.service.gov.uk/manual/seeing-things-in-the-aws-console.html
-[aws]: https://aws.amazon.com
 [athena]: https://aws.amazon.com/athena/
 [athena-queries]: https://docs.aws.amazon.com/athena/latest/ug/functions-operators-reference-section.html
+[aws]: https://aws.amazon.com
+[console-instructions]: https://docs.publishing.service.gov.uk/manual/seeing-things-in-the-aws-console.html
+[rake-count-subscribers]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers['subscriber-list-slug']
 [schema.rb]: https://github.com/alphagov/email-alert-api/tree/master/db/schema.rb

--- a/lib/tasks/count_subscribers.rake
+++ b/lib/tasks/count_subscribers.rake
@@ -2,15 +2,14 @@ namespace :query do
   desc "Query how many active subscribers there are to the given subscription slug"
   task :count_subscribers, %i[subscription_list_slug] => :environment do |_t, args|
     slug = args[:subscription_list_slug]
-    subscription_lists = SubscriberList.where(slug: slug)
-    raise "There is no SubscriberList called '#{slug}'" unless subscription_lists.count == 1
+    subscription_list = SubscriberList.find_by!(slug: slug)
+    active_subscriptions = subscription_list.subscriptions.active
 
-    active_subscriptions = subscription_lists.first.subscriptions.where(ended_at: nil)
     puts """
       The SubscriberList '#{slug}' has #{active_subscriptions.count} active subscriptions, of which:
-        - #{active_subscriptions.where(frequency: 0).count} are signed up for Immediate updates
-        - #{active_subscriptions.where(frequency: 1).count} are signed up for Daily updates
-        - #{active_subscriptions.where(frequency: 2).count} are signed up for Weekly updates
+        - #{active_subscriptions.where(frequency: :immediately).count} are signed up for Immediate updates
+        - #{active_subscriptions.where(frequency: :daily).count} are signed up for Daily updates
+        - #{active_subscriptions.where(frequency: :weekly).count} are signed up for Weekly updates
     """
   end
 end


### PR DESCRIPTION
Documents the new subscriptions count rake task so that it can be searched for in the developer docs.

Also makes it more robust by addressing post-merge PR comments made in #887.