### PR TITLE
Call `chdir` on `Dir` instead of main Object

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,7 +9,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 

--- a/bin/update
+++ b/bin/update
@@ -9,7 +9,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+Dir.chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 


### PR DESCRIPTION
The main Object doesn't have a `chdir` method so using

```
chdir APP_ROOT do
  ...
end
```

results in an error:

```
undefined method `chdir' for main:Object (NoMethodError)
```

Calling `chdir` on `Dir` fixes the issues.