### PR TITLE
Stop reporting exceptions rescued by ActionDispatch

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -2,4 +2,6 @@ Raven.configure do |config|
   config.excluded_exceptions += %w(
     RatelimitExceededError
   )
+
+  config.rails_report_rescued_exceptions = false
 end


### PR DESCRIPTION
Even though we were rescuing ActiveModel::ValidationError with ActionDispatch middleware [here](https://github.com/alphagov/email-alert-api/blob/d11e99913dc2b4df18037b7639661b6106e2219a/config/application.rb#L27), the errors were still being reported to Sentry.

e.g. https://sentry.io/organizations/govuk/issues/1417276773/?environment=production&project=202220&query=is%3Aunresolved&statsPeriod=24h

However, we want to report only application-level errors to Sentry (5xx).

The reason why rescued errors were reaching Sentry, from their docs:

> Rails catches exceptions in the ActionDispatch::ShowExceptions or ActionDispatch::DebugExceptions middlewares, depending on the environment. When rails_report_rescued_exceptions is true (it is by default), Raven will report exceptions even when they are rescued by these middlewares.

--

https://trello.com/c/0gZxY3cj/459-email-alert-api-returns-wrong-code-for-authentication-failures-when-doing-double-opt-in