### PR TITLE
Add descriptions to Travel Advice subscriber lists

### DIFF
--- a/db/migrate/20191016072945_add_descriptions_to_travel_advice.rb
+++ b/db/migrate/20191016072945_add_descriptions_to_travel_advice.rb
@@ -1,0 +1,51 @@
+class AddDescriptionsToTravelAdvice < ActiveRecord::Migration[5.2]
+  COUNTRIES = %w(
+    austria
+    belgium
+    bulgaria
+    croatia
+    cyprus
+    czech-republic
+    denmark
+    estonia
+    finland
+    france
+    germany
+    greece
+    hungary
+    iceland
+    ireland
+    italy
+    latvia
+    liechtenstein
+    lithuania
+    luxembourg
+    malta
+    netherlands
+    norway
+    poland
+    portugal
+    romania
+    slovakia
+    slovenia
+    spain
+    sweden
+    switzerland
+  ).freeze
+
+  DESCRIPTION = "Find out about the changes to [travelling to Europe after Brexit](https://www.gov.uk/visit-europe-brexit).".freeze
+
+  def slugs
+    COUNTRIES.map { |country| "#{country}-travel-advice" }
+  end
+
+  def up
+    updated_count = SubscriberList.where(slug: slugs)
+      .update_all(description: DESCRIPTION)
+    raise "Not all travel advice updated." unless updated_count == COUNTRIES.count
+  end
+
+  def down
+    SubscriberList.where(slug: slugs).update_all(description: "")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_14_131300) do
+ActiveRecord::Schema.define(version: 2019_10_16_072945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This has been requested by the FCO as part of their Brexit campaign to inform subscribers of these lists about potential changes in travelling to Europe.

This PR is draft because the text hasn't been agreed yet.

[Trello Card](https://trello.com/c/pWVGA9hy/810-add-brexit-information-to-travel-advice-emails-for-relevant-countries)