### PR TITLE
Fix unpublishing email template

### DIFF
--- a/app/models/email_template_context.rb
+++ b/app/models/email_template_context.rb
@@ -19,6 +19,6 @@ class EmailTemplateContext
   end
 
   def presented_manage_subscriptions_links(address)
-    ManageSubscriptionsLinkPresenter.call(address: address)
+    ManageSubscriptionsLinkPresenter.call(address)
   end
 end

--- a/spec/services/unpublish_handler_service_spec.rb
+++ b/spec/services/unpublish_handler_service_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe UnpublishHandlerService do
           with(email: having_attributes(body: include(@redirect.url, @redirect.title))).twice
       described_class.call(@content_id, @redirect)
     end
+    it "contains a link to manage emails" do
+      expect(DeliveryRequestService).to receive(:call).
+        with(email: having_attributes(body: include("address=test%40example.com"))).once
+      expect(DeliveryRequestService).to receive(:call).
+        with(email: having_attributes(body: include("address=govuk-email-courtesy-copies%40digital.cabinet-office.gov.uk"))).once
+      described_class.call(@content_id, @redirect)
+    end
     it "sends the email and a courtesy email to the DeliverRequestWorker" do
       expect(DeliveryRequestService).to receive(:call).
           with(email: having_attributes(subject: "Update from GOV.UK – First Subscription",


### PR DESCRIPTION
The 'manage emails' URL in the unpublishing email template was broken. The 'address' parameter
was hash instead of a string containing the email address. This PR fixes that.