### PR TITLE
Support subscriber lists for single pieces of content

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -55,6 +55,7 @@ private
     {
       tags: convert_legacy_params(permitted_params.fetch(:tags, {})),
       links: convert_legacy_params(permitted_params.fetch(:links, {})),
+      content_id: permitted_params[:content_id],
       document_type: permitted_params.fetch(:document_type, ""),
       email_document_supertype: permitted_params.fetch(:email_document_supertype, ""),
       government_document_supertype: permitted_params.fetch(:government_document_supertype, ""),

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -4,6 +4,7 @@ class FindExactQuery
   def initialize(
     tags:,
     links:,
+    content_id:,
     document_type:,
     email_document_supertype:,
     government_document_supertype:,
@@ -11,6 +12,7 @@ class FindExactQuery
   )
     @tags = tags.deep_symbolize_keys
     @links = links.deep_symbolize_keys
+    @content_id = content_id
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
@@ -29,6 +31,7 @@ private
   def base_scope
     @base_scope ||= begin
       scope = SubscriberList
+        .where(content_id: @content_id)
         .where(document_type: @document_type)
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -1,7 +1,8 @@
 class SubscriberListQuery
-  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:)
+  def initialize(tags:, links:, content_id:, document_type:, email_document_supertype:, government_document_supertype:)
     @tags = tags.symbolize_keys
     @links = links.symbolize_keys
+    @content_id = content_id
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
@@ -31,6 +32,7 @@ private
 
   def base_scope
     SubscriberList
+      .where(content_id: [nil, @content_id])
       .where(document_type: ['', @document_type])
       .where(email_document_supertype: ['', @email_document_supertype])
       .where(government_document_supertype: ['', @government_document_supertype])

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -11,7 +11,7 @@ class SubscriberListQuery
     @lists ||= (
       lists_matched_on_links +
       lists_matched_on_tags +
-      lists_matched_on_document_type_only
+      lists_matched_on_empty_links_and_tags_only
     ).uniq(&:id)
   end
 
@@ -25,7 +25,7 @@ private
     MatchedForNotification.new(query_field: :links, scope: base_scope).call(@links)
   end
 
-  def lists_matched_on_document_type_only
+  def lists_matched_on_empty_links_and_tags_only
     FindWithoutLinksAndTags.new(scope: base_scope).call
   end
 

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -32,6 +32,7 @@ private
     SubscriberListQuery.new(
       tags: content_change.tags,
       links: content_change.links,
+      content_id: content_change.content_id,
       document_type: content_change.document_type,
       email_document_supertype: content_change.email_document_supertype,
       government_document_supertype: content_change.government_document_supertype

--- a/app/services/matched_message_generation_service.rb
+++ b/app/services/matched_message_generation_service.rb
@@ -29,6 +29,7 @@ private
     SubscriberListQuery.new(
       tags: message.tags,
       links: message.links,
+      content_id: message.content_id,
       document_type: message.document_type,
       email_document_supertype: message.email_document_supertype,
       government_document_supertype: message.government_document_supertype

--- a/db/migrate/20190823105613_add_content_id_to_subscriber_lists.rb
+++ b/db/migrate/20190823105613_add_content_id_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddContentIdToSubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :content_id, :uuid
+  end
+end

--- a/db/migrate/20190827134506_add_content_id_to_messages.rb
+++ b/db/migrate/20190827134506_add_content_id_to_messages.rb
@@ -1,0 +1,5 @@
+class AddContentIdToMessages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :messages, :content_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 2019_08_29_070710) do
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
     t.string "slug", limit: 10000, null: false
+    t.uuid "content_id"
     t.string "url"
     t.string "description", default: "", null: false
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2019_08_29_070710) do
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "content_id"
     t.index ["sender_message_id"], name: "index_messages_on_sender_message_id", unique: true
   end
 

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
           title
           slug
           description
+          content_id
           document_type
           subscription_url
           gov_delivery_id

--- a/spec/integration/subscriber_lists_controller_spec.rb
+++ b/spec/integration/subscriber_lists_controller_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe "Getting a subscriber list", type: :request do
           expect(subscriber_list['description']).to eq("Some description")
         end
       end
+
+      context "creating subscriber list with a content_id" do
+        it "returns a 201" do
+          post "/subscriber-lists", params: {
+            title: "General title",
+            content_id: "71a573cc-916c-4724-9ab7-758e4637e537",
+          }
+
+          expect(response.status).to eq(201)
+
+          subscriber_list = JSON.parse(response.body)['subscriber_list']
+          expect(subscriber_list["content_id"]).to eq("71a573cc-916c-4724-9ab7-758e4637e537")
+        end
+      end
     end
 
     context "without authentication" do

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe FindExactQuery do
       _subscriber_list = create_subscriber_list(document_type: 'travel_advice')
       expect(query.exact_match).to be_nil
     end
+
+    it "not matched on content_id - even if they match" do
+      query = build_query(links: { policies: { any: %w[aa-11] } }, document_type: 'cd4179c9-6fe4-49bc-8790-da8a1406c8c5')
+      _subscriber_list = create_subscriber_list(document_type: 'cd4179c9-6fe4-49bc-8790-da8a1406c8c5')
+      expect(query.exact_match).to be_nil
+    end
   end
 
   context "when tags are in the query" do
@@ -90,6 +96,12 @@ RSpec.describe FindExactQuery do
       _subscriber_list = create_subscriber_list(document_type: 'travel_advice')
       expect(query.exact_match).to be_nil
     end
+
+    it "not matched on content_id - even if they match" do
+      query = build_query(tags: { policies: { any: %w[beer] } }, document_type: "cd4179c9-6fe4-49bc-8790-da8a1406c8c5")
+      _subscriber_list = create_subscriber_list(document_type: "cd4179c9-6fe4-49bc-8790-da8a1406c8c5")
+      expect(query.exact_match).to be_nil
+    end
   end
 
   it "matched on document type only" do
@@ -101,6 +113,18 @@ RSpec.describe FindExactQuery do
   it "not matched on different document type" do
     query = build_query(tags: { policies: { any: %w[beer] } }, document_type: 'travel_advice')
     _subscriber_list = create_subscriber_list(document_type: 'other')
+    expect(query.exact_match).to be_nil
+  end
+
+  it "matched on content_id only" do
+    query = build_query(document_type: 'cd4179c9-6fe4-49bc-8790-da8a1406c8c5')
+    subscriber_list = create_subscriber_list(document_type: 'cd4179c9-6fe4-49bc-8790-da8a1406c8c5')
+    expect(query.exact_match).to eq(subscriber_list)
+  end
+
+  it "not matched on different document type" do
+    query = build_query(tags: { policies: { any: %w[beer] } }, document_type: 'cd4179c9-6fe4-49bc-8790-da8a1406c8c5')
+    _subscriber_list = create_subscriber_list(document_type: '82ff776b-8762-4e31-8f5f-43d99cd4cee8')
     expect(query.exact_match).to be_nil
   end
 
@@ -126,6 +150,7 @@ RSpec.describe FindExactQuery do
     defaults = {
       tags: {},
       links: {},
+      content_id: nil,
       document_type: '',
       email_document_supertype: '',
       government_document_supertype: '',
@@ -138,6 +163,7 @@ RSpec.describe FindExactQuery do
     defaults = {
       tags: {},
       links: {},
+      content_id: nil,
       document_type: '',
       email_document_supertype: '',
       government_document_supertype: '',

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SubscriberListQuery do
     it_behaves_like "#links matching", tags: { policies: { any: %w[eggs] } }, links: {}
 
     it "excluded when non-matching tags" do
-      subscriber_list = create_subscriber_list(tags: { policies: { any: %w[apples] } })
+      subscriber_list = create(:subscriber_list, tags: { policies: { any: %w[apples] } })
       expect(subject.lists).not_to include(subscriber_list)
     end
   end
@@ -69,8 +69,8 @@ RSpec.describe SubscriberListQuery do
                                        tags: {}
 
     it "excluded when non-matching links" do
-      subscriber_list = create_subscriber_list(links: { policies: { any: %w[aa11] },
-                                                        taxon_tree: { all: %w[taxon1 taxon2] } })
+      subscriber_list = create(:subscriber_list, links: { policies: { any: %w[aa11] },
+                                                          taxon_tree: { all: %w[taxon1 taxon2] } })
       expect(subject.lists).not_to include(subscriber_list)
     end
   end
@@ -139,10 +139,6 @@ RSpec.describe SubscriberListQuery do
       query = described_class.new(defaults.merge(query_params))
       expect(query.lists).not_to include(subscriber_list)
     end
-  end
-
-  def create_subscriber_list(options)
-    create(:subscriber_list, options)
   end
 
   def defaults

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe SubscriberListQuery do
     described_class.new(
       tags: { policies: %w[eggs] },
       links: { policies: %w[11aa], taxon_tree: %w[taxon1 taxon2] },
+      content_id: "a2f95de9-1a02-420b-a2c7-2c6b17dab8c6",
       document_type: 'travel_advice',
       email_document_supertype: 'publications',
       government_document_supertype: 'news_stories',
@@ -10,6 +11,8 @@ RSpec.describe SubscriberListQuery do
   end
 
   shared_examples '#links matching' do |tags_or_links|
+    it { is_included_in_links tags_or_links, content_id: 'a2f95de9-1a02-420b-a2c7-2c6b17dab8c6' }
+    it { is_excluded_from_links tags_or_links, content_id: SecureRandom.uuid }
     it { is_included_in_links tags_or_links, document_type: 'travel_advice' }
     it { is_excluded_from_links tags_or_links, document_type: 'other' }
     it { is_included_in_links tags_or_links, email_document_supertype: 'publications' }
@@ -20,6 +23,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_included_in_links(
         tags_or_links,
+        content_id: 'a2f95de9-1a02-420b-a2c7-2c6b17dab8c6',
         document_type: 'travel_advice',
         email_document_supertype: 'publications',
         government_document_supertype: 'news_stories',
@@ -29,6 +33,17 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
+        content_id: SecureRandom.uuid,
+        document_type: 'travel_advice',
+        email_document_supertype: 'publications',
+        government_document_supertype: 'news_stories',
+      )
+    end
+
+    it do
+      is_excluded_from_links(
+        tags_or_links,
+        content_id: 'a2f95de9-1a02-420b-a2c7-2c6b17dab8c6',
         document_type: 'other',
         email_document_supertype: 'publications',
         government_document_supertype: 'news_stories',
@@ -38,6 +53,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
+        content_id: 'a2f95de9-1a02-420b-a2c7-2c6b17dab8c6',
         document_type: 'travel_advice',
         email_document_supertype: 'other',
         government_document_supertype: 'news_stories',
@@ -47,6 +63,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
+        content_id: 'a2f95de9-1a02-420b-a2c7-2c6b17dab8c6',
         document_type: 'travel_advice',
         email_document_supertype: 'publications',
         government_document_supertype: 'other',
@@ -145,6 +162,7 @@ RSpec.describe SubscriberListQuery do
     {
       links: {},
       tags: {},
+      content_id: nil,
       document_type: '',
       email_document_supertype: '',
       government_document_supertype: '',


### PR DESCRIPTION
This PR adds the ability to create subscriber lists for receiving updates to single piece of content, represented by its `content_id`. It ignores `locale` as we currently don't support [sending emails for non-English content](https://github.com/alphagov/email-alert-service/blob/e7d06553ed0530249fab3f91cbd2b6b2ac8f7c0d/email_alert_service/models/major_change_message_processor.rb#L122-L127).

The need for this comes from being able to subscribe to travel advice updates and allowing travel-advice-publisher to avoid having to manually make a request to email-alert-api to send out the content change, and instead rely on the standard event queue based system which most other apps use.

Currently, we support this behaviour by travel-advice-publisher [creating a links hash which includes the `content_id` of the current page](https://github.com/alphagov/travel-advice-publisher/blob/1b67291be783370f67c2e6f1b444e4c2b3a23fa7/app/presenters/email_alert_presenter.rb#L49-L51) which isn't the links hash of the content itself in the publishing-api. Because of this, if we were to switch over to sending these emails through email-alert-service right now, the content wouldn't match with any travel advice subscriber lists. Rather than making sure that each travel advice document has a link to itself (which doesn't make much sense), we can support a new field on subscriber lists called `content_id` (similar to `document_type` at the moment).

To fully support travel-advice-publisher not talking directly to email-alert-api we will need to [update the sign up page to include the `content_id`](https://github.com/alphagov/travel-advice-publisher/blob/1b67291be783370f67c2e6f1b444e4c2b3a23fa7/app/presenters/email_alert_signup/edition_presenter.rb#L64-L66) and then update the existing subscriber lists.