### PR TITLE
Revert daily digest cron job to original time

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -14,7 +14,7 @@
   - cleanup
 :schedule:
   daily_digest_initiator:
-    cron: '30 9 * * * Europe/London' # every day at 9:30am
+    cron: '30 8 * * * Europe/London' # every day at 8:30am
     class: DailyDigestInitiatorWorker
   weekly_digest_initiator:
     cron: '30 8 * * 6 Europe/London' # every Saturday at 8:30am


### PR DESCRIPTION
To be merged after migration to AWS is completed.

[Trello](https://trello.com/c/wZZsby41/895-revert-email-alert-api-daily-digest-to-830-am)