### PR TITLE
Add digest runs sidekiq job

### DIFF
--- a/app/services/global_metrics_service.rb
+++ b/app/services/global_metrics_service.rb
@@ -24,6 +24,14 @@ class GlobalMetricsService
       gauge("content_changes.warning_total", total)
     end
 
+    def critical_digest_runs_total(total)
+      gauge("digest_runs.critical_total", total)
+    end
+
+    def warning_digest_runs_total(total)
+      gauge("digest_runs.warning_total", total)
+    end
+
   private
 
     def statsd

--- a/app/workers/digest_run_worker.rb
+++ b/app/workers/digest_run_worker.rb
@@ -1,0 +1,35 @@
+class DigestRunWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :cleanup
+
+  def perform
+    GlobalMetricsService.critical_digest_runs_total(critical_digest_runs)
+    GlobalMetricsService.warning_digest_runs_total(warning_digest_runs)
+  end
+
+private
+
+  def critical_digest_runs
+    @critical_digest_runs ||= count_digest_runs(critical_latency)
+  end
+
+  def warning_digest_runs
+    @warning_digest_runs ||= count_digest_runs(warning_latency)
+  end
+
+  def count_digest_runs(age)
+    DigestRun
+      .where("created_at < ?", age.ago)
+      .where(completed_at: nil)
+      .count
+  end
+
+  def critical_latency
+    1.hour
+  end
+
+  def warning_latency
+    20.minutes
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -40,3 +40,6 @@
   content_changes:
     every: '1m'
     class: ContentChangesWorker
+  digest_runs:
+    every: '1m'
+    class: DigestRunWorker

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,10 @@ RSpec.configure do |config|
     allow($stdout).to receive(:puts)
   end
 
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
+
   config.after type: :request do
     logout
   end

--- a/spec/workers/digest_run_worker_spec.rb
+++ b/spec/workers/digest_run_worker_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe DigestRunWorker do
+  describe ".perform" do
+    shared_examples "tests for critical and warning states" do
+      context "find incomplete digest runs" do
+        let(:statsd) { double }
+
+        before do
+          create(:digest_run, created_at: 61.minutes_ago)
+          create(:digest_run, created_at: 21.minutes_ago)
+          allow(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        end
+
+        it "records number of unprocessed digest runs over 1 hour old (critical)" do
+          expect(GlobalMetricsService).to receive(:critical_digest_runs_total).with(1)
+          described_class.new.perform
+        end
+
+        it "records number of unprocessed digest runs over 20 minutes old (warning)" do
+          expect(GlobalMetricsService).to receive(:warning_digest_runs_total).with(2)
+          described_class.new.perform
+        end
+
+        it "sends the correct values to statsd" do
+          expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+            .with("digest_runs.critical_total", 1)
+          expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+            .with("digest_runs.warning_total", 2)
+
+          described_class.new.perform
+        end
+      end
+    end
+  end
+
+  describe ".perform_async" do
+    before do
+      Sidekiq::Testing.fake! do
+        described_class.perform_async
+      end
+    end
+
+    it "gets put on the low priority 'cleanup' queue" do
+      expect(Sidekiq::Queues["cleanup"].size).to eq(1)
+    end
+  end
+end

--- a/spec/workers/status_update_worker_spec.rb
+++ b/spec/workers/status_update_worker_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe StatusUpdateWorker do
     end
 
     it "gets put on the low priority 'cleanup' queue" do
-      expect(Sidekiq::Queues["cleanup"].size).to eq(2)
+      expect(Sidekiq::Queues["cleanup"].size).to eq(1)
     end
   end
 end

--- a/spec/workers/subscription_contents_worker_spec.rb
+++ b/spec/workers/subscription_contents_worker_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe SubscriptionContentsWorker do
     end
 
     it "gets put on the low priority 'cleanup' queue" do
-      expect(Sidekiq::Queues["cleanup"].size).to eq(3)
+      expect(Sidekiq::Queues["cleanup"].size).to eq(1)
     end
   end
 end


### PR DESCRIPTION
We are moving away from healthcheck monitoring for individual
metrics as this places additional DB load on each machine and
creates duplicated Icinga alerts.

This PR adds a sidekiq job which to send critical and warning
digest run metrics to Graphite. This is in advance of a new
Icinga alert being configured in Puppet to monitor these values
and report.

[Trello](https://trello.com/c/vmcbj23s/1662-5-extract-the-digestruns-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check)