### PR TITLE
Increase sidekiq concurrency

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 40
+:concurrency: 45
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:


### PR DESCRIPTION
Increase concurrency to 45 to help with the large queues we are
currently dealing with.