### PR TITLE
Fix prod rake tasks due to missing rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path("config/application", __dir__)
-require "rubocop/rake_task"
 
-RuboCop::RakeTask.new
 Rails.application.load_tasks
 
-task default: %i[spec rubocop]
+task default: %i[spec]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,7 @@
+unless Rails.env.production?
+  require "rubocop/rake_task"
+
+  RuboCop::RakeTask.new
+
+  task(:default).prerequisites << task(:rubocop)
+end


### PR DESCRIPTION
As RuboCop is only a test dependency, it is not available during production. This causes rake in production mode to fail as the Rakefile requires rubocop to define the tasks.