### PR TITLE
Add endpoint to email-alert-api to send single email

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -1,0 +1,11 @@
+class EmailsController < ApplicationController
+  def create
+    email = Email.create!(
+      address: params.require(:address),
+      subject: params.require(:subject),
+      body: params.require(:body),
+    )
+
+    DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
     post "/unpublish-messages", to: "unpublish_messages#create"
 
     post "/notifications", to: "content_changes#create" # for backwards compaibility
+
+    resources :emails, only: %i[create]
     resources :content_changes, only: %i[create], path: "content-changes"
     resources :spam_reports, path: "spam-reports", only: %i[create]
     resources :status_updates, path: "status-updates", only: %i[create]

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "Sending an email", type: :request do
+  before do
+    stub_notify
+  end
+
+  scenario do
+    params = {
+      body: 'Description',
+      subject: 'Update from GOV.UK',
+      address: 'test@test.com'
+    }
+
+    post '/emails', params: params.to_json, headers: JSON_HEADERS
+
+    email_data = expect_an_email_was_sent
+
+    address = email_data.dig(:email_address)
+    subject = email_data.dig(:personalisation, :subject)
+    body = email_data.dig(:personalisation, :body)
+
+    expect(address).to eq("test@test.com")
+    expect(subject).to eq("Update from GOV.UK")
+
+    expect(body).to include("Description")
+  end
+end


### PR DESCRIPTION
Trello:
https://trello.com/c/68dWZW80/46-create-endpoint-on-email-alert-api-to-send-single-email