### PR TITLE
Fix allowed hosts after Rails 6 upgrade

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
 end


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/176