### PR TITLE
Remove ability to specify list slug

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -29,11 +29,10 @@ private
 
   def subscriber_list_params
     title = params.fetch(:title)
-    slug = (params[:slug] || slugify(title))
 
     find_exact_query_params.merge(
       title: title,
-      slug: slug,
+      slug: slugify(title),
       url: params[:url],
       description: (params[:description] || ""),
       signon_user_uid: current_user.uid,

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
         expect(subscriber_list["slug"]).to eq(slug)
       end
     end
+
     context 'when using legacy parameters' do
       it 'creates a new subscriber list' do
         expect {

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -224,22 +224,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
-    context "creating subscriber list with a given slug" do
-      it "returns a 201" do
-        post "/subscriber-lists", params: {
-          title: "General title",
-          slug: "some-concatenated-slug",
-          tags: { "brexit_checklist_criteria" => { "any" => %w[some-value] } }
-        }
-
-        expect(response.status).to eq(201)
-
-        subscriber_list = JSON.parse(response.body)['subscriber_list']
-        expect(subscriber_list['slug']).to eq("some-concatenated-slug")
-        expect(subscriber_list['title']).to eq("General title")
-      end
-    end
-
     context "creating subscriber list with a description" do
       it "returns a 201" do
         post "/subscriber-lists", params: {


### PR DESCRIPTION
Trello: https://trello.com/c/XBuIOfXj/86-reduce-slug-lengths-used-by-brexit-checklist

This depends on https://github.com/alphagov/finder-frontend/pull/1537 being deployed to production

This property lacked any validation and thus allowed users to create
slugs that could not work or that conflicted with existing ones. I'm not
aware we actually have a need for applications to specify these so this
functionality is being removed.