### PR TITLE
Fixes the current create_subscription api call

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -178,13 +178,19 @@ new email address.
 ```json
 {
   "address": "email@address.com",
-  "subscriber_list_id": "The id of a subscriber list"
+  "subscriber_list_id": "The id of a subscriber list",
+  "frequency": "weekly"
 }
 ```
 
 and it will create a new subscription between the email address and the
 subscriber list. It will respond with a `201 Created` if it's a new
-subscription or a `200 OK` if the subscription already exists.
+subscription or a `200 OK` if the subscription already exists. If a 
+subscription already exists but the frequency is different, the
+current subscription is ended and a new one with the updated frequency
+is created. A confirmation email will be sent if a new subscription is 
+created or if the subscriber is reactivated and the subscription already
+exists.
 
 * `PATCH /subscriptions/xxxx` with data:
 


### PR DESCRIPTION
Previously, when a user attempted to create a subscription multiple times the code would end the existing subscription, recreate the subscription and send an email.

This PR fixes the behaviour of the API so that it returns a no-op success when the specified subscription already exists. The API still replaces an existing subscription if the one specified has a different frequency.

Trello: https://trello.com/c/L9Oxr2Qx/279-double-opt-in-ignore-multiple-attempts-to-subscribe