### PR TITLE
Subscriber list descriptions

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -43,7 +43,11 @@ private
 
     <<~BODY
       You’ll get an email each time there are changes to #{title}.
+
+      #{subscriber_list.description}
+
       ---
+
       #{ManageSubscriptionsLinkPresenter.call(subscriber.address)}
     BODY
   end

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -39,6 +39,7 @@ private
       title: title,
       slug: slug,
       url: params[:url],
+      description: (params[:description] || ""),
       signon_user_uid: current_user.uid,
     )
   end

--- a/db/migrate/20190829070710_add_description_to_subscriber_lists.rb
+++ b/db/migrate/20190829070710_add_description_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToSubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :description, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_23_114916) do
+ActiveRecord::Schema.define(version: 2019_08_29_070710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(version: 2019_08_23_114916) do
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
     t.string "url"
+    t.string "description", default: "", null: false
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -36,5 +36,15 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
         expect(email.body).to include(link)
       end
     end
+
+    context "when the subscriber list has a description" do
+      let(:subscriber_list) { create(:subscriber_list, description: "Example description") }
+
+      it "includes the description of the subscriber list" do
+        description = "Example description"
+        email = call
+        expect(email.body).to include(description)
+      end
+    end
   end
 end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
           id
           title
           slug
+          description
           document_type
           subscription_url
           gov_delivery_id

--- a/spec/integration/subscriber_lists_controller_spec.rb
+++ b/spec/integration/subscriber_lists_controller_spec.rb
@@ -62,5 +62,21 @@ RSpec.describe "Getting a subscriber list", type: :request do
         expect(subscriber_list['title']).to eq("General title")
       end
     end
+
+    context "creating subscriber list with a description" do
+      it "returns a 201" do
+        login_with_internal_app
+
+        post "/subscriber-lists", params: {
+          title: "General title",
+          description: "Some description",
+        }
+
+        expect(response.status).to eq(201)
+
+        subscriber_list = JSON.parse(response.body)['subscriber_list']
+        expect(subscriber_list['description']).to eq("Some description")
+      end
+    end
   end
 end

--- a/spec/integration/subscriber_lists_controller_spec.rb
+++ b/spec/integration/subscriber_lists_controller_spec.rb
@@ -24,6 +24,36 @@ RSpec.describe "Getting a subscriber list", type: :request do
           expect(response.status).to eq(404)
         end
       end
+
+      context "creating subscriber list with a given slug" do
+        it "returns a 201" do
+          post "/subscriber-lists", params: {
+            title: "General title",
+            slug: "some-concatenated-slug",
+            tags: { "brexit_checklist_criteria" => { "any" => %w[some-value] } }
+          }
+
+          expect(response.status).to eq(201)
+
+          subscriber_list = JSON.parse(response.body)['subscriber_list']
+          expect(subscriber_list['slug']).to eq("some-concatenated-slug")
+          expect(subscriber_list['title']).to eq("General title")
+        end
+      end
+
+      context "creating subscriber list with a description" do
+        it "returns a 201" do
+          post "/subscriber-lists", params: {
+            title: "General title",
+            description: "Some description",
+          }
+
+          expect(response.status).to eq(201)
+
+          subscriber_list = JSON.parse(response.body)['subscriber_list']
+          expect(subscriber_list['description']).to eq("Some description")
+        end
+      end
     end
 
     context "without authentication" do
@@ -42,40 +72,6 @@ RSpec.describe "Getting a subscriber list", type: :request do
         get "/subscriber-lists/test135"
 
         expect(response.status).to eq(403)
-      end
-    end
-
-    context "creating subscriber list with a given slug" do
-      it "returns a 201" do
-        login_with_internal_app
-
-        post "/subscriber-lists", params: {
-          title: "General title",
-          slug: "some-concatenated-slug",
-          tags: { "brexit_checklist_criteria" => { "any" => %w[some-value] } }
-        }
-
-        expect(response.status).to eq(201)
-
-        subscriber_list = JSON.parse(response.body)['subscriber_list']
-        expect(subscriber_list['slug']).to eq("some-concatenated-slug")
-        expect(subscriber_list['title']).to eq("General title")
-      end
-    end
-
-    context "creating subscriber list with a description" do
-      it "returns a 201" do
-        login_with_internal_app
-
-        post "/subscriber-lists", params: {
-          title: "General title",
-          description: "Some description",
-        }
-
-        expect(response.status).to eq(201)
-
-        subscriber_list = JSON.parse(response.body)['subscriber_list']
-        expect(subscriber_list['description']).to eq("Some description")
       end
     end
   end


### PR DESCRIPTION
This PR adds descriptions to subscriber lists. This allows us to include the description in the subscription confirmation email providing more context to the user about the list they've just subscribed to.

One specific example of where this is useful is in the checklists where we can include a line in the confirmation email such as:

> You can view a copy of your Brexit tool results on GOV.UK.

(This was requested by the content designer to make it clearer to users where they can find their results).

[Trello Card](https://trello.com/c/IMPnQYnj/61-add-dynamic-lists-specific-content-to-subscription-confirmation-email)