### PR TITLE
Refactor immediate email generation worker

### DIFF
--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -1,4 +1,4 @@
-class ImmediateEmailBuilder
+class ContentChangeEmailBuilder
   include EmailBuilderHelper
   def initialize(recipients_and_content)
     @recipients_and_content = recipients_and_content

--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -1,13 +1,13 @@
 class SubscribersForImmediateEmailQuery
   def self.call
-    new.call
-  end
+    unprocessed_subscription_content_exists =
+      SubscriptionContent
+        .joins(:subscription)
+        .where(email_id: nil)
+        .where("subscriptions.subscriber_id = subscribers.id")
+        .arel
+        .exists
 
-  def call
-    subscriber_ids = Subscription.
-        joins(:subscription_contents).
-        where(subscription_contents: { email_id: nil }).
-        select(:subscriber_id)
-    Subscriber.activated.where(id: subscriber_ids)
+    Subscriber.activated.where(unprocessed_subscription_content_exists)
   end
 end

--- a/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
+++ b/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
@@ -10,30 +10,12 @@ class UnprocessedSubscriptionContentsBySubscriberQuery
   end
 
   def call
-    transform_results(subscription_contents)
-  end
-
-  private_class_method :new
-
-private
-
-  def subscription_contents
     SubscriptionContent
       .joins(:subscription)
       .includes(:subscription)
       .where(email_id: nil, subscriptions: { subscriber_id: subscriber_ids })
+      .group_by { |sc| sc.subscription.subscriber_id }
   end
 
-  def transform_results(subscription_contents)
-    subscription_contents.each_with_object({}) do |subscription_content, results|
-      subscriber_id = subscription_content.subscription.subscriber_id
-      current_value = results[subscriber_id] || {}
-      subscription_contents_for_content_change = Array(current_value[subscription_content.content_change_id])
-      subscription_contents_for_content_change << subscription_content
-
-      results[subscriber_id] = current_value.merge(
-        subscription_content.content_change_id => subscription_contents_for_content_change
-      )
-    end
-  end
+  private_class_method :new
 end

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -113,7 +113,7 @@ private
       }
     end
 
-    ImmediateEmailBuilder.call(email_params)
+    ContentChangeEmailBuilder.call(email_params)
   end
 
   def update_subscription_contents(values)

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -5,63 +5,17 @@ class ImmediateEmailGenerationWorker
 
   LOCK_NAME = "immediate_email_generation_worker".freeze
 
-  attr_reader :content_changes
-
   def perform
-    @content_changes = {}
-
     ensure_only_running_once do
-      subscribers.find_in_batches do |group|
+      SubscribersForImmediateEmailQuery.call.find_in_batches do |group|
         subscription_contents = grouped_subscription_contents(group.pluck(:id))
         update_content_change_cache(subscription_contents)
-        import_and_associate_emails(group, subscription_contents)
+        create_content_change_emails(group, subscription_contents)
       end
     end
   end
 
 private
-
-  def import_and_associate_emails(subscribers, subscription_contents)
-    queue = []
-
-    Subscriber.transaction do
-      values = []
-
-      email_ids = import_emails(subscribers, subscription_contents).ids
-
-      subscriber_id_content_change_id_in_order = map_subscriber_content_change_id_in_order(subscribers, subscription_contents) do |subscriber, content_change_id|
-        [subscriber.id, content_change_id]
-      end
-
-      email_ids.each_with_index do |email_id, i|
-        subscriber_id = subscriber_id_content_change_id_in_order[i][0]
-        content_change_id = subscriber_id_content_change_id_in_order[i][1]
-        subscription_contents_in_this_email = subscription_contents[subscriber_id][content_change_id]
-
-        queue << [email_id, content_changes[content_change_id].priority.to_sym]
-
-        subscription_contents_in_this_email.each do |subscription_content|
-          values << "(#{subscription_content.id}, '#{email_id}'::UUID)"
-        end
-      end
-
-      update_subscription_contents(values)
-    end
-
-    queue_delivery_request_workers(queue)
-  end
-
-  def update_content_change_cache(subscription_contents)
-    content_change_ids = subscription_contents.flat_map { |_k, v| v.keys }.uniq
-    existing_content_change_ids = content_changes.keys
-    missing_content_change_ids = content_change_ids - existing_content_change_ids
-
-    if missing_content_change_ids.any?
-      ContentChange.where(id: missing_content_change_ids).each do |cc|
-        content_changes[cc.id] = cc
-      end
-    end
-  end
 
   def ensure_only_running_once
     Subscriber.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
@@ -69,54 +23,59 @@ private
     end
   end
 
-  def queue_delivery_request_workers(queue)
-    queue.each do |email_id, priority|
-      DeliveryRequestWorker.perform_async_in_queue(
-        email_id, queue: queue_for_priority(priority)
-      )
-    end
-  end
-
-  def queue_for_priority(priority)
-    if priority == :high
-      :delivery_immediate_high
-    elsif priority == :normal
-      :delivery_immediate
-    else
-      raise ArgumentError, "priority should be :high or :normal"
-    end
-  end
-
   def grouped_subscription_contents(subscriber_ids)
     UnprocessedSubscriptionContentsBySubscriberQuery.call(subscriber_ids)
   end
 
-  def subscribers
-    SubscribersForImmediateEmailQuery.call
+  def content_changes
+    @content_changes ||= {}
   end
 
-  def map_subscriber_content_change_id_in_order(subscribers, subscription_contents)
-    subscribers.flat_map do |subscriber|
-      subscription_contents[subscriber.id].keys.map do |content_change_id|
-        yield subscriber, content_change_id
-      end
+  def update_content_change_cache(subscription_contents)
+    content_change_ids = subscription_contents.flat_map { |_, sc| sc.map(&:content_change_id) }
+                                              .compact
+                                              .uniq
+    ids = content_change_ids - content_changes.keys
+
+    content_changes.merge!(ContentChange.where(id: ids).index_by(&:id))
+  end
+
+  def create_content_change_emails(subscribers, subscription_contents)
+    email_data = subscribers.flat_map do |subscriber|
+      subscribers_content_change_email_data(subscriber,
+                                            subscription_contents[subscriber.id])
     end
+
+    email_ids = ContentChangeEmailBuilder.call(email_data.map { |e| e[:params] }).ids
+    update_subscription_contents(email_data, email_ids)
+    queue_for_delivery(email_data, email_ids)
   end
 
-  def import_emails(subscribers, subscription_contents)
-    email_params = map_subscriber_content_change_id_in_order(subscribers, subscription_contents) do |subscriber, content_change_id|
+  def subscribers_content_change_email_data(subscriber, subscription_contents)
+    by_content_change_id = subscription_contents.select(&:content_change_id)
+                                                .group_by(&:content_change_id)
+
+    by_content_change_id.map do |content_change_id, matching_subscription_contents|
       {
-        address: subscriber.address,
-        content_change: content_changes[content_change_id],
-        subscriptions: subscription_contents[subscriber.id][content_change_id].map(&:subscription),
-        subscriber_id: subscriber.id,
+        params: {
+          address: subscriber.address,
+          content_change: content_changes[content_change_id],
+          subscriptions: matching_subscription_contents.map(&:subscription),
+          subscriber_id: subscriber.id,
+        },
+        subscription_contents: matching_subscription_contents,
+        priority: content_changes[content_change_id].priority.to_sym,
       }
     end
-
-    ContentChangeEmailBuilder.call(email_params)
   end
 
-  def update_subscription_contents(values)
+  def update_subscription_contents(email_data, email_ids)
+    values = email_data.flat_map.with_index do |data, index|
+      data[:subscription_contents].map do |subscription_content|
+        "(#{subscription_content.id}, '#{email_ids[index]}'::UUID)"
+      end
+    end
+
     ActiveRecord::Base.connection.execute(
       %(
         UPDATE subscription_contents SET email_id = v.email_id
@@ -124,5 +83,12 @@ private
         WHERE subscription_contents.id = v.id
       )
     )
+  end
+
+  def queue_for_delivery(email_data, email_ids)
+    email_data.each.with_index do |data, index|
+      queue = data[:priority] == :high ? :delivery_immediate_high : :delivery_immediate
+      DeliveryRequestWorker.perform_async_in_queue(email_ids[index], queue: queue)
+    end
   end
 end

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -36,7 +36,7 @@ private
     subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
     return unless subscriber
 
-    email_id = ImmediateEmailBuilder.call([
+    email_id = ContentChangeEmailBuilder.call([
       {
         address: subscriber.address,
         subscriptions: [],

--- a/spec/builders/content_change_email_builder_spec.rb
+++ b/spec/builders/content_change_email_builder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ImmediateEmailBuilder do
+RSpec.describe ContentChangeEmailBuilder do
   let(:subscriber) { build(:subscriber, address: "test@example.com") }
 
   let(:subscription_one) {

--- a/spec/workers/process_content_change_worker_spec.rb
+++ b/spec/workers/process_content_change_worker_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ProcessContentChangeWorker do
     let!(:subscriber) { create(:subscriber, address: Email::COURTESY_EMAIL) }
 
     it "creates an email for the courtesy email group" do
-      expect(ImmediateEmailBuilder)
+      expect(ContentChangeEmailBuilder)
         .to receive(:call)
         .with([hash_including(address: subscriber.address)])
         .and_call_original


### PR DESCRIPTION
This refactors the ImmediateEmailGenerationWorker in preparation of adding another type of email that can be generated - messages. It aims to simplify the logic and make the class easier to follow.

As part of this the UnprocessedSubscriptionContentsBySubscriberQuery was also refactored to perform a much simpler grouping.

It also renames the ImmediateEmailBuilder to ContentChangeEmailBuilder.

This code was cherry picked from #927 to make it easier to merge and test individually.

[Trello Card](https://trello.com/c/5rtAmAjc/54-finish-the-messages-endpoint-work-in-email-alert-api)