### PR TITLE
Add status updates sidekiq job

### DIFF
--- a/app/services/global_metrics_service.rb
+++ b/app/services/global_metrics_service.rb
@@ -1,0 +1,25 @@
+class GlobalMetricsService
+  class << self
+    def delivery_attempt_pending_status_total(total)
+      gauge("delivery_attempt.pending_status_total", total)
+    end
+
+    def delivery_attempt_total(total)
+      gauge("delivery_attempt.total", total)
+    end
+
+  private
+
+    def statsd
+      @statsd ||= begin
+        statsd = Statsd.new
+        statsd.namespace = "govuk.email-alert-api"
+        statsd
+      end
+    end
+
+    def gauge(stat, metric)
+      statsd.gauge(stat, metric)
+    end
+  end
+end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -64,14 +64,6 @@ class MetricsService
       increment("delivery_attempt.status.#{status}")
     end
 
-    def delivery_attempt_pending_status_total(total)
-      gauge("delivery_attempt.pending_status_total", total)
-    end
-
-    def delivery_attempt_total(total)
-      gauge("delivery_attempt.total", total)
-    end
-
   private
 
     def increment(metric)
@@ -84,18 +76,6 @@ class MetricsService
 
     def timing(namespace, difference)
       GovukStatsd.timing(namespace, difference)
-    end
-
-    def gauge(stat, metric)
-      statsd.gauge(stat, metric)
-    end
-
-    def statsd
-      @statsd ||= begin
-        statsd = Statsd.new
-        statsd.namespace = "govuk.email-alert-api"
-        statsd
-      end
     end
   end
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -64,6 +64,14 @@ class MetricsService
       increment("delivery_attempt.status.#{status}")
     end
 
+    def delivery_attempt_pending_status_total(total)
+      gauge("delivery_attempt.pending_status_total", total)
+    end
+
+    def delivery_attempt_total(total)
+      gauge("delivery_attempt.total", total)
+    end
+
   private
 
     def increment(metric)

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -77,5 +77,17 @@ class MetricsService
     def timing(namespace, difference)
       GovukStatsd.timing(namespace, difference)
     end
+
+    def gauge(stat, metric)
+      statsd.gauge(stat, metric)
+    end
+
+    def statsd
+      @statsd ||= begin
+        statsd = Statsd.new
+        statsd.namespace = "govuk.email-alert-api"
+        statsd
+      end
+    end
   end
 end

--- a/app/workers/status_update_worker.rb
+++ b/app/workers/status_update_worker.rb
@@ -1,0 +1,31 @@
+class StatusUpdateWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :cleanup
+
+  def perform
+    MetricsService.delivery_attempt_pending_status_total(total_pending)
+    MetricsService.delivery_attempt_total(total)
+  end
+
+private
+
+  def totals
+    @totals ||= DeliveryAttempt
+      .where("created_at > ? AND created_at <= ?", (1.hour + 10.minutes).ago, 10.minutes.ago)
+      .group("CASE WHEN status = 0 THEN 'pending' ELSE 'done' END")
+      .count
+  end
+
+  def total_pending
+    totals.fetch("pending", 0)
+  end
+
+  def total_done
+    totals.fetch("done", 0)
+  end
+
+  def total
+    total_pending + total_done
+  end
+end

--- a/app/workers/status_update_worker.rb
+++ b/app/workers/status_update_worker.rb
@@ -4,8 +4,8 @@ class StatusUpdateWorker
   sidekiq_options queue: :cleanup
 
   def perform
-    MetricsService.delivery_attempt_pending_status_total(total_pending)
-    MetricsService.delivery_attempt_total(total)
+    GlobalMetricsService.delivery_attempt_pending_status_total(total_pending)
+    GlobalMetricsService.delivery_attempt_total(total)
   end
 
 private

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -31,3 +31,6 @@
   digest_run_completion_marker:
     every: '1m'
     class: DigestRunCompletionMarkerWorker
+  status_updates:
+    every: '1m'
+    class: StatusUpdateWorker

--- a/spec/workers/status_update_worker_spec.rb
+++ b/spec/workers/status_update_worker_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe StatusUpdateWorker do
+  describe ".perform" do
+    context "find delivery attempts created within the last hour" do
+      let(:statsd) { double }
+
+      before do
+        3.times { create(:delivery_attempt, status: 0, created_at: 40.minutes.ago) }
+        2.times { create(:delivery_attempt, status: 1, created_at: 20.minutes.ago) }
+        allow(Statsd).to receive(:gauge)
+      end
+
+      it "records a metric for the total number of pending delivery attempts" do
+        expect(MetricsService).to receive(:delivery_attempt_pending_status_total).with(3)
+        described_class.new.perform
+      end
+
+      it "records a metric for the total number of delivery attempts" do
+        expect(MetricsService).to receive(:delivery_attempt_total).with(5)
+        described_class.new.perform
+      end
+
+      it "sends the correct values to statsd" do
+        expect(MetricsService).to receive(:statsd).and_return(statsd).twice
+
+        expect(statsd).to receive(:gauge).with("delivery_attempt.total", 5)
+        expect(statsd).to receive(:gauge).with("delivery_attempt.pending_status_total", 3)
+
+        described_class.new.perform
+      end
+    end
+  end
+
+  describe ".perform_async" do
+    before do
+      Sidekiq::Testing.fake! do
+        described_class.perform_async
+      end
+    end
+
+    it "gets put on the low priority 'cleanup' queue" do
+      expect(Sidekiq::Queues["cleanup"].size).to eq(2)
+    end
+  end
+end

--- a/spec/workers/status_update_worker_spec.rb
+++ b/spec/workers/status_update_worker_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe StatusUpdateWorker do
       before do
         3.times { create(:delivery_attempt, status: 0, created_at: 40.minutes.ago) }
         2.times { create(:delivery_attempt, status: 1, created_at: 20.minutes.ago) }
-        allow(Statsd).to receive(:gauge)
+        allow(GlobalMetricsService.send(:statsd)).to receive(:gauge)
       end
 
       it "records a metric for the total number of pending delivery attempts" do
-        expect(MetricsService).to receive(:delivery_attempt_pending_status_total).with(3)
+        expect(GlobalMetricsService).to receive(:delivery_attempt_pending_status_total).with(3)
         described_class.new.perform
       end
 
       it "records a metric for the total number of delivery attempts" do
-        expect(MetricsService).to receive(:delivery_attempt_total).with(5)
+        expect(GlobalMetricsService).to receive(:delivery_attempt_total).with(5)
         described_class.new.perform
       end
 
       it "sends the correct values to statsd" do
-        expect(MetricsService).to receive(:statsd).and_return(statsd).twice
-
-        expect(statsd).to receive(:gauge).with("delivery_attempt.total", 5)
-        expect(statsd).to receive(:gauge).with("delivery_attempt.pending_status_total", 3)
+        expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        .with("delivery_attempt.total", 5)
+        expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        .with("delivery_attempt.pending_status_total", 3)
 
         described_class.new.perform
       end


### PR DESCRIPTION
We are moving away from using a healthcheck to monitor the status
of delivery attempts created within the past hour.

This sidekiq job will run every 1 min and send the total number
of delivery attempts as well as the number of pending to Graphite.
We can use StatD's `gauge` feature to maintain the current values
until they are next updated.

Trello card: https://trello.com/c/hPiOuVko/1581-5-extract-the-statusupdates-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check