### PR TITLE
Add a partial index on the subscription_contents table

### DIFF
--- a/db/migrate/20191011142014_add_partial_index_on_subscription_contents.rb
+++ b/db/migrate/20191011142014_add_partial_index_on_subscription_contents.rb
@@ -1,0 +1,10 @@
+class AddPartialIndexOnSubscriptionContents < ActiveRecord::Migration[5.2]
+  def change
+    add_index(
+      :subscription_contents,
+      :subscription_id,
+      where: "email_id IS NULL",
+      name: "partial_index_subscription_contents_on_subscription_id",
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_102634) do
+ActiveRecord::Schema.define(version: 2019_10_11_142014) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,6 +176,7 @@ ActiveRecord::Schema.define(version: 2019_09_13_102634) do
     t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true
     t.index ["subscription_id", "message_id"], name: "index_subscription_contents_on_subscription_id_and_message_id", unique: true
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"
+    t.index ["subscription_id"], name: "partial_index_subscription_contents_on_subscription_id", where: "(email_id IS NULL)"
   end
 
   create_table "subscriptions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|


### PR DESCRIPTION
This should improve the performance of the
SubscribersForImmediateEmailQuery, as it looks through the
subscription_contents table for rows where the email_id is
NULL. Previously PostgreSQL would probably do a Bitmap Heap Scan over
the table, however with this new partial index it can just do an Index
Only Scan across the index.

The performance of this query is important, as it's run regularly
through the ImmediateEmailGenerationWorker.