### PR TITLE
Record stats on messages

### DIFF
--- a/app/services/global_metrics_service.rb
+++ b/app/services/global_metrics_service.rb
@@ -32,6 +32,14 @@ class GlobalMetricsService
       gauge("digest_runs.warning_total", total)
     end
 
+    def critical_messages_total(total)
+      gauge("messages.critical_total", total)
+    end
+
+    def warning_messages_total(total)
+      gauge("messages.warning_total", total)
+    end
+
   private
 
     def statsd

--- a/app/workers/messages_worker.rb
+++ b/app/workers/messages_worker.rb
@@ -1,0 +1,35 @@
+class MessagesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :cleanup
+
+  def perform
+    GlobalMetricsService.critical_messages_total(critical_messages)
+    GlobalMetricsService.warning_messages_total(warning_messages)
+  end
+
+private
+
+  def critical_messages
+    @critical_messages ||= count_messages(critical_latency)
+  end
+
+  def warning_messages
+    @warning_messages ||= count_messages(warning_latency)
+  end
+
+  def count_messages(age)
+    Message
+    .where("created_at < ?", age.ago)
+    .where(processed_at: nil)
+    .count
+  end
+
+  def critical_latency
+    10.minutes
+  end
+
+  def warning_latency
+    5.minutes
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -43,3 +43,6 @@
   digest_runs:
     every: '1m'
     class: DigestRunWorker
+  messages:
+    every: '1m'
+    class: MessagesWorker

--- a/spec/workers/messages_worker_spec.rb
+++ b/spec/workers/messages_worker_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe MessagesWorker do
+  describe ".perform" do
+    context "find unprocessed messages" do
+      let(:statsd) { double }
+
+      before do
+        3.times { create(:message, processed_at: nil, created_at: 10.minutes.ago) }
+        2.times { create(:message, processed_at: nil, created_at: 5.minutes.ago) }
+        allow(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+      end
+
+      it "records a metric for the total number of unprocessed messages created
+      over 10 minutes ago (critical)" do
+        expect(GlobalMetricsService).to receive(:critical_messages_total).with(3)
+        described_class.new.perform
+      end
+
+      it "records a metric for the total number of unprocessed messages created
+      over 5 minutes ago (warning)" do
+        expect(GlobalMetricsService).to receive(:warning_messages_total).with(5)
+        described_class.new.perform
+      end
+
+      it "sends the correct values to statsd" do
+        expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        .with("messages.warning_total", 5)
+        expect(GlobalMetricsService.send(:statsd)).to receive(:gauge)
+        .with("messages.critical_total", 3)
+
+        described_class.new.perform
+      end
+    end
+  end
+
+  describe ".perform_async" do
+    before do
+      Sidekiq::Testing.fake! do
+        Sidekiq::Queues["cleanup"].clear
+        described_class.perform_async
+      end
+    end
+
+    it "gets put on the low priority 'cleanup' queue" do
+      expect(Sidekiq::Queues["cleanup"].size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
We are moving away from using healthchecks to monitor specific
things as they were putting unnecessary load on the database on
each machine and triggering duplicate Icinga alerts.

This sidekiq job will run every 1 minute and send the total number
of unprocessed messages that were created over 5 minutes ago (`warning`)
and over 10 minutes ago (`critical`).

We can then configure an Icinga alert in `Puppet` which will trigger
when the number is more than 0. This will no longer be machine
specific and come through from the monitoring machine.

Trello card: https://trello.com/c/z3QoArLh/1661-5-extract-the-messages-check-from-the-healthcheck-endpoint-in-email-alert-api-to-a-separate-icinga-check