### PR TITLE
Explicitly refer to the table name in active_on scope in Subscription

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -14,8 +14,8 @@ class Subscription < ApplicationRecord
   scope :ended, -> { where.not(ended_at: nil) }
 
   scope :active_on, ->(date) do
-    where("created_at <= ?", date)
-      .where("ended_at IS NULL OR ended_at > ?", date)
+    where("subscriptions.created_at <= ?", date)
+      .where("subscriptions.ended_at IS NULL OR subscriptions.ended_at > ?", date)
   end
 
   scope :for_content_change, ->(content_change) do


### PR DESCRIPTION
This helps when 'join'-ing tables and using this scope, i.e. 

```Subscription.active_on(Time.now).joins(:subscriber_list)```

will fail because column references to ```created_at``` (defined within the ```active_on``` scope) 
would be ambiguous