### PR TITLE
Adds rake tasks for querying and unsubscribing subscriptions, and pulls in some docs

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -1,5 +1,91 @@
 # Tasks
 
+Users can manage email subscribers via the [administration interface on GOV.UK][email-manage].
+Support tickets coming through to 2ndline where the user is unaware of this,
+or needs guidance, can be assigned to "2nd Line--User Support Escalation".
+
+> **Note**
+>
+> This applies only to emails sent by GOV.UK.
+> [Drug safety updates][drug-updates] are sent manually by MHRA, who manage
+> their own service using Govdelivery. We do not have access to this.
+
+If it is not possible for changes to be managed by the user, it is
+possible for changes to be made manually. The following rake tasks
+should be run using the Jenkins `Run rake task` job for ease-of-use:
+
+[email-manage]: https://www.gov.uk/email/manage
+[drug-updates]: https://www.gov.uk/drug-safety-update
+
+## Change a subscriber's email address
+
+This task changes a subscriber's email address.
+
+```bash
+$ bundle exec rake manage:change_email_address[<old_email_address>, <new_email_address>]
+```
+
+[⚙ Run rake task on production][change]
+
+[change]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:change_email_address[from@example.org,to@example.org]
+
+## Unsubscribe a subscriber from all emails
+
+This task unsubscribes one subscriber from everything they have subscribed to.
+
+```bash
+$ bundle exec rake manage:unsubscribe_single[<email_address>]
+```
+
+[⚙ Run rake task on production][unsub]
+
+[unsub]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:unsubscribe_single[email@example.org]
+
+## Unsubscribe a list of subscribers from all emails in bulk
+
+> **Note**
+>
+> The CSV file should contain email addresses in the first column. All other data will be ignored.
+
+```shell
+$ bundle exec rake manage:unsubscribe_bulk_from_csv[<path to CSV file>]
+```
+
+## Manually unsubscribe subscribers
+
+This task unsubscribes subscribers from everything they have subscribed to.
+
+To unsubscribe a set of subscribers in bulk from a CSV file:
+
+```bash
+$ bundle exec rake manage:unsubscribe_bulk_from_csv[<path_to_csv_file>]
+```
+
+The CSV file should have email addresses in the first column. All
+other columns will be ignored.
+
+## Move all subscribers from one list to another
+
+This is useful for changes such as departmental name changes, where new lists are created but subscribers should continue to receive emails.
+
+```bash
+$ bundle exec rake manage:move_all_subscribers[<from_slug>, <to_slug>]
+```
+
+You need to supply the `slug` for the source and destination subscriber lists.
+
+[⚙ Run rake task on production][move]
+
+[move]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:move_all_subscribers[<slug-of-old-list>,<slug-of-new-list>]
+
+## Remove empty subscriber lists.
+
+[⚙ Run rake task on production][clean]
+
+Sometimes subscriber lists are created without any subscribers. This task can be run to get rid of these.
+
+[clean]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=clean:remove_empty_subscriberlists%20DRY_RUN=no
+
 ## Send a test email
 
 To send a test email to an existing subscriber:
@@ -14,14 +100,6 @@ To send a test email to an email address (doesn't have to be subscribed to anyth
 $ bundle exec rake deliver:to_test_email[<email_address>]
 ```
 
-## Change a subscriber's email address
-
-This task changes a subscriber's email address.
-
-```bash
-$ bundle exec rake manage:change_email_address[<old_email_address>, <new_email_address>]
-```
-
 ## Resend emails
 
 This task takes an array of email ids and re-sends them.
@@ -29,38 +107,6 @@ This task takes an array of email ids and re-sends them.
 ```bash
 bundle exec rake deliver:resend_failed_emails[<email_one_id>, <email_two_id>]
 ```
-
-## Manually unsubscribe subscribers
-
-This task unsubscribes one or more subscribers from everything they
-have subscribed to.
-
-To unsubscribe a single subscriber:
-
-```bash
-$ bundle exec rake manage:unsubscribe_single[<email_address>]
-```
-
-To unsubscribe a set of subscribers in bulk from a CSV file:
-
-```bash
-$ bundle exec rake manage:unsubscribe_bulk_from_csv[<path_to_csv_file>]
-```
-
-The CSV file should have email addresses in the first column. All
-other columns will be ignored.
-
-## Move subscribers from one list to another
-
-This task moves all subscribers from one subscriber list to another one.
-It is useful for organisation or taxonomy changes.
-
-```bash
-$ bundle exec rake manage:move_all_subscribers[<from_slug>, <to_slug>]
-```
-
-You need to supply the `slug` for the source and destination
-subscriber lists.
 
 ## Query for subscriptions by title
 

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -34,12 +34,12 @@ $ bundle exec rake manage:change_email_address[<old_email_address>, <new_email_a
 This task unsubscribes one subscriber from everything they have subscribed to.
 
 ```bash
-$ bundle exec rake manage:unsubscribe_single[<email_address>]
+$ bundle exec rake manage:unsubscribe_all_subscriptions[<email_address>]
 ```
 
 [⚙ Run rake task on production][unsub]
 
-[unsub]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:unsubscribe_single[email@example.org]
+[unsub]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:unsubscribe_all_subscriptions[email@example.org]
 
 ## Unsubscribe a list of subscribers from all emails in bulk
 

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -71,7 +71,7 @@ namespace :manage do
   end
 
   desc "Unsubscribe a subscriber from all subscriptions"
-  task :unsubscribe_single, [:email_address] => :environment do |_t, args|
+  task :unsubscribe_all_subscriptions, [:email_address] => :environment do |_t, args|
     email_address = args[:email_address]
     subscriber = Subscriber.find_by_address(email_address)
     if subscriber.nil?
@@ -82,7 +82,7 @@ namespace :manage do
     end
   end
 
-  desc "Unsubscribe a list of subscribers from a CSV file"
+  desc "Unsubscribe a list of subscribers (from a CSV file) from all subscriptions"
   task :unsubscribe_bulk_from_csv, [:csv_file_path] => :environment do |_t, args|
     email_addresses = CSV.read(args[:csv_file_path])
     email_addresses.each do |email_address|

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -21,6 +21,10 @@ namespace :manage do
       h[col] = { label: heading, width: [results.map { |g| g[col].size }.max, label.size].max }
     end
 
+    # Example output:
+    # | Status                  | SubscriberList            | Frequency | Timeline                                                       |
+    # | Inactive (unsubscribed) | Test foo (slug: test-foo) | daily     | Subscribed 2020-04-18 15:21:20 +0100, Ended 2020-05-12 11:41:04 +0100 |
+    # | Active                  | Bar bar (slug: bar-bar)   | weekly    | Subscribed 2019-06-10 13:48:43 +0100                           |
     puts "| #{columns.map { |_, g| g[:label].ljust(g[:width]) }.join(' | ')} |"
     results.each do |h|
       str = h.keys.map { |k| h[k].ljust(columns[k][:width]) }.join(" | ")


### PR DESCRIPTION
We're sometimes asked to unsubscribe a user from all subscriptions, which we have an [existing rake task](https://docs.publishing.service.gov.uk/manual/manage-email-subscribers.html#unsubscribe-a-subscriber-from-all-emails) for. But if a user wants to only unsubscribe from some lists and leave the rest alone, we currently have to SSH into email-alert-api machines and manually process that, which is a laborious and slightly risky exercise.

The [code to unsubscribe a specific subscription already exists](https://github.com/alphagov/email-alert-api/blob/70797224f3ba09cdfc02ee9b517d43570df2f363/app/services/unsubscribe_service.rb#L7-L9), but just isn't exposed in a rake task yet. So...

- In the first commit, I add a rake task that lets us unsubscribe a user from a given subscription. All that is needed is their email address and the slug of the subscriber list.
- There was currently no easy way of getting the slug of the subscriber list, so this would still involve some manual SSHing and querying. So...
- In the second commit, I add a rake task that lets us query which subscriptions a user has. We can use this to find out the slug of the subscription we wish to remove, as well as to perform due diligence in seeing which subscriptions a user has and double-checking that an unsubscribe task was successful.

This should hopefully streamline our 2nd line workflow a fair bit, and remove the need to SSH into email-alert-api machines for routine work.

EDIT: while I'm here, I've also pulled in the rake task docs from govuk-developer-docs. Now that email-alert-api docs are indexed, it makes sense to keep the docs in the same repo as the code. The sister PR to remove the docs elsewhere is https://github.com/alphagov/govuk-developer-docs/pull/2540. This made it very easy to then rename a badly named rake task, which no longer needs updating in tandem in a separate repository! 🎉 