### PR TITLE
Add rake task to count the number of emails sent per Message

### DIFF
--- a/lib/tasks/report_brexit_subcriptions.rake
+++ b/lib/tasks/report_brexit_subcriptions.rake
@@ -1,0 +1,17 @@
+namespace :report do
+  desc "Creates a spreadsheet with all the emails sent per Brexit update"
+  task report_brexit_subscriptions: :environment do
+    all_messages = Message.order(:created_at)
+    counts = all_messages.all.map do |message|
+      Subscription.active_on(message.created_at).
+        joins(subscriber_list: :matched_messages).
+        where("matched_messages.message_id" => message).count
+    end
+
+    CSV($stdout, headers: ["date", "message_id", "number of messages sent"], write_headers: true) do |csv|
+      all_messages.zip(counts).each do |message, count|
+        csv << [message.created_at, message.id, count]
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/report_brexit_subscriptions_spec.rb
+++ b/spec/lib/tasks/report_brexit_subscriptions_spec.rb
@@ -1,0 +1,35 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "report:report_brexit_subscriptions" do
+  before :each do
+    Rails.application.load_tasks
+  end
+
+  it "sends the header" do
+    expect {
+      Rake::Task["report:report_brexit_subscriptions"].execute
+    }.to output("date,message_id,number of messages sent\n").to_stdout
+  end
+  it "outputs a message to the csv" do
+    subscriber_list = FactoryBot.create(:subscriber_list)
+    FactoryBot.create(:subscription, subscriber_list: subscriber_list)
+    message = FactoryBot.create(:message)
+    FactoryBot.create(:matched_message, subscriber_list: subscriber_list, message: message)
+
+    expect {
+      Rake::Task["report:report_brexit_subscriptions"].execute
+    }.to output(/#{Regexp.quote(message.created_at.to_s)},#{Regexp.quote(message.id.to_s)},1$/).to_stdout
+  end
+  it "counts the number of emails sent" do
+    number_of_emails_sent = 4
+    subscriber_list = FactoryBot.create(:subscriber_list)
+    FactoryBot.create_list(:subscription, number_of_emails_sent, subscriber_list: subscriber_list)
+    message = FactoryBot.create(:message)
+    FactoryBot.create(:matched_message, subscriber_list: subscriber_list, message: message)
+
+    expect {
+      Rake::Task["report:report_brexit_subscriptions"].execute
+    }.to output(/,#{number_of_emails_sent}$/).to_stdout
+  end
+end


### PR DESCRIPTION
A Message is a 'manual'  trigger to send an e-mail to a number of subscriptions and for now only used to send Brexit related content.

This PR adds a rake task that counts the approximate number of emails sent for each Message.

Trello: https://trello.com/c/z3REh76h/178-export-regular-data-on-email-subscriptions-for-insights-team