### PR TITLE
Encrypt token data (as well as signing it)

### DIFF
--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -22,11 +22,8 @@ private
 
   def generate_token(subscriber)
     AuthTokenGeneratorService.call(
-      {
-        "subscriber_id" => subscriber.id,
-        "redirect" => expected_params[:redirect],
-      },
-      expiry: 1.week.from_now,
+      "subscriber_id" => subscriber.id,
+      "redirect" => expected_params[:redirect],
     )
   end
 

--- a/app/services/auth_token_generator_service.rb
+++ b/app/services/auth_token_generator_service.rb
@@ -1,16 +1,17 @@
 class AuthTokenGeneratorService
+  CIPHER = "aes-256-gcm".freeze
+  OPTIONS = { cipher: CIPHER, serializer: JSON }.freeze
+
   def self.call(*args)
     new.call(*args)
   end
 
-  def call(data, expiry: 1.week.from_now)
-    token_data = {
-      "data" => data,
-      "exp" => expiry.to_i,
-      "iat" => Time.now.to_i,
-      "iss" => "https://www.gov.uk",
-    }
-    JWT.encode(token_data, secret, "HS256")
+  def call(data, expiry: 1.week)
+    len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
+    key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
+    crypt = ActiveSupport::MessageEncryptor.new(key, OPTIONS)
+    token = crypt.encrypt_and_sign(data, expires_in: expiry)
+    CGI.escape(token)
   end
 
   private_class_method :new

--- a/spec/integration/subscriptions_auth_token_spec.rb
+++ b/spec/integration/subscriptions_auth_token_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Subscriptions auth token", type: :request do
+  include TokenHelpers
+
   before { login_with_internal_app }
 
   describe "creating an auth token" do
@@ -70,17 +72,14 @@ RSpec.describe "Subscriptions auth token", type: :request do
     end
 
     it "sends an email with the correct token" do
-      Timecop.freeze do
-        post path, params: params
-        expect(Email.count).to be 1
-        expected_token_data = {
-          "address" => address,
-          "topic_id" => topic_id,
-          "frequency" => frequency,
-        }
-        expected_token = AuthTokenGeneratorService.call(expected_token_data)
-        expect(Email.last.body).to include(expected_token)
-      end
+      post path, params: params
+      expect(Email.count).to be 1
+      token = Email.last.body.match(/token=([^&)]+)/)[1]
+      expect(decrypt_and_verify_token(token)).to eq(
+        "address" => address,
+        "topic_id" => topic_id,
+        "frequency" => frequency,
+      )
     end
   end
 end

--- a/spec/support/token_helpers.rb
+++ b/spec/support/token_helpers.rb
@@ -1,0 +1,13 @@
+module TokenHelpers
+  def decrypt_and_verify_token(data)
+    cipher = AuthTokenGeneratorService::CIPHER
+    len = ActiveSupport::MessageEncryptor.key_len(cipher)
+
+    secret = Rails.application.secrets.email_alert_auth_token
+    key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
+
+    options = AuthTokenGeneratorService::OPTIONS
+    crypt = ActiveSupport::MessageEncryptor.new(key, options)
+    crypt.decrypt_and_verify(CGI.unescape(data))
+  end
+end


### PR DESCRIPTION
https://trello.com/c/FwB5bALg/336-double-opt-in-fix-data-leak

Previously we used JWT tokens as part of an authentication mechanism to
create or manage subscriptions. Only GOV.UK with the shared secret could
decode a token, thus confirming the origin of the data within. However,
only the signature of the token is protected by the shared secret; the
rest of the payload can be decoded to plaintext without.

This replaces the use of JWT with Rails' MessageEncryptor, which signs
and encrypts the payload, thus protecting all of it from exposure in
logs and analytics. Since the exact characters in the token vary with
the same payload, the testing approach now involves decoding the token
in order to verify its content.

Since the token is Base64 encoded, we need to escape the token string,
to avoid the '+', '=' and '/' characters, which are reserved as part of
URLs but can be present in the initial token.

https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/activesupport/lib/active_support/message_encryptor.rb#L179
https://en.wikipedia.org/wiki/Base64