### PR TITLE
[DNM] Add content changes report

### DIFF
--- a/lib/reports/content_changes_information.rb
+++ b/lib/reports/content_changes_information.rb
@@ -1,0 +1,57 @@
+require 'csv'
+
+class Reports::ContentChangesInformation
+  attr_reader :start_date, :end_date
+
+  def initialize(start_date, end_date)
+    @start_date = parse_date(start_date.to_s)
+    @end_date = parse_date(end_date.to_s)
+  end
+
+  def report
+    path = "#{Rails.root}/tmp/content_changes_time_#{start_date}_to_#{end_date}.csv".delete(' ')
+    headers = %w[content_change_id
+                 content_change_base_path
+                 created_at
+                 emails_sent
+                 subscriber_list_titles]
+
+    CSV.open(path, 'wb', headers: headers, write_headers: true) do |csv|
+      email_data.each do |data|
+        csv << data
+      end
+    end
+  end
+
+private
+
+  def parse_date(date)
+    raise ArgumentError, 'Date(s) entered need to be of date/time format' unless Time.zone.parse(date)
+
+    Time.zone.parse(date)
+  end
+
+  def content_changes
+    ContentChange
+      .where(created_at: DateTime.now.beginning_of_day..DateTime.now.end_of_day)
+      .where.not(processed_at: nil)
+      .pluck(:id)
+  end
+
+  def email_data
+    data = SubscriptionContent
+      .joins(:content_change)
+      .joins(:email)
+      .joins(subscription: :subscriber_list)
+      .where(emails: { status: :sent })
+      .where(content_change: content_changes)
+      .group(:content_change_id, "content_changes.created_at", "content_changes.base_path")
+      .pluck(:content_change_id,
+             "content_changes.base_path",
+             "content_changes.created_at",
+             "COUNT(subscription_contents.email_id)",
+             "ARRAY_AGG(subscriber_lists.title)")
+
+    data.map { |x| [x[0], x[1], x[2].to_s, x[3].to_s, x[4].join(', ')] }
+  end
+end

--- a/lib/reports/content_changes_information.rb
+++ b/lib/reports/content_changes_information.rb
@@ -16,11 +16,16 @@ class Reports::ContentChangesInformation
                  emails_sent
                  subscriber_list_titles]
 
+    puts "CSV is being generated for content_changes between #{start_date} - #{end_date}"
+    puts "The information being returned includes content_change_id, content_change_base_path, created_at, emails_sent, subscriber_list_titles"
+
     CSV.open(path, 'wb', headers: headers, write_headers: true) do |csv|
       email_data.each do |data|
         csv << data
       end
     end
+
+    puts "The CSV file is available at - #{path}"
   end
 
 private

--- a/lib/tasks/content_change_emails.rake
+++ b/lib/tasks/content_change_emails.rake
@@ -10,4 +10,10 @@ namespace :report do
     content_change = ContentChange.find(args[:id])
     Reports::ContentChangeEmailFailures.call(content_change)
   end
+
+  desc "Produce a report on all content_change information between given dates, format - '2019-09-02 11:46:29', defaults to today"
+  task :content_changes_information, %i[start_date end_date] => :environment do |_t, args|
+    args.with_defaults(start_date: DateTime.now.beginning_of_day, end_date: DateTime.now.end_of_day)
+    Reports::ContentChangesInformation.new(args[:start_date], args[:end_date]).report
+  end
 end

--- a/spec/lib/reports/content_changes_information_spec.rb
+++ b/spec/lib/reports/content_changes_information_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Reports::ContentChangesInformation do
+  context "successful report" do
+    before do
+      @content_change = create(:content_change, processed_at: Time.now)
+      @subscription_one, @subscription_two = (1..2).map { create(:subscription) }
+      email_one, email_two = (1..2).map { create(:email, status: 'sent') }
+
+      create(:subscription_content, content_change: @content_change,
+             email: email_one, subscription: @subscription_one)
+      create(:subscription_content, content_change: @content_change,
+             email: email_two, subscription: @subscription_two)
+
+      @start_date = Time.zone.parse(DateTime.now.beginning_of_day.to_s)
+      @end_date =  Time.zone.parse(DateTime.now.end_of_day.to_s)
+      @file_path = "#{Rails.root}/tmp/content_changes_time_#{@start_date}_to_#{@end_date}.csv".delete(' ')
+    end
+
+    it "generates CSV containing information around content changes for the given timeframe" do
+      described_class.new(@start_date, @end_date).report
+      expect(CSV.read(@file_path)[1]).to eq(
+        [
+          @content_change.id.to_s,
+          @content_change.base_path.to_s,
+          @content_change.created_at.to_s,
+          "2",
+          "#{@subscription_one.subscriber_list.title}, #{@subscription_two.subscriber_list.title}"
+        ]
+      )
+    end
+  end
+
+  it "raises an error if the time passed in is not in date/time format" do
+    expect { described_class.new("foobartime", "barfootime").call }
+           .to raise_error(ArgumentError, 'Date(s) entered need to be of date/time format')
+  end
+end

--- a/spec/lib/reports/content_changes_information_spec.rb
+++ b/spec/lib/reports/content_changes_information_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Reports::ContentChangesInformation do
         ]
       )
     end
+
+    it "outputs text to stdout describing the report" do
+      expect { described_class.new(@start_date, @end_date).report }.to output(
+        <<~TEXT
+          CSV is being generated for content_changes between #{@start_date} - #{@end_date}
+          The information being returned includes content_change_id, content_change_base_path, created_at, emails_sent, subscriber_list_titles
+          The CSV file is available at - #{@file_path}
+        TEXT
+      ).to_stdout
+    end
   end
 
   it "raises an error if the time passed in is not in date/time format" do


### PR DESCRIPTION
This rake task allows information to be gathered and a CSV to be
generated which contains information around all the content_changes
processed within the dates specified (defaults to the day it's ran on).

So far the information being returned is as follows:
* content_change_id
* content_change_base_path
* created_at
* emails_sent
* subscriber_list_titles (don't know how useful this is but trello card states subscriber list info)

Trello:
https://trello.com/c/Grd9CCC2/63-add-a-rake-task-to-collect-contentchangeids-and-related-data