### PR TITLE
Multiple ImmediateEmailGenerationWorkers

### DIFF
--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -1,9 +1,11 @@
 class SubscribersForImmediateEmailQuery
-  def self.call
+  def self.call(content_change_id: nil, message_id: nil)
+    raise ArgumentError("Must specify either content_change_id or message_id") unless content_change_id || message_id
+
     unprocessed_subscription_content_exists =
       SubscriptionContent
         .joins(:subscription)
-        .where(email_id: nil)
+        .where(email_id: nil, content_change_id: content_change_id, message_id: message_id)
         .where("subscriptions.subscriber_id = subscribers.id")
         .arel
         .exists

--- a/app/queries/subscriptions_for_subscription_content_query.rb
+++ b/app/queries/subscriptions_for_subscription_content_query.rb
@@ -1,0 +1,13 @@
+class SubscriptionsForSubscriptionContentQuery
+  def self.call(filter_name, content_change_or_message)
+    raise ArgumentError.new("Filter must be either :for_content_change or :for_message") unless %i(for_content_change for_message).include?(filter_name)
+
+    Subscription
+        .send(filter_name, content_change_or_message)
+        .active
+        .immediately
+        .subscription_ids_by_subscriber
+        .values
+        .flatten
+  end
+end

--- a/app/services/queue_courtesy_email_service.rb
+++ b/app/services/queue_courtesy_email_service.rb
@@ -1,0 +1,21 @@
+class QueueCourtesyEmailService
+  def self.call(email_builder, content_change: nil, message: nil)
+    raise ArgumentError.new("Filter must be either :for_content_change or :for_message") unless content_change || message
+
+    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
+    return unless subscriber
+
+    additional_parameter = content_change ? { content_change: content_change } : { message: message }
+    email_id = email_builder.call([
+                                      {
+                                          address: subscriber.address,
+                                          subscriptions: [],
+                                          subscriber_id: subscriber.id,
+                                      }.merge(additional_parameter),
+                                  ]).ids.first
+
+    DeliveryRequestWorker.perform_async_in_queue(
+      email_id, queue: :delivery_immediate
+    )
+  end
+end

--- a/app/services/queue_courtesy_email_service.rb
+++ b/app/services/queue_courtesy_email_service.rb
@@ -1,21 +1,51 @@
 class QueueCourtesyEmailService
-  def self.call(email_builder, content_change: nil, message: nil)
-    raise ArgumentError.new("Filter must be either :for_content_change or :for_message") unless content_change || message
+  def initialize(content_change_or_message)
+    raise ArgumentError.new("Must be a Message or a Content Change") unless
+        content_change_or_message.is_a?(Message) ||
+          content_change_or_message.is_a?(ContentChange)
 
-    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
+    @content_change_or_message = content_change_or_message
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
     return unless subscriber
-
-    additional_parameter = content_change ? { content_change: content_change } : { message: message }
-    email_id = email_builder.call([
-                                      {
-                                          address: subscriber.address,
-                                          subscriptions: [],
-                                          subscriber_id: subscriber.id,
-                                      }.merge(additional_parameter),
-                                  ]).ids.first
 
     DeliveryRequestWorker.perform_async_in_queue(
       email_id, queue: :delivery_immediate
     )
+  end
+
+private
+
+  attr_reader :content_change_or_message
+
+  def subscriber
+    @subscriber ||= Subscriber.find_by(address: Email::COURTESY_EMAIL)
+  end
+
+  def email_builder_parameter
+    is_a_content_change? ? { content_change: content_change_or_message } : { message: content_change_or_message }
+  end
+
+  def email_builder
+    is_a_content_change? ? ContentChangeEmailBuilder : MessageEmailBuilder
+  end
+
+  def email_id
+    email_builder.call([
+                          {
+                            address: subscriber.address,
+                            subscriptions: [],
+                            subscriber_id: subscriber.id,
+                          }.merge(email_builder_parameter),
+                      ]).ids.first
+  end
+
+  def is_a_content_change?
+    content_change_or_message.is_a?(ContentChange)
   end
 end

--- a/app/workers/immediate_content_change_email_generation_worker.rb
+++ b/app/workers/immediate_content_change_email_generation_worker.rb
@@ -1,0 +1,14 @@
+class ImmediateContentChangeEmailGenerationWorker
+  include Sidekiq::Worker
+  include ImmediateEmailGeneratorService
+
+  def self.perform_async_in_queue(*args, queue:)
+    set(queue: queue).perform_async(*args)
+  end
+
+  def perform(content_change_id)
+    ensure_only_running_once("content_change", content_change_id) do
+      generate_emails(content_change_id: content_change_id)
+    end
+  end
+end

--- a/app/workers/immediate_message_email_generation_worker.rb
+++ b/app/workers/immediate_message_email_generation_worker.rb
@@ -1,0 +1,14 @@
+class ImmediateMessageEmailGenerationWorker
+  include Sidekiq::Worker
+  include ImmediateEmailGeneratorService
+
+  def self.perform_async_in_queue(*args, queue:)
+    set(queue: queue).perform_async(*args)
+  end
+
+  def perform(message_id)
+    ensure_only_running_once("message", message_id) do
+      generate_emails(message_id: message_id)
+    end
+  end
+end

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -6,7 +6,7 @@ class ProcessContentChangeWorker
     return if content_change.processed?
 
     import_subscription_content(content_change)
-    queue_courtesy_email(content_change)
+    QueueCourtesyEmailService.call(ContentChangeEmailBuilder, content_change: content_change)
 
     content_change.mark_processed!
   end
@@ -16,37 +16,11 @@ private
   def import_subscription_content(content_change)
     SubscriptionContent.import_ignoring_duplicates(
       %i(content_change_id subscription_id),
-      subscription_ids(content_change).map { |id| [content_change.id, id] },
+      SubscriptionsForSubscriptionContentQuery
+        .call(:for_content_change, content_change)
+        .map { |id| [content_change.id, id] },
     )
 
     ImmediateEmailGenerationWorker.perform_async
-  end
-
-  def subscription_ids(content_change)
-    Subscription
-      .for_content_change(content_change)
-      .active
-      .immediately
-      .subscription_ids_by_subscriber
-      .values
-      .flatten
-  end
-
-  def queue_courtesy_email(content_change)
-    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
-    return unless subscriber
-
-    email_id = ContentChangeEmailBuilder.call([
-      {
-        address: subscriber.address,
-        subscriptions: [],
-        content_change: content_change,
-        subscriber_id: subscriber.id,
-      },
-    ]).ids.first
-
-    DeliveryRequestWorker.perform_async_in_queue(
-      email_id, queue: :delivery_immediate
-    )
   end
 end

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -7,7 +7,7 @@ class ProcessMessageWorker
 
     MatchedMessageGenerationService.call(message)
     import_subscription_content(message)
-    QueueCourtesyEmailService.call(MessageEmailBuilder, message: message)
+    QueueCourtesyEmailService.call(message)
 
     message.mark_processed!
   end
@@ -22,6 +22,7 @@ private
         .map { |id| [message.id, id] },
     )
 
-    ImmediateEmailGenerationWorker.perform_async
+    queue = message.high? ? :email_generation_immediate_high : :email_generation_immediate
+    ImmediateMessageEmailGenerationWorker.perform_async_in_queue(message.id, queue: queue)
   end
 end

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -7,7 +7,7 @@ class ProcessMessageWorker
 
     MatchedMessageGenerationService.call(message)
     import_subscription_content(message)
-    queue_courtesy_email(message)
+    QueueCourtesyEmailService.call(MessageEmailBuilder, message: message)
 
     message.mark_processed!
   end
@@ -17,37 +17,11 @@ private
   def import_subscription_content(message)
     SubscriptionContent.import_ignoring_duplicates(
       %i(message_id subscription_id),
-      subscription_ids(message).map { |id| [message.id, id] },
+      SubscriptionsForSubscriptionContentQuery
+        .call(:for_message, message)
+        .map { |id| [message.id, id] },
     )
 
     ImmediateEmailGenerationWorker.perform_async
-  end
-
-  def subscription_ids(message)
-    Subscription
-      .for_message(message)
-      .active
-      .immediately
-      .subscription_ids_by_subscriber
-      .values
-      .flatten
-  end
-
-  def queue_courtesy_email(message)
-    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
-    return unless subscriber
-
-    email_id = MessageEmailBuilder.call([
-      {
-        address: subscriber.address,
-        subscriptions: [],
-        message: message,
-        subscriber_id: subscriber.id,
-      },
-    ]).ids.first
-
-    DeliveryRequestWorker.perform_async_in_queue(
-      email_id, queue: :delivery_immediate
-    )
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,16 +5,14 @@
 :timeout: 4
 :queues:
   - [delivery_immediate_high, 6]
-  - [delivery_immediate, 5]
-  - [email_generation_immediate, 4]
+  - [delivery_immediate, 4]
+  - [email_generation_immediate_high, 5]
+  - [email_generation_immediate, 3]
   - [default, 3]
   - [delivery_digest, 2]
   - [email_generation_digest, 1]
   - cleanup
 :schedule:
-  immediate_email_generation:
-    every: '5s'
-    class: ImmediateEmailGenerationWorker
   daily_digest_initiator:
     cron: '30 8 * * * Europe/London' # every day at 8:30am
     class: DailyDigestInitiatorWorker

--- a/spec/queries/subscribers_for_immediate_email_query_spec.rb
+++ b/spec/queries/subscribers_for_immediate_email_query_spec.rb
@@ -1,36 +1,58 @@
 require "rails_helper"
 
 RSpec.describe SubscribersForImmediateEmailQuery do
-  it "returns Subscriber objects that have an email-less SubscriptionContent" do
-    create(:subscription_content, email: nil)
-    expect(described_class.call.count).to eq(1)
-  end
+  context "when passed a content change" do
+    it "returns Subscriber objects that have an email-less SubscriptionContent" do
+      subscription_content = create(:subscription_content, email: nil)
+      filter_hash = { content_change_id: subscription_content.content_change_id }
+      expect(described_class.call(filter_hash).count).to eq(1)
+    end
 
-  it "does not return Subscriber objects with email_id != nil" do
-    create(:subscription_content, email: build(:email))
-    expect(described_class.call.count).to eq(0)
-  end
+    it "does not return Subscriber objects with email_id != nil" do
+      subscription_content = create(:subscription_content, email: build(:email))
+      filter_hash = { content_change_id: subscription_content.content_change_id }
+      expect(described_class.call(filter_hash).count).to eq(0)
+    end
 
-  it "does not return Subscriber for nullified subscribers" do
-    create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :nullified)))
-    expect(described_class.call.count).to eq(0)
-  end
+    it "does not return Subscriber for nullified subscribers" do
+      subscription = create(:subscription, subscriber: create(:subscriber, :nullified))
+      subscription_content = create(:subscription_content, subscription: subscription)
+      filter_hash = { content_change_id: subscription_content.content_change_id }
+      expect(described_class.call(filter_hash).count).to eq(0)
+    end
 
-  it "does not return Subscriber for deactivates subscribers" do
-    create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :deactivated)))
-    expect(described_class.call.count).to eq(0)
-  end
+    it "does not return Subscriber for deactivates subscribers" do
+      subscription = create(:subscription, subscriber: create(:subscriber, :deactivated))
+      subscription_content = create(:subscription_content, subscription: subscription)
+      filter_hash = { content_change_id: subscription_content.content_change_id }
+      expect(described_class.call(filter_hash).count).to eq(0)
+    end
 
-  it "returns one record per subscriber" do
-    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber = create(:subscriber)))
-    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber))
+    it "returns one record per subscriber" do
+      content_change = create(:content_change)
+      subscriber = create(:subscriber)
+      create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
+      create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
 
-    create(:subscription_content, email: create(:email), subscription: create(:subscription, subscriber: subscriber))
+      create(:subscription_content, email: create(:email), subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
 
-    content_change = ContentChange.last
-    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
-    create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
+      content_change = ContentChange.last
+      create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
+      create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
 
-    expect(described_class.call.count).to eq(1)
+      filter_hash = { content_change_id: content_change.id }
+      expect(described_class.call(filter_hash).count).to eq(1)
+    end
+
+    it "only returns subscribers for that content change" do
+      content_change_one = create(:content_change)
+      content_change_two = create(:content_change)
+      subscriber_one = create(:subscriber)
+      subscriber_two = create(:subscriber)
+      create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_one), content_change: content_change_one)
+      create(:subscription_content, subscription: create(:subscription, subscriber: subscriber_two), content_change: content_change_two)
+      filter_hash = { content_change_id: content_change_one.id }
+      expect(described_class.call(filter_hash)).to eq([subscriber_one])
+    end
   end
 end

--- a/spec/workers/immediate_message_email_generation_worker_spec.rb
+++ b/spec/workers/immediate_message_email_generation_worker_spec.rb
@@ -1,0 +1,127 @@
+RSpec.describe ImmediateMessageEmailGenerationWorker do
+  describe ".perform" do
+    def perform_with_fake_sidekiq(content_change_id)
+      Sidekiq::Testing.fake! do
+        DeliveryRequestWorker.jobs.clear
+        described_class.new.perform(content_change_id)
+      end
+    end
+
+    context "with subscribers that have duplicate subscription contents" do
+      it "deduplicates when creating the emails" do
+        subscriber_one = create(:subscriber)
+        subscription_one = create(:subscription, subscriber: subscriber_one)
+        subscription_two = create(:subscription, subscriber: subscriber_one)
+        message = create(:message)
+
+        create(
+          :subscription_content,
+          subscription: subscription_one,
+          message: message,
+          content_change: nil,
+        )
+
+        create(
+          :subscription_content,
+          subscription: subscription_two,
+          message: message,
+          content_change: nil,
+        )
+
+        described_class.new.perform(message.id)
+
+        expect(Email.count).to eq(1)
+      end
+    end
+
+    context "with many subscription contents" do
+      let!(:message) { create(:message) }
+
+      before do
+        50.times do
+          create(:subscription_content, message: message, content_change: nil)
+        end
+      end
+
+      it "should match up with the right emails" do
+        perform_with_fake_sidekiq(message.id)
+
+        SubscriptionContent.includes(:email, subscription: :subscriber).find_each do |subscription_content|
+          expect(subscription_content.email.address)
+            .to eq(subscription_content.subscription.subscriber.address)
+        end
+      end
+    end
+
+    context "with a subscription content" do
+      let!(:subscription_content) { create(:subscription_content, message: create(:message), content_change: nil) }
+
+      before do
+        create(:subscription_content, email: create(:email))
+        create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :nullified)))
+      end
+
+      it "should create an email" do
+        expect { perform_with_fake_sidekiq(subscription_content.message_id) }
+          .to change { Email.count }
+          .by(1)
+      end
+
+      it "should associate the subscription content with the email" do
+        perform_with_fake_sidekiq(subscription_content.message_id)
+        expect(subscription_content.reload.email).to_not be_nil
+      end
+
+      it "should queue a delivery email job" do
+        perform_with_fake_sidekiq(subscription_content.message_id)
+        expect(DeliveryRequestWorker.jobs.size).to eq(1)
+      end
+
+      context "with a high priority message" do
+        before do
+          subscription_content.message.update(priority: "high")
+        end
+
+        it "should queue a delivery email job with a high priority" do
+          expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+            .with(an_instance_of(String), queue: :delivery_immediate_high)
+
+          perform_with_fake_sidekiq(subscription_content.message_id)
+        end
+      end
+    end
+
+    context "with multiple messages" do
+      it "will only process subscription contents for the message it is passed" do
+        subscriber_one = create(:subscriber)
+        subscriber_two = create(:subscriber)
+        subscription_one = create(:subscription, subscriber: subscriber_one)
+        subscription_two = create(:subscription, subscriber: subscriber_two)
+        message_one = create(:message)
+        message_two = create(:message)
+
+        subscription_content_one = create(
+          :subscription_content,
+          subscription: subscription_one,
+          message: message_one,
+          content_change: nil,
+            )
+
+        subscription_content_two = create(
+          :subscription_content,
+          subscription: subscription_two,
+          message: message_two,
+          content_change: nil,
+            )
+
+        described_class.new.perform(message_one.id)
+
+        expect(Email.count).to eq(1)
+        subscription_content_one.reload
+        subscription_content_two.reload
+        expect(subscription_content_one.email.address).to eq(subscriber_one.address)
+        expect(subscription_content_two.email).to be_nil
+      end
+    end
+  end
+end

--- a/spec/workers/process_content_change_worker_spec.rb
+++ b/spec/workers/process_content_change_worker_spec.rb
@@ -20,6 +20,28 @@ RSpec.describe ProcessContentChangeWorker do
         .to(true)
     end
 
+    context "with a normal priority content change" do
+      it "enqueues a normal priority immediate email generation" do
+        expect(ImmediateContentChangeEmailGenerationWorker)
+            .to receive(:perform_async_in_queue)
+                    .with(content_change.id, queue: :email_generation_immediate)
+
+        subject.perform(content_change.id)
+      end
+    end
+
+    context "with a high priority content change" do
+      before { content_change.update(priority: "high") }
+
+      it "enqueues a high priority immediate email generation" do
+        expect(ImmediateContentChangeEmailGenerationWorker)
+            .to receive(:perform_async_in_queue)
+                    .with(content_change.id, queue: :email_generation_immediate_high)
+
+        subject.perform(content_change.id)
+      end
+    end
+
     context "when the subscription content has already been imported" do
       before { create(:subscription_content, content_change: content_change, subscription: subscription) }
 

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -54,6 +54,28 @@ RSpec.describe ProcessMessageWorker do
     end
   end
 
+  context "with a normal priority message" do
+    it "enqueues a normal priority immediate email generation" do
+      expect(ImmediateMessageEmailGenerationWorker)
+          .to receive(:perform_async_in_queue)
+                  .with(message.id, queue: :email_generation_immediate)
+
+      subject.perform(message.id)
+    end
+  end
+
+  context "with a high priority message" do
+    before { message.update(priority: "high") }
+
+    it "enqueues a high priority immediate email generation" do
+      expect(ImmediateMessageEmailGenerationWorker)
+          .to receive(:perform_async_in_queue)
+                  .with(message.id, queue: :email_generation_immediate_high)
+
+      subject.perform(message.id)
+    end
+  end
+
   context "with a courtesy subscription" do
     let!(:subscriber) { create(:subscriber, address: Email::COURTESY_EMAIL) }
 


### PR DESCRIPTION
One per content change or message
Additionally, has different queues for high
and lower priority ImmediateEmailGenerationWorkers

In response to an incident in which a
Travel Advice email was stuck in a backlog
of ~1 million unprocessed SubscriptionContents.
The bottleneck was that there was only
one ImmediateEmailGenerationWorkers and it
could not prioritise those which were more
important or process them fast enough to
prevent a buildup and a delay of around
4 hours.

In the last year, the most content changes
created in a single day was 1581 and the mean
per day was 277 so this change won't flood Sidekiq