### PR TITLE
Bump the number of Sidekiq workers from 30 to 35

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 35
+  pool: 40
   # Necessary to allow creating a db with different encodings.
   # See http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html for details
   template: template0

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 30
+:concurrency: 35
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:


### PR DESCRIPTION
Across 3 machines, this will increase the number from 90 to 105. It
looks like we have the resources on the machines for this, and more
workers should help sending out emails faster.

The database pool size has been increased as well to allow for the
worker increase.