### PR TITLE
Add subscriber information report

### DIFF
--- a/lib/reports/subscriber_subscriptions.rb
+++ b/lib/reports/subscriber_subscriptions.rb
@@ -1,0 +1,44 @@
+module Reports
+  class SubscriberSubscriptions
+    def initialize(email_addresses)
+      @email_addresses = email_addresses
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def call
+      pp report
+    end
+
+  private
+
+    attr_reader :email_addresses
+
+    SUBSCRIBER_FIELDS = %i[address created_at updated_at deactivated_at].freeze
+    SUBSCRIPTION_FIELDS = %i[created_at frequency source ended_at ended_reason].freeze
+    SUBSCRIPTION_LIST_FIELDS = %i[title tags].freeze
+
+    def report
+      subscribers = Subscriber.where(address: email_addresses)
+
+      subscribers.map do |subscriber|
+        subscriber.as_json(
+          only: SUBSCRIBER_FIELDS,
+        ).merge(
+          subscriptions: subscriber.subscriptions.map do |subscription|
+            subscription.as_json(
+              only: SUBSCRIPTION_FIELDS,
+              include: [],
+            ).merge(
+              subscription.subscriber_list.as_json(
+                only: SUBSCRIPTION_LIST_FIELDS,
+              ),
+            )
+          end,
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/subscribers.rake
+++ b/lib/tasks/subscribers.rake
@@ -1,0 +1,10 @@
+namespace :report do
+  namespace :subscribers do
+    desc "For a set of email addresses, produce a report of the Subscriptions in JSON format"
+    task :subscriptions_for, [:emails] => :environment do |_t, args|
+      raise ArgumentError.new("Missing email addresse(s)") unless args[:emails].present?
+
+      Reports::SubscriberSubscriptions.call(email_addresses: args[:emails].split)
+    end
+  end
+end


### PR DESCRIPTION
Add a report that will take one or more email addresses and return a
JSON payload of subscription information. This will include information
about the subscriber, their subscriptions and the associated
subscriber lists.

The report simply pretty prints to the console. I considered saving to a
file, but the reports are usually fairly one-off and the extra hurdle of
getting onto a machine and grabbing the file seemed unnecessary when we
can just run the task in Jenkins and see the results.