### PR TITLE
Remove code relating to Policies and Policy Areas

### DIFF
--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -7,20 +7,8 @@ class UnpublishHandlerService
     <%=presented_manage_subscriptions_links(address)%>
   BODY
 
-  POLICY_AND_POLICY_AREA_TEMPLATE = <<~BODY.freeze
-    We're changing the way content is organised on GOV.UK.
-
-    Because of this, you will not get email updates about '<%= subject %>' anymore.
-
-    If you want to continue receiving updates relating to this topic, you can [subscribe to the new '<%= redirect.title %>' page](<%= add_utm(redirect.url, utm_parameters) %>).
-
-    <%=presented_manage_subscriptions_links(address)%>
-  BODY
-
   TEMPLATES = {
     taxon_tree: TAXON_TEMPLATE,
-    policy_areas: POLICY_AND_POLICY_AREA_TEMPLATE,
-    policies: POLICY_AND_POLICY_AREA_TEMPLATE,
   }.freeze
 
   def self.call(*args)

--- a/spec/services/unpublish_handler_service_spec.rb
+++ b/spec/services/unpublish_handler_service_spec.rb
@@ -115,24 +115,6 @@ RSpec.describe UnpublishHandlerService do
       it_behaves_like "it_unsubscribes_all_subscribers"
     end
 
-    context "there is a policy area subscriber list" do
-      before :each do
-        @subscriber_list = create_subscriber_list(links: { policy_areas: { any: [@content_id] } })
-      end
-      it_behaves_like "it_sends_an_email_with_body_including",
-                      "email updates about 'First Subscription"
-      it_behaves_like "it_unsubscribes_all_subscribers"
-    end
-
-    context "there is a policy subscriber list" do
-      before :each do
-        @subscriber_list = create_subscriber_list(links: { policies: { any: [@content_id] } })
-      end
-      it_behaves_like "it_sends_an_email_with_body_including",
-                      "email updates about 'First Subscription"
-      it_behaves_like "it_unsubscribes_all_subscribers"
-    end
-
     context "there is a non-taxon subscriber list" do
       before :each do
         create_subscriber_list(links: {


### PR DESCRIPTION
These are old and retired ways of categorising content. Topics (which
use the document_type taxon) are now used instead.