### PR TITLE
Allow slug to be passed in to create subscriber list

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -33,7 +33,7 @@ private
 
   def subscriber_list_params
     title = params.fetch(:title)
-    slug = slugify(title)
+    slug = (params[:slug] || slugify(title))
 
     find_exact_query_params.merge(
       title: title,

--- a/lib/valid_tags.rb
+++ b/lib/valid_tags.rb
@@ -5,6 +5,7 @@ class ValidTags
     alert_type
     appear_in_find_eu_exit_guidance_business_finder
     assessment_date
+    brexit_checklist_criteria
     business_activity
     business_sizes
     business_stages

--- a/spec/integration/subscriber_lists_controller_spec.rb
+++ b/spec/integration/subscriber_lists_controller_spec.rb
@@ -44,5 +44,23 @@ RSpec.describe "Getting a subscriber list", type: :request do
         expect(response.status).to eq(403)
       end
     end
+
+    context "creating subscriber list with a given slug" do
+      it "returns a 201" do
+        login_with_internal_app
+
+        post "/subscriber-lists", params: {
+          title: "General title",
+          slug: "some-concatenated-slug",
+          tags: { "brexit_checklist_criteria" => { "any" => %w[some-value] } }
+        }
+
+        expect(response.status).to eq(201)
+
+        subscriber_list = JSON.parse(response.body)['subscriber_list']
+        expect(subscriber_list['slug']).to eq("some-concatenated-slug")
+        expect(subscriber_list['title']).to eq("General title")
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit makes passing in a slug when creating a subscriber list
possible, this is done so the slug can be unique to the title.

We need to do this as we can't control the length of the title and so
are setting a generic title for the dynamic lists subscriptions so the
user doesn't receive a big long string that makes no sense.

Trello:
https://trello.com/c/Wsm83fy7/56-build-email-signup-workflow