### PR TITLE
Subscription confirmation emails

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -1,0 +1,50 @@
+class SubscriptionConfirmationEmailBuilder
+  def initialize(subscription:)
+    @subscription = subscription
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    Email.create!(
+      subject: subject,
+      body: body,
+      address: subscriber.address,
+      subscriber_id: subscriber.id,
+    )
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscription
+
+  def subscriber
+    @subscriber ||= subscription.subscriber
+  end
+
+  def subscriber_list
+    @subscriber_list ||= subscription.subscriber_list
+  end
+
+  def subject
+    "Your new subscription"
+  end
+
+  def body
+    title = if subscriber_list.url
+              "[#{subscriber_list.title}](#{Plek.new.website_root}#{subscriber_list.url})"
+            else
+              subscriber_list.title
+            end
+
+    <<~BODY
+      You are now subscribed to #{title}.
+      ---
+      #{ManageSubscriptionsLinkPresenter.call(subscriber.address)}
+    BODY
+  end
+end

--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -31,7 +31,7 @@ private
   end
 
   def subject
-    "Your new subscription"
+    "You've subscribed to #{subscriber_list.title}"
   end
 
   def body
@@ -42,7 +42,7 @@ private
             end
 
     <<~BODY
-      You are now subscribed to #{title}.
+      You’ll get an email each time there are changes to #{title}.
       ---
       #{ManageSubscriptionsLinkPresenter.call(subscriber.address)}
     BODY

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -24,6 +24,8 @@ class SubscriptionsController < ApplicationController
       )
     end
 
+    send_subscription_confirmation_email(subscription)
+
     status = existing_subscription ? :ok : :created
     render json: { id: subscription.id }, status: status
   end
@@ -101,5 +103,10 @@ private
 
   def subscription_params
     params.permit(:id, :address, :subscribable_id, :subscriber_list_id, :frequency)
+  end
+
+  def send_subscription_confirmation_email(subscription)
+    email = SubscriptionConfirmationEmailBuilder.call(subscription: subscription)
+    DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
   end
 end

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe SubscriptionConfirmationEmailBuilder do
+  describe ".call" do
+    let(:subscriber_list) { create(:subscriber_list, title: "Example") }
+    let(:subscription) { create(:subscription, subscriber_list: subscriber_list) }
+
+    subject(:call) do
+      described_class.call(subscription: subscription)
+    end
+
+    it { is_expected.to be_instance_of(Email) }
+
+    it "creates an email" do
+      expect { call }.to change(Email, :count).by(1)
+    end
+
+    it "includes the title of the subscriber list" do
+      title = "Example"
+      email = call
+      expect(email.body).to include(title)
+    end
+
+    it "includes a link to manage subscriptions" do
+      text = "View, unsubscribe or change the frequency of your subscriptions"
+      email = call
+      expect(email.body).to include(text)
+    end
+
+    context "when the subscriber list has a URL" do
+      let(:subscriber_list) { create(:subscriber_list, url: "/example") }
+
+      it "includes a link to the subscriber list" do
+        link = "http://www.dev.gov.uk/example"
+        email = call
+        expect(email.body).to include(link)
+      end
+    end
+  end
+end

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
     it "includes the title of the subscriber list" do
       title = "Example"
       email = call
+      expect(email.subject).to include(title)
       expect(email.body).to include(title)
+      expect(email.body).to match(/You’ll get an email each time there are changes to/)
     end
 
     it "includes a link to manage subscriptions" do

--- a/spec/features/subscribing_spec.rb
+++ b/spec/features/subscribing_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe "Subscribing to a subscriber_list", type: :request do
+  before do
+    stub_notify
+  end
+
   scenario "subscribing to a subscriber_list" do
     login_with_internal_app
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -97,7 +97,7 @@ module FeatureHelpers
   def expect_a_subscription_confirmation_email_was_sent
     email_data = expect_an_email_was_sent
     subject = email_data.fetch(:personalisation).fetch(:subject)
-    expect(subject).to match(/new subscription/)
+    expect(subject).to match(/You've subscribed to/)
   end
 
   def extract_unsubscribe_id(email_data)


### PR DESCRIPTION
This means user will receive email confirmation of any new subscriptions including an (optional) link back to the original source of the subscriber list.

Do not merge as we are currently waiting on the content.

Depends on #938.

[Trello Card](https://trello.com/c/IjrikjJs/59-send-out-subscription-confirmation-emails)