### PR TITLE
Add subscriber list description to emails

### DIFF
--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -41,10 +41,22 @@ private
       #{I18n.t!('emails.content_change.opening_line')}
 
       ---
-      #{ContentChangePresenter.call(content_change)}
+      #{presented_content_change(content_change, subscriptions)}
       ---
       #{footer(subscriptions, address).strip}
     BODY
+  end
+
+  def presented_content_change(content_change, subscriptions)
+    copy = ContentChangePresenter.call(content_change)
+    return copy if subscriptions.empty?
+
+    subscriber_list = subscriptions.first.subscriber_list
+    if subscriber_list.description.present?
+      copy += "\n#{subscriber_list.description}\n"
+    end
+
+    copy
   end
 
   def footer(subscriptions, address)

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -45,13 +45,23 @@ private
 
   def presented_segment(segment)
     <<~RESULT
-      # #{presented_title(segment)} &nbsp;
+      #{presented_header(segment)}
 
       #{presented_content(segment.content)}
       ---
 
       #{UnsubscribeLinkPresenter.call(segment.subscription_id, segment.subscriber_list_title)}
     RESULT
+  end
+
+  def presented_header(segment)
+    copy = "# #{presented_title(segment)} &nbsp;"
+
+    if segment.subscriber_list_description.present?
+      copy += "\n\n#{segment.subscriber_list_description}"
+    end
+
+    copy
   end
 
   def presented_title(segment)

--- a/app/builders/message_email_builder.rb
+++ b/app/builders/message_email_builder.rb
@@ -45,9 +45,15 @@ private
     BODY
 
     if subscriptions.any?
+      subscriber_list = subscriptions.first.subscriber_list
+
+      if subscriber_list.description.present?
+        copy += "#{subscriber_list.description}\n"
+      end
+
       copy += <<~BODY
         ---
-        #{permission_reminder(subscriptions.first.subscriber_list)}
+        #{permission_reminder(subscriber_list)}
 
         #{ManageSubscriptionsLinkPresenter.call(address)}
       BODY

--- a/app/queries/digest_subscription_content_query.rb
+++ b/app/queries/digest_subscription_content_query.rb
@@ -1,5 +1,5 @@
 class DigestSubscriptionContentQuery
-  Result = Struct.new(:subscription_id, :subscriber_list_title, :subscriber_list_url, :content)
+  Result = Struct.new(:subscription_id, :subscriber_list_title, :subscriber_list_url, :subscriber_list_description, :content)
 
   def initialize(subscriber, digest_run)
     @subscriber = subscriber
@@ -26,6 +26,7 @@ private
       memo[id] ||= {
         subscriber_list_title: record[:subscriber_list_title],
         subscriber_list_url: record[:subscriber_list_url],
+        subscriber_list_description: record[:subscriber_list_description],
       }
       memo[id][:content_changes] = Array(memo[id][:content_changes]) << record
     end
@@ -35,39 +36,40 @@ private
       memo[id] ||= {
         subscriber_list_title: record[:subscriber_list_title],
         subscriber_list_url: record[:subscriber_list_url],
+        subscriber_list_description: record[:subscriber_list_description],
       }
       memo[id][:messages] = Array(memo[id][:messages]) << record
     end
 
     result_data.map do |key, value|
       content = value.fetch(:content_changes, []) + value.fetch(:messages, [])
-      Result.new(key, value[:subscriber_list_title], value[:subscriber_list_url], content.sort_by(&:created_at))
+      Result.new(key, value[:subscriber_list_title], value[:subscriber_list_url], value[:subscriber_list_description], content.sort_by(&:created_at))
     end
   end
 
   def fetch_content_changes
     ContentChange
-      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url")
+      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url", "subscriber_lists.description AS subscriber_list_description")
       .joins(matched_content_changes: { subscriber_list: { subscriptions: :subscriber } })
       .where(subscribers: { id: subscriber.id })
       .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
       .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "content_changes.created_at ASC")
+      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "subscriber_list_description ASC", "content_changes.created_at ASC")
       .uniq(&:content_id)
   end
 
   def fetch_messages
     Message
-      .select("messages.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url")
+      .select("messages.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url", "subscriber_lists.description AS subscriber_list_description")
       .joins(matched_messages: { subscriber_list: { subscriptions: :subscriber } })
       .where(subscribers: { id: subscriber.id })
       .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
       .where("messages.created_at >= ?", digest_run.starts_at)
       .where("messages.created_at < ?", digest_run.ends_at)
       .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "messages.created_at ASC")
+      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "subscriber_list_description ASC", "messages.created_at ASC")
       .uniq(&:id)
   end
 end

--- a/spec/builders/content_change_email_builder_spec.rb
+++ b/spec/builders/content_change_email_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ContentChangeEmailBuilder do
       :subscription,
       id: "69ca6fce-34f5-4ebd-943c-83bd1b2e70fb",
       subscriber: subscriber,
-      subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription"),
+      subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription", description: "subscriber_list_description"),
     )
   end
   let(:subscriptions) do
@@ -129,7 +129,7 @@ RSpec.describe ContentChangeEmailBuilder do
         end
       end
 
-      context "with a URL" do
+      context "with a URL and a description" do
         let(:subscription_content) do
           double(subscription: subscription_two, content_change: content_change)
         end
@@ -146,6 +146,8 @@ RSpec.describe ContentChangeEmailBuilder do
 
               ---
               presented_content_change
+
+              subscriber_list_description
 
               ---
               ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscriptions.second.subscriber_list.title}](#{Plek.new.website_root}#{subscriptions.second.subscriber_list.url})’ on GOV.UK.

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DigestEmailBuilder do
         subscription_id: "ABC1",
         subscriber_list_title: "Test title 1",
         subscriber_list_url: nil,
+        subscriber_list_description: "",
         content: [
           build(:content_change),
           build(:message),
@@ -18,6 +19,7 @@ RSpec.describe DigestEmailBuilder do
         subscription_id: "ABC2",
         subscriber_list_title: "Test title 2",
         subscriber_list_url: "/test-title-2",
+        subscriber_list_description: "Test description",
         content: [
           build(:message),
           build(:content_change),
@@ -77,6 +79,8 @@ RSpec.describe DigestEmailBuilder do
         &nbsp;
 
         # [Test title 2](http://www.dev.gov.uk/test-title-2) &nbsp;
+
+        Test description
 
         presented_message
 

--- a/spec/builders/message_email_builder_spec.rb
+++ b/spec/builders/message_email_builder_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MessageEmailBuilder do
   let(:subscription_two) do
     create(:subscription,
            subscriber: subscriber,
-           subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription"))
+           subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription", description: "subscriber_list_description"))
   end
 
   let(:subscriptions) do
@@ -106,7 +106,7 @@ RSpec.describe MessageEmailBuilder do
         end
       end
 
-      context "with a URL" do
+      context "with a URL and a description" do
         let(:subscription) { subscription_two }
 
         it "sets the body" do
@@ -121,6 +121,7 @@ RSpec.describe MessageEmailBuilder do
 
               Some content
 
+              subscriber_list_description
               ---
               ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscription.subscriber_list.title}](#{Plek.new.website_root}#{subscription.subscriber_list.url})’ on GOV.UK.
 

--- a/spec/queries/digest_subscription_content_query_spec.rb
+++ b/spec/queries/digest_subscription_content_query_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe DigestSubscriptionContentQuery do
           .to match(subscription_id: subscription.id,
                     subscriber_list_title: subscriber_list.title,
                     subscriber_list_url: subscriber_list.url,
+                    subscriber_list_description: subscriber_list.description,
                     content: [content_change, message])
       end
 
@@ -77,7 +78,7 @@ RSpec.describe DigestSubscriptionContentQuery do
 
     context "with multiple subscriber lists" do
       let(:subscriber_list1) { create(:subscriber_list, title: "Subscriber List A") }
-      let(:subscriber_list2) { create(:subscriber_list, title: "Subscriber List B", url: "/example") }
+      let(:subscriber_list2) { create(:subscriber_list, title: "Subscriber List B", url: "/example", description: "Description") }
 
       let!(:subscription1) do
         create(:subscription,
@@ -109,12 +110,14 @@ RSpec.describe DigestSubscriptionContentQuery do
           .to match(subscription_id: subscription1.id,
                     subscriber_list_title: subscriber_list1.title,
                     subscriber_list_url: subscriber_list1.url,
+                    subscriber_list_description: subscriber_list1.description,
                     content: [content_change1])
 
         expect(results.last.to_h)
           .to match(subscription_id: subscription2.id,
                     subscriber_list_title: subscriber_list2.title,
                     subscriber_list_url: subscriber_list2.url,
+                    subscriber_list_description: subscriber_list2.description,
                     content: [content_change2])
       end
 
@@ -128,6 +131,7 @@ RSpec.describe DigestSubscriptionContentQuery do
           .to match(subscription_id: subscription1.id,
                     subscriber_list_title: subscriber_list1.title,
                     subscriber_list_url: subscriber_list1.url,
+                    subscriber_list_description: subscriber_list1.description,
                     content: [message])
       end
     end

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -36,12 +36,14 @@ RSpec.describe DigestEmailGenerationWorker do
           subscription_id: subscription_one.id,
           subscriber_list_title: "Test title 1",
           subscriber_list_url: nil,
+          subscriber_list_description: nil,
           content: [create(:content_change)],
         ),
         double(
           subscription_id: subscription_two.id,
           subscriber_list_title: "Test title 2",
           subscriber_list_url: "/test-title-2",
+          subscriber_list_description: "Test description",
           content: [create(:message)],
         ),
       ]


### PR DESCRIPTION
Currently the description only appears at the bottom of the subscription confirmation email, this changes that behaviour so it appears in all email types.

This is required to complete a request by the FCO to have a piece of text appear under each travel advice email.

[Trello Card](https://trello.com/c/pWVGA9hy/1380-1-add-brexit-information-to-travel-advice-emails-for-relevant-countries)