### PR TITLE
Process content change in transaction

### DIFF
--- a/app/services/content_change_handler_service.rb
+++ b/app/services/content_change_handler_service.rb
@@ -10,9 +10,12 @@ class ContentChangeHandlerService
   end
 
   def call
-    content_change = ContentChange.create!(content_change_params)
-    MetricsService.content_change_created
-    MatchedContentChangeGenerationService.call(content_change: content_change)
+    content_change = nil
+    ActiveRecord::Base.transaction do
+      content_change = ContentChange.create!(content_change_params)
+      MetricsService.content_change_created
+      MatchedContentChangeGenerationService.call(content_change: content_change)
+    end
     ProcessContentChangeAndGenerateEmailsWorker.perform_async(content_change.id)
   end
 


### PR DESCRIPTION
If any errors are encountered during this process, the content change should
be rolled back and the caller should re-attempt.
This is in response to a problem where the content change
was created but no MatchedContentChanges were created.
When this happens any further attempts to create the content
change will fail (as one already exists) so we should
rollback creating the content change so that further
attempt(s) can be made.