### PR TITLE
Remove SubscriptionContentWorker

### DIFF
--- a/app/workers/subscription_content_worker.rb
+++ b/app/workers/subscription_content_worker.rb
@@ -1,9 +1,0 @@
-# This is a legacy class that is used as Sidekiq stores the names of workers
-# once Sidekiq no longer has this class in it's queue it can be removed.
-class SubscriptionContentWorker
-  include Sidekiq::Worker
-
-  def perform(content_change_id, _batch_size = 1000)
-    ProcessContentChangeWorker.new.perform(content_change_id)
-  end
-end

--- a/spec/workers/subscription_content_worker_spec.rb
+++ b/spec/workers/subscription_content_worker_spec.rb
@@ -1,8 +1,0 @@
-RSpec.describe SubscriptionContentWorker do
-  it "delegates to ProcessContentChange" do
-    content_change = create(:content_change)
-    expect_any_instance_of(ProcessContentChangeWorker)
-      .to receive(:perform).with(content_change.id).and_call_original
-    subject.perform(content_change.id)
-  end
-end


### PR DESCRIPTION
https://github.com/alphagov/email-alert-api/pull/929 has been deployed so we can safely remove this worker now.

[Trello Card](https://trello.com/c/5rtAmAjc/54-finish-the-messages-endpoint-work-in-email-alert-api)