### PR TITLE
Don't send invalid email address errors to Sentry

### DIFF
--- a/app/providers/notify_provider.rb
+++ b/app/providers/notify_provider.rb
@@ -23,7 +23,9 @@ class NotifyProvider
     :sending
   rescue Notifications::Client::RequestError => e
     MetricsService.failed_to_send_to_notify
-    GovukError.notify(e, tags: { provider: "notify" })
+    unless e.message.end_with?("Not a valid email address")
+      GovukError.notify(e, tags: { provider: "notify" })
+    end
     :technical_failure
   end
 

--- a/spec/providers/notify_provider_spec.rb
+++ b/spec/providers/notify_provider_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe NotifyProvider do
         expect(GovukError).to receive(:notify)
         described_class.call(arguments)
       end
+
+      context "and it's an invalid email address error" do
+        before do
+          error_response = double(code: 404, body: '{"errors": [{"error": "ValidationError", "message": "email_address Not a valid email address"}]}')
+          allow_any_instance_of(Notifications::Client).to receive(:send_email)
+            .and_raise(Notifications::Client::BadRequestError.new(error_response))
+        end
+
+        it "does not notify GovukError" do
+          expect(GovukError).not_to receive(:notify)
+          described_class.call(arguments)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/9s6vdqQP/1712-3-prevent-email-alert-api-from-sending-invalid-email-domain-errors-to-sentry

This creates unneccesary noise in Sentry