### PR TITLE
Allow rake task to run with multiple ids

### DIFF
--- a/lib/tasks/content_change_email.rake
+++ b/lib/tasks/content_change_email.rake
@@ -16,9 +16,20 @@ namespace :report do
     end
   end
 
-  desc "Produce a report on failed emails for a given content change"
-  task :content_change_failed_emails, [:id] => :environment do |_t, args|
-    content_change = ContentChange.find(args[:id])
-    Reports::ContentChangeEmailFailures.call(content_change)
+  desc <<~DESCRIPTION
+    Produce a report on failed emails for given content change id or ids
+    At least one ContentChange id must be given. Usage:
+    - report:content_change_failed_emails[id_1]
+    - report:content_change_failed_emails[id_1,id_2,id_n]
+  DESCRIPTION
+  task content_change_failed_emails: :environment do |_t, args|
+    if args.extras.present?
+      content_changes = ContentChange.where(id: args.extras)
+      Reports::ContentChangeEmailFailures.call(content_changes)
+    else
+      puts "At least one ContentChange id must be given. Usage:"
+      puts "- report:content_change_failed_emails[id_1]"
+      puts "- report:content_change_failed_emails[id_1,id_2,id_n]"
+    end
   end
 end

--- a/spec/lib/reports/content_change_email_failures_spec.rb
+++ b/spec/lib/reports/content_change_email_failures_spec.rb
@@ -3,18 +3,14 @@ RSpec.describe Reports::ContentChangeEmailFailures do
     failure_reasons = %w[permanent_failure retries_exhausted_failure]
 
     3.times { create(:email, status: "sent") }
-    3.times do
-      create(:email,
-             status: "failed",
-             failure_reason: failure_reasons.sample)
-    end
+    3.times { create(:email, status: "failed", failure_reason: failure_reasons.sample) }
   end
 
   context "generate report" do
     let(:content_change) { create(:content_change) }
 
     let(:sent)    { Email.where(status: "sent") }
-    let(:failed)  { Email.where(status: "failed") }
+    let(:failed)  { Email.where(status: "failed").sort_by(&:created_at) }
 
     let(:failure_one)   { failed[0] }
     let(:failure_two)   { failed[1] }
@@ -24,37 +20,31 @@ RSpec.describe Reports::ContentChangeEmailFailures do
 
     let!(:subscription_contents) do
       emails.each do |email|
-        create(:subscription_content,
-               email: email,
-               content_change: content_change)
+        create(:subscription_content, email: email, content_change: content_change)
       end
     end
 
     it "produces a count of emails statuses for a given content change" do
-      described_class.call(content_change)
-      expect { described_class.call(content_change) }
-        .to output(
-          <<~TEXT,
-            #{failed.count} Email failures for Content Change #{content_change.id}
-            -------------------------------------------
+      message = <<~TEXT
 
-            Email Id:       #{failure_one.id}
-            Failure Reason: #{failure_one.failure_reason}
+        ------------------------------------------------------------------------
+        #{failed.count} Email failures for Content Change #{content_change.id}
+        ------------------------------------------------------------------------
 
-            -------------------------------------------
+        Email Id:       #{failure_one.id}
+        Failure Reason: #{failure_one.failure_reason}
+        ------------------------------------------------------------------------
 
-            Email Id:       #{failure_two.id}
-            Failure Reason: #{failure_two.failure_reason}
+        Email Id:       #{failure_two.id}
+        Failure Reason: #{failure_two.failure_reason}
+        ------------------------------------------------------------------------
 
-            -------------------------------------------
+        Email Id:       #{failure_three.id}
+        Failure Reason: #{failure_three.failure_reason}
+        ------------------------------------------------------------------------
+      TEXT
 
-            Email Id:       #{failure_three.id}
-            Failure Reason: #{failure_three.failure_reason}
-
-            -------------------------------------------
-
-          TEXT
-        ).to_stdout
+      expect { described_class.call([content_change]) }.to output(message).to_stdout
     end
   end
 end


### PR DESCRIPTION
This will allow us to run either
`rake task report:content_change_failed_emails[id_1]`
or
`report:content_change_failed_emails[id_1,id_2,id_n]`