### PR TITLE
Change delivery retry times

### DIFF
--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -1,5 +1,5 @@
 class StatusUpdateService
-  TEMPORARY_FAILURE_RETRY_DELAY = 3.hours
+  TEMPORARY_FAILURE_RETRY_DELAY = 6.hours
   TEMPORARY_FAILURE_RETRY_TIMEOUT = 24.hours
 
   def initialize(reference:, status:, completed_at:, sent_at:, user: nil)

--- a/app/services/update_email_status_service.rb
+++ b/app/services/update_email_status_service.rb
@@ -35,7 +35,7 @@ private
                        .where(email: email, status: :temporary_failure)
                        .minimum(:completed_at)
 
-    first_completed && first_completed < 1.day.ago
+    first_completed && first_completed < StatusUpdateService::TEMPORARY_FAILURE_RETRY_TIMEOUT.ago
   end
 
   def handle_permanent_failure

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -1,7 +1,7 @@
 class DeliveryRequestWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: 3
+  sidekiq_options retry: 9
 
   sidekiq_retries_exhausted do |msg, _e|
     if msg["error_class"] == "RatelimitExceededError"

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -3,10 +3,6 @@ class DeliveryRequestWorker
 
   sidekiq_options retry: 3
 
-  sidekiq_retry_in do |count|
-    10 * (count + 1) # 10, 20, 30, 40 ish
-  end
-
   sidekiq_retries_exhausted do |msg, _e|
     if msg["error_class"] == "RatelimitExceededError"
       email_id = msg["args"].first

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe StatusUpdateService do
 
     it "retries sending the email" do
       expect(DeliveryRequestWorker).to receive(:perform_in)
-        .with(3.hours, delivery_attempt.email.id, :default)
+        .with(6.hours, delivery_attempt.email.id, :default)
 
       status_update
     end


### PR DESCRIPTION
Following various incidents we had over the weekend we've decided to change the delivery retry times. See individual commits for more details on each change.