### PR TITLE
Record stats on delivery attempt status

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -29,7 +29,10 @@ class DeliveryRequestService
       status = call_provider(address, reference, email)
 
       ActiveRecord::Base.transaction do
-        delivery_attempt.update!(status: status) if status != :sending
+        unless status == :sending
+          delivery_attempt.update!(status: status)
+          MetricsService.delivery_attempt_status_changed(status)
+        end
         UpdateEmailStatusService.call(delivery_attempt)
       end
     end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -56,6 +56,10 @@ class MetricsService
       timing(namespace, difference)
     end
 
+    def delivery_attempt_status_changed(status)
+      increment("delivery_attempt.status.#{status}")
+    end
+
   private
 
     def increment(metric)

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -37,6 +37,7 @@ class StatusUpdateService
       DeliveryRequestWorker.perform_in(3.hours, email.id, :default)
     end
 
+    MetricsService.delivery_attempt_status_changed(status.underscore)
     GovukStatsd.increment("status_update.success")
   rescue StandardError
     GovukStatsd.increment("status_update.failure")


### PR DESCRIPTION
We'll use this in Icinga alerts checking our technical and internal failures.
    
Currently we check this using a healthcheck, but it has a number of problems:
    
- The healthchecks are no longer machine specific, meaning they can't be used correctly by the load balancer to decide where to send traffic.
- The healthchecks have ended up doing a lot of work (including database queries) which slow themselves down but also put unnecessary load on the database.
- In Icinga, a single healthcheck problem in email-alert-api ends up being duplicated for each machine which can be confusing.
    
Once the statistics on delivery attempt status are being collected correctly, we'll remove these healthchecks and use individual Icinga checks instead.

[Trello Card](https://trello.com/c/abNGpq1l/1480-5-extract-the-technicalfailures-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)
