### PR TITLE
Allow rake task to run with multiple ids

### DIFF
--- a/lib/reports/content_change_email_status_count.rb
+++ b/lib/reports/content_change_email_status_count.rb
@@ -1,8 +1,7 @@
 module Reports
   class ContentChangeEmailStatusCount
-    def initialize(content_change)
-      @content_change = content_change
-      @email_status_count = email_status_count
+    def initialize(content_changes)
+      @content_changes = content_changes
     end
 
     def self.call(*args)
@@ -10,26 +9,26 @@ module Reports
     end
 
     def call
-      puts <<~TEXT
-        -------------------------------------------
-        Email status counts for Content Change #{@content_change.id}
-        -------------------------------------------
+      @content_changes.each do |content_change|
+        email_status_count_for_content_change = email_status_count(content_change)
 
-        Sent emails: #{@email_status_count['sent']}
+        puts <<~TEXT
 
-        Pending emails: #{@email_status_count['pending']}
-
-        Failed emails: #{@email_status_count['failed']}
-
-        -------------------------------------------
-      TEXT
+          ---------------------------------------------------------------------------
+          Email status counts for Content Change #{content_change.id}
+          ---------------------------------------------------------------------------
+          Sent emails: #{email_status_count_for_content_change['sent']}
+          Pending emails: #{email_status_count_for_content_change['pending']}
+          Failed emails: #{email_status_count_for_content_change['failed']}
+          ---------------------------------------------------------------------------
+        TEXT
+      end
     end
 
   private
 
-    def email_status_count
-      subscription_contents_ids = @content_change.subscription_contents.pluck(:id)
-      email_ids = SubscriptionContent.where(id: subscription_contents_ids).pluck(:email_id)
+    def email_status_count(content_change)
+      email_ids = content_change.subscription_contents.select(:email_id)
       Email.where(id: email_ids).group(:status).count
     end
   end

--- a/lib/tasks/content_change_email.rake
+++ b/lib/tasks/content_change_email.rake
@@ -1,8 +1,19 @@
 namespace :report do
-  desc "Produce a report on sent, pending and failed emails for a given content change"
-  task :content_change_email_status_count, [:id] => :environment do |_t, args|
-    content_change = ContentChange.find(args[:id])
-    Reports::ContentChangeEmailStatusCount.call(content_change)
+  desc <<~DESCRIPTION
+    Produce a report on sent, pending and failed emails for given content change id or ids
+    At least one ContentChange id must be given. Usage:
+    - report:content_change_email_status_count[id_1]
+    - report:content_change_email_status_count[id_1,id_2,id_n]
+  DESCRIPTION
+  task content_change_email_status_count: :environment do |_t, args|
+    if args.extras.present?
+      content_changes = ContentChange.where(id: args.extras)
+      Reports::ContentChangeEmailStatusCount.call(content_changes)
+    else
+      puts "At least one ContentChange id must be given. Usage:"
+      puts "- report:content_change_email_status_count[id_1]"
+      puts "- report:content_change_email_status_count[id_1,id_2,id_n]"
+    end
   end
 
   desc "Produce a report on failed emails for a given content change"

--- a/spec/lib/reports/content_change_email_status_count_spec.rb
+++ b/spec/lib/reports/content_change_email_status_count_spec.rb
@@ -21,22 +21,18 @@ RSpec.describe Reports::ContentChangeEmailStatusCount do
     end
 
     it "produces a count of emails statuses for a given content change" do
-      described_class.call(content_change)
-      expect { described_class.call(content_change) }.to output(
-        <<~TEXT,
-          -------------------------------------------
-          Email status counts for Content Change #{content_change.id}
-          -------------------------------------------
+      message = <<~TEXT
 
-          Sent emails: #{sent.count}
+        ---------------------------------------------------------------------------
+        Email status counts for Content Change #{content_change.id}
+        ---------------------------------------------------------------------------
+        Sent emails: #{sent.count}
+        Pending emails: #{pending.count}
+        Failed emails: #{failed.count}
+        ---------------------------------------------------------------------------
+      TEXT
 
-          Pending emails: #{pending.count}
-
-          Failed emails: #{failed.count}
-
-          -------------------------------------------
-        TEXT
-      ).to_stdout
+      expect { described_class.call([content_change]) }.to output(message).to_stdout
     end
   end
 end


### PR DESCRIPTION
This will allow us to run either
`rake task report:content_change_email_status_count[id_1]`
or
`report:content_change_email_status_count[id_1,id_2,id_n]`