### PR TITLE
Record stats on content changes

### DIFF
--- a/app/services/global_metrics_service.rb
+++ b/app/services/global_metrics_service.rb
@@ -16,6 +16,14 @@ class GlobalMetricsService
       gauge("subscription_contents.warning_total", total)
     end
 
+    def critical_content_changes_total(total)
+      gauge("content_changes.critical_total", total)
+    end
+
+    def warning_content_changes_total(total)
+      gauge("content_changes.warning_total", total)
+    end
+
   private
 
     def statsd

--- a/app/workers/content_changes_worker.rb
+++ b/app/workers/content_changes_worker.rb
@@ -1,0 +1,35 @@
+class ContentChangesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :cleanup
+
+  def perform
+    GlobalMetricsService.critical_content_changes_total(critical_content_changes)
+    GlobalMetricsService.warning_content_changes_total(warning_content_changes)
+  end
+
+private
+
+  def critical_content_changes
+    @critical_content_changes ||= count_content_changes(critical_latency)
+  end
+
+  def warning_content_changes
+    @warning_content_changes ||= count_content_changes(warning_latency)
+  end
+
+  def count_content_changes(age)
+    ContentChange
+      .where("created_at < ?", age.ago)
+      .where(processed_at: nil)
+      .count
+  end
+
+  def critical_latency
+    10.minutes
+  end
+
+  def warning_latency
+    5.minutes
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -37,3 +37,6 @@
   subscription_contents:
     every: '1m'
     class: SubscriptionContentsWorker
+   content_changes:
+    every: '1m'
+    class: ContentChangesWorker

--- a/spec/workers/content_changes_worker_spec.rb
+++ b/spec/workers/content_changes_worker_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe ContentChangesWorker do
+  describe ".perform" do
+    shared_examples "tests for critical and warning states" do
+      context "find content changes from last 15 minutes" do
+        let(:statsd) { double }
+
+        before do
+          create(:content_change, created_at: 11.minutes_ago)
+          create(:content_change, created_at: 6.minutes_ago)
+          allow(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        end
+
+        it "records number of unprocessed content changes over 10 minutes old (critical)" do
+          expect(GlobalMetricsService).to receive(:critical_content_changes_total).with(1)
+          described_class.new.perform
+        end
+
+        it "records number of unprocessed content changes over 5 minutes old (warning)" do
+          expect(GlobalMetricsService).to receive(:warning_content_changes_total).with(2)
+          described_class.new.perform
+        end
+
+        it "sends the correct values to statsd" do
+          expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+            .with("content_changes.critical_total", 1)
+          expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+            .with("content_changes.warning_total", 2)
+
+          described_class.new.perform
+        end
+      end
+    end
+  end
+
+  describe ".perform_async" do
+    before do
+      Sidekiq::Testing.fake! do
+        described_class.perform_async
+      end
+    end
+
+    it "gets put on the low priority 'cleanup' queue" do
+      expect(Sidekiq::Queues["cleanup"].size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
We are moving away from healthcheck monitoring for individual
metrics as this places additional DB load on each machine and
creates duplicated Icinga alerts.

This PR adds a sidekiq job which to send `critical` and `warning`
content change metrics to Graphite. This is in advance of a new
Icinga alert being configured in Puppet to monitor these values
and report.

[Trello](https://trello.com/c/c6mWg9jP/1627-3-extract-the-contentchanges-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)