### PR TITLE
Rake task to remove invalid subscriber lists

### DIFF
--- a/lib/clean/invalid_subscriber_lists.rb
+++ b/lib/clean/invalid_subscriber_lists.rb
@@ -1,0 +1,20 @@
+module Clean
+  class InvalidSubscriberLists
+    def invalid_lists
+      SubscriberList.select(&:invalid?)
+    end
+
+    def destroy_invalid_subscriber_lists(dry_run: true)
+      count = 0
+      invalid_lists.each do |list|
+        next if list.subscriptions.active.any?
+
+        count += 1
+        puts "#{dry_run ? '[DRY RUN]' : ''} Deleting subscriber_list #{list.slug}"
+        list.destroy unless dry_run
+      end
+      dry_msg = dry_run ? "[DRY RUN] Would have deleted" : "Deleted"
+      puts "#{dry_msg} #{count} subscriber lists"
+    end
+  end
+end

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -6,6 +6,13 @@ namespace :clean do
     cleaner.remove_empty_subscriberlists(dry_run: dry_run)
   end
 
+  desc "Destroys SubscriberLists that don't pass validations and don't have active subscriptions"
+  task delete_invalid_subscriber_lists: :environment do
+    dry_run = is_dry_run?
+    cleaner = Clean::InvalidSubscriberLists.new
+    cleaner.destroy_invalid_subscriber_lists(dry_run: dry_run)
+  end
+
   def is_dry_run?
     dry = ENV["DRY_RUN"] != "no"
     puts "Warning: Running in DRY_RUN mode. Use DRY_RUN=no to run live." if dry

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -176,7 +176,27 @@ FactoryBot.define do
         create_list(:subscriber, evaluator.subscriber_count, subscriber_lists: [list])
       end
     end
+
+    factory :subscriber_list_with_invalid_tags do
+      tags {
+        {
+          organisations: { any: %w[bar] },
+          case_type: { any: %w[*!123] },
+        }
+      }
+
+      transient do
+        subscriber_count { 5 }
+      end
+
+      after(:create) do |list, evaluator|
+        list = build_list(:subscriber, evaluator.subscriber_count, subscriber_lists: [list])
+        list.each { |item| item.save!(validate: false) }
+      end
+    end
   end
+
+
 
   factory :subscription do
     subscriber

--- a/spec/lib/clean/invalid_subscriber_lists_spec.rb
+++ b/spec/lib/clean/invalid_subscriber_lists_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Clean::InvalidSubscriberLists do
+  let(:subject) { described_class.new }
+  context "when there are invalid lists" do
+    let!(:list) { create(:subscriber_list_with_invalid_tags, :skip_validation) }
+
+    describe "#invalid_lists" do
+      it "returns all invalid subscriber lists" do
+        expect(subject.invalid_lists.count).to eq(1)
+        expect(subject.invalid_lists).to include(list)
+      end
+    end
+  end
+
+  context "when there are no invalid lists" do
+    let!(:list) { create(:subscriber_list) }
+
+    describe "#invalid_lists" do
+      it "returns zero subscriber lists" do
+        expect(subject.invalid_lists.count).to eq(0)
+        expect(subject.invalid_lists).to_not include(list)
+      end
+    end
+  end
+
+  describe "#destroy_invalid_subscriber_lists" do
+    let!(:invalid_list1) { create(:subscriber_list_with_invalid_tags, :skip_validation, subscriber_count: 0) }
+    let!(:invalid_list2) { create(:subscriber_list_with_invalid_tags, :skip_validation, subscriber_count: 2) }
+    let!(:valid_list) { create(:subscriber_list) }
+    let!(:subscriber) { create(:subscriber) }
+    let!(:subscription) { create(:subscription, :ended, subscriber: subscriber, subscriber_list: invalid_list1) }
+
+    it "deletes invalid subscriber lists which don't have active subscriptions" do
+      expect {
+        subject.destroy_invalid_subscriber_lists(dry_run: false)
+      }.to(change { SubscriberList.count }.by(-1))
+    end
+
+    it "deletes subscriptions to invalid subscriber lists" do
+      expect {
+        subject.destroy_invalid_subscriber_lists(dry_run: false)
+      }.to(change { subscriber.subscriptions.count }.by(-1))
+    end
+
+    it "does nothing during a dry run which is the default" do
+      expect {
+        subject.destroy_invalid_subscriber_lists
+      }.not_to(change { SubscriberList.count })
+    end
+  end
+end


### PR DESCRIPTION
Reinstating @bilbof 's rake task removed by [382472f0c98eb3](https://github.com/alphagov/email-alert-api/commit/382472f0c98eb31b994af41f1f81794b1bbc95c2#diff-685304a729502535f29ded7b4907b9f4). 

See: [Trello  #1254](https://trello.com/c/aATEBPlI/1254-remove-invalid-subscriber-lists-from-email-alert-api-database)

There are currently over 200 invalid SubscriberLists in the database since validations were added for invalid tags. See #1091.  None of them currently have active subscriptions.