### PR TITLE
Add tags links digest to existing subscriber lists

### DIFF
--- a/db/migrate/20190902133711_add_tags_links_digest_to_existing_subscriber_lists.rb
+++ b/db/migrate/20190902133711_add_tags_links_digest_to_existing_subscriber_lists.rb
@@ -1,0 +1,11 @@
+class AddTagsLinksDigestToExistingSubscriberLists < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    SubscriberList.where("tags_digest IS NULL AND links_digest IS NULL").find_each do |list|
+      list.tags_digest = HashDigest.new(list.tags).generate
+      list.links_digest = HashDigest.new(list.links).generate
+      list.save!
+    end
+  end
+end


### PR DESCRIPTION
This migration will update all existing subscriber lists to
have a digest that we can query on.

Should it fail we can restart it and it will resume from where
it left off. Disabled the transaction so we don't lock the table.

Should be merged after https://github.com/alphagov/email-alert-api/pull/963

https://trello.com/c/TUITRnQv/993-improve-performance-of-subscriber-list-lookup-query