### PR TITLE
Count failures / successes per subscriber

### DIFF
--- a/db/migrate/20200319142711_add_successes_and_failures_to_subscribers.rb
+++ b/db/migrate/20200319142711_add_successes_and_failures_to_subscribers.rb
@@ -1,6 +1,6 @@
 class AddSuccessesAndFailuresToSubscribers < ActiveRecord::Migration[6.0]
-  def change
-    add_column :subscribers, :successes, :integer, :default =>0
-    add_column :subscribers, :failures, :integer, :default =>0
+  change_table :subscribers, bulk: true do |t|
+    t.integer :successes, default: 0
+    t.integer :failures, default: 0
   end
 end

--- a/db/migrate/20200319142711_add_successes_and_failures_to_subscribers.rb
+++ b/db/migrate/20200319142711_add_successes_and_failures_to_subscribers.rb
@@ -1,0 +1,6 @@
+class AddSuccessesAndFailuresToSubscribers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :subscribers, :successes, :integer, :default =>0
+    add_column :subscribers, :failures, :integer, :default =>0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_111954) do
+ActiveRecord::Schema.define(version: 2020_03_19_142711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -159,6 +159,8 @@ ActiveRecord::Schema.define(version: 2020_03_10_111954) do
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
     t.datetime "deactivated_at"
+    t.integer "successes", default: 0
+    t.integer "failures", default: 0
     t.index "lower((address)::text)", name: "index_subscribers_on_lower_address", unique: true
   end
 


### PR DESCRIPTION
We need to know which subscribers are invalid and cause repeated failures so we can remove them.

This PR adds success/failure counts for each email sent for a subscriber. This is being updated each time the emails are archived.

Trello: https://trello.com/c/85zUTpds/24-investigate-removing-invalid-email-addresses-so-we-reduce-the-number-of-email-retries