### PR TITLE
Record timing of full email batch inserts

### DIFF
--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -8,7 +8,9 @@ class ContentChangeEmailBuilder
   end
 
   def call
-    Email.import!(columns, records)
+    Email.timed_bulk_insert(columns,
+                            records,
+                            ImmediateEmailGenerationWorker::BATCH_SIZE)
   end
 
   private_class_method :new

--- a/app/builders/message_email_builder.rb
+++ b/app/builders/message_email_builder.rb
@@ -8,7 +8,9 @@ class MessageEmailBuilder
   end
 
   def call
-    Email.import!(columns, records)
+    Email.timed_bulk_insert(columns,
+                            records,
+                            ImmediateEmailGenerationWorker::BATCH_SIZE)
   end
 
   private_class_method :new

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -14,4 +14,10 @@ class Email < ApplicationRecord
   enum failure_reason: { permanent_failure: 0, retries_exhausted_failure: 1 }
 
   validates :address, :subject, :body, presence: true
+
+  def self.timed_bulk_insert(columns, records, batch_size)
+    return import!(columns, records) unless records.size == batch_size
+
+    MetricsService.email_bulk_insert(batch_size) { import!(columns, records) }
+  end
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -32,6 +32,10 @@ class MetricsService
       time("digest_initiator_service.#{range}.timing", &block)
     end
 
+    def email_bulk_insert(size, &block)
+      time("email_bulk_insert.#{size}.timing", &block)
+    end
+
     def first_delivery_attempt(email, time)
       return if DeliveryAttempt.exists?(email: email)
 

--- a/app/workers/immediate_email_generation_worker.rb
+++ b/app/workers/immediate_email_generation_worker.rb
@@ -4,10 +4,11 @@ class ImmediateEmailGenerationWorker
   sidekiq_options queue: :email_generation_immediate
 
   LOCK_NAME = "immediate_email_generation_worker".freeze
+  BATCH_SIZE = 5000
 
   def perform
     ensure_only_running_once do
-      SubscribersForImmediateEmailQuery.call.find_in_batches(batch_size: 5000) do |group|
+      SubscribersForImmediateEmailQuery.call.find_in_batches(batch_size: BATCH_SIZE) do |group|
         subscription_contents = grouped_subscription_contents(group.pluck(:id))
         update_content_change_cache(subscription_contents)
         update_message_cache(subscription_contents)

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -10,4 +10,28 @@ RSpec.describe Email do
       expect(subject.errors[:body]).not_to be_empty
     end
   end
+
+  describe ".timed_bulk_insert" do
+    let(:columns) { %w[subject body address] }
+
+    let(:records) do
+      3.times.map { |i| ["subject #{i}", "body #{i}", "#{i}@example.com"] }
+    end
+
+    context "when we're inserting a full batch of emails" do
+      it "times the insert" do
+        expect(MetricsService).to receive(:email_bulk_insert).and_call_original
+        expect(described_class).to receive(:import!).with(columns, records)
+        described_class.timed_bulk_insert(columns, records, 3)
+      end
+    end
+
+    context "when we're not inserting a full batch of emails" do
+      it "doesn't time the insert" do
+        expect(MetricsService).not_to receive(:email_bulk_insert)
+        expect(described_class).to receive(:import!).with(columns, records)
+        described_class.timed_bulk_insert(columns, records, 5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This sets up metrics to record when a full batch of 5000 emails is
inserted into the database. We only want to time a full batch as that
provide an accurate basis for performance comparison. The intention is
to use this data to get an understanding of the performance impacts of
these large inserts.

The statsd key uses the number of items inserted so that any changes to
this number can be represented as a new data point.

/cc @bevanloon @oscarwyatt 