### PR TITLE
Add tracking to the subscription confirmation title link

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -35,12 +35,6 @@ private
   end
 
   def body
-    title = if subscriber_list.url
-              "[#{subscriber_list.title}](#{Plek.new.website_root}#{subscriber_list.url})"
-            else
-              subscriber_list.title
-            end
-
     <<~BODY
       You’ll get an email each time there are changes to #{title}.
 
@@ -50,5 +44,24 @@ private
 
       #{ManageSubscriptionsLinkPresenter.call(subscriber.address)}
     BODY
+  end
+
+  def title
+    return subscriber_list.title unless subscriber_list.url
+
+    "[#{subscriber_list.title}](#{title_url})"
+  end
+
+  def title_url
+    query = {
+      utm_source: subscriber_list.slug,
+      utm_medium: "email",
+      utm_campaign: "govuk-notifications-subscription-confirmation",
+    }.to_query
+
+    url = subscriber_list.url
+    tracked_url = url + (url.include?("?") ? "&" : "?") + query
+
+    PublicUrlService.url_for(base_path: tracked_url)
   end
 end

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
       let(:subscriber_list) { create(:subscriber_list, url: "/example") }
 
       it "includes a link to the subscriber list" do
-        link = "http://www.dev.gov.uk/example"
+        link = "http://www.dev.gov.uk/example?utm_campaign=govuk-notifications-subscription-confirmation&utm_medium=email&utm_source=#{subscriber_list.slug}"
         email = call
         expect(email.body).to include(link)
       end


### PR DESCRIPTION
This allows us to know if a user clicks on the title in an email subscription confirmation.

[Trello Card](https://trello.com/c/OwwRCH7s/62-add-utm-analytics-to-the-subscription-confirmation-message)