### PR TITLE
Add a service to unsubscribe all Brexit Readiness Finder emails

### DIFF
--- a/app/services/unsubscribe_brf_service.rb
+++ b/app/services/unsubscribe_brf_service.rb
@@ -1,0 +1,79 @@
+class UnsubscribeBRFService
+  MESSAGE = <<~BODY.freeze
+    goes here!
+  BODY
+
+  SUBJECT = "subject goes here".freeze
+
+  def self.call
+    UnsubscribeBRFService.new.call
+  end
+
+  def call
+    subscriber_lists = SubscriberList.where("title like ?", "%Brexit guidance for your business%")
+    puts "Unsubscribing #{subscriber_lists.count} subscriptions"
+    subscriber_lists.inject(false) do |result, subscriber_list|
+      puts "Unsubscribe #{subscriber_list.title}"
+      result | process_subscriber_list(subscriber_list)
+    end && send_courtesy_emails
+  end
+
+private
+
+  def process_subscriber_list(subscriber_list)
+    subscriptions = subscriber_list
+                      .subscriptions
+                      .includes(:subscriber)
+                      .active
+
+    return false if subscriptions.empty?
+
+    email_parameters = subscriptions.map do |subscription|
+      {
+        address: subscription.subscriber.address,
+        subject: SUBJECT,
+        body: MESSAGE,
+      }
+    end
+
+    email_ids = Email.import!(email_parameters).ids
+
+    email_ids.zip(subscriptions) do |email_id, subscription|
+      DeliveryRequestWorker.perform_async_in_queue(
+        email_id,
+        queue: :delivery_immediate,
+      )
+
+      subscription.update!(
+        ended_reason: :unpublished,
+        ended_at: Time.zone.now,
+        ended_email_id: email_id,
+      )
+    end
+
+    SubscriberDeactivationWorker.perform_async(
+      subscriptions.map(&:subscriber_id),
+    )
+    true
+  end
+
+  def send_courtesy_emails
+    subscribers = Subscriber.where(address: Email::COURTESY_EMAIL)
+    email_parameters = subscribers.map do |subscriber|
+      {
+        address: subscriber.address,
+        subject: SUBJECT,
+        body: MESSAGE,
+      }
+    end
+
+    email_ids = Email.import!(email_parameters).ids
+
+    email_ids.each do |email_id|
+      DeliveryRequestWorker.perform_async_in_queue(
+        email_id,
+        queue: :delivery_immediate,
+      )
+    end
+  end
+end

--- a/lib/tasks/unsubscribe_brf.rake
+++ b/lib/tasks/unsubscribe_brf.rake
@@ -1,0 +1,6 @@
+namespace :brf do
+  desc "Send an email to all users subscribed to the Business Readiness Finder and deactivate the subscriptions."
+  task :unsubscribe, [] => :environment do
+    UnsubscribeBRFService.call
+  end
+end

--- a/spec/services/unsubscribe_brf_service_spec.rb
+++ b/spec/services/unsubscribe_brf_service_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe UnsubscribeBRFService do
+  before :each do
+    create(
+      :subscriber,
+      address: Email::COURTESY_EMAIL,
+    )
+  end
+
+  def create_brf_subscriber_list(address: "test@example.com")
+    create_subscriber_list(title: "Find Brexit guidance for your business in the following", address: address)
+  end
+
+  def create_non_brf_subscriber_list
+    create_subscriber_list(title: "Something else")
+  end
+
+  def create_subscriber_list(
+    links: {},
+        tags: {},
+        title: "First Subscription",
+        address: "test@example.com"
+      )
+    subscriber = create(
+      :subscriber,
+      address: address,
+    )
+    subscriber_list = create(
+      :subscriber_list,
+      links: links,
+      tags: tags,
+      title: title,
+    )
+    create(
+      :subscription,
+      subscriber: subscriber,
+      subscriber_list: subscriber_list,
+    )
+    subscriber_list
+  end
+
+  shared_examples_for "it_does_not_send_an_email" do
+    it "it does not create an email" do
+      expect { described_class.call }.to_not(change { Email.count })
+    end
+    it "does not send emails" do
+      expect(DeliveryRequestService).to receive(:call).never
+    end
+  end
+
+  describe ".call" do
+    context "No subscriber lists are found" do
+      it_behaves_like "it_does_not_send_an_email"
+    end
+
+    context "All subscriptions are ended" do
+      before :each do
+        subscriber_list = create_brf_subscriber_list
+        subscriber_list.subscriptions.each do |subscription|
+          subscription.end(reason: :unpublished)
+        end
+      end
+      it_behaves_like "it_does_not_send_an_email"
+    end
+
+    context "A BFR subscriber list exists" do
+      before :each do
+        @subscriber_list = create_brf_subscriber_list
+      end
+      it "creates an email and a courtesy email" do
+        expect { described_class.call }.to change { Email.count }.by(2)
+      end
+      it "contains the message in the body" do
+        expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(body: eq(UnsubscribeBRFService::MESSAGE))).twice
+        described_class.call
+      end
+      it "contains the correct subject" do
+        expect(DeliveryRequestService).to receive(:call).
+          with(email: having_attributes(subject: eq(UnsubscribeBRFService::SUBJECT))).twice
+        described_class.call
+      end
+      it "unsubscribes all subscriptions" do
+        described_class.call
+        expect(@subscriber_list.subscriptions.map(&:ended_at)).to all(be_truthy)
+      end
+      it "deactivates subscribers without subscriptions" do
+        described_class.call
+        expect(@subscriber_list.subscribers.map(&:deactivated_at)).to all(be_present)
+      end
+    end
+
+    context "There are subscriber lists but no BRF ones" do
+      before :each do
+        create_non_brf_subscriber_list
+      end
+      it_behaves_like "it_does_not_send_an_email"
+    end
+
+    context "with multiple subscriber lists" do
+      before :each do
+        @first_subscriber_list = create_brf_subscriber_list(address: "first@test.com")
+        @second_subscriber_list = create_brf_subscriber_list(address: "second@test.com")
+      end
+
+      it "correctly associates emails to subscriptions" do
+        described_class.call
+        Subscription.all.each do |subscription|
+          email = Email.find(subscription.ended_email_id)
+          expect(email.address).to eq(subscription.subscriber.address)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
and deactiveate all subscriptions.

trello: 

https://trello.com/c/ChmNnVRZ/523-remove-all-business-readiness-finder-subscriptions
https://trello.com/c/EgTYD0qt/497-send-a-message-to-subscribers-to-the-business-readiness-finder