### PR TITLE
Drop the title param from unsubscribe links

### DIFF
--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -19,8 +19,7 @@ private
   attr_reader :id, :title
 
   def url
-    escaped_title = ERB::Util.url_encode(title)
-    base_path = "/email/unsubscribe/#{id}?title=#{escaped_title}"
+    base_path = "/email/unsubscribe/#{id}"
     PublicUrlService.url_for(base_path: base_path)
   end
 end

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
 
       &nbsp;
 
@@ -80,7 +80,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id})
 
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
@@ -117,7 +117,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id})
 
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
@@ -296,7 +296,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
 
       &nbsp;
 
@@ -328,7 +328,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id}?title=Subscriber%20list%20two)
+      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id})
 
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 
@@ -366,7 +366,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?title=Subscriber%20list%20one)
+      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id})
 
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 

--- a/spec/presenters/unsubscribe_link_presenter_spec.rb
+++ b/spec/presenters/unsubscribe_link_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UnsubscribeLinkPresenter do
   describe ".call" do
     it "returns a presented unsubscribe link" do
-      expected = "[Unsubscribe from ‘Test title’](http://www.dev.gov.uk/email/unsubscribe/abc123?title=Test%20title)"
+      expected = "[Unsubscribe from ‘Test title’](http://www.dev.gov.uk/email/unsubscribe/abc123)"
       expect(described_class.call("abc123", "Test title")).to eq(expected)
     end
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -109,7 +109,7 @@ module FeatureHelpers
 
   def extract_unsubscribe_id(email_data)
     body = email_data.dig(:personalisation, :body)
-    body[%r{/unsubscribe/(.*)\?}, 1]
+    body[%r{/unsubscribe/(.*)\)}, 1]
   end
 
   def clear_any_requests_that_have_been_recorded!


### PR DESCRIPTION
This hasn't been needed for Email Alert Frontend since 83707011 was
merged in.