### PR TITLE
Change wording on manage subscriptions email

### DIFF
--- a/app/builders/subscriber_auth_email_builder.rb
+++ b/app/builders/subscriber_auth_email_builder.rb
@@ -25,16 +25,16 @@ private
   attr_reader :subscriber, :destination, :token
 
   def subject
-    "Confirm your email address"
+    "Manage your subscriptions"
   end
 
   def body
     <<~BODY
-      # Click the link to confirm your email address
+      # Click the link to manage your subscriptions
 
-      ^ [Confirm your email address](#{link})
+      ^ [Manage your subscriptions](#{link})
 
-      You need to do this to manage your GOV.UK email subscriptions. The link will stop working in 7 days.
+      You need to confirm your email address to manage your GOV.UK email subscriptions. The link will stop working in 7 days.
 
       # Didn’t request this email?
 

--- a/spec/features/create_an_auth_token_spec.rb
+++ b/spec/features/create_an_auth_token_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Create an auth token", type: :request do
         "body" => hash_including(
           "email_address" => subscriber.address,
           "personalisation" => hash_including(
-            "subject" => "Confirm your email address",
+            "subject" => "Manage your subscriptions",
             "body" => include("http://www.dev.gov.uk#{destination}?token="),
           ),
         ),


### PR DESCRIPTION
Users have been getting confused by the wording in the email that is sent out when they manage their subscriptions, leading to a large number of Zendesk tickets.

Therefore changing "Confirm your email address" to "Manage your subscriptions".