### PR TITLE
Look up SubscriberLists by Criteria

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -32,6 +32,10 @@ class SubscriberList < ApplicationRecord
     where(sql, id: "\"#{content_id}\"")
   end
 
+  scope :matching_criteria_rules, ->(criteria_rules) do
+    SubscriberListsByCriteriaQuery.call(self, criteria_rules)
+  end
+
   def subscription_url
     PublicUrlService.subscription_url(slug: slug)
   end

--- a/app/queries/subscriber_lists_by_criteria_query.rb
+++ b/app/queries/subscriber_lists_by_criteria_query.rb
@@ -1,0 +1,61 @@
+class SubscriberListsByCriteriaQuery
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(initial_scope, criteria_rules)
+    @initial_scope = initial_scope
+    @criteria_rules = criteria_rules
+  end
+
+  def call
+    all_of_rule(initial_scope, criteria_rules)
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :initial_scope, :criteria_rules
+
+  def rule_condition(scope, rule)
+    return type_rule(scope, rule) if rule[:type]
+    return any_of_rule(scope, rule[:any_of]) if rule[:any_of]
+    return all_of_rule(scope, rule[:all_of]) if rule[:all_of]
+
+    raise "Invalid rule: #{rule.inspect}"
+  end
+
+  def all_of_rule(scope, rule_list)
+    rule_list.inject(scope) do |accumulative_scope, rule|
+      accumulative_scope.merge(rule_condition(scope, rule))
+    end
+  end
+
+  def any_of_rule(scope, rule_list)
+    or_scope = rule_condition(scope, rule_list.first)
+
+    rule_list.drop(1).inject(or_scope) do |accumulative_scope, rule|
+      accumulative_scope.or(rule_condition(scope, rule))
+    end
+  end
+
+  def type_rule(scope, type:, key:, value:)
+    field = case type
+            when "tag" then "tags"
+            when "link" then "links"
+            else
+              raise "Unexpected rule type: #{type}"
+            end
+
+    # we only apply this rule to SubscriberList tagged to "any", it didn't seem
+    # to make logical sense to apply this to "all" ones
+    scope.where(
+      ":value IN (SELECT json_array_elements(#{field}->:key->'any')::text)",
+      key: key,
+      # Postgres returns a string in double quotes where other double quote
+      # characters are escaped
+      value: %{"#{value.gsub('"', '\\"')}"}
+    )
+  end
+end

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -168,4 +168,19 @@ RSpec.describe SubscriberList, type: :model do
       )
     end
   end
+
+  describe "matching_criteria_rules scope" do
+    it "can look up subscriber lists that match criteria rules" do
+      list = create(:subscriber_list, tags: { format: { any: %w[match] } })
+      create(:subscriber_list)
+
+      result = described_class.matching_criteria_rules(
+        [
+          { type: "tag", key: "format", value: "match" }
+        ]
+      )
+
+      expect(result).to match([list])
+    end
+  end
 end

--- a/spec/queries/subscriber_lists_by_criteria_query_spec.rb
+++ b/spec/queries/subscriber_lists_by_criteria_query_spec.rb
@@ -1,0 +1,174 @@
+RSpec.describe SubscriberListsByCriteriaQuery do
+  describe ".call" do
+    it "can match a tag" do
+      list = create(:subscriber_list, tags: { format: { any: %w[match] } })
+      create(:subscriber_list, tags: { format: { any: %w[no-match] } })
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          { type: "tag", key: "format", value: "match" }
+        ]
+      )
+
+      expect(result).to match([list])
+    end
+
+    it "can match a link" do
+      uuid = SecureRandom.uuid
+      list = create(:subscriber_list, links: { format: { any: [uuid] } })
+      create(:subscriber_list, links: { format: { any: [SecureRandom] } })
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          { type: "link", key: "format", value: uuid }
+        ]
+      )
+
+      expect(result).to match([list])
+    end
+
+    it "can match multiple tags" do
+      list = create(:subscriber_list, tags: { format: { any: %w[match part_of_match] } })
+      create(:subscriber_list, tags: { format: { any: %w[part_of_match] } })
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          { type: "tag", key: "format", value: "match" },
+          { type: "tag", key: "format", value: "part_of_match" }
+        ]
+      )
+
+      expect(result).to match([list])
+    end
+
+    it "can match tags and links" do
+      uuid = SecureRandom.uuid
+      list = create(:subscriber_list,
+                    tags: { format: { any: %w[match] } },
+                    links: { format: { any: [uuid] } })
+      create(:subscriber_list)
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          { type: "tag", key: "format", value: "match" },
+          { type: "link", key: "format", value: uuid }
+        ]
+      )
+
+      expect(result).to match([list])
+    end
+
+    it "can match a tag with a double quote inside it" do
+      unusual_tag = %{unusual string 'with things' that "might be escaped" like {} and []}
+      list = create(:subscriber_list, tags: { format: { any: [unusual_tag] } })
+      create(:subscriber_list)
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          { type: "tag", key: "format", value: unusual_tag },
+        ]
+      )
+
+      expect(result).to match([list])
+    end
+
+    it "can match optional conditions" do
+      list_a = create(:subscriber_list, tags: { format: { any: %w[match_a] } })
+      list_b = create(:subscriber_list, tags: { format: { any: %w[match_b] } })
+      create(:subscriber_list)
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          {
+            any_of: [
+              { type: "tag", key: "format", value: "match_a" },
+              { type: "tag", key: "format", value: "match_b" }
+            ]
+          }
+        ]
+      )
+
+      expect(result).to match([list_a, list_b])
+    end
+
+    it "can match nested and conditions in or conditions" do
+      list_a = create(:subscriber_list, tags: { format: { any: %w[match_a another_a] } })
+      list_b = create(:subscriber_list, tags: { format: { any: %w[match_b another_b] } })
+      create(:subscriber_list, tags: { format: { any: %w[another_a] } })
+      create(:subscriber_list, tags: { format: { any: %w[another_b] } })
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          {
+            any_of: [
+              {
+                all_of: [
+                  { type: "tag", key: "format", value: "match_a" },
+                  { type: "tag", key: "format", value: "another_a" }
+                ]
+              },
+              {
+                all_of: [
+                  { type: "tag", key: "format", value: "match_b" },
+                  { type: "tag", key: "format", value: "another_b" }
+                ],
+              }
+            ]
+          }
+        ]
+      )
+
+      expect(result).to match([list_a, list_b])
+    end
+
+    it "can match a complicated nested scenario" do
+      list = create(
+        :subscriber_list,
+        tags: { format: { any: %w[match_a match_c match_d match_e] } }
+      )
+      create(:subscriber_list)
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          { type: "tag", key: "format", value: "match_a" },
+          {
+            any_of: [
+              {
+                all_of: [
+                  {
+                    any_of: [
+                      { type: "tag", key: "format", value: "match_b" },
+                      { type: "tag", key: "format", value: "not_match_b" }
+                    ]
+                  },
+                  {
+                    any_of: [
+                      { type: "tag", key: "format", value: "match_c" },
+                      { type: "tag", key: "format", value: "not_match_c" }
+                    ]
+                  },
+                ]
+              },
+              {
+                all_of: [
+                  { type: "tag", key: "format", value: "match_d" },
+                  { type: "tag", key: "format", value: "match_e" }
+                ],
+              }
+            ]
+          }
+        ]
+      )
+
+      expect(result).to match([list])
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/jtD4dW4t/79-match-email-alert-api-messages-based-on-criteria

This adds in the means to look up a subscriber list based on criteria rules. Criteria rules are a concept introduced in https://github.com/alphagov/email-alert-api/pull/959 which are used to determine a particular subscriber list that meets a variety of criteria.

It is a somewhat strange concept where we expect messages to come in with a bunch of rules on them and they are used to find the appropriate list. This is an inversion of our normal logic approach where we have content changes with properties that are matched to lists with rules on what they accept. This has been done to support the "Get ready for Brexit" tool where there are lots of rules as to who should receive advice.
