### PR TITLE
Generate emails in ProcessWorkers

### DIFF
--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -1,9 +1,14 @@
 class SubscribersForImmediateEmailQuery
-  def self.call
+  def self.call(content_change_id: nil, message_id: nil)
+    additional_parameters = {
+      content_change_id: content_change_id,
+      message_id: message_id,
+    }.compact
+
     unprocessed_subscription_content_exists =
       SubscriptionContent
         .joins(:subscription)
-        .where(email_id: nil)
+        .where({ email_id: nil }.merge(additional_parameters))
         .where("subscriptions.subscriber_id = subscribers.id")
         .arel
         .exists

--- a/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
+++ b/app/queries/unprocessed_subscription_contents_by_subscriber_query.rb
@@ -14,6 +14,7 @@ class UnprocessedSubscriptionContentsBySubscriberQuery
       .joins(:subscription)
       .includes(:subscription)
       .where(email_id: nil, subscriptions: { subscriber_id: subscriber_ids })
+      .lock
       .group_by { |sc| sc.subscription.subscriber_id }
   end
 

--- a/app/services/content_change_handler_service.rb
+++ b/app/services/content_change_handler_service.rb
@@ -13,7 +13,7 @@ class ContentChangeHandlerService
     content_change = ContentChange.create!(content_change_params)
     MetricsService.content_change_created
     MatchedContentChangeGenerationService.call(content_change: content_change)
-    ProcessContentChangeWorker.perform_async(content_change.id)
+    ProcessContentChangeAndGenerateEmailsWorker.perform_async(content_change.id)
   end
 
   private_class_method :new

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -12,7 +12,7 @@ class MessageHandlerService
   def call
     message = Message.create!(message_params)
     MetricsService.message_created
-    ProcessMessageWorker.perform_async(message.id)
+    ProcessMessageAndGenerateEmailsWorker.perform_async(message.id)
   end
 
   private_class_method :new

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -29,7 +29,7 @@ private
         priority: params.fetch(:priority, "normal"),
         govuk_request_id: govuk_request_id,
         signon_user_uid: user&.uid,
-        id: params[:sender_message_id]
+        id: params[:sender_message_id],
       )
   end
 end

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -24,10 +24,12 @@ private
   def message_params
     params
       .slice(:title, :url, :body, :sender_message_id)
-      .merge(criteria_rules: params[:criteria_rules].presence,
-             priority: params.fetch(:priority, "normal"),
-             govuk_request_id: govuk_request_id,
-             signon_user_uid: user&.uid,
-             id: params[:sender_message_id])
+      .merge(
+        criteria_rules: params[:criteria_rules].presence,
+        priority: params.fetch(:priority, "normal"),
+        govuk_request_id: govuk_request_id,
+        signon_user_uid: user&.uid,
+        id: params[:sender_message_id]
+      )
   end
 end

--- a/app/workers/process_and_generate_emails_worker.rb
+++ b/app/workers/process_and_generate_emails_worker.rb
@@ -1,0 +1,119 @@
+class ProcessAndGenerateEmailsWorker
+  BATCH_SIZE = 5000
+
+  def initialize
+    @content_changes = {}
+    @messages = {}
+  end
+
+private
+
+  attr_accessor :content_changes, :messages
+
+  def ensure_subscription_content_import_running_only_once(content_change_or_message)
+    SubscriptionContent.with_advisory_lock("#{content_change_or_message.class.name}_#{content_change_or_message.id}}", timeout_seconds: 0) do
+      yield
+    end
+  end
+
+  def update_content_change_cache(subscription_contents)
+    content_change_ids = subscription_contents.flat_map { |_, sc| sc.map(&:content_change_id) }
+                             .compact
+                             .uniq
+    ids = content_change_ids - content_changes.keys
+
+    content_changes.merge!(ContentChange.where(id: ids).index_by(&:id))
+  end
+
+  def update_message_cache(subscription_contents)
+    message_ids = subscription_contents.flat_map { |_, sc| sc.map(&:message_id) }
+                    .compact
+                    .uniq
+    ids = message_ids - messages.keys
+
+    messages.merge!(Message.where(id: ids).index_by(&:id))
+  end
+
+  def create_content_change_emails(subscribers, subscription_contents)
+    email_data = subscribers.flat_map do |subscriber|
+      subscribers_content_change_email_data(subscriber,
+                                            subscription_contents[subscriber.id])
+    end
+
+    email_ids = ContentChangeEmailBuilder.call(email_data.map { |e| e[:params] }).ids
+    update_subscription_contents(email_data, email_ids)
+    [email_data, email_ids]
+  end
+
+  def subscribers_content_change_email_data(subscriber, subscription_contents)
+    by_content_change_id = subscription_contents.to_a.select(&:content_change_id)
+                               .group_by(&:content_change_id)
+
+    by_content_change_id.map do |content_change_id, matching_subscription_contents|
+      {
+          params: {
+              address: subscriber.address,
+              content_change: content_changes[content_change_id],
+              subscriptions: matching_subscription_contents.map(&:subscription),
+              subscriber_id: subscriber.id,
+          },
+          subscription_contents: matching_subscription_contents,
+          priority: content_changes[content_change_id].priority.to_sym,
+      }
+    end
+  end
+
+  def create_message_emails(subscribers, subscription_contents)
+    email_data = subscribers.flat_map do |subscriber|
+      subscribers_message_email_data(subscriber,
+                                     subscription_contents[subscriber.id])
+    end
+
+    email_ids = MessageEmailBuilder.call(email_data.map { |e| e[:params] }).ids
+    update_subscription_contents(email_data, email_ids)
+    [email_data, email_ids]
+  end
+
+  def subscribers_message_email_data(subscriber, subscription_contents)
+    by_message_id = subscription_contents.select(&:message_id)
+                        .group_by(&:message_id)
+
+    by_message_id.map do |message_id, matching_subscription_contents|
+      {
+          params: {
+              address: subscriber.address,
+              message: messages[message_id],
+              subscriptions: matching_subscription_contents.map(&:subscription),
+              subscriber_id: subscriber.id,
+          },
+          subscription_contents: matching_subscription_contents,
+          priority: messages[message_id].priority.to_sym,
+      }
+    end
+  end
+
+  def update_subscription_contents(email_data, email_ids)
+    return if email_data.empty?
+
+    values = email_data.flat_map.with_index do |data, index|
+      data[:subscription_contents].map do |subscription_content|
+        "(#{subscription_content.id}, '#{email_ids[index]}'::UUID)"
+      end
+    end
+
+    ActiveRecord::Base.connection.execute(
+      %(
+        UPDATE subscription_contents SET email_id = v.email_id
+        FROM (VALUES #{values.join(',')}) AS v(id, email_id)
+        WHERE subscription_contents.id = v.id
+      ),
+        )
+  end
+
+  def queue_for_delivery(email_data_to_deliver, email_ids_to_deliver)
+    email_data_to_deliver.each.with_index do |data, index|
+      queue = data[:priority] == :high ? :delivery_immediate_high : :delivery_immediate
+      DeliveryRequestWorker.perform_async_in_queue(email_ids_to_deliver[index], queue: queue)
+    end
+  end
+end

--- a/app/workers/process_and_generate_emails_worker.rb
+++ b/app/workers/process_and_generate_emails_worker.rb
@@ -40,7 +40,7 @@ private
     email_data = subscribers.flat_map do |subscriber|
       subscribers_content_change_email_data(
         subscriber,
-        subscription_contents[subscriber.id]
+        subscription_contents[subscriber.id],
       )
     end
 
@@ -73,7 +73,7 @@ private
     email_data = subscribers.flat_map do |subscriber|
       subscribers_message_email_data(
         subscriber,
-        subscription_contents[subscriber.id]
+        subscription_contents[subscriber.id],
       )
     end
 

--- a/app/workers/process_content_change_and_generate_emails_worker.rb
+++ b/app/workers/process_content_change_and_generate_emails_worker.rb
@@ -1,0 +1,64 @@
+class ProcessContentChangeAndGenerateEmailsWorker < ProcessAndGenerateEmailsWorker
+  include Sidekiq::Worker
+
+  def perform(content_change_id)
+    content_change = ContentChange.find(content_change_id)
+    return if content_change.processed?
+
+    import_subscription_content(content_change)
+
+    SubscribersForImmediateEmailQuery.call(content_change_id: content_change_id, message_id: nil).find_in_batches(batch_size: BATCH_SIZE) do |group|
+      email_data = []
+      email_ids = {}
+      ActiveRecord::Base.transaction do
+        subscription_contents = UnprocessedSubscriptionContentsBySubscriberQuery.call(group.pluck(:id))
+        if subscription_contents.any?
+          update_content_change_cache(subscription_contents)
+          email_data, email_ids = create_content_change_emails(group, subscription_contents)
+        end
+      end
+      queue_for_delivery(email_data, email_ids)
+    end
+    content_change.mark_processed!
+    queue_courtesy_email(content_change)
+  end
+
+private
+
+  def import_subscription_content(content_change)
+    ensure_subscription_content_import_running_only_once(content_change) do
+      SubscriptionContent.import_ignoring_duplicates(
+        %i(content_change_id subscription_id),
+        subscription_ids(content_change).map { |id| [content_change.id, id] },
+        )
+    end
+  end
+
+  def subscription_ids(content_change)
+    Subscription
+        .for_content_change(content_change)
+        .active
+        .immediately
+        .subscription_ids_by_subscriber
+        .values
+        .flatten
+  end
+
+  def queue_courtesy_email(content_change)
+    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
+    return unless subscriber
+
+    email_id = ContentChangeEmailBuilder.call([
+                                                  {
+                                                      address: subscriber.address,
+                                                      subscriptions: [],
+                                                      content_change: content_change,
+                                                      subscriber_id: subscriber.id,
+                                                  },
+                                              ]).ids.first
+
+    DeliveryRequestWorker.perform_async_in_queue(
+      email_id, queue: :delivery_immediate
+    )
+  end
+end

--- a/app/workers/process_content_change_and_generate_emails_worker.rb
+++ b/app/workers/process_content_change_and_generate_emails_worker.rb
@@ -1,6 +1,8 @@
 class ProcessContentChangeAndGenerateEmailsWorker < ProcessAndGenerateEmailsWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :process_and_generate_emails
+
   def perform(content_change_id)
     content_change = ContentChange.find(content_change_id)
     return if content_change.processed?

--- a/app/workers/process_content_change_and_generate_emails_worker.rb
+++ b/app/workers/process_content_change_and_generate_emails_worker.rb
@@ -32,18 +32,18 @@ private
       SubscriptionContent.import_ignoring_duplicates(
         %i(content_change_id subscription_id),
         subscription_ids(content_change).map { |id| [content_change.id, id] },
-        )
+      )
     end
   end
 
   def subscription_ids(content_change)
     Subscription
-        .for_content_change(content_change)
-        .active
-        .immediately
-        .subscription_ids_by_subscriber
-        .values
-        .flatten
+      .for_content_change(content_change)
+      .active
+      .immediately
+      .subscription_ids_by_subscriber
+      .values
+      .flatten
   end
 
   def queue_courtesy_email(content_change)
@@ -51,13 +51,13 @@ private
     return unless subscriber
 
     email_id = ContentChangeEmailBuilder.call([
-                                                  {
-                                                      address: subscriber.address,
-                                                      subscriptions: [],
-                                                      content_change: content_change,
-                                                      subscriber_id: subscriber.id,
-                                                  },
-                                              ]).ids.first
+      {
+        address: subscriber.address,
+        subscriptions: [],
+        content_change: content_change,
+        subscriber_id: subscriber.id,
+      },
+    ]).ids.first
 
     DeliveryRequestWorker.perform_async_in_queue(
       email_id, queue: :delivery_immediate

--- a/app/workers/process_message_and_generate_emails_worker.rb
+++ b/app/workers/process_message_and_generate_emails_worker.rb
@@ -1,0 +1,65 @@
+class ProcessMessageAndGenerateEmailsWorker < ProcessAndGenerateEmailsWorker
+  include Sidekiq::Worker
+
+  def perform(message_id)
+    message = Message.find(message_id)
+    return if message.processed?
+
+    MatchedMessageGenerationService.call(message)
+    import_subscription_content(message)
+
+    SubscribersForImmediateEmailQuery.call(content_change_id: nil, message_id: message_id).find_in_batches(batch_size: BATCH_SIZE) do |group|
+      email_data = []
+      email_ids = {}
+      ActiveRecord::Base.transaction do
+        subscription_contents = UnprocessedSubscriptionContentsBySubscriberQuery.call(group.pluck(:id))
+        if subscription_contents.any?
+          update_message_cache(subscription_contents)
+          email_data, email_ids = create_message_emails(group, subscription_contents)
+        end
+      end
+      queue_for_delivery(email_data, email_ids)
+    end
+    queue_courtesy_email(message)
+    message.mark_processed!
+  end
+
+private
+
+  def import_subscription_content(message)
+    ensure_subscription_content_import_running_only_once(message) do
+      SubscriptionContent.import_ignoring_duplicates(
+        %i(message_id subscription_id),
+        subscription_ids(message).map { |id| [message.id, id] },
+      )
+    end
+  end
+
+  def subscription_ids(message)
+    Subscription
+      .for_message(message)
+      .active
+      .immediately
+      .subscription_ids_by_subscriber
+      .values
+      .flatten
+  end
+
+  def queue_courtesy_email(message)
+    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
+    return unless subscriber
+
+    email_id = MessageEmailBuilder.call([
+      {
+        address: subscriber.address,
+        subscriptions: [],
+        message: message,
+        subscriber_id: subscriber.id,
+      },
+    ]).ids.first
+
+    DeliveryRequestWorker.perform_async_in_queue(
+      email_id, queue: :delivery_immediate
+    )
+  end
+end

--- a/app/workers/process_message_and_generate_emails_worker.rb
+++ b/app/workers/process_message_and_generate_emails_worker.rb
@@ -1,6 +1,8 @@
 class ProcessMessageAndGenerateEmailsWorker < ProcessAndGenerateEmailsWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :process_and_generate_emails
+
   def perform(message_id)
     message = Message.find(message_id)
     return if message.processed?

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,9 +12,6 @@
   - [email_generation_digest, 1]
   - cleanup
 :schedule:
-  immediate_email_generation:
-    every: '5s'
-    class: ImmediateEmailGenerationWorker
   daily_digest_initiator:
     cron: '30 8 * * * Europe/London' # every day at 8:30am
     class: DailyDigestInitiatorWorker

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,6 +7,7 @@
   - [delivery_immediate_high, 6]
   - [delivery_immediate, 5]
   - [email_generation_immediate, 4]
+  - [process_and_generate_emails, 3]
   - [default, 3]
   - [delivery_digest, 2]
   - [email_generation_digest, 1]

--- a/spec/services/content_change_handler_service_spec.rb
+++ b/spec/services/content_change_handler_service_spec.rb
@@ -38,15 +38,15 @@ RSpec.describe ContentChangeHandlerService do
 
   let(:document_type_hash) do
     {
-        navigation_document_supertype: "other",
-        content_purpose_document_supertype: "news",
-        user_journey_document_supertype: "thing",
-        search_user_need_document_supertype: "government",
-        email_document_supertype: "other",
-        government_document_supertype: "other",
-        content_purpose_subgroup: "news",
-        content_purpose_supergroup: "news_and_communications",
-        content_store_document_type: "news_article",
+      navigation_document_supertype: "other",
+      content_purpose_document_supertype: "news",
+      user_journey_document_supertype: "thing",
+      search_user_need_document_supertype: "government",
+      email_document_supertype: "other",
+      government_document_supertype: "other",
+      content_purpose_subgroup: "news",
+      content_purpose_supergroup: "news_and_communications",
+      content_store_document_type: "news_article",
     }
   end
 
@@ -71,12 +71,11 @@ RSpec.describe ContentChangeHandlerService do
         base_path: "/government/things",
         change_note: "This is a change note",
         description: "This is a description",
-        links:
-          hash_including(
-            organisations: %w[c380ea42-5d91-41cc-b3cd-0a4cfe439461],
-            content_store_document_type: "news_article",
-            taxon_tree: %w[6416e4e0-c0c1-457a-8337-4bf8ed9d5f80],
-),
+        links: hash_including(
+          organisations: %w[c380ea42-5d91-41cc-b3cd-0a4cfe439461],
+          content_store_document_type: "news_article",
+          taxon_tree: %w[6416e4e0-c0c1-457a-8337-4bf8ed9d5f80],
+        ),
         tags: hash_including(
           topics: ["oil-and-gas/licensing"],
           content_store_document_type: "news_article",

--- a/spec/services/content_change_handler_service_spec.rb
+++ b/spec/services/content_change_handler_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ContentChangeHandlerService do
     it "enqueues the content change to be processed by the subscription content worker" do
       allow(ContentChange).to receive(:create!).and_return(content_change)
 
-      expect(ProcessContentChangeWorker)
+      expect(ProcessContentChangeAndGenerateEmailsWorker)
         .to receive(:perform_async)
         .with(content_change.id)
 

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MessageHandlerService do
     end
 
     it "queues a job" do
-      expect(ProcessMessageWorker).to receive(:perform_async)
+      expect(ProcessMessageAndGenerateEmailsWorker).to receive(:perform_async)
 
       described_class.call(params: params, govuk_request_id: govuk_request_id)
     end

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe MessageHandlerService do
       described_class.call(
         params: params,
         govuk_request_id: govuk_request_id,
-        user: user
+        user: user,
       )
 
       expect(Message.last).to have_attributes(signon_user_uid: user.uid)
@@ -58,7 +58,7 @@ RSpec.describe MessageHandlerService do
 
       described_class.call(
         params: params.merge(sender_message_id: uuid),
-        govuk_request_id: govuk_request_id
+        govuk_request_id: govuk_request_id,
       )
 
       expect(Message.last).to have_attributes(

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -44,9 +44,11 @@ RSpec.describe MessageHandlerService do
     it "can store the user that created the item" do
       user = create(:user)
 
-      described_class.call(params: params,
-                           govuk_request_id: govuk_request_id,
-                           user: user)
+      described_class.call(
+        params: params,
+        govuk_request_id: govuk_request_id,
+        user: user
+      )
 
       expect(Message.last).to have_attributes(signon_user_uid: user.uid)
     end
@@ -54,8 +56,10 @@ RSpec.describe MessageHandlerService do
     it "can use the sender_message_id as the Message id" do
       uuid = SecureRandom.uuid
 
-      described_class.call(params: params.merge(sender_message_id: uuid),
-                           govuk_request_id: govuk_request_id)
+      described_class.call(
+        params: params.merge(sender_message_id: uuid),
+        govuk_request_id: govuk_request_id
+      )
 
       expect(Message.last).to have_attributes(
         id: uuid,

--- a/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
         :subscription_content,
         subscription: subscription_one,
         content_change: content_change,
-          )
+      )
 
       create(
         :subscription_content,
         subscription: subscription_two,
         content_change: content_change,
-          )
+      )
 
       subject.perform(content_change.id)
 
@@ -97,7 +97,7 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
 
       SubscriptionContent.includes(:email, subscription: :subscriber).find_each do |subscription_content|
         expect(subscription_content.email.address)
-            .to eq(subscription_content.subscription.subscriber.address)
+          .to eq(subscription_content.subscription.subscriber.address)
       end
     end
   end
@@ -112,8 +112,8 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
 
     it "should create an email" do
       expect { subject.perform(content_change.id) }
-          .to change { Email.count }
-                  .by(1)
+        .to change { Email.count }
+        .by(1)
     end
 
     it "should associate the subscription content with the email" do
@@ -124,7 +124,7 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
     context "with a normal priority content change" do
       it "should queue a delivery email job with a normal priority" do
         expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-                                             .with(an_instance_of(String), queue: :delivery_immediate)
+          .with(an_instance_of(String), queue: :delivery_immediate)
 
         subject.perform(content_change.id)
       end
@@ -137,7 +137,7 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
 
       it "should queue a delivery email job with a high priority" do
         expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-                                             .with(an_instance_of(String), queue: :delivery_immediate_high)
+          .with(an_instance_of(String), queue: :delivery_immediate_high)
 
         subject.perform(content_change.id)
       end
@@ -157,13 +157,13 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
         :subscription_content,
         subscription: subscription_one,
         content_change: content_change_one,
-          )
+      )
 
       subscription_content_two = create(
         :subscription_content,
         subscription: subscription_two,
         content_change: content_change_two,
-          )
+      )
 
       subject.perform(content_change_one.id)
 

--- a/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
@@ -1,0 +1,249 @@
+RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
+  let(:content_change) { create(:content_change, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
+  let(:email) { create(:email) }
+
+  context "with a subscription" do
+    let(:subscriber) { create(:subscriber) }
+    let(:subscriber_list) { create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
+    let!(:matched_content_change) { create(:matched_content_change, subscriber_list: subscriber_list, content_change: content_change) }
+    let!(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
+
+    it "creates subscription content for the content change" do
+      expect { subject.perform(content_change.id) }
+        .to change { SubscriptionContent.count }
+        .by(1)
+    end
+
+    it "marks the content_change as processed" do
+      expect { subject.perform(content_change.id) }
+        .to change { content_change.reload.processed? }
+        .to(true)
+    end
+
+    context "when the subscription content has already been imported" do
+      before { create(:subscription_content, content_change: content_change, subscription: subscription) }
+
+      it "doesn't create another subscription content" do
+        expect { subject.perform(content_change.id) }
+          .to_not(change { SubscriptionContent.count })
+      end
+    end
+  end
+
+  context "with a courtesy subscription" do
+    let!(:subscriber) { create(:subscriber, address: Email::COURTESY_EMAIL) }
+
+    it "creates an email for the courtesy email group" do
+      expect(ContentChangeEmailBuilder)
+        .to receive(:call)
+        .with([hash_including(address: subscriber.address)])
+        .and_call_original
+
+      subject.perform(content_change.id)
+    end
+
+    it "enqueues the email to send to the courtesy subscription group" do
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(kind_of(String), queue: :delivery_immediate)
+
+      subject.perform(content_change.id)
+    end
+  end
+
+  context "with an already processed content change" do
+    before { content_change.mark_processed! }
+
+    it "should return immediate" do
+      expect(content_change).to_not receive(:mark_processed!)
+      subject.perform(content_change.id)
+    end
+  end
+
+  context "with subscribers that have duplicate subscription contents" do
+    it "deduplicates when creating the emails" do
+      subscriber_one = create(:subscriber)
+      subscription_one = create(:subscription, subscriber: subscriber_one)
+      subscription_two = create(:subscription, subscriber: subscriber_one)
+      content_change = create(:content_change)
+
+      create(
+        :subscription_content,
+        subscription: subscription_one,
+        content_change: content_change,
+          )
+
+      create(
+        :subscription_content,
+        subscription: subscription_two,
+        content_change: content_change,
+          )
+
+      subject.perform(content_change.id)
+
+      expect(Email.count).to eq(1)
+    end
+  end
+
+  context "with many subscription contents" do
+    before do
+      50.times do
+        create(:subscription_content, content_change: content_change)
+      end
+    end
+
+    it "should match up with the right emails" do
+      subject.perform(content_change.id)
+
+      SubscriptionContent.includes(:email, subscription: :subscriber).find_each do |subscription_content|
+        expect(subscription_content.email.address)
+            .to eq(subscription_content.subscription.subscriber.address)
+      end
+    end
+  end
+
+  context "with a subscription content" do
+    let!(:subscription_content) { create(:subscription_content, content_change: content_change) }
+
+    before do
+      create(:subscription_content, content_change: content_change, email: create(:email))
+      create(:subscription_content, content_change: content_change, subscription: create(:subscription, subscriber: create(:subscriber, :nullified)))
+    end
+
+    it "should create an email" do
+      expect { subject.perform(content_change.id) }
+          .to change { Email.count }
+                  .by(1)
+    end
+
+    it "should associate the subscription content with the email" do
+      subject.perform(content_change.id)
+      expect(subscription_content.reload.email).to_not be_nil
+    end
+
+    context "with a normal priority content change" do
+      it "should queue a delivery email job with a normal priority" do
+        expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+                                             .with(an_instance_of(String), queue: :delivery_immediate)
+
+        subject.perform(content_change.id)
+      end
+    end
+
+    context "with a high priority content change" do
+      before do
+        subscription_content.content_change.update(priority: "high")
+      end
+
+      it "should queue a delivery email job with a high priority" do
+        expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+                                             .with(an_instance_of(String), queue: :delivery_immediate_high)
+
+        subject.perform(content_change.id)
+      end
+    end
+  end
+
+  context "with multiple content changes" do
+    it "will only process subscription contents for the content change it is passed" do
+      subscriber_one = create(:subscriber)
+      subscriber_two = create(:subscriber)
+      subscription_one = create(:subscription, subscriber: subscriber_one)
+      subscription_two = create(:subscription, subscriber: subscriber_two)
+      content_change_one = create(:content_change)
+      content_change_two = create(:content_change)
+
+      subscription_content_one = create(
+        :subscription_content,
+        subscription: subscription_one,
+        content_change: content_change_one,
+          )
+
+      subscription_content_two = create(
+        :subscription_content,
+        subscription: subscription_two,
+        content_change: content_change_two,
+          )
+
+      subject.perform(content_change_one.id)
+
+      expect(Email.count).to eq(1)
+      subscription_content_one.reload
+      subscription_content_two.reload
+      expect(subscription_content_one.email.address).to eq(subscriber_one.address)
+      expect(subscription_content_two.email).to be_nil
+    end
+  end
+
+  context "with multiple jobs for the same content_id running at the same time" do
+    let(:subscriber_list) { create(:subscriber_list) }
+    let(:subscriptions) { create_list(:subscription, 100, subscriber_list: subscriber_list) }
+    let(:matched_content_change) { create(:matched_content_change, subscriber_list: subscriber_list) }
+    let!(:content_change) { matched_content_change.content_change }
+
+    it "will only process each subscription_content once" do
+      allow_any_instance_of(ProcessContentChangeAndGenerateEmailsWorker).to receive(:BATCH_SIZE).and_return(50)
+      allow_any_instance_of(ProcessContentChangeAndGenerateEmailsWorker).to receive(:perform_in).and_return(true)
+
+      subscriptions.each do |subscription|
+        create(:subscription_content, content_change: content_change, subscription: subscription)
+      end
+
+      wait_for_it = true
+      threads = 10.times.map do
+        Thread.new do
+          true while wait_for_it
+          # rubocop:disable HandleExceptions
+          begin
+            ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)
+          rescue ActiveRecord::ActiveRecordError
+            # The thread has hit a database contention error.
+            # Sidekiq will retry this for us so we don't need to handle it in the worker
+            # But if we don't rescue it here it the test will occasionally fail
+          end
+          # rubocop:enable HandleExceptions
+        end
+      end
+      wait_for_it = false
+      threads.each(&:join)
+
+      expect(Email.count).to eq(100)
+      expect(Email.all.pluck(:address).uniq.count).to eq(100)
+    end
+  end
+
+  context "with a job running at the same time as ImmediateEmailGenerationWorker" do
+    let(:subscriber_list) { create(:subscriber_list) }
+    let(:subscriptions) { create_list(:subscription, 100, subscriber_list: subscriber_list) }
+    let(:matched_content_change) { create(:matched_content_change, subscriber_list: subscriber_list) }
+    let!(:content_change) { matched_content_change.content_change }
+
+    it "will only process each subscription_content once" do
+      allow_any_instance_of(ProcessContentChangeAndGenerateEmailsWorker).to receive(:BATCH_SIZE).and_return(50)
+      allow_any_instance_of(ProcessContentChangeAndGenerateEmailsWorker).to receive(:perform_in).and_return(true)
+
+      subscriptions.each do |subscription|
+        create(:subscription_content, content_change: content_change, subscription: subscription)
+      end
+
+      wait_for_it = true
+      threads = []
+
+      threads << Thread.new do
+        true while wait_for_it
+        ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)
+      end
+
+      threads << Thread.new do
+        true while wait_for_it
+        ImmediateEmailGenerationWorker.new.perform
+      end
+
+      wait_for_it = false
+      threads.each(&:join)
+
+      expect(Email.count).to eq(100)
+      expect(Email.all.pluck(:address).uniq.count).to eq(100)
+    end
+  end
+end

--- a/spec/workers/process_message_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_message_and_generate_emails_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
       :message,
       criteria_rules: [
         { type: "tag", key: "topics", value: "oil-and-gas/licensing" },
-      ]
+      ],
     )
   end
 
@@ -38,7 +38,7 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
           :subscription_content,
           :with_message,
           message: message,
-          subscription: subscription
+          subscription: subscription,
         )
       end
 

--- a/spec/workers/process_message_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_message_and_generate_emails_worker_spec.rb
@@ -1,9 +1,11 @@
 RSpec.describe ProcessMessageAndGenerateEmailsWorker do
   let(:message) do
-    create(:message,
-           criteria_rules: [
-             { type: "tag", key: "topics", value: "oil-and-gas/licensing" },
-           ])
+    create(
+      :message,
+      criteria_rules: [
+        { type: "tag", key: "topics", value: "oil-and-gas/licensing" },
+      ]
+    )
   end
 
   let(:email) { create(:email) }
@@ -32,10 +34,12 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
 
     context "when the subscription content has already been imported for the message" do
       before do
-        create(:subscription_content,
-               :with_message,
-               message: message,
-               subscription: subscription)
+        create(
+          :subscription_content,
+          :with_message,
+          message: message,
+          subscription: subscription
+        )
       end
 
       it "doesn't create another subscription content" do
@@ -87,14 +91,14 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
         subscription: subscription_one,
         message: message,
         content_change: nil,
-          )
+      )
 
       create(
         :subscription_content,
         subscription: subscription_two,
         message: message,
         content_change: nil,
-          )
+      )
 
       described_class.new.perform(message.id)
 
@@ -114,7 +118,7 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
 
       SubscriptionContent.includes(:email, subscription: :subscriber).find_each do |subscription_content|
         expect(subscription_content.email.address)
-            .to eq(subscription_content.subscription.subscriber.address)
+          .to eq(subscription_content.subscription.subscriber.address)
       end
     end
   end
@@ -129,8 +133,8 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
 
     it "should create an email" do
       expect { subject.perform(message.id) }
-          .to change { Email.count }
-                  .by(1)
+        .to change { Email.count }
+        .by(1)
     end
 
     it "should associate the subscription content with the email" do
@@ -141,7 +145,7 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
     context "with a normal priority message" do
       it "should queue a delivery email job" do
         expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-                                             .with(an_instance_of(String), queue: :delivery_immediate)
+          .with(an_instance_of(String), queue: :delivery_immediate)
 
         subject.perform(message.id)
       end
@@ -154,7 +158,7 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
 
       it "should queue a delivery email job with a high priority" do
         expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-                                             .with(an_instance_of(String), queue: :delivery_immediate_high)
+          .with(an_instance_of(String), queue: :delivery_immediate_high)
 
         subject.perform(message.id)
       end
@@ -175,14 +179,14 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
         subscription: subscription_one,
         message: message_one,
         content_change: nil,
-          )
+      )
 
       subscription_content_two = create(
         :subscription_content,
         subscription: subscription_two,
         message: message_two,
         content_change: nil,
-          )
+      )
 
       described_class.new.perform(message_one.id)
 

--- a/spec/workers/process_message_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_message_and_generate_emails_worker_spec.rb
@@ -1,0 +1,268 @@
+RSpec.describe ProcessMessageAndGenerateEmailsWorker do
+  let(:message) do
+    create(:message,
+           criteria_rules: [
+             { type: "tag", key: "topics", value: "oil-and-gas/licensing" },
+           ])
+  end
+
+  let(:email) { create(:email) }
+
+  context "with a subscription" do
+    let(:subscriber) { create(:subscriber) }
+    let(:subscriber_list) { create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
+    let!(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
+
+    it "creates subscription content for the message" do
+      expect { subject.perform(message.id) }
+        .to change { SubscriptionContent.count }
+        .by(1)
+    end
+
+    it "marks the message as processed" do
+      expect { subject.perform(message.id) }
+        .to change { message.reload.processed? }
+        .to(true)
+    end
+
+    it "creates a MatchedMessage" do
+      expect { subject.perform(message.id) }
+        .to change { MatchedMessage.count }.by(1)
+    end
+
+    context "when the subscription content has already been imported for the message" do
+      before do
+        create(:subscription_content,
+               :with_message,
+               message: message,
+               subscription: subscription)
+      end
+
+      it "doesn't create another subscription content" do
+        expect { subject.perform(message.id) }
+          .to_not(change { SubscriptionContent.count })
+      end
+    end
+  end
+
+  context "with an already processed message" do
+    before { message.mark_processed! }
+
+    it "shouldn't process the message" do
+      expect(message).to_not receive(:mark_processed!)
+      subject.perform(message.id)
+    end
+  end
+
+  context "with a courtesy subscription" do
+    let!(:subscriber) { create(:subscriber, address: Email::COURTESY_EMAIL) }
+
+    it "creates an email for the courtesy email group" do
+      expect(MessageEmailBuilder)
+        .to receive(:call)
+        .with([hash_including(address: subscriber.address)])
+        .and_call_original
+
+      subject.perform(message.id)
+    end
+
+    it "enqueues the email to send to the courtesy subscription group" do
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(kind_of(String), queue: :delivery_immediate)
+
+      subject.perform(message.id)
+    end
+  end
+
+  context "with subscribers that have duplicate subscription contents" do
+    it "deduplicates when creating the emails" do
+      subscriber_one = create(:subscriber)
+      subscription_one = create(:subscription, subscriber: subscriber_one)
+      subscription_two = create(:subscription, subscriber: subscriber_one)
+      message = create(:message)
+
+      create(
+        :subscription_content,
+        subscription: subscription_one,
+        message: message,
+        content_change: nil,
+          )
+
+      create(
+        :subscription_content,
+        subscription: subscription_two,
+        message: message,
+        content_change: nil,
+          )
+
+      described_class.new.perform(message.id)
+
+      expect(Email.count).to eq(1)
+    end
+  end
+
+  context "with many subscription contents" do
+    before do
+      50.times do
+        create(:subscription_content, message: message, content_change: nil)
+      end
+    end
+
+    it "should match up with the right emails" do
+      subject.perform(message.id)
+
+      SubscriptionContent.includes(:email, subscription: :subscriber).find_each do |subscription_content|
+        expect(subscription_content.email.address)
+            .to eq(subscription_content.subscription.subscriber.address)
+      end
+    end
+  end
+
+  context "with a subscription content" do
+    let!(:subscription_content) { create(:subscription_content, message: message, content_change: nil) }
+
+    before do
+      create(:subscription_content, email: create(:email))
+      create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :nullified)))
+    end
+
+    it "should create an email" do
+      expect { subject.perform(message.id) }
+          .to change { Email.count }
+                  .by(1)
+    end
+
+    it "should associate the subscription content with the email" do
+      subject.perform(message.id)
+      expect(subscription_content.reload.email).to_not be_nil
+    end
+
+    context "with a normal priority message" do
+      it "should queue a delivery email job" do
+        expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+                                             .with(an_instance_of(String), queue: :delivery_immediate)
+
+        subject.perform(message.id)
+      end
+    end
+
+    context "with a high priority message" do
+      before do
+        subscription_content.message.update(priority: "high")
+      end
+
+      it "should queue a delivery email job with a high priority" do
+        expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+                                             .with(an_instance_of(String), queue: :delivery_immediate_high)
+
+        subject.perform(message.id)
+      end
+    end
+  end
+
+  context "with multiple messages" do
+    it "will only process subscription contents for the message it is passed" do
+      subscriber_one = create(:subscriber)
+      subscriber_two = create(:subscriber)
+      subscription_one = create(:subscription, subscriber: subscriber_one)
+      subscription_two = create(:subscription, subscriber: subscriber_two)
+      message_one = create(:message)
+      message_two = create(:message)
+
+      subscription_content_one = create(
+        :subscription_content,
+        subscription: subscription_one,
+        message: message_one,
+        content_change: nil,
+          )
+
+      subscription_content_two = create(
+        :subscription_content,
+        subscription: subscription_two,
+        message: message_two,
+        content_change: nil,
+          )
+
+      described_class.new.perform(message_one.id)
+
+      expect(Email.count).to eq(1)
+      subscription_content_one.reload
+      subscription_content_two.reload
+      expect(subscription_content_one.email.address).to eq(subscriber_one.address)
+      expect(subscription_content_two.email).to be_nil
+    end
+  end
+
+  context "with multiple jobs for the same content_id running at the same time" do
+    let(:subscriber_list) { create(:subscriber_list) }
+    let(:subscriptions) { create_list(:subscription, 100, subscriber_list: subscriber_list) }
+    let(:matched_message) { create(:matched_message, subscriber_list: subscriber_list) }
+    let!(:content_change) { matched_message.message }
+
+    it "will only process each subscription_content once" do
+      allow_any_instance_of(ProcessMessageAndGenerateEmailsWorker).to receive(:BATCH_SIZE).and_return(50)
+      allow_any_instance_of(ProcessContentChangeAndGenerateEmailsWorker).to receive(:perform_in).and_return(true)
+
+      subscriptions.each do |subscription|
+        create(:subscription_content, message: message, content_change: nil, subscription: subscription)
+      end
+
+      wait_for_it = true
+      threads = 5.times.map do
+        Thread.new do
+          true while wait_for_it
+          # rubocop:disable HandleExceptions
+          begin
+            ProcessMessageAndGenerateEmailsWorker.new.perform(message.id)
+          rescue ActiveRecord::ActiveRecordError
+            # The thread has hit a database contention error.
+            # Sidekiq will retry this for us so we don't need to handle it in the worker
+            # But if we don't rescue it here it the test will occasionally fail
+          end
+          # rubocop:enable HandleExceptions
+        end
+      end
+      wait_for_it = false
+      threads.each(&:join)
+
+      expect(Email.count).to eq(100)
+      expect(Email.all.pluck(:address).uniq.count).to eq(100)
+    end
+  end
+
+  context "with a job running at the same time as ImmediateEmailGenerationWorker" do
+    let(:subscriber_list) { create(:subscriber_list) }
+    let(:subscriptions) { create_list(:subscription, 100, subscriber_list: subscriber_list) }
+    let(:matched_message) { create(:matched_message, subscriber_list: subscriber_list) }
+    let!(:message) { matched_message.message }
+
+    it "will only process each subscription_content once" do
+      allow_any_instance_of(ProcessMessageAndGenerateEmailsWorker).to receive(:BATCH_SIZE).and_return(50)
+      allow_any_instance_of(ProcessContentChangeAndGenerateEmailsWorker).to receive(:perform_in).and_return(true)
+
+      subscriptions.each do |subscription|
+        create(:subscription_content, message: message, content_change: nil, subscription: subscription)
+      end
+
+      wait_for_it = true
+      threads = []
+
+      threads << Thread.new do
+        true while wait_for_it
+        ProcessMessageAndGenerateEmailsWorker.new.perform(message.id)
+      end
+
+      threads << Thread.new do
+        true while wait_for_it
+        ImmediateEmailGenerationWorker.new.perform
+      end
+
+      wait_for_it = false
+      threads.each(&:join)
+
+      expect(Email.count).to eq(100)
+      expect(Email.all.pluck(:address).uniq.count).to eq(100)
+    end
+  end
+end


### PR DESCRIPTION
In response to an incident in which a
Travel Advice email was stuck in a backlog
of ~1 million unprocessed SubscriptionContents.
The bottleneck was that there was only
one ImmediateEmailGenerationWorker and it
could not process SubscriptionContents
concurrently.

By moving the generation of emails to the
ProcessContentChangeAndGenerateEmailsWorker and
ProcessMessageAndGenerateEmailsWorker, it will now be able
to create emails concurrently, thus
removing the bottleneck. It will also make
the system conceptually simpler and make it easier
to see where emails are in the system as the
length of job time or number in the queue
will be more visible.

In the last year, the most content changes
created in a single day was 1581 and the mean
per day was 277 so although this will increase
the time these new workers will take to run,
it shouldn't cause huge backlogs to build up.

The existing ProcessContentChangeWorker
and ProcessMessageWorker and
ImmediateEmailGenerationWorkers are left in.
This is to make the deploying process simpler
and so existing jobs can continue to run and be
restarted if necessary. A few months after
this is merged, we can remove the old workers

Made with @AlanGabbianelli 

Trello: https://trello.com/c/aYHlLIJt/1491-continue-working-on-existing-multiple-immediateemailgenerationworkers-pr