### PR TITLE
Change daily digest kick off

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -16,7 +16,7 @@
     every: '5s'
     class: ImmediateEmailGenerationWorker
   daily_digest_initiator:
-    cron: '0 9 * * * Europe/London' # every day at 9:00am
+    cron: '30 9 * * * Europe/London' # every day at 9:30am
     class: DailyDigestInitiatorWorker
   weekly_digest_initiator:
     cron: '30 8 * * 6 Europe/London' # every Saturday at 8:30am


### PR DESCRIPTION
Incrementally bump the email-alert-api daily digest kick off time from
8:30am to 9:30 am in increments. This commit bumps it to start at 9:30 am.

We want this to kick off a bit later to support email alert api
migration to AWS.

[Trello](https://trello.com/c/D7gapfB0/1598-incrementally-bump-the-email-digest-time-to-930)