### PR TITLE
Use a hash instead of a full Subscriber model

### DIFF
--- a/app/queries/subscribers_for_immediate_email_query.rb
+++ b/app/queries/subscribers_for_immediate_email_query.rb
@@ -1,5 +1,5 @@
 class SubscribersForImmediateEmailQuery
-  def self.call(content_change_id: nil, message_id: nil)
+  def self.call_in_batches(content_change_id: nil, message_id: nil)
     additional_parameters = {
       content_change_id: content_change_id,
       message_id: message_id,
@@ -13,6 +13,11 @@ class SubscribersForImmediateEmailQuery
         .arel
         .exists
 
-    Subscriber.activated.where(unprocessed_subscription_content_exists)
+    Subscriber.in_batches(of: ImmediateEmailGenerationWorker::BATCH_SIZE).each do |relation|
+      subscribers = relation.activated.where(unprocessed_subscription_content_exists).
+        pluck(:id, :address).
+        map { |id_address| { id: id_address.first, address: id_address.second } }
+      yield(subscribers)
+    end
   end
 end

--- a/app/workers/process_and_generate_emails_worker.rb
+++ b/app/workers/process_and_generate_emails_worker.rb
@@ -40,7 +40,7 @@ private
     email_data = subscribers.flat_map do |subscriber|
       subscribers_content_change_email_data(
         subscriber,
-        subscription_contents[subscriber.id],
+        subscription_contents[subscriber[:id]],
       )
     end
 
@@ -58,10 +58,10 @@ private
     by_content_change_id.map do |content_change_id, matching_subscription_contents|
       {
         params: {
-          address: subscriber.address,
+          address: subscriber[:address],
           content_change: content_changes[content_change_id],
           subscriptions: matching_subscription_contents.map(&:subscription),
-          subscriber_id: subscriber.id,
+          subscriber_id: subscriber[:id],
         },
         subscription_contents: matching_subscription_contents,
         priority: content_changes[content_change_id].priority.to_sym,
@@ -73,7 +73,7 @@ private
     email_data = subscribers.flat_map do |subscriber|
       subscribers_message_email_data(
         subscriber,
-        subscription_contents[subscriber.id],
+        subscription_contents[subscriber[:id]],
       )
     end
 
@@ -90,10 +90,10 @@ private
     by_message_id.map do |message_id, matching_subscription_contents|
       {
         params: {
-          address: subscriber.address,
+          address: subscriber[:address],
           message: messages[message_id],
           subscriptions: matching_subscription_contents.map(&:subscription),
-          subscriber_id: subscriber.id,
+          subscriber_id: subscriber[:id],
         },
         subscription_contents: matching_subscription_contents,
         priority: messages[message_id].priority.to_sym,

--- a/spec/queries/subscribers_for_immediate_email_query_spec.rb
+++ b/spec/queries/subscribers_for_immediate_email_query_spec.rb
@@ -1,24 +1,32 @@
 require "rails_helper"
 
 RSpec.describe SubscribersForImmediateEmailQuery do
+  def count
+    count = 0
+    described_class.call_in_batches do |batch|
+      count += batch.count
+    end
+    count
+  end
+
   it "returns Subscriber objects that have an email-less SubscriptionContent" do
     create(:subscription_content, email: nil)
-    expect(described_class.call.count).to eq(1)
+    expect(count).to eq(1)
   end
 
   it "does not return Subscriber objects with email_id != nil" do
     create(:subscription_content, email: build(:email))
-    expect(described_class.call.count).to eq(0)
+    expect(count).to eq(0)
   end
 
   it "does not return Subscriber for nullified subscribers" do
     create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :nullified)))
-    expect(described_class.call.count).to eq(0)
+    expect(count).to eq(0)
   end
 
   it "does not return Subscriber for deactivates subscribers" do
     create(:subscription_content, subscription: create(:subscription, subscriber: create(:subscriber, :deactivated)))
-    expect(described_class.call.count).to eq(0)
+    expect(count).to eq(0)
   end
 
   it "returns one record per subscriber" do
@@ -31,6 +39,6 @@ RSpec.describe SubscribersForImmediateEmailQuery do
     create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
     create(:subscription_content, subscription: create(:subscription, subscriber: subscriber), content_change: content_change)
 
-    expect(described_class.call.count).to eq(1)
+    expect(count).to eq(1)
   end
 end


### PR DESCRIPTION
Should save some memory and potentially a small speed increase