### PR TITLE
Add a load testing task to create delivery attempts

### DIFF
--- a/lib/tasks/load_testing.rake
+++ b/lib/tasks/load_testing.rake
@@ -1,0 +1,22 @@
+namespace :load_testing do
+  desc "Create fake delivery attempts which can be used to load test the status updates endpoint."
+  task :create_fake_delivery_attempts, [:count] => :environment do |_t, args|
+    email_id = Email.last.id
+    ids = args[:count].to_i.times.map { SecureRandom.uuid }
+    records = ids.map do |id|
+      { id: id, email_id: email_id, status: :sending, provider: "pseudo" }
+    end
+
+    DeliveryAttempt.import(records)
+
+    path = "/tmp/delivery_attempt_ids_#{Time.now.strftime('%Y%m%d_%H%M%S')}"
+
+    File.open(path, "w") do |file|
+      file.write(ids.join("\n"))
+      file.write("\n")
+    end
+
+    puts "Delivery Attempt IDs available at:"
+    puts path
+  end
+end


### PR DESCRIPTION
We want to do some load testing of the public /status-updates endpoint and for that we need a lot of delivery attempts. This task makes it easy to create lots of fake delivery attempts and then writes the references to a file so the endpoint can be used.

The reason we need to create many delivery attempts is that the endpoint will refuse any status update on a delivery attempt which has already been updated, so we need many delivery attempts available to set the status on.

[Trello Card](https://trello.com/c/7dvE0r6d/1428-8-load-test-notify-delivery-receipts-endpoint-%F0%9F%8D%90)