### PR TITLE
Reduce existing SubscriberList slug lengths

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -62,7 +62,7 @@ private
     slug = title.parameterize.truncate(255, omission: '', separator: '-')
 
     while SubscriberList.where(slug: slug).exists?
-      slug = title.parameterize.truncate(242, omission: '', separator: '-')
+      slug = title.parameterize.truncate(244, omission: '', separator: '-')
       slug += "-#{SecureRandom.hex(5)}"
     end
 

--- a/db/migrate/20190911112938_reduce_slug_lengths.rb
+++ b/db/migrate/20190911112938_reduce_slug_lengths.rb
@@ -1,0 +1,24 @@
+class ReduceSlugLengths < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    SubscriberList.where("LENGTH(slug) > 255").find_each do |list|
+      list.update!(slug: slugify(list.title))
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def slugify(title)
+    slug = title.parameterize.truncate(255, omission: '', separator: '-')
+
+    while SubscriberList.where(slug: slug).exists?
+      slug = title.parameterize.truncate(244, omission: '', separator: '-')
+      slug += "-#{SecureRandom.hex(5)}"
+    end
+
+    slug
+  end
+end

--- a/db/migrate/20190911115859_remove_limits_on_subscriber_lists.rb
+++ b/db/migrate/20190911115859_remove_limits_on_subscriber_lists.rb
@@ -1,0 +1,6 @@
+class RemoveLimitsOnSubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    change_column :subscriber_lists, :title, :string, limit: nil
+    change_column :subscriber_lists, :slug, :string, limit: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_04_182908) do
+ActiveRecord::Schema.define(version: 2019_09_11_112938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_11_112938) do
+ActiveRecord::Schema.define(version: 2019_09_11_115859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,7 +130,7 @@ ActiveRecord::Schema.define(version: 2019_09_11_112938) do
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
-    t.string "title", limit: 10000, null: false
+    t.string "title", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 2019_09_11_112938) do
     t.string "email_document_supertype", default: "", null: false
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
-    t.string "slug", limit: 10000, null: false
+    t.string "slug", null: false
     t.string "url"
     t.string "description", default: "", null: false
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"


### PR DESCRIPTION
Trello: https://trello.com/c/XBuIOfXj/86-reduce-slug-lengths-used-by-brexit-checklist

This has a migration that reduces the existing slugs of SubscriberLists to be all 255 characters or less. This also removes the length limits on title and slug columns of the SubscriberList table for consistency with other string columns.

This change will be a little nervy to deploy as it could disrupt users in the process of signing up, if someone is signing up to a list with a long slug this could be broken for them. To counter this I'm going to try deploy this rather delicately with a monitor on current usage.