### PR TITLE
Reduce post-archival retention of emails from 14 to 13 days.

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -7,7 +7,7 @@ class Email < ApplicationRecord
   }
 
   scope :deleteable, lambda {
-    where.not(status: :pending).where("archived_at < ?", 14.days.ago)
+    where.not(status: :pending).where("archived_at < ?", 13.days.ago)
   }
 
   enum status: { pending: 0, sent: 1, failed: 2 }


### PR DESCRIPTION
This is step 1 of several for gradually reducing the retention period
from 14 days after archival to 7 days after archival.

The change is being made gradually so as to avoid any negative effects
of the hourly deletion query taking much longer than normal to run.

The reduction is desirable because we expect it to reduce the size of
the `email` table by roughly half. It is hoped that this will
significantly reduce the time needed to copy the data during the
upcoming migration of email-alert-api from Carrenza/6degrees to AWS.