### PR TITLE
Fix link to prepopulated rake task

### DIFF
--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -204,5 +204,5 @@ LIMIT 10;
 [aws]: https://aws.amazon.com
 [console-instructions]: https://docs.publishing.service.gov.uk/manual/seeing-things-in-the-aws-console.html
 [rake-count-subscribers]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers['subscriber-list-slug']
-[rake-count-subscribers-on]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers-on[yyyy-mm-dd,'subscriber-list-slug']
+[rake-count-subscribers-on]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=query:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']
 [schema.rb]: https://github.com/alphagov/email-alert-api/tree/master/db/schema.rb


### PR DESCRIPTION
The old link contained a typo which meant the rake task failed.