### PR TITLE
Only include lint task in a development environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-# RSpec shoves itself into the default task without asking, which confuses the ordering.
-# https://github.com/rspec/rspec-rails/blob/eb3377bca425f0d74b9f510dbb53b2a161080016/lib/rspec/rails/tasks/rspec.rake#L6
-Rake::Task[:default].clear
-task default: %i[lint spec]
+unless Rails.env.production?
+  Rake::Task[:default].clear
+  task default: %i[lint spec]
+end


### PR DESCRIPTION
This is similar to #1045 as without it deploys aren't currently possible.