### PR TITLE
Send a confirmation email as part of double opt in

### DIFF
--- a/app/builders/subscriber_auth_email_builder.rb
+++ b/app/builders/subscriber_auth_email_builder.rb
@@ -1,4 +1,4 @@
-class AuthEmailBuilder
+class SubscriberAuthEmailBuilder
   def initialize(subscriber:, destination:, token:)
     @subscriber = subscriber
     @destination = destination

--- a/app/builders/subscription_auth_email_builder.rb
+++ b/app/builders/subscription_auth_email_builder.rb
@@ -1,0 +1,55 @@
+class SubscriptionAuthEmailBuilder
+  def initialize(address:, token:, topic_id:, frequency:)
+    @address = address
+    @token = token
+    @topic_id = topic_id
+    @frequency = frequency
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    Email.create!(
+      subject: subject,
+      body: body,
+      address: address,
+      )
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :address, :token, :frequency, :topic_id
+
+  def subject
+    "Confirm your subscription"
+  end
+
+  def body
+    <<~BODY
+      # Click the link to confirm your subscription
+
+      ^[Confirm your subscription](#{link})^
+
+      This link will stop working in 7 days.
+
+      **Didn’t request this email?**
+
+      Ignore or delete this email if you didn’t request it.
+
+      [Read our privacy policy (opens in a new tab)](https://www.gov.uk/help/privacy-notice) to find out how we use and protect your data.
+
+      [Contact GOV.UK](https://www.gov.uk/contact/govuk) if you have any problems with your email subscriptions.
+    BODY
+  end
+
+  def link
+    Plek.new.website_uri.tap do |uri|
+      uri.path = "/email/subscriptions/authenticate"
+      uri.query = "token=#{token}&topic_id=#{topic_id}&frequency=#{frequency}"
+    end
+  end
+end

--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -31,7 +31,7 @@ private
   end
 
   def build_email(subscriber, token)
-    AuthEmailBuilder.call(
+    SubscriberAuthEmailBuilder.call(
       subscriber: subscriber,
       destination: expected_params.require(:destination),
       token: token,

--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -22,8 +22,10 @@ private
 
   def generate_token(subscriber)
     AuthTokenGeneratorService.call(
-      subscriber,
-      redirect: expected_params[:redirect],
+      {
+        "subscriber_id" => subscriber.id,
+        "redirect" => expected_params[:redirect],
+      },
       expiry: 1.week.from_now,
     )
   end

--- a/app/controllers/subscribers_controller.rb
+++ b/app/controllers/subscribers_controller.rb
@@ -4,7 +4,7 @@ class SubscribersController < ApplicationController
 
   def subscriptions
     if !valid_ordering_param?
-      return render json: { error: "Order paramater not valid" }, status: :unprocessable_entity
+      return render json: { error: "Order parameter not valid" }, status: :unprocessable_entity
     end
 
     render json: { subscriber: subscriber.as_json, subscriptions: ordered_subscriptions }

--- a/app/controllers/subscriptions_auth_token_controller.rb
+++ b/app/controllers/subscriptions_auth_token_controller.rb
@@ -1,5 +1,23 @@
 class SubscriptionsAuthTokenController < ApplicationController
+  before_action :validate_params
+
   def auth_token
     render json: {}, status: :ok
+  end
+
+  def validate_params
+    ParamsValidator.new(expected_params).validate!
+  end
+
+  def expected_params
+    params.permit(:address, :topic_id, :frequency)
+  end
+
+  class ParamsValidator < OpenStruct
+    include ActiveModel::Validations
+
+    validates :address, email_address: true, presence: true
+    validates :topic_id, presence: true
+    validates :frequency, presence: true, inclusion: { in: Subscription.frequencies.keys }
   end
 end

--- a/app/controllers/subscriptions_auth_token_controller.rb
+++ b/app/controllers/subscriptions_auth_token_controller.rb
@@ -1,0 +1,5 @@
+class SubscriptionsAuthTokenController < ApplicationController
+  def auth_token
+    render json: {}, status: :ok
+  end
+end

--- a/app/controllers/subscriptions_auth_token_controller.rb
+++ b/app/controllers/subscriptions_auth_token_controller.rb
@@ -2,7 +2,20 @@ class SubscriptionsAuthTokenController < ApplicationController
   before_action :validate_params
 
   def auth_token
+    address = params.fetch(:address)
+    topic_id = params.fetch(:topic_id)
+    frequency = params.fetch(:frequency)
+
+    token = AuthTokenGeneratorService.call(address: address, topic_id: topic_id, frequency: frequency)
+    email = SubscriptionAuthEmailBuilder.call(address: address, token: token, topic_id: topic_id, frequency: frequency)
+
+    do_send email
     render json: {}, status: :ok
+  end
+
+  def do_send(email)
+    DeliveryRequestWorker
+      .perform_async_in_queue(email.id, queue: :delivery_immediate_high)
   end
 
   def validate_params

--- a/app/services/auth_token_generator_service.rb
+++ b/app/services/auth_token_generator_service.rb
@@ -3,26 +3,19 @@ class AuthTokenGeneratorService
     new.call(*args)
   end
 
-  def call(subscriber, redirect: nil, expiry: 1.week.from_now)
-    data = token_data(subscriber, redirect, expiry)
-    JWT.encode(data, secret, "HS256")
+  def call(data, expiry: 1.week.from_now)
+    token_data = {
+      "data" => data,
+      "exp" => expiry.to_i,
+      "iat" => Time.now.to_i,
+      "iss" => "https://www.gov.uk",
+    }
+    JWT.encode(token_data, secret, "HS256")
   end
 
   private_class_method :new
 
 private
-
-  def token_data(subscriber, redirect, expiry)
-    {
-      "data" => {
-        "subscriber_id" => subscriber.id,
-        "redirect" => redirect,
-      },
-      "exp" => expiry.to_i,
-      "iat" => Time.now.to_i,
-      "iss" => "https://www.gov.uk",
-    }
-  end
 
   def secret
     Rails.application.secrets.email_alert_auth_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Rails.application.routes.draw do
     patch "/subscribers/:id", to: "subscribers#change_address"
     delete "/subscribers/:id", to: "unsubscribe#unsubscribe_all"
     get "/subscribers/:id/subscriptions", to: "subscribers#subscriptions"
+
     post "/subscribers/auth-token", to: "subscribers_auth_token#auth_token"
+    post "/subscriptions/auth-token", to: "subscriptions_auth_token#auth_token"
 
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
 

--- a/spec/builders/subscriber_auth_email_builder_spec.rb
+++ b/spec/builders/subscriber_auth_email_builder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AuthEmailBuilder do
+RSpec.describe SubscriberAuthEmailBuilder do
   describe ".call" do
     let(:subscriber) { create(:subscriber) }
     let(:destination) { "/destination" }

--- a/spec/builders/subscription_auth_email_builder_spec.rb
+++ b/spec/builders/subscription_auth_email_builder_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe SubscriptionAuthEmailBuilder do
+  describe ".call" do
+    let(:address) { "test@gov.uk" }
+    let(:token) { "secret" }
+    let(:frequency) { "weekly" }
+    let(:topic_id) { "business-tax-corporation-tax" }
+
+    subject(:call) do
+      described_class.call(
+        address: address,
+        token: token,
+        topic_id: topic_id,
+        frequency: frequency,
+        )
+    end
+
+    it { is_expected.to be_instance_of(Email) }
+
+    it "creates an email" do
+      expect { call }.to change(Email, :count).by(1)
+    end
+
+    it "has a link to authenticate" do
+      link = "http://www.dev.gov.uk/email/subscriptions/authenticate?token=#{token}&topic_id=business-tax-corporation-tax&frequency=weekly"
+      email = call
+      expect(email.body).to include(link)
+    end
+  end
+end

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe "Subscribers auth token", type: :request do
       post path, params: params
     end
 
+    it "sends an email with the correct token" do
+      Timecop.freeze do
+        post path, params: params
+        expect(Email.count).to be 1
+        expected_token_data = {
+          "subscriber_id" => subscriber.id,
+          "redirect" => redirect,
+        }
+        expected_token = AuthTokenGeneratorService.call(expected_token_data)
+        expect(Email.last.body).to include(expected_token)
+      end
+    end
+
     context "when it's a user we didn't previously know" do
       before { subscriber.delete }
 

--- a/spec/integration/subscriptions_auth_token_spec.rb
+++ b/spec/integration/subscriptions_auth_token_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe "Subscriptions auth token", type: :request do
+  before { login_with_internal_app }
+
+  describe "creating an auth token" do
+    let(:path) { "/subscriptions/auth-token" }
+
+    it "returns 200" do
+      post path
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/integration/subscriptions_auth_token_spec.rb
+++ b/spec/integration/subscriptions_auth_token_spec.rb
@@ -3,10 +3,61 @@ RSpec.describe "Subscriptions auth token", type: :request do
 
   describe "creating an auth token" do
     let(:path) { "/subscriptions/auth-token" }
+    let(:address) { "test@example.com" }
+    let(:topic_id) { "business-tax-corporation-tax" }
+    let(:frequency) { "weekly" }
+    let(:params) do
+      {
+        address: address,
+        topic_id: topic_id,
+        frequency: frequency,
+      }
+    end
 
     it "returns 200" do
-      post path
+      post path, params: params
       expect(response.status).to eq(200)
+    end
+
+    context "when we're provided with no email address" do
+      let(:address) { nil }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+    context "when we're provided with a badly formatted email address" do
+      let(:address) { "wrong.bad" }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+    context "when we're provided with no topic_id" do
+      let(:topic_id) { nil }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+    context "when we're provided with no frequency" do
+      let(:frequency) { nil }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+    context "when we're provided with a bad frequency" do
+      let(:frequency) { "something_else" }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
     end
   end
 end

--- a/spec/services/auth_token_generator_service_spec.rb
+++ b/spec/services/auth_token_generator_service_spec.rb
@@ -1,11 +1,16 @@
 RSpec.describe AuthTokenGeneratorService do
   describe ".call" do
-    let(:subscriber) { create(:subscriber) }
     let(:secret) { Rails.application.secrets.email_alert_auth_token }
     let(:algorithim) { "HS256" }
     let(:expiry) { 1.day.from_now }
+    let(:data) do
+      {
+        token: "token_data_string",
+        id: "id",
+      }
+    end
 
-    subject(:token) { described_class.call(subscriber, redirect: nil, expiry: expiry) }
+    subject(:token) { described_class.call(data, expiry: expiry) }
 
     it { is_expected.to be_a(String) }
 
@@ -14,16 +19,11 @@ RSpec.describe AuthTokenGeneratorService do
         decoded = JWT.decode(token, secret, true, algorithim: algorithim)
 
         expect(decoded).to include(
-          a_hash_including(
-            "data" => a_hash_including(
-              "subscriber_id" => subscriber.id,
-              "redirect" => nil,
-            ),
-            "exp" => expiry.to_i,
-            "iat" => Time.now.to_i,
-            "iss" => "https://www.gov.uk",
-          ),
-        )
+          "data" => data.stringify_keys,
+          "exp" => expiry.to_i,
+          "iat" => Time.now.to_i,
+          "iss" => "https://www.gov.uk",
+          )
       end
     end
   end


### PR DESCRIPTION
This PR creates a new internal API in email-alert-api that will generate a confirmation email to a specified address. The API does not rely upon or create a subscriber; this will be done as part of confirming the subscription.

The email contains a link back to the signup flow, where the user completes their subscription. The email contains a 'token' query param that will be used to authenticate the address being subscribed.

Trello: https://trello.com/c/Dte8k1Aa/280-double-opt-in-create-an-internal-api-to-send-double-opt-in-emails