### PR TITLE
Set sidekiq verbosity to false

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:verbose: true
+:verbose: false
 :concurrency: 30
 :logfile: ./log/sidekiq.json.log
 :timeout: 4


### PR DESCRIPTION
Sidekiq is logging a lot on production and during large email runs is
filling up the disk. Set the log verbosity to false to keep it a little
more succinct.