### PR TITLE
Return validation errors (and a few small fixes)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,12 @@ class ApplicationController < ActionController::API
 
   before_action :authorise
 
+  rescue_from ActiveRecord::RecordInvalid do |exception|
+    render json: { message: "Unprocessable Entity",
+                   errors: exception.record.errors.messages },
+           status: :unprocessable_entity
+  end
+
 private
 
   def authorise

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,8 @@ class ApplicationController < ActionController::API
   before_action :authorise
 
   rescue_from ActiveRecord::RecordInvalid do |exception|
-    render json: { message: "Unprocessable Entity",
-                   errors: exception.record.errors.messages },
+    render json: { error: "Unprocessable Entity",
+                   details: exception.record.errors.messages },
            status: :unprocessable_entity
   end
 

--- a/app/controllers/content_changes_controller.rb
+++ b/app/controllers/content_changes_controller.rb
@@ -8,7 +8,7 @@ class ContentChangesController < ApplicationController
       govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
     )
 
-    render json: { message: "Content change queued for sending" }, status: 202
+    render json: { message: "Content change queued for sending" }, status: :accepted
   end
 
 private
@@ -36,7 +36,7 @@ private
   end
 
   def render_conflict
-    render json: { error: "Content change already received" }, status: 409
+    render json: { error: "Content change already received" }, status: :conflict
   end
 
   def content_change_exists?

--- a/app/controllers/content_changes_controller.rb
+++ b/app/controllers/content_changes_controller.rb
@@ -36,7 +36,7 @@ private
   end
 
   def render_conflict
-    render json: { message: "Content change already received" }, status: 409
+    render json: { error: "Content change already received" }, status: 409
   end
 
   def content_change_exists?

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -8,6 +8,6 @@ class EmailsController < ApplicationController
 
     DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
 
-    render json: { message: "Email has been queued for sending" }, status: 202
+    render json: { message: "Email has been queued for sending" }, status: :accepted
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,7 +8,7 @@ class MessagesController < ApplicationController
       govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
     )
 
-    render json: { message: "Message queued for sending" }, status: 202
+    render json: { message: "Message queued for sending" }, status: :accepted
   end
 
 private
@@ -28,7 +28,7 @@ private
   end
 
   def render_conflict
-    render json: { message: "Message already received" }, status: 409
+    render json: { message: "Message already received" }, status: :conflict
   end
 
   def message_exists?

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -4,7 +4,7 @@ class SubscriberListsController < ApplicationController
     if subscriber_list
       render json: subscriber_list.to_json
     else
-      render json: { error: "Could not find the subscriber list" }, status: 404
+      render json: { error: "Could not find the subscriber list" }, status: :not_found
     end
   end
 
@@ -16,13 +16,13 @@ class SubscriberListsController < ApplicationController
         subscriber_list: subscriber_list.attributes,
       }, status: status
     else
-      render json: { error: "Could not find the subcsriber list" }, status: 404
+      render json: { error: "Could not find the subcsriber list" }, status: :not_found
     end
   end
 
   def create
     subscriber_list = SubscriberList.create!(subscriber_list_params)
-    render json: subscriber_list.to_json, status: 201
+    render json: subscriber_list.to_json, status: :created
   end
 
 private

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -21,12 +21,8 @@ class SubscriberListsController < ApplicationController
   end
 
   def create
-    subscriber_list = SubscriberList.new(subscriber_list_params)
-    if subscriber_list.save
-      render json: subscriber_list.to_json, status: 201
-    else
-      render json: { message: subscriber_list.errors.full_messages.to_sentence }, status: 422
-    end
+    subscriber_list = SubscriberList.create!(subscriber_list_params)
+    render json: subscriber_list.to_json, status: 201
   end
 
 private

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -4,7 +4,7 @@ class SubscriberListsController < ApplicationController
     if subscriber_list
       render json: subscriber_list.to_json
     else
-      render json: { message: "Could not find the subscriber list" }, status: 404
+      render json: { error: "Could not find the subscriber list" }, status: 404
     end
   end
 
@@ -16,7 +16,7 @@ class SubscriberListsController < ApplicationController
         subscriber_list: subscriber_list.attributes,
       }, status: status
     else
-      render json: { message: "Could not find the subcsriber list" }, status: 404
+      render json: { error: "Could not find the subcsriber list" }, status: 404
     end
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -61,7 +61,7 @@ class SubscriptionsController < ApplicationController
       end
     end
 
-    render json: { subscription: subscription }, status: :ok
+    render json: { subscription: subscription }
   end
 
   def latest_matching

--- a/app/controllers/unpublish_messages_controller.rb
+++ b/app/controllers/unpublish_messages_controller.rb
@@ -5,7 +5,7 @@ class UnpublishMessagesController < ApplicationController
       unpublishing_params[:content_id], ContentItem.new(redirect_path)
     )
 
-    render json: { message: "Unpublish message queued for sending" }, status: 202
+    render json: { message: "Unpublish message queued for sending" }, status: :accepted
   end
 
 private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,7 @@ class Message < ApplicationRecord
 
   validates_presence_of :title, :body, :criteria_rules, :govuk_request_id
   validates :url, root_relative_url: true, allow_nil: true
-  validates :criteria_rules, criteria_schema: true
+  validates :criteria_rules, criteria_schema: true, allow_blank: true
   validates :sender_message_id,
             format: {
               with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z/i,

--- a/app/services/content_change_handler_service.rb
+++ b/app/services/content_change_handler_service.rb
@@ -31,7 +31,7 @@ private
       base_path: params[:base_path],
       links: with_supertypes(params.fetch(:links, {})),
       tags: with_supertypes(params.fetch(:tags, {})),
-      public_updated_at: Time.parse(params[:public_updated_at]),
+      public_updated_at: params[:public_updated_at],
       email_document_supertype: params[:email_document_supertype],
       government_document_supertype: params[:government_document_supertype],
       govuk_request_id: govuk_request_id,

--- a/spec/integration/send_content_change_spec.rb
+++ b/spec/integration/send_content_change_spec.rb
@@ -31,9 +31,8 @@ RSpec.describe "Sending a content change", type: :request do
            headers: JSON_HEADERS
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)).to match(
-        a_hash_including(
-          "errors" => { "title" => ["can't be blank"] }
-        )
+        "error" => "Unprocessable Entity",
+        "details" => { "title" => ["can't be blank"] }
       )
     end
   end

--- a/spec/integration/send_content_change_spec.rb
+++ b/spec/integration/send_content_change_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe "Sending a content change", type: :request do
     }
   end
 
+  context "with an invalid request" do
+    it "returns a 422" do
+      post "/content-changes",
+           params: valid_request_params.merge(title: nil).to_json,
+           headers: JSON_HEADERS
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)).to match(
+        a_hash_including(
+          "errors" => { "title" => ["can't be blank"] }
+        )
+      )
+    end
+  end
+
   context "with authentication and authorisation" do
     before do
       login_with_internal_app

--- a/spec/integration/send_message_spec.rb
+++ b/spec/integration/send_message_spec.rb
@@ -21,9 +21,8 @@ RSpec.describe "Sending a message", type: :request do
            headers: JSON_HEADERS
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)).to match(
-        a_hash_including(
-          "errors" => { "url" => ["must be a root-relative URL"] }
-        )
+        "error" => "Unprocessable Entity",
+        "details" => { "url" => ["must be a root-relative URL"] }
       )
     end
   end

--- a/spec/integration/send_message_spec.rb
+++ b/spec/integration/send_message_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe "Sending a message", type: :request do
            params: valid_request_params.merge(url: "invalid").to_json,
            headers: JSON_HEADERS
       expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)).to match(
+        a_hash_including(
+          "errors" => { "url" => ["must be a root-relative URL"] }
+        )
+      )
     end
   end
 

--- a/spec/integration/subscriber_lists_controller_spec.rb
+++ b/spec/integration/subscriber_lists_controller_spec.rb
@@ -54,6 +54,21 @@ RSpec.describe "Getting a subscriber list", type: :request do
           expect(subscriber_list['description']).to eq("Some description")
         end
       end
+
+      context "an invalid subscriber list" do
+        it "returns 422" do
+          post "/subscriber-lists", params: {
+            title: "",
+            description: "Some description",
+          }
+
+          expect(response.status).to eq(422)
+
+          expect(JSON.parse(response.body)).to match(
+            a_hash_including("errors" => { "title" => ["can't be blank"] })
+          )
+        end
+      end
     end
 
     context "without authentication" do

--- a/spec/integration/subscriber_lists_controller_spec.rb
+++ b/spec/integration/subscriber_lists_controller_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe "Getting a subscriber list", type: :request do
           expect(response.status).to eq(422)
 
           expect(JSON.parse(response.body)).to match(
-            a_hash_including("errors" => { "title" => ["can't be blank"] })
+            "error" => "Unprocessable Entity",
+            "details" => { "title" => ["can't be blank"] }
           )
         end
       end

--- a/spec/queries/subscriber_lists_by_criteria_query_spec.rb
+++ b/spec/queries/subscriber_lists_by_criteria_query_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list])
+      expect(result).to contain_exactly(list)
     end
 
     it "can match a link" do
@@ -26,7 +26,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list])
+      expect(result).to contain_exactly(list)
     end
 
     it "can match multiple tags" do
@@ -41,7 +41,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list])
+      expect(result).to contain_exactly(list)
     end
 
     it "can match tags and links" do
@@ -59,7 +59,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list])
+      expect(result).to contain_exactly(list)
     end
 
     it "can match a tag with a double quote inside it" do
@@ -74,7 +74,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list])
+      expect(result).to contain_exactly(list)
     end
 
     it "can match optional conditions" do
@@ -94,7 +94,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list_a, list_b])
+      expect(result).to contain_exactly(list_a, list_b)
     end
 
     it "can match nested and conditions in or conditions" do
@@ -125,7 +125,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list_a, list_b])
+      expect(result).to contain_exactly(list_a, list_b)
     end
 
     it "can match a complicated nested scenario" do
@@ -168,7 +168,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         ]
       )
 
-      expect(result).to match([list])
+      expect(result).to contain_exactly(list)
     end
   end
 end


### PR DESCRIPTION
This resolves an issue where validation failures were mostly not returning information on errors, and were done so inconsistently.

Before this you could see the following request/responses:

```
➜  email-alert-api git:(validation-errors) curl -H 'Content-Type: application/json' -d '{}' http://localhost:3000/content-changes
{"status":422,"error":"Unprocessable Entity"}%
➜  email-alert-api git:(validation-errors) ✗ curl -H 'Content-Type: application/json' -d '{}' http://localhost:3000/messages
{"status":422,"error":"Unprocessable Entity"}%
➜  email-alert-api git:(validation-errors) ✗ curl -H 'Content-Type: application/json' -d '{ "title": "", "url": "test" }' http://localhost:3000/subscriber-lists
{"message":"Title can't be blank and Url must be a root-relative URL"}%
```

After:

```
➜  email-alert-api git:(validation-errors) ✗ curl -H 'Content-Type: application/json' -d '{}' http://localhost:3000/content-changes
{"message":"Unprocessable Entity","errors":{"content_id":["can't be blank"],"title":["can't be blank"],"base_path":["can't be blank"],"change_note":["can't be blank"],"public_updated_at":["can't be blank"],"email_document_supertype":["can't be blank"],"government_document_supertype":["can't be blank"],"govuk_request_id":["can't be blank"],"document_type":["can't be blank"],"publishing_app":["can't be blank"]}}
➜  email-alert-api git:(validation-errors) ✗ curl -H 'Content-Type: application/json' -d '{}' http://localhost:3000/messages
{"message":"Unprocessable Entity","errors":{"title":["can't be blank"],"body":["can't be blank"],"criteria_rules":["can't be blank"],"govuk_request_id":["can't be blank"]}}
➜  email-alert-api git:(validation-errors) ✗ curl -H 'Content-Type: application/json' -d '{ "title": "", "url": "test" }' http://localhost:3000/subscriber-lists
{"message":"Unprocessable Entity","errors":{"title":["can't be blank"],"url":["must be a root-relative URL"]}}
```

As part of this PR there is also a couple of small fixes and an attempt to make API and responses status' consistent without breaking any apps that use this API.