### PR TITLE
Avoid reporting email addresses to Sentry

### DIFF
--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -3,7 +3,8 @@ require "csv"
 namespace :manage do
   def change_email_address(old_email_address:, new_email_address:)
     subscriber = Subscriber.find_by_address(old_email_address)
-    raise "Cannot find subscriber with email address #{old_email_address}" if subscriber.nil?
+
+    abort("Cannot find any subscriber with email address #{old_email_address}.") if subscriber.nil?
 
     subscriber.address = new_email_address
     if subscriber.save!


### PR DESCRIPTION
Any raised exception is reported to Sentry. This PR replaces a `raise` with an `abort` to avoid reporting to Sentry the email address (sensitive PII) that is contained in the error message.

Instead of raising an error, `abort` exits the task with a code 1 and outputs the error message to stderr.

## Examples
[internal server error](https://sentry.io/organizations/govuk/issues/356403617/?environment=production&project=202221&query=is%3Aunresolved)
[output from rake task](https://sentry.io/organizations/govuk/issues/1595509705/?environment=production&project=202220&referrer=alert_email)

https://trello.com/c/cAejgt4S/77-remove-pii-data-on-email-subscriptions-from-sentry