### PR TITLE
Run RuboCop as part of `bundle exec rake` defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,17 +7,6 @@ inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  Exclude:
-    - tmp/**/**
-    - db/schema.rb
-    - db/migrate/201*.rb
-
-Metrics/BlockLength:
-  Exclude:
-    - config/routes.rb
-    - spec/**/**
-
 Rails/DynamicFindBy:
   Enabled: false
 Rails/OutputSafety:

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,7 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
+# RSpec shoves itself into the default task without asking, which confuses the ordering.
+# https://github.com/rspec/rspec-rails/blob/eb3377bca425f0d74b9f510dbb53b2a161080016/lib/rspec/rails/tasks/rspec.rake#L6
+Rake::Task[:default].clear
 task default: %i[lint spec]

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-task default: %i[spec]
+task default: %i[lint spec]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run RuboCop"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end


### PR DESCRIPTION
- This is a prerequisite for moving to GitHub Actions eventually: we
  want to be able to run one single `bundle exec rake` command and have it
  to tests, linting, etc.
- Also remove old excludes that are dealt with now by upstream gem
  configs.

https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks