### PR TITLE
Switch to using criteria for messages instead of links/tags/document-types

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -21,12 +21,7 @@ private
       :title,
       :url,
       :body,
-      :document_type,
-      :email_document_supertype,
-      :government_document_supertype,
       :priority,
-      links: {},
-      tags: {}
     ).merge(
       criteria_rules: criteria_rules
     )

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,7 +4,7 @@ class Message < ApplicationRecord
   has_many :matched_messages
   has_many :subscription_contents
 
-  validates_presence_of :title, :body, :criteria_rules
+  validates_presence_of :title, :body, :criteria_rules, :govuk_request_id
   validates :url, root_relative_url: true, allow_nil: true
   validates :criteria_rules, criteria_schema: true
   validates :sender_message_id,

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,9 +4,16 @@ class Message < ApplicationRecord
   has_many :matched_messages
   has_many :subscription_contents
 
-  validates_presence_of :title, :body
+  validates_presence_of :title, :body, :criteria_rules
   validates :url, root_relative_url: true, allow_nil: true
-  validates :criteria_rules, criteria_schema: true, allow_nil: true
+  validates :criteria_rules, criteria_schema: true
+  validates :sender_message_id,
+            format: {
+              with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z/i,
+              message: "is not a UUID"
+            },
+            uniqueness: true,
+            allow_nil: true
 
   enum priority: { normal: 0, high: 1 }
 

--- a/app/queries/email_archive_query.rb
+++ b/app/queries/email_archive_query.rb
@@ -16,6 +16,7 @@ private
       :created_at,
       content_change_ids,
       digest_run_ids,
+      message_ids,
       :finished_sending_at,
       :id,
       :marked_as_spam,
@@ -37,9 +38,19 @@ private
   def content_change_ids
     query = SubscriptionContent
       .where("email_id = emails.id")
+      .where.not(content_change_id: nil)
       .distinct
       .select(:content_change_id)
     "ARRAY(#{query.to_sql}) AS content_change_ids"
+  end
+
+  def message_ids
+    query = SubscriptionContent
+      .where("email_id = emails.id")
+      .where.not(message_id: nil)
+      .distinct
+      .select(:message_id)
+    "ARRAY(#{query.to_sql}) AS message_ids"
   end
 
   def digest_run_ids

--- a/app/services/matched_message_generation_service.rb
+++ b/app/services/matched_message_generation_service.rb
@@ -22,16 +22,8 @@ private
   end
 
   def records
-    subscriber_lists.map { |subscriber_list| [message.id, subscriber_list.id] }
-  end
-
-  def subscriber_lists
-    SubscriberListQuery.new(
-      tags: message.tags,
-      links: message.links,
-      document_type: message.document_type,
-      email_document_supertype: message.email_document_supertype,
-      government_document_supertype: message.government_document_supertype
-    ).lists
+    SubscriberList
+      .matching_criteria_rules(message.criteria_rules)
+      .map { |subscriber_list| [message.id, subscriber_list.id] }
   end
 end

--- a/app/services/matched_message_generation_service.rb
+++ b/app/services/matched_message_generation_service.rb
@@ -1,5 +1,5 @@
 class MatchedMessageGenerationService
-  def initialize(message:)
+  def initialize(message)
     @message = message
   end
 

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -25,21 +25,8 @@ private
     params
       .slice(:title, :url, :body, :sender_message_id)
       .merge(criteria_rules: params[:criteria_rules].presence,
-             links: with_supertypes(params.fetch(:links, {})),
-             tags: with_supertypes(params.fetch(:tags, {})),
-             document_type: params[:document_type].presence,
-             email_document_supertype: params[:email_document_supertype].presence,
-             government_document_supertype: params[:government_document_supertype].presence,
              priority: params.fetch(:priority, "normal"),
              govuk_request_id: govuk_request_id,
              signon_user_uid: user&.uid)
-  end
-
-  def with_supertypes(hash)
-    return hash unless params[:document_type].present?
-
-    supertypes = GovukDocumentTypes.supertypes(document_type: params[:document_type])
-    content_store_document_type = { content_store_document_type: params[:document_type] }
-    supertypes.merge(hash).merge(content_store_document_type)
   end
 end

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -27,6 +27,7 @@ private
       .merge(criteria_rules: params[:criteria_rules].presence,
              priority: params.fetch(:priority, "normal"),
              govuk_request_id: govuk_request_id,
-             signon_user_uid: user&.uid)
+             signon_user_uid: user&.uid,
+             id: params[:sender_message_id])
   end
 end

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -12,7 +12,6 @@ class MessageHandlerService
   def call
     message = Message.create!(message_params)
     MetricsService.message_created
-    MatchedMessageGenerationService.call(message: message)
     ProcessMessageWorker.perform_async(message.id)
   end
 

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -5,6 +5,7 @@ class ProcessMessageWorker
     message = Message.find(message_id)
     return if message.processed?
 
+    MatchedMessageGenerationService.call(message)
     import_subscription_content(message)
     queue_courtesy_email(message)
 

--- a/db/migrate/20190904182908_remove_superfluous_message_fields.rb
+++ b/db/migrate/20190904182908_remove_superfluous_message_fields.rb
@@ -1,0 +1,11 @@
+class RemoveSuperfluousMessageFields < ActiveRecord::Migration[5.2]
+  def change
+    change_table :messages, bulk: true do |t|
+      t.remove :links,
+               :tags,
+               :document_type,
+               :email_document_supertype,
+               :government_document_supertype
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_03_101929) do
+ActiveRecord::Schema.define(version: 2019_09_04_182908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,11 +119,6 @@ ActiveRecord::Schema.define(version: 2019_09_03_101929) do
     t.text "title", null: false
     t.text "url"
     t.text "body", null: false
-    t.json "links", default: {}, null: false
-    t.json "tags", default: {}, null: false
-    t.string "document_type"
-    t.string "email_document_supertype"
-    t.string "government_document_supertype"
     t.datetime "processed_at"
     t.string "signon_user_uid"
     t.string "govuk_request_id", null: false

--- a/doc/api.md
+++ b/doc/api.md
@@ -61,24 +61,20 @@ The following fields are accepted on this endpoint: `subject`, `from_address_id`
 
 ```json
 {
-  "sender_message_id": "unique-identifier-for-each-message",
-  "title": "This is the title of my bulletin",
-  "url": "https://www.url.com",
-  "body": "Email body here",
-  "document_type": "",
-  "email_document_supertype": "",
-  "government_document_supertype": "",
-  "priority": "weekly",
-  "tags": {
-    "tag": ["some-tag"]
-  },
-  "links": {
-    "link": ["some-link"]
-  }
+  "sender_message_id": "4da7a6a7-c8f7-482e-aeb9-a26cea90780c",
+  "title": "Message title",
+  "url": "/path-to-a-govuk-page",
+  "body": "Message body",
+  "criteria_rules": [
+    { "type": "tag", "key": "tag-name", "value": "tag-value" }
+  ]
 }
 ```
 
 and it will respond with `202 Accepted` (the call is queued).
+
+The following fields are accepted on this endpoint: `sender_message_id`,
+`title`, `url`, `body`, `criteria_rules`, and `priority`.
 
 * `POST /emails` with data:
 
@@ -88,6 +84,7 @@ and it will respond with `202 Accepted` (the call is queued).
   "body": "Email body here",
   "address": "recipient-email@address.com"
 }
+```
 
 and it will respond with `202 Accepted` (the call is queued).
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
       [
         {
           type: "tag",
-          key: "brexit_checker_criteria",
+          key: "brexit_checklist_criteria",
           value: "eu-national"
         },
       ]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
   factory :message do
     title { "Title" }
     body { "Body" }
-    criteria_rules {
+    criteria_rules do
       [
         {
           type: "tag",
@@ -44,7 +44,7 @@ FactoryBot.define do
           value: "eu-national"
         },
       ]
-    }
+    end
 
     sequence(:govuk_request_id) { |i| "request-id-#{i}" }
 

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -191,9 +191,9 @@ RSpec.describe "creating and delivering digests", type: :request do
     Timecop.freeze "2017-01-01 09:31" do
       create_message(
         title: "Title two",
-        links: {
-          topics: [list_one_topic_id, list_two_topic_id]
-        }
+        criteria_rules: [
+          { type: "link", key: "topics", value: list_one_topic_id }
+        ]
       )
     end
 
@@ -441,9 +441,9 @@ RSpec.describe "creating and delivering digests", type: :request do
       create_message(
         title: "Title two",
         url: "/base-path",
-        links: {
-          topics: [list_one_topic_id]
-        }
+        criteria_rules: [
+          { type: "link", key: "topics", value: list_one_topic_id }
+        ]
       )
     end
 

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -29,9 +29,13 @@ RSpec.describe "Sending an email", type: :request do
   scenario "sending an email for a message" do
     login_with_internal_app
 
-    subscriber_list_id = create_subscriber_list
+    subscriber_list_id = create_subscriber_list(
+      tags: { brexit_checklist_criteria: { any: %w[eu-national] } }
+    )
     subscribe_to_subscriber_list(subscriber_list_id)
-    create_message
+    create_message(
+      criteria_rules: [{ type: "tag", key: "brexit_checklist_criteria", value: "eu-national" }]
+    )
     email_data = expect_an_email_was_sent
 
     address = email_data.dig(:email_address)

--- a/spec/integration/send_message_spec.rb
+++ b/spec/integration/send_message_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Sending a message", type: :request do
       criteria_rules: [
         {
           type: "tag",
-          key: "brexit_checker_criteria",
+          key: "brexit_checklist_criteria",
           value: "eu-national"
         },
       ]

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Message do
-  describe "url" do
+  describe "url validation" do
     it "is valid when url is nil" do
       expect(build(:message, url: nil)).to be_valid
     end
@@ -10,6 +10,25 @@ RSpec.describe Message do
 
     it "is invalid when url is an absolute URI" do
       expect(build(:message, url: "https://example.com/test")).to be_invalid
+    end
+  end
+
+  describe "criteria_rules validation" do
+    it "is valid with criteria_rules are valid" do
+      message = build(:message, criteria_rules: [
+        { type: "tag", key: "topic", value: "a" }
+      ])
+      expect(message).to be_valid
+    end
+
+    it "is not valid with invalid criteria_rules" do
+      message = build(:message, criteria_rules: [])
+      expect(message).not_to be_valid
+    end
+
+    it "is not valid without criteria rules" do
+      message = build(:message, criteria_rules: nil)
+      expect(message).not_to be_valid
     end
   end
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe Message do
       message = build(:message, sender_message_id: "12345")
       expect(message).not_to be_valid
     end
+
+    it "disallows a non unique sender_message_id" do
+      uuid = SecureRandom.uuid
+      create(:message, sender_message_id: uuid)
+      message = build(:message, sender_message_id: uuid)
+      expect(message).not_to be_valid
+    end
   end
 
   describe "#mark_processed!" do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe Message do
     end
   end
 
+  describe "sender_message_id validation" do
+    it "is valid when nil" do
+      message = build(:message, sender_message_id: nil)
+      expect(message).to be_valid
+    end
+
+    it "is valid with a UUID" do
+      message = build(:message, sender_message_id: SecureRandom.uuid)
+      expect(message).to be_valid
+    end
+
+    it "is not valid without a UUID" do
+      message = build(:message, sender_message_id: "12345")
+      expect(message).not_to be_valid
+    end
+  end
+
   describe "#mark_processed!" do
     it "sets processed_at" do
       Timecop.freeze do

--- a/spec/services/matched_message_generation_service_spec.rb
+++ b/spec/services/matched_message_generation_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MatchedMessageGenerationService do
 
   describe ".call" do
     it "creates a MatchedMessage" do
-      expect { described_class.call(message: message) }
+      expect { described_class.call(message) }
         .to change { MatchedMessage.count }.by(1)
     end
   end

--- a/spec/services/matched_message_generation_service_spec.rb
+++ b/spec/services/matched_message_generation_service_spec.rb
@@ -1,6 +1,9 @@
 RSpec.describe MatchedMessageGenerationService do
   let(:message) do
-    create(:message, tags: { topics: ["oil-and-gas/licensing"] })
+    create(:message,
+           criteria_rules: [
+             { type: "tag", key: "topics", value: "oil-and-gas/licensing" }
+           ])
   end
 
   before do

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -4,18 +4,13 @@ RSpec.describe MessageHandlerService do
       {
         title: "Message title",
         body: "Message body",
-        document_type: "document_type",
         criteria_rules: [
           {
             type: "tag",
             key: "brexit_checker_criteria",
             value: "eu-national"
           },
-        ],
-        tags: {
-          topics: ["oil-and-gas/licensing"],
-        },
-        links: {},
+        ]
       }
     end
 
@@ -27,7 +22,6 @@ RSpec.describe MessageHandlerService do
       expect(Message.last).to have_attributes(
         title: "Message title",
         body: "Message body",
-        document_type: "document_type",
       )
     end
 
@@ -55,35 +49,6 @@ RSpec.describe MessageHandlerService do
                            user: user)
 
       expect(Message.last).to have_attributes(signon_user_uid: user.uid)
-    end
-
-    it "can add content_store_document_type to links and tags" do
-      document_type = "news_story"
-      modified_params = params.merge(document_type: document_type)
-
-      described_class.call(params: modified_params,
-                           govuk_request_id: govuk_request_id)
-
-      expect(Message.last).to have_attributes(
-        links: a_hash_including(content_store_document_type: document_type),
-        tags: a_hash_including(content_store_document_type: document_type),
-      )
-    end
-
-    it "can add GOV.UK supertypes to links and tags" do
-      allow(GovukDocumentTypes)
-        .to receive(:supertypes)
-        .and_return(navigation_document_supertype: "other")
-
-      modified_params = params.merge(document_type: "news_story")
-
-      described_class.call(params: modified_params,
-                           govuk_request_id: govuk_request_id)
-
-      expect(Message.last).to have_attributes(
-        links: a_hash_including(navigation_document_supertype: "other"),
-        tags: a_hash_including(navigation_document_supertype: "other"),
-      )
     end
   end
 end

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe MessageHandlerService do
 
     let(:govuk_request_id) { SecureRandom.uuid }
 
-    let!(:subscriber_list) do
-      create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
-    end
-
     it "creates a Message" do
       expect { described_class.call(params: params, govuk_request_id: govuk_request_id) }
         .to change { Message.count }.by(1)
@@ -33,11 +29,6 @@ RSpec.describe MessageHandlerService do
         body: "Message body",
         document_type: "document_type",
       )
-    end
-
-    it "creates a MatchedMessage" do
-      expect { described_class.call(params: params, govuk_request_id: govuk_request_id) }
-        .to change { MatchedMessage.count }.by(1)
     end
 
     it "records a metric" do

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -50,5 +50,17 @@ RSpec.describe MessageHandlerService do
 
       expect(Message.last).to have_attributes(signon_user_uid: user.uid)
     end
+
+    it "can use the sender_message_id as the Message id" do
+      uuid = SecureRandom.uuid
+
+      described_class.call(params: params.merge(sender_message_id: uuid),
+                           govuk_request_id: govuk_request_id)
+
+      expect(Message.last).to have_attributes(
+        id: uuid,
+        sender_message_id: uuid,
+      )
+    end
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -74,7 +74,7 @@ module FeatureHelpers
       criteria_rules: [
         {
           type: "tag",
-          key: "brexit_checker_criteria",
+          key: "brexit_checklist_criteria",
           value: "eu-national"
         },
       ]

--- a/spec/validators/criteria_schema_validator_spec.rb
+++ b/spec/validators/criteria_schema_validator_spec.rb
@@ -14,31 +14,31 @@ RSpec.describe CriteriaSchemaValidator do
       rules = [
         {
           type: "tag",
-          key: "brexit_checker_criteria",
+          key: "brexit_checklist_criteria",
           value: "eu-national"
         },
         {
           type: "tag",
-          key: "brexit_checker_criteria",
+          key: "brexit_checklist_criteria",
           value: "eu-resident"
         },
         {
           any_of: [
             {
               type: "tag",
-              key: "brexit_checker_criteria",
+              key: "brexit_checklist_criteria",
               value: "uk-resident"
             },
             {
               all_of: [
                 {
                   type: "tag",
-                  key: "brexit_checker_criteria",
+                  key: "brexit_checklist_criteria",
                   value: "ip"
                 },
                 {
                   type: "tag",
-                  key: "brexit_checker_criteria",
+                  key: "brexit_checklist_criteria",
                   value: "exports"
                 }
               ]
@@ -58,7 +58,7 @@ RSpec.describe CriteriaSchemaValidator do
       incorrectly_formatted_rules = [
         {
           type: "not-a-tag",
-          key: "brexit_checker_criteria",
+          key: "brexit_checklist_criteria",
           value: "eu-national"
         },
       ]
@@ -70,9 +70,7 @@ RSpec.describe CriteriaSchemaValidator do
   end
 
   context "Non json object" do
-    before do
-      model.criteria_rules = ''
-    end
+    before { model.criteria_rules = "" }
 
     it { is_expected.not_to be_valid }
   end

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -1,11 +1,10 @@
 RSpec.describe ProcessMessageWorker do
-  let(:message) { create(:message, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
+  let(:message) { create(:message, tags: { topics: ["oil-and-gas/licensing"] }) }
   let(:email) { create(:email) }
 
   context "with a subscription" do
     let(:subscriber) { create(:subscriber) }
     let(:subscriber_list) { create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
-    let!(:matched_message) { create(:matched_message, subscriber_list: subscriber_list, message: message) }
     let!(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
 
     it "creates subscription content for the message" do
@@ -18,6 +17,11 @@ RSpec.describe ProcessMessageWorker do
       expect { subject.perform(message.id) }
         .to change { message.reload.processed? }
         .to(true)
+    end
+
+    it "creates a MatchedMessage" do
+      expect { subject.perform(message.id) }
+        .to change { MatchedMessage.count }.by(1)
     end
 
     context "when the subscription content has already been imported for the message" do

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -1,5 +1,11 @@
 RSpec.describe ProcessMessageWorker do
-  let(:message) { create(:message, tags: { topics: ["oil-and-gas/licensing"] }) }
+  let(:message) do
+    create(:message,
+           criteria_rules: [
+             { type: "tag", key: "topics", value: "oil-and-gas/licensing" }
+           ])
+  end
+
   let(:email) { create(:email) }
 
   context "with a subscription" do


### PR DESCRIPTION
Trello: https://trello.com/c/9pic1BWS/78-create-criteria-rules-for-messages-model

This PR switches the looking up of SubscriberLists for a Message to be based upon CriteriaRules rather than by using SubscriberListQuery.

Following this this then removes the unused fields on a message (links, tags, document types) and then validates that sender_message_id should be a UUID.