### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
   Exclude:
     - tmp/**/**
     - db/schema.rb
+    - db/migrate/201*.rb
 
 Metrics/BlockLength:
   Exclude:

--- a/db/migrate/20200123161117_update_brexit_subscriber_list_to_transition.rb
+++ b/db/migrate/20200123161117_update_brexit_subscriber_list_to_transition.rb
@@ -2,6 +2,7 @@ class UpdateBrexitSubscriberListToTransition < ActiveRecord::Migration[5.2]
   def up
     subscriber_list = SubscriberList.find_by_slug("brexit-p")
     return if subscriber_list.nil?
+
     subscriber_list.slug = "transition-p"
     subscriber_list.title = "Transition"
     subscriber_list.save
@@ -10,6 +11,7 @@ class UpdateBrexitSubscriberListToTransition < ActiveRecord::Migration[5.2]
   def down
     subscriber_list = SubscriberList.find_by_slug("transition-p")
     return if subscriber_list.nil?
+
     subscriber_list.slug = "brexit-p"
     subscriber_list.title = "Brexit"
     subscriber_list.save

--- a/db/migrate/20200203103706_update_brexit_checker_titles.rb
+++ b/db/migrate/20200203103706_update_brexit_checker_titles.rb
@@ -1,6 +1,6 @@
 class UpdateBrexitCheckerTitles < ActiveRecord::Migration[5.2]
-  OLD_TITLE = "How to prepare for a no deal Brexit"
-  NEW_TITLE = "Get ready for 2021"
+  OLD_TITLE = "How to prepare for a no deal Brexit".freeze
+  NEW_TITLE = "Get ready for 2021".freeze
 
   def up
     SubscriberList.where(title: OLD_TITLE).update_all(title: NEW_TITLE)


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.