### PR TITLE
Rename Brexit to Transition in subscriber list titles

### DIFF
--- a/db/migrate/20200310111954_rename_brexit_to_transition.rb
+++ b/db/migrate/20200310111954_rename_brexit_to_transition.rb
@@ -1,0 +1,11 @@
+class RenameBrexitToTransition < ActiveRecord::Migration[6.0]
+  def up
+    lists = SubscriberList.where("title like ?", "%Brexit%")
+    lists.each do |list|
+      print "Rename #{list.title} to"
+      list.title.gsub!("Brexit", "Transition")
+      list.save!
+      puts " #{list.title}"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_134444) do
+ActiveRecord::Schema.define(version: 2020_03_10_111954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We still have 85 active and a number of inactive subscriber lists with the word 'Brexit' in the title. They need to be renamed to 'Transition'

Trello: https://trello.com/c/6j6umOGk/469-migrate-email-notifications-for-policy-consultations
https://trello.com/c/1QEkNkzI/467-migrate-email-notifications-for-transition-guidance-regulations
https://trello.com/c/8CkrMQO7/468-migrate-email-notifications-for-news-and-communications