### PR TITLE
Add validation to SubsciberList tags

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -5,6 +5,7 @@ class SubscriberList < ApplicationRecord
   self.include_root_in_json = true
 
   validates :tags, tags: true
+  validates :links, links: true
   validate :link_values_are_valid
 
   validates :title, presence: true

--- a/app/validators/links_validator.rb
+++ b/app/validators/links_validator.rb
@@ -1,0 +1,19 @@
+class LinksValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, links)
+    invalidly_formatted = invalid_formatted_links(links)
+    if invalidly_formatted.any?
+      record.errors.add(attribute, "#{invalidly_formatted.to_sentence} has a value with an invalid format.")
+    end
+  end
+
+private
+
+  def invalid_formatted_links(links)
+    invalid = links.select do |_key, link_values|
+      link_values.flat_map(&:last)
+        .any? { |link| !link.to_s.match?(/\A[a-zA-Z0-9\-_]*\z/) }
+    end
+
+    invalid.keys
+  end
+end

--- a/app/validators/tags_validator.rb
+++ b/app/validators/tags_validator.rb
@@ -7,6 +7,11 @@ class TagsValidator < ActiveModel::EachValidator
     if invalid_tags(tags).any?
       record.errors.add(attribute, "#{invalid_tags(tags).to_sentence} are not valid tags.")
     end
+
+    invalidly_formatted = invalid_formatted_tags(tags)
+    if invalidly_formatted.any?
+      record.errors.add(attribute, "#{invalidly_formatted.to_sentence} has a value with an invalid format.")
+    end
   end
 
 private
@@ -21,5 +26,14 @@ private
         %i[all any].include?(operator) && values.is_a?(Array)
       end
     end
+  end
+
+  def invalid_formatted_tags(tags)
+    invalid = tags.select do |_key, tag_values|
+      tag_values.flat_map(&:last)
+        .any? { |tag| !tag.to_s.match?(/\A[a-zA-Z0-9\-_\/]*\z/) }
+    end
+
+    invalid.keys
   end
 end

--- a/spec/integration/browsing_subscriber_lists_spec.rb
+++ b/spec/integration/browsing_subscriber_lists_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe "Browsing subscriber lists", type: :request do
         login_with_internal_app
       end
 
+      let(:uuid) { SecureRandom.uuid }
+
       let!(:subscriber_list_links_only) do
         create(
           :subscriber_list,
           links: {
-            topics: { any: ["oil-and-gas/licensing", "drug-device-alert"] },
+            topics: { any: [uuid, "drug-device-alert"] },
           },
           tags: {},
           document_type: "",
@@ -59,7 +61,7 @@ RSpec.describe "Browsing subscriber lists", type: :request do
       end
 
       it "responds with the matching subscriber list" do
-        get_subscriber_list(links: { topics: { any: ["drug-device-alert", "oil-and-gas/licensing"] } })
+        get_subscriber_list(links: { topics: { any: [uuid, "drug-device-alert"] } })
 
         database_subscriber_list = subscriber_list_links_only
         response_subscriber_list = JSON.parse(response.body).fetch("subscriber_list").deep_symbolize_keys
@@ -77,7 +79,7 @@ RSpec.describe "Browsing subscriber lists", type: :request do
       end
 
       it "finds subscriber lists that match all of the links" do
-        get_subscriber_list(links: { topics: { any: ["drug-device-alert", "oil-and-gas/licensing"] } })
+        get_subscriber_list(links: { topics: { any: [uuid, "drug-device-alert"] } })
         expect(response.status).to eq(200)
 
         subscriber_list = JSON.parse(response.body).fetch("subscriber_list")

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
     it "creates a subscriber_list with a digest of the JSON content" do
       create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
                                      location: { all: %w[france germany] } },
-                             links: { topics: { any: ["oil-and-gas/licensing"] },
+                             links: { topics: { any: %w[oil-and-gas-licensing] },
                                      location: { all: %w[france germany] } })
       expect(SubscriberList.last.tags_digest).to eq(digested(SubscriberList.last.tags))
       expect(SubscriberList.last.links_digest).to eq(digested(SubscriberList.last.links))

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MatchedForNotification do
   describe "#call" do
     before do
       @subscriber_list_that_should_never_match = create(:subscriber_list, tags: {
-        topics: { any: ["Badical Turbo Radness"] }, format: { any: %w[news_story] }
+        topics: { any: %w[Badical-Turbo-Radness] }, format: { any: %w[news_story] }
       })
     end
 

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe SubscriberListQuery do
   subject do
     described_class.new(
       tags: { policies: %w[eggs] },
-      links: { policies: %w[11aa], taxon_tree: %w[taxon1 taxon2] },
+      links: { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] },
       document_type: "travel_advice",
       email_document_supertype: "publications",
       government_document_supertype: "news_stories",
@@ -64,13 +64,13 @@ RSpec.describe SubscriberListQuery do
   end
 
   context "when matching has links fields" do
-    it_behaves_like "#links matching", links: { policies: { any: %w[11aa] },
-                                                taxon_tree: { all: %w[taxon2] } },
+    it_behaves_like "#links matching", links: { policies: { any: %w[f05dc04b-ca95-4cca-9875-a7591d055467] },
+                                                taxon_tree: { all: %w[f05dc04b-ca95-4cca-9875-a7591d055448] } },
                                        tags: {}
 
     it "excluded when non-matching links" do
-      subscriber_list = create_subscriber_list(links: { policies: { any: %w[aa11] },
-                                                        taxon_tree: { all: %w[taxon1 taxon2] } })
+      subscriber_list = create_subscriber_list(links: { policies: { any: %w[f05dc04b-ca95-4cca-9875-a7591d055467] },
+                                                        taxon_tree: { all: %w[f05dc04b-ca95-4cca-9875-a7591d055448 f05dc04b-ca95-4cca-9875-a7591d055446] } })
       expect(subject.lists).not_to include(subscriber_list)
     end
   end

--- a/spec/queries/subscriber_lists_by_criteria_query_spec.rb
+++ b/spec/queries/subscriber_lists_by_criteria_query_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SubscriberListsByCriteriaQuery do
     it "can match a link" do
       uuid = SecureRandom.uuid
       list = create(:subscriber_list, links: { format: { any: [uuid] } })
-      create(:subscriber_list, links: { format: { any: [SecureRandom] } })
+      create(:subscriber_list, links: { format: { any: [SecureRandom.uuid] } })
 
       result = described_class.call(
         SubscriberList,
@@ -56,21 +56,6 @@ RSpec.describe SubscriberListsByCriteriaQuery do
         [
           { type: "tag", key: "format", value: "match" },
           { type: "link", key: "format", value: uuid },
-        ],
-      )
-
-      expect(result).to contain_exactly(list)
-    end
-
-    it "can match a tag with a double quote inside it" do
-      unusual_tag = %{unusual string 'with things' that "might be escaped" like {} and []}
-      list = create(:subscriber_list, tags: { format: { any: [unusual_tag] } })
-      create(:subscriber_list)
-
-      result = described_class.call(
-        SubscriberList,
-        [
-          { type: "tag", key: "format", value: unusual_tag },
         ],
       )
 

--- a/spec/validators/links_validator_spec.rb
+++ b/spec/validators/links_validator_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe LinksValidator do
+  class LinksValidatable
+    include ActiveModel::Validations
+    include ActiveModel::Model
+
+    attr_accessor :links
+    validates :links, links: true
+  end
+
+  subject(:model) { LinksValidatable.new }
+
+  context "when valid links are provided" do
+    before {
+      model.links = {
+        commodity_type: { any: %w(f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a) },
+      }
+    }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when invalid links are provided" do
+    before {
+      model.links = {
+        organisations: { any: %w(dogs cats) },
+        topics: { any: %w(dogs cats) },
+        foo: { any: %w([dogs] !cats) },
+        people: { any: %w(\u0000) },
+        policies: { any: "><script>alert(1);</script>" },
+      }
+    }
+
+    it "has an error" do
+      expect(model.valid?).to be false
+      expect(model.errors[:links]).to match([
+       "foo, people, and policies has a value with an invalid format.",
+      ])
+    end
+  end
+end

--- a/spec/validators/tags_validator_spec.rb
+++ b/spec/validators/tags_validator_spec.rb
@@ -10,7 +10,14 @@ RSpec.describe TagsValidator do
   subject(:model) { TagsValidatable.new }
 
   context "when valid tags are provided" do
-    before { model.tags = { topics: { any: %w(dogs cats), all: %w(horses) } } }
+    before {
+      model.tags = {
+        topics: { any: %w(dogs cats), all: %w(horses) },
+        policies: { any: %w(wWelcome1098-_/), all: %w(news_story) },
+        commodity_type: { any: %w(f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a), all: %w(123-Abc) },
+      }
+    }
+
     it { is_expected.to be_valid }
   end
 
@@ -19,9 +26,10 @@ RSpec.describe TagsValidator do
       model.tags = {
         organisations: { any: %w(dogs cats) },
         topics: { any: %w(dogs cats) },
-        foo: { any: %w(dogs cats) },
-        people: { any: %w(dogs cats) },
+        foo: { any: %w([dogs] !cats) },
+        people: { any: %w(\u0000) },
         world_locations: { any: "dogs" },
+        policies: { any: "><script>alert(1);</script>" },
       }
     }
 
@@ -30,6 +38,7 @@ RSpec.describe TagsValidator do
       expect(model.errors[:tags]).to match([
         "All tag values must be sent as Arrays",
         "organisations, foo, people, and world_locations are not valid tags.",
+        "foo, people, and policies has a value with an invalid format.",
       ])
     end
   end


### PR DESCRIPTION
The tag is allows characters that cannot be processed in email alert api.
Therefore, we are adding validations to tags, which will only allow alphanumeric, dashes, quotes, brackets and underscores.

Trello: https://trello.com/c/so20SdvH/808