### PR TITLE
Revert "Add a partial index on the subscription_contents table"

### DIFF
--- a/db/migrate/20191014131300_remove_partial_index_on_subscription_contents.rb
+++ b/db/migrate/20191014131300_remove_partial_index_on_subscription_contents.rb
@@ -1,0 +1,8 @@
+class RemovePartialIndexOnSubscriptionContents < ActiveRecord::Migration[5.2]
+  def change
+    remove_index(
+      :subscription_contents,
+      name: "partial_index_subscription_contents_on_subscription_id",
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_11_142014) do
+ActiveRecord::Schema.define(version: 2019_10_14_131300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,7 +176,6 @@ ActiveRecord::Schema.define(version: 2019_10_11_142014) do
     t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true
     t.index ["subscription_id", "message_id"], name: "index_subscription_contents_on_subscription_id_and_message_id", unique: true
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"
-    t.index ["subscription_id"], name: "partial_index_subscription_contents_on_subscription_id", where: "(email_id IS NULL)"
   end
 
   create_table "subscriptions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|


### PR DESCRIPTION
This did indeed improve the performance of the
SubscribersForImmediateEmailQuery, but appears to have slowed down the
DeliveryRequestWorker, probably because it updates the index to mark
the email as having been sent.

This reverts the changes in commit
d9ccfed09bb33440461bf3423c1e45fe24daeea5.