### PR TITLE
Mark emails that haven't sent because of a technical failure as "failed"

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -11,7 +11,7 @@ class Email < ApplicationRecord
   }
 
   enum status: { pending: 0, sent: 1, failed: 2 }
-  enum failure_reason: { permanent_failure: 0, retries_exhausted_failure: 1 }
+  enum failure_reason: { permanent_failure: 0, retries_exhausted_failure: 1, technical_failure: 2 }
 
   validates :address, :subject, :body, presence: true
 

--- a/spec/services/update_email_status_service_spec.rb
+++ b/spec/services/update_email_status_service_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe UpdateEmailStatusService do
       include_examples "email finished_sending_at timestamp"
     end
 
+    context "when a delivery attempt is a technical failure" do
+      let(:delivery_attempt) do
+        create(:technical_failure_delivery_attempt, email: email)
+      end
+
+      it "marks an email as failed" do
+        expect { described_class.call(delivery_attempt) }
+          .to change { email.reload.status }
+          .to("failed")
+      end
+      include_examples "email finished_sending_at timestamp"
+    end
+
     context "when a delivery attempt is delivered" do
       let(:delivery_attempt) do
         create(:delivered_delivery_attempt, email: email)


### PR DESCRIPTION
Previously, if a delivery attempt was marked as "technical_failure",
the email would stay marked as "pending".

This meant we weren't able to use [this rake task][rake-task] to resend
failed emails during a recent incident (after the cause of the failure
had been fixed), so we had to manually query for them.

Trello: https://trello.com/c/M8dulgoy/1938-3-mark-emails-that-havent-sent-because-of-a-technical-failure-as-failed

[rake-task]: https://github.com/alphagov/email-alert-api/blob/c7c03a0f292df40d4d7c2957014b67d8ac11b2dc/lib/tasks/deliver.rake#L24-L32