### PR TITLE
Fix subscription auth email builder.

### DIFF
--- a/app/builders/subscription_auth_email_builder.rb
+++ b/app/builders/subscription_auth_email_builder.rb
@@ -32,11 +32,11 @@ private
     <<~BODY
       # Click the link to confirm your subscription
 
-      ^[Confirm your subscription](#{link})^
+      ^ [Confirm your subscription](#{link})
 
       This link will stop working in 7 days.
 
-      **Didn’t request this email?**
+      # Didn’t request this email?
 
       Ignore or delete this email if you didn’t request it.
 


### PR DESCRIPTION
The previous version sent Govspeak, but that is not the format
Notify accepts. This PR fixes this.

![image](https://user-images.githubusercontent.com/6050162/70067828-ca5d6080-15e6-11ea-9f36-774a0835dab1.png)
