### PR TITLE
Run healthcheck inside a controller

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,21 @@
+class HealthcheckController < ApplicationController
+  skip_before_action :authorise
+
+  def index
+    healthcheck = GovukHealthcheck.healthcheck([
+                    GovukHealthcheck::SidekiqRedis,
+                    GovukHealthcheck::ActiveRecord,
+                    Healthcheck::ContentChanges,
+                    Healthcheck::Messages,
+                    Healthcheck::DigestRuns,
+                    Healthcheck::QueueLatency,
+                    Healthcheck::QueueSize,
+                    Healthcheck::RetrySize,
+                    Healthcheck::StatusUpdates,
+                    Healthcheck::SubscriptionContents,
+                    Healthcheck::TechnicalFailures,
+                    Healthcheck::InternalFailures,
+                  ])
+    render json: healthcheck
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,19 +26,6 @@ Rails.application.routes.draw do
 
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
 
-    get "/healthcheck", to: GovukHealthcheck.rack_response(
-      GovukHealthcheck::SidekiqRedis,
-      GovukHealthcheck::ActiveRecord,
-      Healthcheck::ContentChanges,
-      Healthcheck::Messages,
-      Healthcheck::DigestRuns,
-      Healthcheck::QueueLatency,
-      Healthcheck::QueueSize,
-      Healthcheck::RetrySize,
-      Healthcheck::StatusUpdates,
-      Healthcheck::SubscriptionContents,
-      Healthcheck::TechnicalFailures,
-      Healthcheck::InternalFailures,
-    )
+    get "/healthcheck", to: "healthcheck#index"
   end
 end


### PR DESCRIPTION
This allows this request to be logged by the Rails logger which is
otherwise omitted when a rack response is returned for a route.

We have seen timeouts for the Healthchecks for Email Alert API so it'd
be useful to have logging information available to determine how long
these are regularly taking.

This is flagged as an issue on govuk_app_config: https://github.com/alphagov/govuk_app_config/issues/121