### PR TITLE
Fix query in fill_completed_at_time Rake task

### DIFF
--- a/lib/tasks/complete_technical_failure_emails.rake
+++ b/lib/tasks/complete_technical_failure_emails.rake
@@ -1,7 +1,10 @@
 namespace :complete_technical_failure_emails do
   desc "Update emails marked as technical failure to have a completed_at time"
   task fill_completed_at_time: :environment do
-    incomplete_technical_failure_emails = Email.where(failure_reason: :technical_failure, finished_sending_at: nil).includes(:delivery_attempt)
+    incomplete_technical_failure_emails = Email
+      .where(failure_reason: :technical_failure, finished_sending_at: nil)
+      .includes(:delivery_attempts)
+
     incomplete_technical_failure_emails.find_each do |email|
       email.update(finished_sending_at: email.delivery_attempts.last.created_at)
     end


### PR DESCRIPTION
This fixes the query to have the correct delivery attempt association with the email model.

[Trello Card](https://trello.com/c/nbNAVLwS/1965-3-fix-archiving-of-technical-failure-emails)