### PR TITLE
Add delivery_interaction queue

### DIFF
--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -7,7 +7,7 @@ class SubscribersAuthTokenController < ApplicationController
     email = build_email(subscriber, token)
 
     DeliveryRequestWorker
-      .perform_async_in_queue(email.id, queue: :delivery_immediate_high)
+      .perform_async_in_queue(email.id, queue: :delivery_transactional)
 
     render json: { subscriber: subscriber }, status: :created
   end

--- a/app/controllers/subscriptions_auth_token_controller.rb
+++ b/app/controllers/subscriptions_auth_token_controller.rb
@@ -15,7 +15,7 @@ class SubscriptionsAuthTokenController < ApplicationController
 
   def do_send(email)
     DeliveryRequestWorker
-      .perform_async_in_queue(email.id, queue: :delivery_immediate_high)
+      .perform_async_in_queue(email.id, queue: :delivery_transactional)
   end
 
   def validate_params

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -112,6 +112,6 @@ private
 
   def send_subscription_confirmation_email(subscription)
     email = SubscriptionConfirmationEmailBuilder.call(subscription: subscription)
-    DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
+    DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_transactional)
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,6 +4,7 @@
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:
+  - [delivery_transactional, 7]
   - [delivery_immediate_high, 6]
   - [delivery_immediate, 5]
   - [email_generation_immediate, 4]


### PR DESCRIPTION
This adds a separate Sidekiq queue for emails that are in the critical path of user interaction. e.g. subscription confirms. Having a separate queue to lower the delay it takes to send these emails.