### PR TITLE
Fix archiving emails

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -31,7 +31,7 @@ class DeliveryRequestService
 
     ActiveRecord::Base.transaction do
       unless status == :sending
-        delivery_attempt.update!(status: status)
+        delivery_attempt.update!(status: status, completed_at: Time.zone.now)
         MetricsService.delivery_attempt_status_changed(status)
       end
       UpdateEmailStatusService.call(delivery_attempt)

--- a/lib/tasks/complete_technical_failure_emails.rake
+++ b/lib/tasks/complete_technical_failure_emails.rake
@@ -1,0 +1,9 @@
+namespace :complete_technical_failure_emails do
+  desc "Update emails marked as technical failure to have a completed_at time"
+  task fill_completed_at_time: :environment do
+    incomplete_technical_failure_emails = Email.where(failure_reason: :technical_failure, finished_sending_at: nil).includes(:delivery_attempt)
+    incomplete_technical_failure_emails.find_each do |email|
+      email.update(finished_sending_at: email.delivery_attempts.last.created_at)
+    end
+  end
+end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -76,6 +76,24 @@ RSpec.describe DeliveryRequestService do
       include_examples "records a statistic", "internal_failure"
     end
 
+    context "when the provider raises a technical failure exception" do
+      before do
+        expect(subject.provider).to receive(:call).and_return(:technical_failure)
+      end
+
+      it "sets the status to technical_failure" do
+        subject.call(email: email)
+        expect(DeliveryAttempt.last.status).to eq("technical_failure")
+      end
+
+      it "adds a completed_at time" do
+        subject.call(email: email)
+        expect(DeliveryAttempt.last.completed_at).not_to be(nil)
+      end
+
+      include_examples "records a statistic", "technical_failure"
+    end
+
     context "when the email address is overridden" do
       let(:subject) do
         described_class.new(config: config.merge(email_address_override: address))


### PR DESCRIPTION
When emails are marked as technical failure they do not have a
finished_sending_at time. This means that the EmailArchivePresenter
fails later when trying to read the field. Here we have changed the
method which updates the status of the delivery_attempt to set the
finished_sending_at time to the current time so the field is not nil.
There is also a rake task added to update the emails currently in 
the database which do not have a completed_at time, to it to the 
current time.

Trello card: https://trello.com/c/nbNAVLwS/1965-3-fix-archiving-of-technical-failure-emails