### PR TITLE
group_id field for associating similar subscriber lists

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -35,6 +35,7 @@ private
       slug: slugify(title),
       url: params[:url],
       description: (params[:description] || ""),
+      group_id: params[:group_id],
       signon_user_uid: current_user.uid,
     )
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,13 +6,7 @@ class Message < ApplicationRecord
 
   validates_presence_of :title, :body, :criteria_rules, :govuk_request_id
   validates :criteria_rules, criteria_schema: true, allow_blank: true
-  validates :sender_message_id,
-            format: {
-              with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z/i,
-              message: "is not a UUID"
-            },
-            uniqueness: true,
-            allow_nil: true
+  validates :sender_message_id, uuid: true, uniqueness: true, allow_nil: true
 
   validates_each :url, allow_nil: true do |record, attribute, value|
     parsed = URI.parse(value)

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -10,6 +10,7 @@ class SubscriberList < ApplicationRecord
   validates :title, presence: true
   validates_uniqueness_of :slug
   validates :url, root_relative_url: true, allow_nil: true
+  validates :group_id, uuid: true, allow_nil: true
 
   has_many :subscriptions, dependent: :destroy
   has_many :subscribers, through: :subscriptions

--- a/app/validators/uuid_validator.rb
+++ b/app/validators/uuid_validator.rb
@@ -1,0 +1,9 @@
+class UuidValidator < ActiveModel::EachValidator
+  UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z/i.freeze
+
+  def validate_each(record, attribute, value)
+    unless UUID_REGEX =~ value
+      record.errors.add(attribute, "is not a valid UUID")
+    end
+  end
+end

--- a/db/migrate/20190913102634_add_group_id_to_subscriber_lists.rb
+++ b/db/migrate/20190913102634_add_group_id_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddGroupIdToSubscriberLists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :subscriber_lists, :group_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_12_161623) do
+ActiveRecord::Schema.define(version: 2019_09_13_102634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 2019_09_12_161623) do
     t.string "slug", null: false
     t.string "url"
     t.string "description", default: "", null: false
+    t.string "group_id"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"

--- a/doc/api.md
+++ b/doc/api.md
@@ -11,6 +11,7 @@
     "title": "Title of topic",
     "subscription_url": "https://public-url/subscribe-here?topic_id=123",
     "gov_delivery_id": "123",
+    "group_id": "f513e107-b2c6-44a6-8d8a-9e6a3ea37b9d",
     "document_type": "",
     "created_at": "20141010T12:00:00",
     "updated_at": "20141010T12:00:00",
@@ -28,6 +29,7 @@
 ```json
 {
   "title": "My title",
+  "group_id": "f513e107-b2c6-44a6-8d8a-9e6a3ea37b9d",
   "tags": {
     "any": {
       "organisations": ["my-org"],
@@ -38,6 +40,30 @@
 
 and it will respond with the JSON response for the `GET` call above.
 
+The following fields are accepted:
+
+- title: The title of this particular list, which will be shown to the user;
+- description: Markdown text that will be used as copy in the confirmation
+  email sent to a user;
+- url: A url to a page that reflects what the user signed up to and can be
+  linked to with their list;
+- group_id: A UUID that can be provided by an application to group together
+  lists for the same resource with different criteria;
+- links: An object where keys are a link type and the value is an object
+  containing a key of "any" or "all" associated with an array of link values,
+  this is used to match content changes and messages to the list;
+- tags: An object where keys are [valid tags][] and the value is an object
+  containing a key of "any" or "all" associated with an array of link values
+  this is used to match content changes and messages to the list;
+- document_type: A field that can be used to match with content changes that
+  share the corresponding field;
+- email_document_supertype: A field that can be used to match with content
+  changes that share the corresponding field;
+- government_document_supertype: A field that can be used to match with
+  content changes that share the corresponding field.
+
+[valid tags]: https://github.com/alphagov/email-alert-api/blob/b6428880aa730e316803d7129db3ec47304e933b/lib/valid_tags.rb
+
 * `POST /content-changes` with data:
 
 ```json
@@ -45,7 +71,9 @@ and it will respond with the JSON response for the `GET` call above.
   "subject": "This is the subject/title of my bulletin",
   "body": "Email body here",
   "tags": {
-    "tag": ["values"]
+    "tag": {
+      "any": ["values"]
+    }
   }
 }
 ```

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
           url
           tags
           links
+          group_id
           email_document_supertype
           government_document_supertype
           active_subscriptions_count
@@ -236,6 +237,22 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
         subscriber_list = JSON.parse(response.body)['subscriber_list']
         expect(subscriber_list['description']).to eq("Some description")
+      end
+    end
+
+    context "creating subscriber list with a group_id" do
+      it "returns a 201" do
+        group_id = SecureRandom.uuid
+        post "/subscriber-lists", params: {
+          title: "General title",
+          description: "Some description",
+          group_id: group_id,
+        }
+
+        expect(response.status).to eq(201)
+
+        subscriber_list = JSON.parse(response.body)['subscriber_list']
+        expect(subscriber_list['group_id']).to eq(group_id)
       end
     end
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe SubscriberList, type: :model do
         expect(build(:subscriber_list, url: "https://example.com/test")).to be_invalid
       end
     end
+
+    describe "group_id" do
+      it "is valid when group_id is a valid UUID" do
+        expect(build(:subscriber_list, group_id: SecureRandom.uuid)).to be_valid
+      end
+
+      it "is valid when group_id is nil" do
+        expect(build(:subscriber_list, group_id: nil)).to be_valid
+      end
+
+      it "is invalid when group_id is not a valid UUID" do
+        expect(build(:subscriber_list, group_id: "notavaliduuid")).to be_invalid
+      end
+    end
   end
 
   context "when a subscriber_list is deleted" do

--- a/spec/validators/uuid_validator_spec.rb
+++ b/spec/validators/uuid_validator_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe UuidValidator do
+  class UuidValidatable
+    include ActiveModel::Validations
+    include ActiveModel::Model
+
+    attr_accessor :uuid
+    validates :uuid, uuid: true
+  end
+
+  subject(:model) { UuidValidatable.new }
+
+  context "when a valid UUID is provided" do
+    before { model.uuid = SecureRandom.uuid }
+    it { is_expected.to be_valid }
+  end
+
+  context "when an invalid UUID is provided" do
+    before { model.uuid = "ThisIsNotAValidUUID" }
+
+    it "has an error" do
+      expect(model.valid?).to be false
+      expect(model.errors[:uuid]).to match(["is not a valid UUID"])
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/sWBqpBeQ/84-create-an-id-to-represent-a-family-of-subscriberlists

This picks up the work from https://github.com/alphagov/email-alert-api/pull/971 and https://github.com/alphagov/email-alert-api/pull/967

This introduces a UUID that can be set on a subscriber_list as a means to group together variants of the same list. The intention is that an application calling Email Alert API can set an id each time they create variants of a list and this id can then be used as a means for calculating statistics for all variants of a list.

The anticipated usage of this is for the Get ready for Brexit checker where there are currently over 8000 lists, this would likely have been useful for the Business Readiness finder that has over 4000 distinct lists. 

In many ways this is actually just a plaster over a gap where the system should probably have a concept of variant of SubscriberList so we can store options on a core list and then have means to model variances separately. However this isn't something that is realistic to do in the short term and represents a bigger architectural change.