### PR TITLE
Add clean:migrate_specialist_subscribers rake task

### DIFF
--- a/lib/clean/migrate_specialist_subscriber_lists.rb
+++ b/lib/clean/migrate_specialist_subscriber_lists.rb
@@ -1,0 +1,88 @@
+module Clean
+  # A document_type filter was incorrectly added to some subscriber lists
+  # via a change to specialist publisher.
+  class MigrateSpecialistSubscriberLists
+    def migrate_subscribers_to_working_lists(dry_run: true)
+      lists.each { |from_list|
+        to_list = find_to_list(from_list)
+        migrate_list(from_list, to_list, dry_run: dry_run)
+      }
+
+      puts "Found #{dry_run ? '' : 'and migrated '}#{lists.count} #{'lists'.pluralize(lists.count)}"
+    end
+
+    def lists
+      @lists ||= begin
+        lists = SubscriberList.where(created_at: Date.new(2019, 12, 13)..Date.new(2020, 1, 22))
+        lists.select { |l|
+          l.tags != {} && l.title.exclude?("Brexit") &&
+            l.matched_content_changes.count.zero? &&
+            l.subscribers.activated.count.positive? && l.tags.key?(:document_type)
+        }
+      end
+    end
+
+  private
+
+    def find_to_list(from_list)
+      new_tags = from_list.tags
+      new_tags.delete :document_type
+      query = FindExactQuery.new(
+        tags: new_tags,
+        links: from_list.links,
+        document_type: from_list.document_type,
+        email_document_supertype: from_list.email_document_supertype,
+        government_document_supertype: from_list.government_document_supertype,
+      )
+      query.exact_match || create_list!(from_list, new_tags)
+    end
+
+    def migrate_list(from_list, to_list, dry_run: true)
+      subscribers = from_list.subscribers
+      if dry_run
+        puts "[DRY RUN] Would've moved #{subscribers.count} active subscribers from #{from_list.slug} to #{to_list.slug}"
+        return
+      end
+      puts "Moving #{subscribers.count} active subscribers from #{from_list.slug} to #{to_list.slug}"
+
+      subscribers.each do |subscriber|
+        Subscription.transaction do
+          existing_subscription = Subscription.active.find_by(
+            subscriber: subscriber,
+            subscriber_list: from_list,
+          )
+
+          next unless existing_subscription
+
+          existing_subscription.end(reason: :subscriber_list_changed)
+
+          subscribed_to_destination_subscriber_list = Subscription.find_by(
+            subscriber: subscriber,
+            subscriber_list: to_list,
+          )
+
+          if subscribed_to_destination_subscriber_list.nil?
+            Subscription.create!(
+              subscriber: subscriber,
+              subscriber_list: to_list,
+              frequency: existing_subscription.frequency,
+              source: :subscriber_list_changed,
+            )
+          end
+        end
+      end
+    end
+
+    def create_list!(from_list, new_tags)
+      SubscriberList.create!(
+        slug: from_list.slug += "-#{SecureRandom.hex(5)}",
+        title: from_list.title,
+        tags: new_tags,
+        links: from_list.links,
+        document_type: from_list.document_type,
+        email_document_supertype: from_list.email_document_supertype,
+        government_document_supertype: from_list.government_document_supertype,
+      )
+    end
+  end
+end

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -13,6 +13,13 @@ namespace :clean do
     cleaner.destroy_invalid_subscriber_lists(dry_run: dry_run)
   end
 
+  desc "Migrate subscribers to working specialist finder lists"
+  task migrate_specialist_subscribers: :environment do
+    dry_run = is_dry_run?
+    cleaner = Clean::MigrateSpecialistSubscriberLists.new
+    cleaner.migrate_subscribers_to_working_lists(dry_run: dry_run)
+  end
+
   def is_dry_run?
     dry = ENV["DRY_RUN"] != "no"
     puts "Warning: Running in DRY_RUN mode. Use DRY_RUN=no to run live." if dry

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -173,7 +173,7 @@ FactoryBot.define do
       end
 
       after(:create) do |list, evaluator|
-        create_list(:subscriber, evaluator.subscriber_count, subscriber_lists: [list])
+        create_list(:subscriber, evaluator.subscriber_count, :activated, subscriber_lists: [list])
       end
     end
 

--- a/spec/lib/clean/migrate_specialist_subscriber_lists_spec.rb
+++ b/spec/lib/clean/migrate_specialist_subscriber_lists_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe Clean::MigrateSpecialistSubscriberLists do
+  context "when there are affected lists" do
+    subject(:cleaner) { described_class.new }
+
+    let(:created_at) { Date.new(2019, 12, 20) }
+    let!(:a_list_bad) { create(:subscriber_list_with_subscribers, slug: a_list_bad_slug, tags: a_list_tags_bad, created_at: created_at) }
+    let!(:a_list_good) { create(:subscriber_list_with_subscribers, slug: a_list_good_slug, tags: a_list_tags_good, created_at: created_at) }
+    let!(:b_list_bad) { create(:subscriber_list_with_subscribers, slug: b_list_bad_slug, tags: b_list_tags_bad, created_at: created_at) }
+
+    let(:a_list_bad_slug) { "a_list_bad_slug" }
+    let(:a_list_good_slug) { "a_list_good_slug" }
+    let(:b_list_bad_slug) { "b_list_bad_slug" }
+
+    let(:a_list_tags_bad) { { "vessel_type" => { "any" => %w[recreational-craft-power] }, "document_type" => { "any" => %w[maib_report] }, "format" => { "any" => %w[maib_report] } } }
+    let(:a_list_tags_good) { { "vessel_type" => { "any" => %w[recreational-craft-power] }, "format" => { "any" => %w[maib_report] } } }
+    let(:b_list_tags_bad) { { "case_type" => { "any" => %w[markets mergers consumer-enforcement regulatory-references-and-appeals review-of-orders-and-undertakings] }, "document_type" => { "any" => %w[cma_case] }, "format" => { "any" => %w[cma_case] } } }
+    let(:b_list_tags_good) { { "case_type" => { "any" => %w[markets mergers consumer-enforcement regulatory-references-and-appeals review-of-orders-and-undertakings] }, "format" => { "any" => %w[cma_case] } } }
+
+    describe "#lists" do
+      it "returns only the invalid subscriber lists" do
+        expect(cleaner.lists.count).to eq(2)
+        expect(cleaner.lists).to eq([a_list_bad, b_list_bad])
+      end
+    end
+
+    describe "#migrate_subscribers_to_working_lists" do
+      subject(:migration) { cleaner.migrate_subscribers_to_working_lists(dry_run: dry_run) }
+      let(:dry_run) { false }
+
+      context "during a dry run" do
+        let(:dry_run) { true }
+        it "wont migrate subscribers" do
+          expect { subject }.not_to(change { a_list_good.subscriptions.active.count })
+          expect { subject }.not_to(change { SubscriberList.count })
+        end
+      end
+
+      it "migrates all affected subscribers to new working lists" do
+        expect { subject }.to(change { a_list_good.subscriptions.active.count }.by(5))
+      end
+
+      it "deactivates existing subscriptions" do
+        expect { subject }.to(change { a_list_bad.subscriptions.active.count }.by(-5))
+      end
+
+      it "creates a new subscriber list when necessary" do
+        expect(b_list_bad.subscriptions.active.count).to eq(5)
+        migration
+        expect(SubscriberList.last.tags).to eq(b_list_tags_good.deep_symbolize_keys)
+        expect(SubscriberList.last.slug).to include(b_list_bad_slug)
+        expect(b_list_bad.subscriptions.active.count).to eq(0)
+        expect(SubscriberList.last.subscriptions.active.count).to eq(5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rake task will migrate subscriptions to valid subscriber lists.

Practice run on integration: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/114878/console

https://trello.com/c/yLsG8ecR/1292-fix-specialist-publisher-email-signups