### PR TITLE
Move courtesy copies for travel advice to the high queue

### DIFF
--- a/app/workers/process_content_change_and_generate_emails_worker.rb
+++ b/app/workers/process_content_change_and_generate_emails_worker.rb
@@ -59,8 +59,10 @@ private
       },
     ]).ids.first
 
+    queue = content_change.priority == "high" ? :delivery_immediate_high : :delivery_immediate
+
     DeliveryRequestWorker.perform_async_in_queue(
-      email_id, queue: :delivery_immediate
+      email_id, queue: queue
     )
   end
 end

--- a/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
 
   context "with a courtesy subscription" do
     let!(:subscriber) { create(:subscriber, address: Email::COURTESY_EMAIL) }
+    let(:content_change_high_priority) { create(:content_change, priority: "high") }
 
     it "creates an email for the courtesy email group" do
       expect(ContentChangeEmailBuilder)
@@ -48,6 +49,14 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
         .with(kind_of(String), queue: :delivery_immediate)
 
       subject.perform(content_change.id)
+    end
+
+    it "enqueues the email on the delivery_immediate_high queue when the content change is high priority" do
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(kind_of(String), queue: :delivery_immediate_high)
+
+      subject.perform(content_change_high_priority.id)
     end
   end
 


### PR DESCRIPTION
Emails to travel advice subscribers are enqueud to
delivery_immediate_high. This queue has the highest priority.

Courtesy copies for travel advice are currently enqueued to
delivery_immediate.

Content changes for travel advice publications have a field called
`priority` which is set to `high`. I believe the same is set for drug
alerts and so this commit applies to drug alerts as well.

If there is lots of publishing activity (for example from whitehall),
the delivery_immediate queue can become quite large. As travel advice
courtesy copy emails are enqueued they become mixed with emails for all
other publishing.

As the delivery_immediate_high queue is processed with a higher priority
than delivery_immediate, we can end up sending travel advice emails to
all subscribers, but still not have sent the courtesy copy email.

When we check the courtesy copy inbox for travel advice and find recent
travel advice missing, we alert and page developers, both in and out of
hours.

The intent of the alert is to warn developers that there might be
something wrong with email-alert-api. However, with the recent high
volume of publishing, we can end up with travel alerts sent to
subscribers having completed while the courtesy copy has not yet been
sent. When delivery_immediate queue is large, there can be a
considerable delay to the travel advice reaching the courtesy copy
inbox. In these cases, we page on-call developers even though there is
very little they can do but wait for queues to clear.

Since travel advice and the travel advice courtesy copy are processed on
different queues with different priorities, slow email
delivery to the courtesy copy group does not represent slow email
delivery to travel advice subscribers.

Instead, enqueue courtesy copies for content changes with high priority
to delivery_immediate_high.

This gives a more accurate representation of travel alert emails
to real subscribers and will hopefully quieten some alerts that have
paged people unnecessarily.

I considered, instead, creating another queue specifically for travel
alert courtesy copies that would have a priority between delively_immediate_high
and delivery_immediate, but that seemed like more complexity for little
reward.