### PR TITLE
Remove h1 from email

### DIFF
--- a/lib/subscriber_list_mover.rb
+++ b/lib/subscriber_list_mover.rb
@@ -70,12 +70,10 @@ class SubscriberListMover
     bulk_move_template = <<~BODY.freeze
       Hello,
 
-      You've subscribed to get emails about #{list_title}.
+      You’ve subscribed to get emails about #{list_title}.
       
       GOV.UK is changing the way we send emails, so you may notice a difference in the number and type of updates you get.
       
-      # If you’re getting too many emails
-
       You can [manage your subscription](#{email_redirect}) to choose how often you want to receive emails.
       
       Thanks,


### PR DESCRIPTION
This PR removes the h1 from the `Changes to GOV.UK emails` email template.

After viewing the email in a browser and discussing with Neil, we decided that the styling of the h1 dominates too much.

Neil is going to raise a support ticket with Notify to let them know that the formatting limitations have forced this content change, to find out more about:

* the reasons for the styling of the h1
* the reason other heading classes are not available
* whether Notify plan to revisit these design decisions