### PR TITLE
Remove redundant transaction from DeliveryRequestService

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -29,11 +29,11 @@ class DeliveryRequestService
       call_provider(address, reference, email)
     end
 
+    return true if status == :sending
+
     ActiveRecord::Base.transaction do
-      unless status == :sending
-        delivery_attempt.update!(status: status, completed_at: Time.zone.now)
-        MetricsService.delivery_attempt_status_changed(status)
-      end
+      delivery_attempt.update!(status: status, completed_at: Time.zone.now)
+      MetricsService.delivery_attempt_status_changed(status)
       UpdateEmailStatusService.call(delivery_attempt)
     end
 


### PR DESCRIPTION
This transaction has nothing to do if the status returned from notify is sending, so removing this removes the need to issue a transaction. It seems unlikely this will have a huge performance impact but it does at least make this code easier to reason.