### PR TITLE
Fix email send request time metric

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -25,16 +25,16 @@ class DeliveryRequestService
 
     delivery_attempt = create_delivery_attempt(email, reference)
 
-    MetricsService.email_send_request(provider_name) do
-      status = call_provider(address, reference, email)
+    status = MetricsService.email_send_request(provider_name) do
+      call_provider(address, reference, email)
+    end
 
-      ActiveRecord::Base.transaction do
-        unless status == :sending
-          delivery_attempt.update!(status: status)
-          MetricsService.delivery_attempt_status_changed(status)
-        end
-        UpdateEmailStatusService.call(delivery_attempt)
+    ActiveRecord::Base.transaction do
+      unless status == :sending
+        delivery_attempt.update!(status: status)
+        MetricsService.delivery_attempt_status_changed(status)
       end
+      UpdateEmailStatusService.call(delivery_attempt)
     end
 
     true

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe DeliveryRequestService do
     it "records a metric for the request to the provdier" do
       expect(MetricsService).to receive(:email_send_request)
         .with("pseudo")
+        .and_return(:sending)
 
       subject.call(email: email)
     end


### PR DESCRIPTION
Currently the metric also includes the time it takes to perform a database update on our side, so it's not an accurate representation of how long it took for the email send request to happen, which is what this metric was designed to show.

This metric is visible on the dashboard in this graph: https://grafana.production.govuk.digital/dashboard/file/email_alert_api.json?orgId=1&from=now-3h&to=now&refresh=10s&panelId=5&fullscreen