### PR TITLE
Reduce concurrency to 45

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 50
+:concurrency: 45
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:


### PR DESCRIPTION
We're going to be creating a new email-alert-api machine, so this should bring the total concurrency up to 180 (45 * 4). Sidekiq doesn't recommend having a concurrency setting higher than 50, so we've done this rather than setting the concurrency to 60.