### PR TITLE
Update the title on the Brexit Checker subscriber lists.

### DIFF
--- a/db/migrate/20200203103706_update_brexit_checker_titles.rb
+++ b/db/migrate/20200203103706_update_brexit_checker_titles.rb
@@ -1,0 +1,12 @@
+class UpdateBrexitCheckerTitles < ActiveRecord::Migration[5.2]
+  OLD_TITLE = "How to prepare for a no deal Brexit"
+  NEW_TITLE = "Get ready for 2021"
+
+  def up
+    SubscriberList.where(title: OLD_TITLE).update_all(title: NEW_TITLE)
+  end
+
+  def down
+    SubscriberList.where(title: NEW_TITLE).update_all(title: OLD_TITLE)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_23_161117) do
+ActiveRecord::Schema.define(version: 2020_02_03_103706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This is shown in the Brexit Checker confirmation page and should
reflect the new situation

https://trello.com/c/zhbARiXd/440-migrate-email-notifications-for-brexit-checker