### PR TITLE
Make test conditions wider

### DIFF
--- a/spec/services/auth_token_generator_service_spec.rb
+++ b/spec/services/auth_token_generator_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AuthTokenGeneratorService do
         expect(decrypt_and_verify_token(token)).to_not be_nil
       end
 
-      Timecop.freeze(1.week.from_now) do
+      Timecop.freeze(8.days.from_now) do
         expect(decrypt_and_verify_token(token)).to be_nil
       end
     end


### PR DESCRIPTION
This test happened to break on the 22nd March because of day light saving happening one week later (29th March). By increasing the date range by 1 day, we can avoid this problem.