### PR TITLE
Add new email content if user is authenticating to manage their subscriptions

### DIFF
--- a/app/builders/subscriber_auth_email_builder.rb
+++ b/app/builders/subscriber_auth_email_builder.rb
@@ -25,16 +25,20 @@ private
   attr_reader :subscriber, :destination, :token
 
   def subject
-    "Confirm your email address"
+    "Manage your GOV.UK email subscriptions"
   end
 
   def body
     <<~BODY
-      # Click the link to confirm your email address
+      # Manage your GOV.UK email subscriptions
 
-      ^ [Confirm your email address](#{link})
+      You can unsubscribe from emails or change your subscription at:
 
-      You need to do this to manage your GOV.UK email subscriptions. The link will stop working in 7 days.
+      #{link}
+
+      You’ll need to confirm your email address before you can make any changes.
+
+      The link will stop working in 7 days.
 
       # Didn’t request this email?
 

--- a/spec/builders/subscriber_auth_email_builder_spec.rb
+++ b/spec/builders/subscriber_auth_email_builder_spec.rb
@@ -18,7 +18,13 @@ RSpec.describe SubscriberAuthEmailBuilder do
       expect { call }.to change(Email, :count).by(1)
     end
 
-    it "has a link to authenticate" do
+    it "has a subject line prompting the user to manage their subscriptions" do
+      subject = "Manage your GOV.UK email subscriptions"
+      email = call
+      expect(email.subject).to include(subject)
+    end
+
+    it "has body content has a link allowing users to authenticate and manage their subscriptions" do
       link = "http://www.dev.gov.uk/destination?token=secret"
       email = call
       expect(email.body).to include(link)

--- a/spec/features/create_an_auth_token_spec.rb
+++ b/spec/features/create_an_auth_token_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe "Create an auth token", type: :request do
         "body" => hash_including(
           "email_address" => subscriber.address,
           "personalisation" => hash_including(
-            "subject" => "Confirm your email address",
+            "subject" => "Manage your GOV.UK email subscriptions",
             "body" => include("http://www.dev.gov.uk#{destination}?token="),
           ),
         ),
       )
       .with { |request|
-        token = request.body.match(/token=([^&)]+)/)[1]
+        token = request.body.match(/token=([^&\\]+)/)[1]
 
         expect(decrypt_and_verify_token(token)).to eq(
           "subscriber_id" => subscriber.id,

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Subscribers auth token", type: :request do
     it "sends an email with the correct token" do
       post path, params: params
       expect(Email.count).to be 1
-      token = Email.last.body.match(/token=([^&)]+)/)[1]
+      token = Email.last.body.match(/token=([^&\n]+)/)[1]
       expect(decrypt_and_verify_token(token)).to eq(
         "subscriber_id" => subscriber.id,
         "redirect" => redirect,


### PR DESCRIPTION
Trello: https://trello.com/c/QV5aaDq1/37-update-content-to-existing-manage-your-subscription-email

# What

If the destination is /manage/authenticate, we can use a different subject line and body

# Why

We're getting a lot of user confusion about the unsubscription flow. This is a first attempt at clarifying the content to see if it helps