### PR TITLE
Record stats on subscription contents

### DIFF
--- a/app/services/global_metrics_service.rb
+++ b/app/services/global_metrics_service.rb
@@ -8,6 +8,14 @@ class GlobalMetricsService
       gauge("delivery_attempt.total", total)
     end
 
+    def critical_subscription_contents_total(total)
+      gauge("subscription_contents.critical_total", total)
+    end
+
+    def warning_subscription_contents_total(total)
+      gauge("subscription_contents.warning_total", total)
+    end
+
   private
 
     def statsd

--- a/app/workers/subscription_contents_worker.rb
+++ b/app/workers/subscription_contents_worker.rb
@@ -1,0 +1,71 @@
+class SubscriptionContentsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :cleanup
+
+  def perform
+    GlobalMetricsService.critical_subscription_contents_total(critical_subscription_contents)
+    GlobalMetricsService.warning_subscription_contents_total(warning_subscription_contents)
+  end
+
+private
+
+  def critical_subscription_contents
+    @critical_subscription_contents ||= count_subscription_contents.fetch(:critical)
+  end
+
+  def warning_subscription_contents
+    @warning_subscription_contents ||= count_subscription_contents.fetch(:warning)
+  end
+
+  def count_subscription_contents
+    @count_subscription_contents ||= begin
+      group_sql = ActiveRecord::Base::sanitize_sql([
+        "CASE WHEN subscription_contents.created_at < ? THEN 'critical' ELSE 'warning' END",
+        critical_latency.ago,
+      ])
+
+      # The `merge(Subscription.active)` check is because there is a
+      # race condition in email generation: if someone unsubscribes
+      # after the `ContentChange` has been processed but before the
+      # generated `SubscriptionContent`s have been, then those
+      # `SubscriptionContent`s will never get an email associated with
+      # them - this is the correct behaviour, we don't want to email
+      # people who have unsubscribed.
+      counts = SubscriptionContent
+      .where(email: nil)
+      .joins(:subscription)
+      .merge(Subscription.active)
+      .where("subscription_contents.created_at < ?", warning_latency.ago)
+      .group(group_sql)
+      .count
+
+      warning = counts.fetch("warning", 0)
+      critical = counts.fetch("critical", 0)
+
+      { warning: warning + critical, critical: critical }
+    end
+  end
+
+  def critical_latency
+    is_scheduled_publishing_time? ? 50.minutes : 15.minutes
+  end
+
+  def warning_latency
+    is_scheduled_publishing_time? ? 35.minutes : 10.minutes
+  end
+
+  # There's a lot of scheduled publishing at 09:30 UK time, so we
+  # want larger thresholds around then.
+  def is_scheduled_publishing_time?
+    @is_scheduled_publishing_time ||= begin
+      now = Time.zone.now
+      SCHEDULED_PUBLISHING_TIMES.any? { |min, max| now.between?(min, max) }
+    end
+  end
+
+  SCHEDULED_PUBLISHING_TIMES = [
+    [Time.zone.parse("09:30"), Time.zone.parse("11:00")],
+    [Time.zone.parse("12:30"), Time.zone.parse("13:30")],
+  ].freeze
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -34,3 +34,6 @@
   status_updates:
     every: '1m'
     class: StatusUpdateWorker
+  status_updates:
+    every: '1m'
+    class: SubscriptionContentsWorker

--- a/spec/workers/subscription_contents_worker_spec.rb
+++ b/spec/workers/subscription_contents_worker_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe SubscriptionContentsWorker do
+  describe ".perform" do
+    shared_examples "tests for critical and warning states" do
+      context "find subscription contents created within the last hour" do
+        let(:statsd) { double }
+
+        before do
+          create(:subscription_content, created_at: 51.minutes.ago)
+          create(:subscription_content, created_at: 36.minutes.ago)
+          allow(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        end
+
+        it "records a metric for the number of subscription contents created over
+        50 minutes ago (critical)" do
+          expect(GlobalMetricsService).to receive(:critical_subscription_contents_total).with(1)
+          described_class.new.perform
+        end
+
+        it "records a metric for the number of subscription contents created over
+        35 minutes ago (warning)" do
+          expect(GlobalMetricsService).to receive(:warning_subscription_contents_total).with(2)
+          described_class.new.perform
+        end
+
+        it "sends the correct values to statsd" do
+          expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+          .with("subscription_contents.critical_total", 1)
+          expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+          .with("subscription_contents.warning_total", 2)
+
+          described_class.new.perform
+        end
+      end
+    end
+
+    context "between 09:30 and 11:00" do
+      around do |example|
+        Timecop.freeze("10:00") { example.run }
+      end
+
+      include_examples "tests for critical and warning states"
+    end
+
+    context "between 12:30 and 13:30" do
+      around do |example|
+        Timecop.freeze("13:00") { example.run }
+      end
+
+      include_examples "tests for critical and warning states"
+    end
+
+
+    context "when not scheduled publishing time" do
+      let(:statsd) { double }
+
+      before do
+        create(:subscription_content, created_at: 21.minutes.ago)
+        create(:subscription_content, created_at: 11.minutes.ago)
+        allow(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+      end
+
+      around do |example|
+        Timecop.freeze("12:00") { example.run }
+      end
+
+      it "records a metric for the number of subscription contents created over
+      15 minutes ago (critical)" do
+        expect(GlobalMetricsService).to receive(:critical_subscription_contents_total).with(1)
+        described_class.new.perform
+      end
+
+      it "records a metric for the number of subscription contents created over
+      10 minutes ago (warning)" do
+        expect(GlobalMetricsService).to receive(:warning_subscription_contents_total).with(2)
+        described_class.new.perform
+      end
+
+      it "sends the correct values to statsd" do
+        expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        .with("subscription_contents.critical_total", 1)
+        expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        .with("subscription_contents.warning_total", 2)
+
+        described_class.new.perform
+      end
+    end
+  end
+
+  describe ".perform_async" do
+    before do
+      Sidekiq::Testing.fake! do
+        described_class.perform_async
+      end
+    end
+
+    it "gets put on the low priority 'cleanup' queue" do
+      expect(Sidekiq::Queues["cleanup"].size).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
We are moving away from using healthchecks to monitor specific
things as they were putting unnecessary load on the database on
each machine and triggering duplicate Icinga alerts.

This sidekiq job will run every 1 min and send the total number
of `critical` and `warning` subscription contents to Graphite.
We can use StatD's gauge feature to maintain the current values
until they are next updated.

We can then configure an Icinga alert in `Puppet` which will trigger
when certain values are reached. This will not longer be machine
specific and come through from the monitoring machine.

Trello card: https://trello.com/c/dtdY0kAK/1606-5-extract-the-subscriptioncontents-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check