### PR TITLE
Update manage subscriptions email content

### DIFF
--- a/app/builders/subscriber_auth_email_builder.rb
+++ b/app/builders/subscriber_auth_email_builder.rb
@@ -32,17 +32,15 @@ private
     <<~BODY
       # Manage your GOV.UK email subscriptions
 
-      You can unsubscribe from emails or change your subscription at:
+      Use this link to unsubscribe or change your email subscriptions:
 
       #{link}
-
-      You’ll need to confirm your email address before you can make any changes.
 
       The link will stop working in 7 days.
 
       # Didn’t request this email?
 
-      Ignore or delete this email if you didn’t request it. Your subscriptions won’t be changed.
+      Ignore or delete this email if you didn’t request it. Your subscriptions will not be changed.
 
       [Contact GOV.UK](https://www.gov.uk/contact/govuk) if you have any problems with your email subscriptions.
     BODY


### PR DESCRIPTION
# What

This PR updates the content of the **manage subscriptions** email.

# Why make these changes

1. Confirming your email address isn't the focus of the current journey, so this line could be confusing.
2. Making the mention of a link explicit in the lead in line should set user expectations about seeing an exposed URL. This wording is closer to the content Notify produced for accessibility research on sending accessible file downloads by email.
3. Removed one instance of a [negative contraction](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#contractions) to make the meaning clearer. We have left other negative contractions in for the time being, because they're probably a common pattern in multiple email templates.