### PR TITLE
Allow providing document types to messages

### DIFF
--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -27,6 +27,7 @@ private
       .slice(:title, :url, :body, :sender_message_id)
       .merge(links: with_supertypes(params.fetch(:links, {})),
              tags: with_supertypes(params.fetch(:tags, {})),
+             document_type: params[:document_type].presence,
              email_document_supertype: params[:email_document_supertype].presence,
              government_document_supertype: params[:government_document_supertype].presence,
              priority: params.fetch(:priority, "normal"),

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe MessageHandlerService do
       {
         title: "Message title",
         body: "Message body",
+        document_type: "document_type",
         tags: {
           topics: ["oil-and-gas/licensing"],
         },
@@ -23,6 +24,7 @@ RSpec.describe MessageHandlerService do
       expect(Message.last).to have_attributes(
         title: "Message title",
         body: "Message body",
+        document_type: "document_type",
       )
     end
 


### PR DESCRIPTION
This was missed in https://github.com/alphagov/email-alert-api/pull/936 and is one of the things we match messages against subscriber lists.

[Trello Card](https://trello.com/c/5rtAmAjc/54-finish-the-messages-endpoint-work-in-email-alert-api)