### PR TITLE
Support HTTPS absolute URLs in Messages

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,7 +5,6 @@ class Message < ApplicationRecord
   has_many :subscription_contents
 
   validates_presence_of :title, :body, :criteria_rules, :govuk_request_id
-  validates :url, root_relative_url: true, allow_nil: true
   validates :criteria_rules, criteria_schema: true, allow_blank: true
   validates :sender_message_id,
             format: {
@@ -14,6 +13,17 @@ class Message < ApplicationRecord
             },
             uniqueness: true,
             allow_nil: true
+
+  validates_each :url, allow_nil: true do |record, attribute, value|
+    parsed = URI.parse(value)
+    if parsed.absolute? && parsed.scheme != "https"
+      record.errors.add(attribute, "must use https")
+    elsif parsed.relative? && (parsed.host || parsed.path[0] != "/")
+      record.errors.add(attribute, "must be a root-relative URL or an absolute URL")
+    end
+  rescue URI::InvalidURIError
+    record.errors.add(attribute, "must be a valid URL")
+  end
 
   enum priority: { normal: 0, high: 1 }
 

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -23,7 +23,24 @@ private
 
   delegate :title, :body, :url, to: :message
 
-  def content_url
+  def absolute_url
+    return unless url
+
+    parsed = URI.join(Plek.new.website_root, url)
+    add_ga_query_params(parsed)
+
+    parsed.to_s
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def add_ga_query_params(uri)
+    return unless uri.to_s.start_with?(Plek.new.website_root)
+
+    query_params = Rack::Utils.parse_nested_query(uri.query)
+
+    return if query_params.keys.any? { |k| k.match(/\Autm/) }
+
     query = {
       utm_source: message.id,
       utm_medium: "email",
@@ -31,14 +48,16 @@ private
       utm_content: frequency,
     }.to_query
 
-    tracked_url = url + (url.include?("?") ? "&" : "?") + query
-
-    PublicUrlService.url_for(base_path: tracked_url)
+    if uri.query
+      uri.query += "&#{query}"
+    else
+      uri.query = query
+    end
   end
 
   def title_markdown
-    return title unless url
+    return title unless (destination = absolute_url)
 
-    "[#{title}](#{content_url})"
+    "[#{title}](#{destination})"
   end
 end

--- a/app/validators/root_relative_url_validator.rb
+++ b/app/validators/root_relative_url_validator.rb
@@ -9,7 +9,7 @@ private
 
   def valid_url?(url)
     parsed = URI.parse(url)
-    parsed.relative? && url[0] == "/"
+    parsed.relative? && !parsed.host && url[0] == "/"
   rescue URI::InvalidURIError
     false
   end

--- a/spec/integration/send_message_spec.rb
+++ b/spec/integration/send_message_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Sending a message", type: :request do
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)).to match(
         "error" => "Unprocessable Entity",
-        "details" => { "url" => ["must be a root-relative URL"] }
+        "details" => { "url" => ["must be a root-relative URL or an absolute URL"] }
       )
     end
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -4,12 +4,28 @@ RSpec.describe Message do
       expect(build(:message, url: nil)).to be_valid
     end
 
-    it "is valid when url is an absolute path" do
-      expect(build(:message, url: "/test")).to be_valid
+    it "is invalid when url is incorrectly formatted" do
+      expect(build(:message, url: "bad url")).to be_invalid
     end
 
-    it "is invalid when url is an absolute URI" do
-      expect(build(:message, url: "https://example.com/test")).to be_invalid
+    it "is valid when url is root-relative" do
+      expect(build(:message, url: "/test?query=this#anchor")).to be_valid
+    end
+
+    it "is invalid when url is relative but not a root path" do
+      expect(build(:message, url: "test")).to be_invalid
+    end
+
+    it "is valid when url is absolute and uses a https scheme" do
+      expect(build(:message, url: "https://example.com/test")).to be_valid
+    end
+
+    it "is invalid when url lacks a scheme" do
+      expect(build(:message, url: "//example.com/test")).to be_invalid
+    end
+
+    it "is invalid when url doesn't use https" do
+      expect(build(:message, url: "http://example.com/test")).to be_invalid
     end
   end
 

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 RSpec.describe MessagePresenter do
   describe ".call" do
+    around do |example|
+      ClimateControl.modify(GOVUK_APP_DOMAIN: 'gov.uk') { example.run }
+    end
+
     it "returns a presenter message" do
       message = create(:message,
                        title: "My title",
@@ -24,7 +28,7 @@ RSpec.describe MessagePresenter do
                        body: "Some information\nfor a user")
 
       expected = <<~MESSAGE
-        [My title](http://www.dev.gov.uk/my-page?#{message_utm_params(message.id, 'immediate')})
+        [My title](https://www.gov.uk/my-page?#{message_utm_params(message.id, 'immediate')})
 
         Some information
         for a user
@@ -40,7 +44,55 @@ RSpec.describe MessagePresenter do
                        body: "Some information\nfor a user")
 
       expected = <<~MESSAGE
-        [My title](http://www.dev.gov.uk/my-page?my-query=this&#{message_utm_params(message.id, 'immediate')})
+        [My title](https://www.gov.uk/my-page?my-query=this&#{message_utm_params(message.id, 'immediate')})
+
+        Some information
+        for a user
+      MESSAGE
+
+      expect(described_class.call(message)).to eq(expected)
+    end
+
+    it "doesn't replace the host of an absolute URL" do
+      message = create(:message,
+                       title: "My title",
+                       url: "https://other-government-service/test",
+                       body: "Some information\nfor a user")
+
+      expected = <<~MESSAGE
+        [My title](https://other-government-service/test)
+
+        Some information
+        for a user
+      MESSAGE
+
+      expect(described_class.call(message)).to eq(expected)
+    end
+
+    it "doesn't add Google Analytics params to a URL which already has this" do
+      message = create(:message,
+                       title: "My title",
+                       url: "/test?utm_source=custom-source",
+                       body: "Some information\nfor a user")
+
+      expected = <<~MESSAGE
+        [My title](https://www.gov.uk/test?utm_source=custom-source)
+
+        Some information
+        for a user
+      MESSAGE
+
+      expect(described_class.call(message)).to eq(expected)
+    end
+
+    it "adds Google Analytics params to an absolute GOV.UK URL" do
+      message = create(:message,
+                       title: "My title",
+                       url: "https://www.gov.uk/test",
+                       body: "Some information\nfor a user")
+
+      expected = <<~MESSAGE
+        [My title](https://www.gov.uk/test?#{message_utm_params(message.id, 'immediate')})
 
         Some information
         for a user

--- a/spec/validators/root_relative_url_validator_spec.rb
+++ b/spec/validators/root_relative_url_validator_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RootRelativeUrlValidator do
     it { is_expected.not_to be_valid }
   end
 
+  context "when a protocol-relative url is provided" do
+    before { model.url = "//example.com/test" }
+
+    it { is_expected.not_to be_valid }
+  end
+
   context "when a path with query string is provided" do
     before { model.url = "/test?test=this" }
 


### PR DESCRIPTION
Trello: https://trello.com/c/IN5xWtDR/82-allow-absolute-urls-for-email-alert-api-messages

This allows support for HTTPS URLs as destinations for messages. It appends analytics query strings only if the URL is for the current GOV.UK environment and doesn't already have analytics (^utm) params.

This is also fixes an issue in the RootRelativeUrl validator.