### PR TITLE
Add migration for renaming coronavirus email subscription

### DIFF
--- a/db/migrate/20200406094740_rename_coronavirus_topical_event_sub.rb
+++ b/db/migrate/20200406094740_rename_coronavirus_topical_event_sub.rb
@@ -1,0 +1,13 @@
+class RenameCoronavirusTopicalEventSub < ActiveRecord::Migration[6.0]
+  NEW_TITLE = "Coronavirus (COVID-19)".freeze
+
+  def up
+    lists = SubscriberList.where("title like ?", "%Coronavirus (COVID-19): UK government response%")
+    lists.each do |list|
+      print "Rename #{list.title} to"
+      list.title = NEW_TITLE
+      list.save!
+      puts " #{list.title}"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_111954) do
+ActiveRecord::Schema.define(version: 2020_04_06_094740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/x2QeWfip/61-rename-coronavirus-email-subscription-title

## What
Adds a data migration to rename the email subscriber list with title 'Coronavirus (COVID-19): UK government response' to 'Coronavirus (COVID-19)'.

## Why
The old title has been taken automatically from the topical event. We've now moved to a custom landing page and this will soon be driven by the taxonomy. We want to rename the email subscription now to better describe what people are signing up to and to (hopefully) reflect what the taxon will be called when we switch over to that.