### PR TITLE
Update Brexit results list description terminology

### DIFF
--- a/db/migrate/20190912161623_amend_brexit_result_descriptions.rb
+++ b/db/migrate/20190912161623_amend_brexit_result_descriptions.rb
@@ -1,0 +1,17 @@
+class AmendBrexitResultDescriptions < ActiveRecord::Migration[5.2]
+  def up
+    SubscriberList.connection.execute("
+      UPDATE subscriber_lists
+      SET description = REGEXP_REPLACE(
+        description,
+        '\\[.*\\]\\((.*)\\).*',
+        '[You can view a copy of your results on GOV.UK.](\\1)'
+      )
+      WHERE description like '%You can view a copy of your Brexit tool results%'
+    ")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_11_115859) do
+ActiveRecord::Schema.define(version: 2019_09_12_161623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/FGYU4NlN/92-differentiate-between-your-get-ready-for-brexit-results-in-subscription-management

This makes the terminology in the existing list descriptions consistent
with the changes made in https://github.com/alphagov/finder-frontend/pull/1538

An example of this migration running:

```
➜  email-alert-api git:(amend-brexit-descriptions) ✗ RAILS_ENV=test rails c
Loading test environment (Rails 5.2.3)
irb(main):001:0> SubscriberList.last.description
  SubscriberList Load (2.3ms)  SELECT  "subscriber_lists".* FROM "subscriber_lists" ORDER BY "subscriber_lists"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> "[You can view a copy of your Brexit tool results](https://www.gov.uk/get-ready-brexit-check/results?c%5B%5D=personal-service&c%5B%5D=digital&c%5B%5D=sell-goods-provide-services-in-uk&c%5B%5D=provide-services-do-business-in-eu&c%5B%5D=ip&c%5B%5D=ip-copyright&c%5B%5D=ip-trade-marks&c%5B%5D=ip-designs&c%5B%5D=sell-public-sector&c%5B%5D=sell-public-sector-contracts&c%5B%5D=do-not-eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=personal-eu-org-provide&c%5B%5D=do-not-employ-eu-citizens&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=travelling&c%5B%5D=visiting-uk&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk) on GOV.UK."
irb(main):002:0> exit
➜  email-alert-api git:(amend-brexit-descriptions) ✗ RAILS_ENV=test rails db:migrate
== 20190912161623 AmendBrexitResultDescriptions: migrating ====================
== 20190912161623 AmendBrexitResultDescriptions: migrated (0.0273s) ===========

➜  email-alert-api git:(amend-brexit-descriptions) ✗ RAILS_ENV=test rails c
Loading test environment (Rails 5.2.3)
irb(main):001:0> SubscriberList.last.description
  SubscriberList Load (2.2ms)  SELECT  "subscriber_lists".* FROM "subscriber_lists" ORDER BY "subscriber_lists"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> "[You can view a copy of your results on GOV.UK.](https://www.gov.uk/get-ready-brexit-check/results?c%5B%5D=personal-service&c%5B%5D=digital&c%5B%5D=sell-goods-provide-services-in-uk&c%5B%5D=provide-services-do-business-in-eu&c%5B%5D=ip&c%5B%5D=ip-copyright&c%5B%5D=ip-trade-marks&c%5B%5D=ip-designs&c%5B%5D=sell-public-sector&c%5B%5D=sell-public-sector-contracts&c%5B%5D=do-not-eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=personal-eu-org-provide&c%5B%5D=do-not-employ-eu-citizens&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=travelling&c%5B%5D=visiting-uk&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)"
```