### PR TITLE
Increase number of concurrent workers

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 40
+  pool: 50
   # Necessary to allow creating a db with different encodings.
   # See http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html for details
   template: template0

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 35
+:concurrency: 40
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:


### PR DESCRIPTION
Since upgrading the database, it seems like we have more capacity for workers. We're still seeing some high latency on travel advice emails, so we can try and increase the workers some more.

Follows on from https://github.com/alphagov/email-alert-api/pull/1169.