### PR TITLE
Support archiving unsent emails

### DIFF
--- a/app/presenters/email_archive_presenter.rb
+++ b/app/presenters/email_archive_presenter.rb
@@ -13,7 +13,7 @@ class EmailArchivePresenter
       content_change: build_content_change(record),
       message: build_message(record),
       created_at_utc: record.fetch("created_at").utc.strftime(S3_DATETIME_FORMAT),
-      finished_sending_at_utc: record.fetch("finished_sending_at").utc.strftime(S3_DATETIME_FORMAT),
+      finished_sending_at_utc: record.fetch("finished_sending_at")&.utc&.strftime(S3_DATETIME_FORMAT),
       id: record.fetch("id"),
       marked_as_spam: record.fetch("marked_as_spam"),
       sent: record.fetch("sent"),

--- a/spec/presenters/email_archive_presenter_spec.rb
+++ b/spec/presenters/email_archive_presenter_spec.rb
@@ -79,5 +79,18 @@ RSpec.describe EmailArchivePresenter do
           .to raise_error(KeyError)
       end
     end
+
+    context "when the email was never sent" do
+      it "still presents the data" do
+        record["finished_sending_at"] = nil
+
+        expect(described_class.for_s3(record, archived_at)).to match(
+          a_hash_including(
+            finished_sending_at_utc: nil,
+            id: record["id"],
+          ),
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/govuk/issues/1639671311/?project=202220&query=is%3Aunresolved

Previously this would raise a NoMethodError on nil in the case we
try to archive an email that wasn't sent. This fixes the presenter
to cope with that scenario, noting that it's still useful to store
history about emails, whether or not they successfully sent.