### PR TITLE
Order subscriptions by when they were created

### DIFF
--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -1,12 +1,13 @@
 class SubscribersController < ApplicationController
-  def subscriptions
-    subscriptions = Subscription.active.
-      includes(:subscriber_list).
-      where(subscriber: subscriber).
-      order('subscriber_lists.title').
-      as_json(include: :subscriber_list)
+  DEFAULT_ORDERING = "-created_at".freeze
+  ORDER_FIELDS = %w[title created_at].freeze
 
-    render json: { subscriber: subscriber.as_json, subscriptions: subscriptions }
+  def subscriptions
+    if !valid_ordering_param?
+      return render json: { error: "Order paramater not valid" }, status: :unprocessable_entity
+    end
+
+    render json: { subscriber: subscriber.as_json, subscriptions: ordered_subscriptions }
   end
 
   def change_address
@@ -16,8 +17,36 @@ class SubscribersController < ApplicationController
 
 private
 
+  def valid_ordering_param?
+    allowed_sort_columns = ORDER_FIELDS.flat_map do |item|
+      [item, "-#{item}"]
+    end
+
+    allowed_sort_columns.include?(params.fetch(:order, DEFAULT_ORDERING))
+  end
+
+  def subscription_ordering
+    order = params.fetch(:order, DEFAULT_ORDERING)
+    direction = order.chars.first == "-" ? "desc" : "asc"
+    column = order.delete_prefix("-")
+
+    order_column = (column == 'title' ? 'subscriber_lists.title' : 'created_at')
+    { "#{order_column}": direction }
+  end
+
   def subscriber
     @subscriber ||= Subscriber.find(id)
+  end
+
+  def ordered_subscriptions
+    Subscription
+      .active
+      .joins(:subscriber_list)
+      .includes(:subscriber_list)
+      .where(subscriber: subscriber)
+      .order(subscription_ordering)
+      .order(id: :asc)
+      .as_json(include: :subscriber_list)
   end
 
   def new_address


### PR DESCRIPTION
This is needed as we are adding when subscriptions have been created on
the subscription management page in email-alert-frontend and it makes
sense for the order to default to created_at descending.

The api has also been updated to allow an order parameter to be passed
for either the `created_at` field for a subscription or the `title` for
a subscriber list. The syntax for descending or ascending values is as
follows `-title` for descending and just `title` for ascending. This
makes the endpoint less coupled to email-alert-frontends code and more
flexible if this endpoint was to be used by something else.

This specific action seemes to be only used for the subscription
management flow, from a git search and a local grep.

Trello:
https://trello.com/c/FGYU4NlN/92-differentiate-between-your-get-ready-for-brexit-results-in-subscription-management