### PR TITLE
Add tags & links digest columns to subscriber list

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -17,6 +17,11 @@ class SubscriberList < ApplicationRecord
   has_many :matched_content_changes
   has_many :matched_messages
 
+  before_save do
+    self.tags_digest = HashDigest.new(tags).generate
+    self.links_digest = HashDigest.new(links).generate
+  end
+
   scope :find_by_links_value, ->(content_id) do
       # For this query to return the content id has to be wrapped in a
       # double quote blame psql 9.

--- a/db/migrate/20190902130018_add_tags_links_digest_to_subscriber_lists.rb
+++ b/db/migrate/20190902130018_add_tags_links_digest_to_subscriber_lists.rb
@@ -1,0 +1,6 @@
+class AddTagsLinksDigestToSubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :tags_digest, :string
+    add_column :subscriber_lists, :links_digest, :string
+  end
+end

--- a/db/migrate/20190905162914_add_indexes_to_subscriber_list_digests.rb
+++ b/db/migrate/20190905162914_add_indexes_to_subscriber_list_digests.rb
@@ -1,0 +1,12 @@
+class AddIndexesToSubscriberListDigests < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscriber_lists,
+              :tags_digest,
+              algorithm: :concurrently
+    add_index :subscriber_lists,
+              :links_digest,
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,11 +142,15 @@ ActiveRecord::Schema.define(version: 2019_09_13_102634) do
     t.string "slug", null: false
     t.string "url"
     t.string "description", default: "", null: false
+    t.string "tags_digest"
+    t.string "links_digest"
     t.string "group_id"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"
+    t.index ["links_digest"], name: "index_subscriber_lists_on_links_digest"
     t.index ["slug"], name: "index_subscriber_lists_on_slug", unique: true
+    t.index ["tags_digest"], name: "index_subscriber_lists_on_tags_digest"
   end
 
   create_table "subscribers", force: :cascade do |t|

--- a/lib/hash_digest.rb
+++ b/lib/hash_digest.rb
@@ -1,0 +1,33 @@
+require 'digest'
+
+class HashDigest
+  def initialize(hash)
+    @original_hash = hash.deep_symbolize_keys
+  end
+
+  def generate
+    return nil if original_hash.empty?
+
+    Digest::SHA256.hexdigest(sort_hash(original_hash).to_s)
+  end
+
+private
+
+  attr_reader :original_hash
+
+  # We sort the hash because the order of keys and values shouldn't matter.
+  # You should get the same digest for a hash regardless of structure.
+  def sort_hash(hash)
+    value_sorted_hash = hash.each_with_object({}) do |(key, value), hsh|
+      hsh[key] = if value.is_a?(Hash)
+                   sort_hash(value)
+                 elsif value.is_a?(Array)
+                   value.compact.sort
+                 else
+                   value
+                 end
+    end
+
+    value_sorted_hash.sort
+  end
+end

--- a/spec/lib/hash_digest_spec.rb
+++ b/spec/lib/hash_digest_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe HashDigest do
+  describe ".generate" do
+    subject { described_class.new(input).generate }
+    let(:input) { {} }
+
+    it "returns nil when given an empty hash" do
+      expect(subject).to be_nil
+    end
+
+    context "when a hash is provided" do
+      let(:input) do
+        {
+          a: 1, b: 2, aircraft_type: %w(plane helicopter),
+          c: 3, d: 4, boat_type: %w(boat ship)
+        }
+      end
+
+      it "returns a digest for a hash" do
+        expect(subject).to eq("ee38bab7cf3dcfa3c0181cb26ad2bc25f006ca62fa030a81dc2b0ac353b4bddb")
+      end
+
+      it "returns the same digest every time the input is provided" do
+        digests = (1..3).map { described_class.new(input).generate }
+        expect(digests.uniq.count).to eq 1
+      end
+    end
+
+    it "returns the same digest regardless of hash structure" do
+      first_input = {
+        a: [1, 2, 3, 4], b: %w(a b c d),
+        prior: 'one',
+        nested_tags: {
+          number: 2,
+          deep_nest: { foo: 'bar' },
+          more_tags: %w(more and more),
+        }
+      }
+      second_input = {
+        b: %w(a c b d), a: [1, 4, 3, 2],
+        nested_tags: {
+          more_tags: %w(more more and),
+          number: 2,
+          deep_nest: { foo: 'bar' },
+        },
+        prior: 'one'
+      }
+      first_output = described_class.new(first_input).generate
+      second_output = described_class.new(second_input).generate
+      expect(first_output).to eq(second_output)
+    end
+  end
+end


### PR DESCRIPTION
The tags_digest and links_digest columns will be used to find exact matches using provided tags or links.

A later commit will use these in queries.

https://trello.com/c/TUITRnQv/993-improve-performance-of-subscriber-list-lookup-query