### PR TITLE
Fix linting error in master

### DIFF
--- a/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
       threads = 10.times.map do
         Thread.new do
           true while wait_for_it
-          # rubocop:disable HandleExceptions
+          # rubocop:disable Lint/SuppressedException
           begin
             ProcessContentChangeAndGenerateEmailsWorker.new.perform(content_change.id)
           rescue ActiveRecord::ActiveRecordError
@@ -201,7 +201,7 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
             # Sidekiq will retry this for us so we don't need to handle it in the worker
             # But if we don't rescue it here it the test will occasionally fail
           end
-          # rubocop:enable HandleExceptions
+          # rubocop:enable Lint/SuppressedException
         end
       end
       wait_for_it = false

--- a/spec/workers/process_message_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_message_and_generate_emails_worker_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
       threads = 5.times.map do
         Thread.new do
           true while wait_for_it
-          # rubocop:disable HandleExceptions
+          # rubocop:disable Lint/SuppressedException
           begin
             ProcessMessageAndGenerateEmailsWorker.new.perform(message.id)
           rescue ActiveRecord::ActiveRecordError
@@ -224,7 +224,7 @@ RSpec.describe ProcessMessageAndGenerateEmailsWorker do
             # Sidekiq will retry this for us so we don't need to handle it in the worker
             # But if we don't rescue it here it the test will occasionally fail
           end
-          # rubocop:enable HandleExceptions
+          # rubocop:enable Lint/SuppressedException
         end
       end
       wait_for_it = false


### PR DESCRIPTION
This is [preventing builds from succeeding](https://ci.integration.publishing.service.gov.uk/job/email-alert-api/job/master/986/console):

```
spec/workers/process_content_change_and_generate_emails_worker_spec.rb:196:11: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of HandleExceptions (unknown cop).
spec/workers/process_content_change_and_generate_emails_worker_spec.rb:199:11: W: Lint/SuppressedException: Do not suppress exceptions. (https://rubystyle.guide#dont-hide-exceptions)
spec/workers/process_message_and_generate_emails_worker_spec.rb:219:11: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of HandleExceptions (unknown cop).
spec/workers/process_message_and_generate_emails_worker_spec.rb:222:11: W: Lint/SuppressedException: Do not suppress exceptions. (https://rubystyle.guide#dont-hide-exceptions)
```