### PR TITLE
Add rake task to give subscriber count for a given date

### DIFF
--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -199,6 +199,6 @@ LIMIT 10;
 [athena-queries]: https://docs.aws.amazon.com/athena/latest/ug/functions-operators-reference-section.html
 [aws]: https://aws.amazon.com
 [console-instructions]: https://docs.publishing.service.gov.uk/manual/seeing-things-in-the-aws-console.html
-[rake-count-subscribers]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers['subscriber-list-slug']
-[rake-count-subscribers-on]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers-on[yyyy-mm-dd,'subscriber-list-slug']
+[rake-count-subscribers]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers['subscriber-list-slug']
+[rake-count-subscribers-on]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers-on[yyyy-mm-dd,'subscriber-list-slug']
 [schema.rb]: https://github.com/alphagov/email-alert-api/tree/master/db/schema.rb

--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -45,6 +45,11 @@ includes a breakdown of subscriptions that are Immediate, Daily or Weekly:
 Subscription.active_on("2018-06-01").where(subscriber_list_id: 4194).count
 ```
 
+There is a [rake task][rake-count-subscribers-on] that does this for you, and
+includes a breakdown of subscriptions that are Immediate, Daily or Weekly:
+
+`query:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']`
+
 ### Lists with most new subscriptions in a time frame
 
 ```ruby
@@ -195,4 +200,5 @@ LIMIT 10;
 [aws]: https://aws.amazon.com
 [console-instructions]: https://docs.publishing.service.gov.uk/manual/seeing-things-in-the-aws-console.html
 [rake-count-subscribers]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers['subscriber-list-slug']
+[rake-count-subscribers-on]: https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers-on[yyyy-mm-dd,'subscriber-list-slug']
 [schema.rb]: https://github.com/alphagov/email-alert-api/tree/master/db/schema.rb

--- a/lib/tasks/count_subscribers.rake
+++ b/lib/tasks/count_subscribers.rake
@@ -12,4 +12,18 @@ namespace :query do
         - #{active_subscriptions.where(frequency: :weekly).count} are signed up for Weekly updates
     """
   end
+
+  desc "Query how many active subscribers there are to the given subscription slug at the given point in time"
+  task :count_subscribers_on, %i[date subscription_list_slug] => :environment do |_t, args|
+    slug = args[:subscription_list_slug]
+    subscription_list = SubscriberList.find_by!(slug: slug)
+    active_subscriptions = Subscription.active_on(args[:date]).where(subscriber_list_id: subscription_list.id)
+
+    puts """
+      The SubscriberList '#{slug}' has #{active_subscriptions.count} active subscriptions, of which:
+        - #{active_subscriptions.where(frequency: :immediately).count} are signed up for Immediate updates
+        - #{active_subscriptions.where(frequency: :daily).count} are signed up for Daily updates
+        - #{active_subscriptions.where(frequency: :weekly).count} are signed up for Weekly updates
+    """
+  end
 end


### PR DESCRIPTION
"How many people were subscribed to email list X in months A, B, and C" is a fairly common 2ndline request, so it makes sense to add a rake task for that.