### PR TITLE
Use find_by_address method in unsubscribe rake task

### DIFF
--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -14,7 +14,7 @@ namespace :manage do
   end
 
   def unsubscribe(email_address:)
-    subscriber = Subscriber.find_by(address: email_address)
+    subscriber = Subscriber.find_by_address(email_address)
     if subscriber.nil?
       puts "Subscriber #{email_address} not found"
     else


### PR DESCRIPTION
Currently we are matching on a case sensitive email address when manually unsubscribing users.  Changing to use the find_by_address method to match behaviour in the UI.

This has caused an issue where a developer unsubscribed an email containing an uppercase character, but the user's email was stored all lowercase.  This meant they were never unsubscribed.