### PR TITLE
Manually deliver emails immediately for a content change

### DIFF
--- a/app/queries/subscription_contents_and_unsent_email_for_content_change.rb
+++ b/app/queries/subscription_contents_and_unsent_email_for_content_change.rb
@@ -1,0 +1,8 @@
+class SubscriptionContentsAndUnsentEmailForContentChange
+  def self.call(content_change_id)
+    SubscriptionContent.
+      includes(:email).
+      where(content_change_id: content_change_id).
+      where.not(emails: { status: "sent" })
+  end
+end

--- a/lib/immediate_delivery/queue_unsent_emails_for_content_change.rb
+++ b/lib/immediate_delivery/queue_unsent_emails_for_content_change.rb
@@ -1,0 +1,25 @@
+module ImmediateDelivery
+  class QueueUnsentEmailsForContentChange
+    def initialize(content_change_id:)
+      @content_change_id = content_change_id
+    end
+
+    def self.call(content_change_id:)
+      new(content_change_id: content_change_id).execute
+    end
+
+    def execute
+      resend
+    end
+
+  private
+
+    attr_accessor :content_change_id
+
+    def resend
+      SubscriptionContentsAndUnsentEmailForContentChange.call(content_change_id).each do |subscription_content|
+        DeliveryRequestWorker.perform_async_in_queue(subscription_content.email.id, queue: :delivery_immediate_high)
+      end
+    end
+  end
+end

--- a/lib/tasks/content_change_email.rake
+++ b/lib/tasks/content_change_email.rake
@@ -32,4 +32,14 @@ namespace :report do
       puts "- report:content_change_failed_emails[id_1,id_2,id_n]"
     end
   end
+
+  desc <<~DESCRIPTION
+    For a ContentChange Id, find any unsent emails and queue
+    them for delivery on the immediate high queue
+  DESCRIPTION
+  task :force_send_emails, %i[content_change_id] => :environment do |_t, args|
+    raise ArgumentError.new("Missing content change id") unless args[:content_change_id].present?
+
+    ImmediateDelivery::QueueUnsentEmailsForContentChange.call(content_change_id: args[:content_change_id])
+  end
 end

--- a/spec/lib/immediate_delivery/queue_unsent_emails_for_content_change_spec.rb
+++ b/spec/lib/immediate_delivery/queue_unsent_emails_for_content_change_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ImmediateDelivery::QueueUnsentEmailsForContentChange do
+  let(:content_change_travel_advice) { create(:content_change) }
+  let(:email_travel_advice) { create(:email) }
+  let(:email_travel_advice_two) { create(:email) }
+
+  let(:content_change_other) { create(:content_change) }
+  let(:email_other) { create(:email) }
+
+  before :each do
+    create(:subscription_content, content_change: content_change_travel_advice, email: email_travel_advice)
+    create(:subscription_content, content_change: content_change_travel_advice, email: email_travel_advice_two)
+    create(:subscription_content, content_change: content_change_other, email: email_other)
+  end
+
+  around(:example) do |example|
+    Sidekiq::Testing.fake! do
+      example.run
+    end
+  end
+
+  it "should send emails related to travel advice subscription content" do
+    expect(DeliveryRequestWorker).to receive(:perform_async_in_queue).with(email_travel_advice.id, queue: :delivery_immediate_high)
+    expect(DeliveryRequestWorker).to receive(:perform_async_in_queue).with(email_travel_advice_two.id, queue: :delivery_immediate_high)
+    described_class.call(content_change_id: content_change_travel_advice.id)
+  end
+
+  it "should not send emails that are related to other content changes" do
+    expect(DeliveryRequestWorker).not_to receive(:perform_async_in_queue).with(email_other.id, queue: :delivery_immediate_high)
+    described_class.call(content_change_id: content_change_travel_advice.id)
+  end
+end

--- a/spec/queries/subscription_contents_and_unsent_email_for_content_change_spec.rb
+++ b/spec/queries/subscription_contents_and_unsent_email_for_content_change_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe SubscriptionContentsAndUnsentEmailForContentChange do
+  let(:relevant_content_change) { create(:content_change) }
+  let!(:subscription_content_one) {
+    create(
+      :subscription_content,
+      content_change: relevant_content_change,
+      email: build(:email),
+    )
+  }
+  let!(:subscription_content_two) {
+    create(
+      :subscription_content,
+      content_change: relevant_content_change,
+      email: build(:email),
+    )
+  }
+  let!(:subscription_content_not_relevant) {
+    create(
+      :subscription_content,
+      content_change: build(:content_change),
+      email: build(:email),
+    )
+  }
+
+  it "returns only the subscription content relevant to the content change" do
+    expected_result_set = described_class.call(relevant_content_change.id)
+    expect(expected_result_set).to match_array([subscription_content_one, subscription_content_two])
+  end
+
+  it "does not return non-relevant subscription content" do
+    expected_ids = described_class.call(relevant_content_change.id).pluck(:id)
+    expect(expected_ids).not_to include(subscription_content_not_relevant.id)
+  end
+end


### PR DESCRIPTION
When we are paged to investigate travel advice emails not being sent, there have been occasions when we want to immediately trigger them to be sent, without waiting for the inbuilt retry mechanism.

This PR adds a module and class to allow us to immediately deliver emails for a content change id.

The code can be triggered by a rake task.

Although this has been written specifically to help during a travel alert incident, the code is generic enough that it can be used for any content change id.

[Trello](https://trello.com/c/9yKnCMhi/1471-create-a-task-to-easily-resend-travel-alerts)