### PR TITLE
Remove Travel Advice Brexit descriptions

### DIFF
--- a/db/migrate/20200212134444_remove_descriptions_from_travel_advice.rb
+++ b/db/migrate/20200212134444_remove_descriptions_from_travel_advice.rb
@@ -1,0 +1,7 @@
+class RemoveDescriptionsFromTravelAdvice < ActiveRecord::Migration[5.2]
+  DESCRIPTION = "Find out about the changes to [travelling to Europe after Brexit](https://www.gov.uk/visit-europe-brexit).".freeze
+
+  def change
+    SubscriberList.where(description: DESCRIPTION).update_all(description: "")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_03_103706) do
+ActiveRecord::Schema.define(version: 2020_02_12_134444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Back in October 2019, we added a description to Travel Advice subscriber
lists that linked to some guidance on what to do to visit Europe after
Brexit: https://github.com/alphagov/email-alert-api/pull/1006

Brexit happened and Number 10 requested to remove all Brexit language so
this description needs to be deleted too.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3917026