### PR TITLE
Add migration to rename brexit related subscriber list titles

### DIFF
--- a/db/migrate/20191101111212_update_title_in_brexit_subscriber_lists.rb
+++ b/db/migrate/20191101111212_update_title_in_brexit_subscriber_lists.rb
@@ -1,0 +1,24 @@
+class UpdateTitleInBrexitSubscriberLists < ActiveRecord::Migration[5.2]
+  OLD_TITLE = "Your Get ready for Brexit results".freeze
+  NEW_TITLE = "How to prepare for a no deal Brexit".freeze
+
+  def up
+    if subscriber_lists.any? { |list| list.title != OLD_TITLE }
+      raise "Some Brexit related lists have unexpected titles"
+    end
+
+    subscriber_lists.update_all(title: NEW_TITLE)
+  end
+
+  def down
+    if subscriber_lists.any? { |list| list.title != NEW_TITLE }
+      raise "Some Brexit related lists have unexpected titles"
+    end
+
+    subscriber_lists.update_all(title: OLD_TITLE)
+  end
+
+  def subscriber_lists
+    @subscriber_lists ||= SubscriberList.where("(tags->'brexit_checklist_criteria')::json IS NOT NULL")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_072945) do
+ActiveRecord::Schema.define(version: 2019_11_01_111212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/migrations/20191101111212_update_title_in_brexit_subscriber_lists_spec.rb
+++ b/spec/migrations/20191101111212_update_title_in_brexit_subscriber_lists_spec.rb
@@ -1,0 +1,38 @@
+require File.join(Rails.root, "db", "migrate", "20191101111212_update_title_in_brexit_subscriber_lists")
+
+RSpec.describe UpdateTitleInBrexitSubscriberLists do
+  it "renames the title" do
+    list = FactoryBot.create(:subscriber_list, tags: { "brexit_checklist_criteria" => {} }, title: UpdateTitleInBrexitSubscriberLists::OLD_TITLE)
+    expect {
+      UpdateTitleInBrexitSubscriberLists.new.up
+    }.to change {
+      SubscriberList.find(list.id).title
+    }.from(UpdateTitleInBrexitSubscriberLists::OLD_TITLE).to(UpdateTitleInBrexitSubscriberLists::NEW_TITLE)
+  end
+
+  it "does not rename the title because the tags are not brexit related" do
+    list = FactoryBot.create(:subscriber_list, tags: { "alert_type" => {} }, title: UpdateTitleInBrexitSubscriberLists::OLD_TITLE)
+    expect {
+      UpdateTitleInBrexitSubscriberLists.new.up
+    }.to_not(change {
+      SubscriberList.find(list.id).title
+    })
+  end
+
+  it "raises an exception because the title is unexpected" do
+    FactoryBot.create(:subscriber_list, tags: { "brexit_checklist_criteria" => {} }, title: "something else")
+    expect {
+      UpdateTitleInBrexitSubscriberLists.new.up
+    }.to raise_error("Some Brexit related lists have unexpected titles")
+  end
+
+  it "down reverts up" do
+    list = FactoryBot.create(:subscriber_list, tags: { "brexit_checklist_criteria" => {} }, title: UpdateTitleInBrexitSubscriberLists::OLD_TITLE)
+    expect {
+      UpdateTitleInBrexitSubscriberLists.new.up
+      UpdateTitleInBrexitSubscriberLists.new.down
+    }.to_not(change {
+      SubscriberList.find(list.id).title
+    })
+  end
+end


### PR DESCRIPTION
Adds a migration to rename Brexit related subscriber list titles

Trello card: https://trello.com/c/dhHPa8eK/201-pre-election-changes-to-brexit-checker-notification-emails