### PR TITLE
Increase subscription contents healthcheck thresholds

### DIFF
--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -68,11 +68,11 @@ module Healthcheck
     end
 
     def critical_latency
-      is_scheduled_publishing_time? ? 45.minutes : 15.minutes
+      is_scheduled_publishing_time? ? 50.minutes : 15.minutes
     end
 
     def warning_latency
-      is_scheduled_publishing_time? ? 30.minutes : 10.minutes
+      is_scheduled_publishing_time? ? 35.minutes : 10.minutes
     end
 
     # There's a lot of scheduled publishing at 09:30 UK time, so we

--- a/app/models/healthcheck/subscription_contents.rb
+++ b/app/models/healthcheck/subscription_contents.rb
@@ -85,7 +85,7 @@ module Healthcheck
     end
 
     SCHEDULED_PUBLISHING_TIMES = [
-      [Time.zone.parse("09:30"), Time.zone.parse("10:30")],
+      [Time.zone.parse("09:30"), Time.zone.parse("11:00")],
       [Time.zone.parse("12:30"), Time.zone.parse("13:30")],
     ].freeze
   end

--- a/spec/models/healthcheck/subscription_contents_spec.rb
+++ b/spec/models/healthcheck/subscription_contents_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Healthcheck::SubscriptionContents do
       end
     end
 
-    context "between 09:30 and 10:30" do
+    context "between 09:30 and 11:00" do
       around do |example|
         Timecop.freeze("10:00") { example.run }
       end

--- a/spec/models/healthcheck/subscription_contents_spec.rb
+++ b/spec/models/healthcheck/subscription_contents_spec.rb
@@ -2,17 +2,17 @@ RSpec.describe Healthcheck::SubscriptionContents do
   context "when scheduled publishing" do
     shared_examples "an ok healthcheck" do
       specify { expect(subject.status).to eq(:ok) }
-      specify { expect(subject.message).to match(/0 created over 2700 seconds ago/) }
+      specify { expect(subject.message).to match(/0 created over 3000 seconds ago/) }
     end
 
     shared_examples "a warning healthcheck" do
       specify { expect(subject.status).to eq(:warning) }
-      specify { expect(subject.message).to match(/1 created over 1800 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 2100 seconds ago/) }
     end
 
     shared_examples "a critical healthcheck" do
       specify { expect(subject.status).to eq(:critical) }
-      specify { expect(subject.message).to match(/1 created over 2700 seconds ago/) }
+      specify { expect(subject.message).to match(/1 created over 3000 seconds ago/) }
     end
 
     shared_examples "tests all three states" do
@@ -21,13 +21,13 @@ RSpec.describe Healthcheck::SubscriptionContents do
         it_behaves_like "an ok healthcheck"
       end
 
-      context "when a subscription content was created over 30 minutes ago" do
-        before { create(:subscription_content, created_at: 31.minutes.ago) }
+      context "when a subscription content was created over 35 minutes ago" do
+        before { create(:subscription_content, created_at: 36.minutes.ago) }
         it_behaves_like "a warning healthcheck"
       end
 
-      context "when a subscription content was created over 45 minutes ago" do
-        before { create(:subscription_content, created_at: 46.minutes.ago) }
+      context "when a subscription content was created over 50 minutes ago" do
+        before { create(:subscription_content, created_at: 51.minutes.ago) }
         it_behaves_like "a critical healthcheck"
       end
     end


### PR DESCRIPTION
This increases various thresholds for the subscription contents healthcheck as we often see it alerting during the day when there isn't a problem. See commits for more details on the individual changes.

I've chosen the numbers based on when 2nd line have seen the alert when there was nothing for them to do.

This is more of a temporary measure to try and avoid the healthcheck becoming critical so much, further work on these healthchecks should happen in the future.

[Trello Card](https://trello.com/c/Cds6gUWl/1315-2-increase-thresholds-for-email-alert-api-healthchecks)