### PR TITLE
Add rake task to remove subscribers with failed send attempts

### DIFF
--- a/lib/clean/invalid_subscribers.rb
+++ b/lib/clean/invalid_subscribers.rb
@@ -1,0 +1,44 @@
+require "csv"
+
+module Clean
+  class InvalidSubscribers
+    MIN_FAILURES = 5
+
+    def initialize(sent_csv:, failed_csv:)
+      @sent_rows = CSV.new(sent_csv, headers: true).to_a
+      @failed_rows = CSV.new(failed_csv, headers: true).to_a
+      if @failed_rows.count > @sent_rows.count
+        raise "Are the sent and failed csv files swapped?"
+      end
+    end
+
+    def deactivate_subscribers(dry_run: true)
+      rows_to_remove = remove_rows_with_successes remove_rows_without_failures @failed_rows
+      subscriber_ids_to_remove = rows_to_remove.map { |row| row.fetch("subscriber_id") }
+      subscribers_to_remove =  Subscriber.where(id: subscriber_ids_to_remove).activated
+      puts "Removing the following email subscriptions"
+      puts subscribers_to_remove.pluck(:address)
+      subscribers_to_remove.update_all(deactivated_at: Time.zone.now) unless dry_run
+    end
+
+  private
+
+    def remove_rows_without_failures(failed_rows)
+      failed_rows.reject { |row| row.fetch("count").to_i < MIN_FAILURES }
+    end
+
+    def remove_rows_with_successes(failed_rows)
+      sent_hash = rows_to_hash(@sent_rows)
+      failed_rows.reject do |row|
+        subscriber_id = row.fetch("subscriber_id")
+        sent_hash.fetch(subscriber_id, 0).to_i.positive?
+      end
+    end
+
+    def rows_to_hash(rows)
+      rows.each_with_object({}) do |row, result|
+        result[row.fetch("subscriber_id")] = row.fetch("count")
+      end
+    end
+  end
+end

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -20,6 +20,35 @@ namespace :clean do
     cleaner.migrate_subscribers_to_working_lists(dry_run: dry_run)
   end
 
+  desc <<~DESC
+    Remove subscribers with multiple emails that failed to send
+
+    Usage: rake clean:invalid_subscribers[/path/to/sent_csv,/path_to_failed_csv]
+
+    Run the following queries on Athena:
+
+    select subscriber_id, COUNT(id) as count
+      from email_archive
+      where sent=false and subscriber_id is not null
+      group by subscriber_id
+
+    and
+
+     select subscriber_id, COUNT(id) as count
+      from email_archive
+      where sent=true and subscriber_id is not null
+      group by subscriber_id
+
+    Download the results to two CSV files and use the respective paths as the parameters.
+
+    Set the environment variable DRY_RUN=false if the subscribers should be deactivated.
+  DESC
+  task :invalid_subscribers, %i[sent_csv failed_csv] => :environment do |_t, args|
+    dry_run = is_dry_run?
+    cleaner = Clean::InvalidSubscribers.new(sent_csv: args[:sent_csv], failed_csv: args[:failed_csv])
+    cleaner.deactivate_subscribers(dry_run: dry_run)
+  end
+
   def is_dry_run?
     dry = ENV["DRY_RUN"] != "no"
     puts "Warning: Running in DRY_RUN mode. Use DRY_RUN=no to run live." if dry

--- a/spec/lib/clean/invalid_subscribers_spec.rb
+++ b/spec/lib/clean/invalid_subscribers_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe Clean::InvalidSubscribers do
+  context "There are four subscribers" do
+    before :each do
+      @subscriber1 = FactoryBot.create(:subscriber, id: 1)
+      @subscriber2 = FactoryBot.create(:subscriber, id: 2)
+      @subscriber3 = FactoryBot.create(:subscriber, id: 3)
+      @subscriber4 = FactoryBot.create(:subscriber, id: 4)
+      @subscriber5 = FactoryBot.create(:subscriber, id: 5)
+    end
+
+    let(:sent_csv) {
+      <<~CSV
+        subscriber_id,count
+        1,10
+        2,5
+        6,3
+        7,4
+      CSV
+    }
+
+    let(:failed_csv) {
+      <<~CSV
+        subscriber_id,count
+        2,#{Clean::InvalidSubscribers::MIN_FAILURES}
+        3,#{Clean::InvalidSubscribers::MIN_FAILURES}
+        4,1
+        5,#{Clean::InvalidSubscribers::MIN_FAILURES}
+      CSV
+    }
+
+    before :each do
+      Clean::InvalidSubscribers.new(sent_csv: StringIO.new(sent_csv),
+                                    failed_csv: StringIO.new(failed_csv)).deactivate_subscribers(dry_run: false)
+    end
+    it "does not deactivate subscriber 1 - no failures" do
+      expect(Subscriber.find(1)).to_not be_deactivated
+    end
+    it "does not deactivate subscriber 2 - there are successes" do
+      expect(Subscriber.find(2)).to_not be_deactivated
+    end
+    it "deactivates subscriber 3 and 5 - at least 5 failures" do
+      expect(Subscriber.find(3)).to be_deactivated
+      expect(Subscriber.find(5)).to be_deactivated
+    end
+    it "does not deactivate subscriber 4 - not enough failures" do
+      expect(Subscriber.find(4)).to_not be_deactivated
+    end
+  end
+
+  context "the failed csv is bigger than the successes csv" do
+    let(:sent_csv) {
+      <<~CSV
+        subscriber_id,count
+        1,10
+      CSV
+    }
+
+    let(:failed_csv) {
+      <<~CSV
+        subscriber_id,count
+        2,5
+        3,5
+      CSV
+    }
+    it "reports there has been a mistake" do
+      expect {
+        Clean::InvalidSubscribers.new(sent_csv: StringIO.new(sent_csv),
+                                      failed_csv: StringIO.new(failed_csv)).deactivate_subscribers
+      }.to raise_error(RuntimeError, "Are the sent and failed csv files swapped?")
+    end
+  end
+end


### PR DESCRIPTION
Identify and remove those subscribers that have failed send
attempts and no successful ones.

The rake task requires two queries to be run on Athena to get the
required data which should be passed to the rake task.

trello: https://trello.com/c/85zUTpds/24-investigate-removing-invalid-email-addresses-so-we-reduce-the-number-of-email-retries