### PR TITLE
Increase batch size to process subscription contents faster

### DIFF
--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -7,7 +7,7 @@ class ImmediateEmailGenerationWorker
 
   def perform
     ensure_only_running_once do
-      SubscribersForImmediateEmailQuery.call.find_in_batches do |group|
+      SubscribersForImmediateEmailQuery.call.find_in_batches(batch_size: 5000) do |group|
         subscription_contents = grouped_subscription_contents(group.pluck(:id))
         update_content_change_cache(subscription_contents)
         update_message_cache(subscription_contents)


### PR DESCRIPTION
SubscriptionContents are not being processed quickly
enough and are building up. As the SubscribersForImmediateEmailQuery
takes tens of seconds and up to two minutes to complete
increasing the batch size may reduce the number
of these queries and overall increase the speed
at which SubscriptionContent records are processed