### PR TITLE
Include links to subscriber lists in emails

### DIFF
--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -50,16 +50,23 @@ private
   def footer(subscriptions, address)
     return feedback_link if subscriptions.empty?
 
-    permission_reminder = I18n.t!("emails.content_change.permission_reminder",
-                                  topic: subscriptions.first.subscriber_list.title)
-
     <<~BODY
-      #{permission_reminder}
+      #{permission_reminder(subscriptions.first.subscriber_list)}
 
       #{ManageSubscriptionsLinkPresenter.call(address)}
 
       #{feedback_link}
     BODY
+  end
+
+  def permission_reminder(subscriber_list)
+    topic = if subscriber_list.url
+              "[#{subscriber_list.title}](#{Plek.new.website_root}#{subscriber_list.url})"
+            else
+              subscriber_list.title
+            end
+
+    I18n.t!("emails.content_change.permission_reminder", topic: topic)
   end
 
   def feedback_link

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -45,13 +45,21 @@ private
 
   def presented_segment(segment)
     <<~RESULT
-      ##{segment.subscriber_list_title}&nbsp;
+      # #{presented_title(segment)} &nbsp;
 
       #{presented_content(segment.content)}
       ---
 
       #{UnsubscribeLinkPresenter.call(segment.subscription_id, segment.subscriber_list_title)}
     RESULT
+  end
+
+  def presented_title(segment)
+    if segment.subscriber_list_url
+      "[#{segment.subscriber_list_title}](#{Plek.new.website_root}#{segment.subscriber_list_url})"
+    else
+      segment.subscriber_list_title
+    end
   end
 
   def presented_content(content)

--- a/app/builders/message_email_builder.rb
+++ b/app/builders/message_email_builder.rb
@@ -47,7 +47,7 @@ private
     if subscriptions.any?
       copy += <<~BODY
         ---
-        #{permission_reminder(subscriptions)}
+        #{permission_reminder(subscriptions.first.subscriber_list)}
 
         #{ManageSubscriptionsLinkPresenter.call(address)}
       BODY
@@ -56,8 +56,13 @@ private
     copy
   end
 
-  def permission_reminder(subscriptions)
-    title = subscriptions.first.subscriber_list.title
-    I18n.t!("emails.message.permission_reminder", topic: title)
+  def permission_reminder(subscriber_list)
+    topic = if subscriber_list.url
+              "[#{subscriber_list.title}](#{Plek.new.website_root}#{subscriber_list.url})"
+            else
+              subscriber_list.title
+            end
+
+    I18n.t!("emails.message.permission_reminder", topic: topic)
   end
 end

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -38,6 +38,7 @@ private
     find_exact_query_params.merge(
       title: title,
       slug: slug,
+      url: params[:url],
       signon_user_uid: current_user.uid,
     )
   end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -9,6 +9,7 @@ class SubscriberList < ApplicationRecord
 
   validates :title, presence: true
   validates_uniqueness_of :slug
+  validates :url, root_relative_url: true, allow_nil: true
 
   has_many :subscriptions, dependent: :destroy
   has_many :subscribers, through: :subscriptions

--- a/app/queries/digest_subscription_content_query.rb
+++ b/app/queries/digest_subscription_content_query.rb
@@ -1,5 +1,5 @@
 class DigestSubscriptionContentQuery
-  Result = Struct.new(:subscription_id, :subscriber_list_title, :content)
+  Result = Struct.new(:subscription_id, :subscriber_list_title, :subscriber_list_url, :content)
 
   def initialize(subscriber, digest_run)
     @subscriber = subscriber
@@ -23,45 +23,51 @@ private
   def build_results(content_changes, messages)
     result_data = content_changes.each_with_object({}) do |record, memo|
       id = record[:subscription_id]
-      memo[id] ||= { subscriber_list_title: record[:subscriber_list_title] }
+      memo[id] ||= {
+        subscriber_list_title: record[:subscriber_list_title],
+        subscriber_list_url: record[:subscriber_list_url],
+      }
       memo[id][:content_changes] = Array(memo[id][:content_changes]) << record
     end
 
     result_data = messages.each_with_object(result_data) do |record, memo|
       id = record[:subscription_id]
-      memo[id] ||= { subscriber_list_title: record[:subscriber_list_title] }
+      memo[id] ||= {
+        subscriber_list_title: record[:subscriber_list_title],
+        subscriber_list_url: record[:subscriber_list_url],
+      }
       memo[id][:messages] = Array(memo[id][:messages]) << record
     end
 
     result_data.map do |key, value|
       content = value.fetch(:content_changes, []) + value.fetch(:messages, [])
-      Result.new(key, value[:subscriber_list_title], content.sort_by(&:created_at))
+      Result.new(key, value[:subscriber_list_title], value[:subscriber_list_url], content.sort_by(&:created_at))
     end
   end
 
   def fetch_content_changes
     ContentChange
-      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title")
+      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url")
       .joins(matched_content_changes: { subscriber_list: { subscriptions: :subscriber } })
       .where(subscribers: { id: subscriber.id })
       .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
       .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "content_changes.created_at ASC")
+      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "content_changes.created_at ASC")
       .uniq(&:content_id)
   end
 
   def fetch_messages
     Message
-      .select("messages.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title")
+      .select("messages.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url")
       .joins(matched_messages: { subscriber_list: { subscriptions: :subscriber } })
       .where(subscribers: { id: subscriber.id })
       .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
       .where("messages.created_at >= ?", digest_run.starts_at)
       .where("messages.created_at < ?", digest_run.ends_at)
       .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "messages.created_at ASC")
+      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "messages.created_at ASC")
       .uniq(&:id)
   end
 end

--- a/db/migrate/20190823114916_add_url_to_subscriber_lists.rb
+++ b/db/migrate/20190823114916_add_url_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddUrlToSubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_15_192913) do
+ActiveRecord::Schema.define(version: 2019_08_23_114916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 2019_08_15_192913) do
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
+    t.string "url"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DigestEmailBuilder do
       double(
         subscription_id: "ABC1",
         subscriber_list_title: "Test title 1",
+        subscriber_list_url: nil,
         content: [
           build(:content_change),
           build(:message),
@@ -16,6 +17,7 @@ RSpec.describe DigestEmailBuilder do
       double(
         subscription_id: "ABC2",
         subscriber_list_title: "Test title 2",
+        subscriber_list_url: "/test-title-2",
         content: [
           build(:message),
           build(:content_change),
@@ -60,7 +62,7 @@ RSpec.describe DigestEmailBuilder do
       <<~BODY
         Daily update from GOV.UK.
 
-        #Test title 1&nbsp;
+        # Test title 1 &nbsp;
 
         presented_content_change
 
@@ -74,7 +76,7 @@ RSpec.describe DigestEmailBuilder do
 
         &nbsp;
 
-        #Test title 2&nbsp;
+        # [Test title 2](http://www.dev.gov.uk/test-title-2) &nbsp;
 
         presented_message
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     <<~BODY
       Daily update from GOV.UK.
 
-      #Subscriber list one&nbsp;
+      # Subscriber list one &nbsp;
 
       [Title one](#{url}#{utm_params(content_change_one.id, 'daily')})
 
@@ -52,7 +52,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       &nbsp;
 
-      #Subscriber list two&nbsp;
+      # Subscriber list two &nbsp;
 
       [Title three](#{url}#{utm_params(content_change_two.id, 'daily')})
 
@@ -96,7 +96,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     <<~BODY
       Daily update from GOV.UK.
 
-      #Subscriber list one&nbsp;
+      # Subscriber list one &nbsp;
 
       [Title one](#{url}#{utm_params(content_change_one.id, 'daily')})
 
@@ -275,7 +275,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     <<~BODY
       Updates on GOV.UK this week.
 
-      #Subscriber list one&nbsp;
+      # Subscriber list one &nbsp;
 
       [Title one](#{url}#{utm_params(content_change_one.id, 'weekly')})
 
@@ -300,7 +300,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       &nbsp;
 
-      #Subscriber list two&nbsp;
+      # Subscriber list two &nbsp;
 
       [Title three](#{url}#{utm_params(content_change_two.id, 'weekly')})
 
@@ -345,7 +345,7 @@ RSpec.describe "creating and delivering digests", type: :request do
     <<~BODY
       Updates on GOV.UK this week.
 
-      #Subscriber list one&nbsp;
+      # Subscriber list one &nbsp;
 
       [Title one](#{url}#{utm_params(content_change_one.id, 'weekly')})
 

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
           gov_delivery_id
           created_at
           updated_at
+          url
           tags
           links
           email_document_supertype

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -83,6 +83,15 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(subscriber_list["slug"]).to eq("oil-and-gas-licensing")
     end
 
+    it "creates a subscriber_list with a url" do
+      create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
+                                     location: { all: %w[france germany] } },
+                             url: "/oil-and-gas")
+
+      expect(SubscriberList.count).to eq(1)
+      expect(SubscriberList.first.url).to eq("/oil-and-gas")
+    end
+
     describe 'using legacy parameters' do
       it 'creates a new subscriber list' do
         expect {

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -81,6 +81,20 @@ RSpec.describe SubscriberList, type: :model do
     it "is not recognised as medical safety alert" do
       expect(subject.is_medical_safety_alert?).to be false
     end
+
+    describe "url" do
+      it "is valid when url is nil" do
+        expect(build(:subscriber_list, url: nil)).to be_valid
+      end
+
+      it "is valid when url is an absolute path" do
+        expect(build(:subscriber_list, url: "/test")).to be_valid
+      end
+
+      it "is invalid when url is an absolute URI" do
+        expect(build(:subscriber_list, url: "https://example.com/test")).to be_invalid
+      end
+    end
   end
 
   context "when a subscriber_list is deleted" do

--- a/spec/queries/digest_subscription_content_query_spec.rb
+++ b/spec/queries/digest_subscription_content_query_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe DigestSubscriptionContentQuery do
         expect(results.first.to_h)
           .to match(subscription_id: subscription.id,
                     subscriber_list_title: subscriber_list.title,
+                    subscriber_list_url: subscriber_list.url,
                     content: [content_change, message])
       end
 
@@ -76,7 +77,7 @@ RSpec.describe DigestSubscriptionContentQuery do
 
     context "with multiple subscriber lists" do
       let(:subscriber_list1) { create(:subscriber_list, title: "Subscriber List A") }
-      let(:subscriber_list2) { create(:subscriber_list, title: "Subscriber List B") }
+      let(:subscriber_list2) { create(:subscriber_list, title: "Subscriber List B", url: "/example") }
 
       let!(:subscription1) do
         create(:subscription,
@@ -107,11 +108,13 @@ RSpec.describe DigestSubscriptionContentQuery do
         expect(results.first.to_h)
           .to match(subscription_id: subscription1.id,
                     subscriber_list_title: subscriber_list1.title,
+                    subscriber_list_url: subscriber_list1.url,
                     content: [content_change1])
 
         expect(results.last.to_h)
           .to match(subscription_id: subscription2.id,
                     subscriber_list_title: subscriber_list2.title,
+                    subscriber_list_url: subscriber_list2.url,
                     content: [content_change2])
       end
 
@@ -124,6 +127,7 @@ RSpec.describe DigestSubscriptionContentQuery do
         expect(results.first.to_h)
           .to match(subscription_id: subscription1.id,
                     subscriber_list_title: subscriber_list1.title,
+                    subscriber_list_url: subscriber_list1.url,
                     content: [message])
       end
     end

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -35,11 +35,13 @@ RSpec.describe DigestEmailGenerationWorker do
         double(
           subscription_id: subscription_one.id,
           subscriber_list_title: "Test title 1",
+          subscriber_list_url: nil,
           content: [create(:content_change)],
         ),
         double(
           subscription_id: subscription_two.id,
           subscriber_list_title: "Test title 2",
+          subscriber_list_url: "/test-title-2",
           content: [create(:message)],
         ),
       ]


### PR DESCRIPTION
This adds a new `url` field to subscriber lists which allows emails to include a link back to the original thing that the user subscribed to.

This also allows us to implement #943 which includes a link back to the subscriber list in the subscription confirmation email.

[Trello Card](https://trello.com/c/pHWNpL5w/49-store-url-of-a-subscriber-list-and-allow-including-that-in-email)