### PR TITLE
Present messages when archiving emails

### DIFF
--- a/app/presenters/email_archive_presenter.rb
+++ b/app/presenters/email_archive_presenter.rb
@@ -11,6 +11,7 @@ class EmailArchivePresenter
     {
       archived_at_utc: archived_at.utc.strftime(S3_DATETIME_FORMAT),
       content_change: build_content_change(record),
+      message: build_message(record),
       created_at_utc: record.fetch("created_at").utc.strftime(S3_DATETIME_FORMAT),
       finished_sending_at_utc: record.fetch("finished_sending_at").utc.strftime(S3_DATETIME_FORMAT),
       id: record.fetch("id"),
@@ -36,6 +37,22 @@ private
 
     {
       content_change_ids: record.fetch("content_change_ids"),
+      digest_run_id: record.fetch("digest_run_ids").first,
+      subscription_ids: record.fetch("subscription_ids"),
+    }
+  end
+
+  def build_message(record)
+    return if record.fetch("message_ids").empty?
+
+    if record.fetch("digest_run_ids").count > 1
+      error = "Email with id: #{record['id']} is associated with "\
+        "multiple digest runs: #{record['digest_run_ids'].join(', ')}"
+      GovukError.notify(error)
+    end
+
+    {
+      message_ids: record.fetch("message_ids"),
       digest_run_id: record.fetch("digest_run_ids").first,
       subscription_ids: record.fetch("subscription_ids"),
     }


### PR DESCRIPTION
https://trello.com/c/z3REh76h/178-export-regular-data-on-email-subscriptions-for-insights-team

Previously we only (optionally) presented the content change associated
with an archived email. This extends the presenter to also cope with
emails originating from ad-hoc messages. Since content changes and
messages are the only potential origins, I've gone with a duplication
approach in the code/tests, rather than trying to abstract anything.

One of the tests, which checks exception notification behaviour, seemed
unnecessary, since it's tangential to the behaviour of the presenter.
Otherwise, coping with an array of digest IDs should still be covered
implicitly by the use of an array in the input records.