### PR TITLE
Scope '/authenticate' route under '/manage'

### DIFF
--- a/app/services/public_url_service.rb
+++ b/app/services/public_url_service.rb
@@ -14,7 +14,7 @@ module PublicUrlService
     end
 
     def authenticate_url(address:)
-      "#{website_root}/email/authenticate?#{param('address', address)}"
+      "#{website_root}/email/manage/authenticate?#{param('address', address)}"
     end
 
     def absolute_url(path:)

--- a/spec/builders/content_change_email_builder_spec.rb
+++ b/spec/builders/content_change_email_builder_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ContentChangeEmailBuilder do
               ---
               ^You’re getting this email because you subscribed to immediate updates to ‘#{subscriptions.first.subscriber_list.title}’ on GOV.UK.
 
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
+              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
 
               Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
             BODY
@@ -152,7 +152,7 @@ RSpec.describe ContentChangeEmailBuilder do
               ---
               ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscriptions.second.subscriber_list.title}](#{Plek.new.website_root}#{subscriptions.second.subscriber_list.url})’ on GOV.UK.
 
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
+              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
 
               Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
             BODY

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe DigestEmailBuilder do
 
         ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
-        [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+        [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
         Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
       BODY

--- a/spec/builders/message_email_builder_spec.rb
+++ b/spec/builders/message_email_builder_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe MessageEmailBuilder do
               ---
               ^You’re getting this email because you subscribed to immediate updates to ‘#{subscriptions.first.subscriber_list.title}’ on GOV.UK.
 
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
+              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
             BODY
           )
         end
@@ -125,7 +125,7 @@ RSpec.describe MessageEmailBuilder do
               ---
               ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscription.subscriber_list.title}](#{Plek.new.website_root}#{subscription.subscriber_list.url})’ on GOV.UK.
 
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test%40example.com)
+              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
             BODY
           )
         end

--- a/spec/features/create_and_deliver_digests_spec.rb
+++ b/spec/features/create_and_deliver_digests_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -121,7 +121,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -332,7 +332,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
@@ -370,7 +370,7 @@ RSpec.describe "creating and delivering digests", type: :request do
 
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
 
       Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Sending an email", type: :request do
     expect(body).to include("Change note")
     expect(body).to include("12:00am, 1 January 2017")
     expect(body).to include("View, unsubscribe or change the frequency of your subscriptions")
-    expect(body).to include("gov.uk/email/authenticate?address=")
+    expect(body).to include("gov.uk/email/manage/authenticate?address=")
   end
 
   scenario "sending an email for a message" do
@@ -47,6 +47,6 @@ RSpec.describe "Sending an email", type: :request do
 
     expect(body).to include("Body")
     expect(body).to include("View, unsubscribe or change the frequency of your subscriptions")
-    expect(body).to include("gov.uk/email/authenticate?address=")
+    expect(body).to include("gov.uk/email/manage/authenticate?address=")
   end
 end

--- a/spec/presenters/manage_subscriptions_link_presenter_spec.rb
+++ b/spec/presenters/manage_subscriptions_link_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ManageSubscriptionsLinkPresenter do
   describe ".call" do
     it "returns a manage subscriptions link" do
-      expected = "[View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/authenticate?address=test-email%40test.com)"
+      expected = "[View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test-email%40test.com)"
       expect(described_class.call("test-email@test.com")).to eq(expected)
     end
   end


### PR DESCRIPTION
https://trello.com/c/dIAlk2dp/278-double-opt-in-create-a-subscription-before-the-success-page

This updates the path we embed in emails for managing subscriptions to
match the new scoped route in email-alert-frontend.

https://github.com/alphagov/email-alert-frontend/pull/609