### PR TITLE
Add rake tasks to generate high load

### DIFF
--- a/app/providers/delay_provider.rb
+++ b/app/providers/delay_provider.rb
@@ -1,0 +1,12 @@
+class DelayProvider
+  def self.call(*args)
+    new.call(*args)
+  end
+
+  def call(**_args)
+    Kernel.sleep 0.1
+    :delivered
+  end
+
+  private_class_method :new
+end

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -2,6 +2,7 @@ class DeliveryRequestService
   PROVIDERS = {
     "notify" => NotifyProvider,
     "pseudo" => PseudoProvider,
+    "delay" => DelayProvider,
   }.freeze
 
   attr_reader :provider_name, :provider, :subject_prefix, :overrider

--- a/lib/overloader.rb
+++ b/lib/overloader.rb
@@ -1,0 +1,80 @@
+class Overloader
+  def initialize(requested_volume)
+    @requested_volume = requested_volume
+  end
+
+  def with_big_lists
+    generate_emails(SubscriberList.all.sort_by { |list| -list_size(list) })
+  end
+
+  def with_small_lists
+    generate_emails(SubscriberList.all.sort_by { |list| list_size(list) })
+  end
+
+private
+
+  attr_reader :requested_volume
+
+  def generate_emails(sorted_lists)
+    generated_volume = 0
+
+    while generated_volume < requested_volume
+      content_change = create_fake_content_change
+
+      generated_volume += generate_matches(
+        content_change,
+        sorted_lists,
+        requested_volume - generated_volume,
+      )
+
+      ProcessContentChangeAndGenerateEmailsWorker
+        .perform_async(content_change.id)
+    end
+  end
+
+  def generate_matches(content_change, sorted_lists, volume)
+    generated_volume = 0
+    total_lists = 0
+
+    sorted_lists.each do |list|
+      next if list_size(list).zero?
+      break if generated_volume >= volume
+
+      generated_volume += list_size(list)
+      total_lists += 1
+
+      MatchedContentChange.create!(
+        content_change: content_change, subscriber_list: list,
+      )
+    end
+
+    raise "Aborting as no lists have subscribers" if generated_volume.zero?
+
+    puts "Generated fake matches against #{total_lists} lists"
+    puts "Preparing to send #{generated_volume} emails via these lists"
+    generated_volume
+  end
+
+  def list_size(list)
+    list.subscriptions.active.immediately.count
+  end
+
+  def create_fake_content_change
+    content_change = ContentChange.create(
+      publishing_app: "test",
+      document_type: "test",
+      govuk_request_id: 1,
+      government_document_supertype: "test",
+      email_document_supertype: "test",
+      content_id: SecureRandom.uuid,
+      public_updated_at: Time.zone.now,
+      change_note: "test",
+      base_path: "/test",
+      title: "Test",
+      description: "test",
+    )
+
+    puts "Created fake content change #{content_change.content_id}"
+    content_change
+  end
+end

--- a/lib/tasks/load_testing.rake
+++ b/lib/tasks/load_testing.rake
@@ -19,4 +19,25 @@ namespace :load_testing do
     puts "Delivery Attempt IDs available at:"
     puts path
   end
+
+  desc "Generate a large number of content changes using the smallest number of lists"
+  task :generate_emails_with_big_lists, %i[requested_volume] => :environment do |_t, args|
+    requested_volume = args[:requested_volume].to_i
+    raise("Specify a volume of emails to generate") unless requested_volume
+
+    Overloader.new(requested_volume).with_big_lists
+  end
+
+  desc "Generate a large number of content changes using the biggest number of lists"
+  task :generate_emails_with_small_lists, %i[requested_volume] => :environment do |_t, args|
+    requested_volume = args[:requested_volume].to_i
+    raise("Specify a volume of emails to generate") unless requested_volume
+
+    Overloader.new(requested_volume).with_small_lists
+  end
+
+  desc "Clear any remaining load"
+  task clear_emails: :environment do
+    Sidekiq::Queue.new("delivery_immediate").clear
+  end
 end

--- a/spec/lib/overloader_spec.rb
+++ b/spec/lib/overloader_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe Overloader do
+  let(:list_1) { create :subscriber_list }
+  let(:list_2) { create :subscriber_list }
+
+  before do
+    list_1.subscriptions << create_list(:subscription, 2)
+    list_2.subscriptions << create_list(:subscription, 1)
+  end
+
+  describe "#with_big_lists" do
+    it "creates a fake content change" do
+      expect { described_class.new(1).with_big_lists }
+        .to change { ContentChange.count }.by 1
+    end
+
+    it "generates fake matches for the change" do
+      expect { described_class.new(1).with_big_lists }
+        .to change { MatchedContentChange.count }.by 1
+    end
+
+    it "kicks off a job to process the matches" do
+      expect(ProcessContentChangeAndGenerateEmailsWorker)
+        .to receive(:perform_async)
+
+      described_class.new(1).with_big_lists
+    end
+
+    it "prefers lists with more subscribers" do
+      described_class.new(1).with_big_lists
+      expect(list_1.matched_content_changes.count).to eq 1
+    end
+
+    it "loops to meet the required email volume" do
+      expect { described_class.new(5).with_big_lists }
+        .to change { ContentChange.count }.by(2)
+        .and change { MatchedContentChange.count }.by 3
+    end
+  end
+
+  describe "#with_small_lists" do
+    it "prefers lists with more subscribers" do
+      described_class.new(1).with_small_lists
+      expect(list_2.matched_content_changes.count).to eq 1
+    end
+
+    it "loops to meet the required email volume" do
+      expect { described_class.new(5).with_small_lists }
+        .to change { ContentChange.count }.by(2)
+        .and change { MatchedContentChange.count }.by 4
+    end
+  end
+end

--- a/spec/providers/delay_provider_spec.rb
+++ b/spec/providers/delay_provider_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe DelayProvider do
+  describe ".call" do
+    let(:args) do
+      {
+        address: "email@address.com",
+        subject: "subject",
+        body: "body",
+        reference: "ref-123",
+      }
+    end
+
+    it "simulates an API delay" do
+      expect(Kernel).to receive(:sleep)
+      described_class.call(**args)
+    end
+
+    it "returns a status of delivered" do
+      return_value = described_class.call(**args)
+      expect(return_value).to be(:delivered)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/epDHdjIe/311-placeholder-increase-database-connections-and-workers

This adds tasks that simulate the ContentChangeHandlerService by
creating a backlog of matched content changes that will be processed
into a specified volume of emails to send. In order to avoid a high
number of largely unnecessary API calls, this also adds a 'delay'
provider that can be used to simulate a delay; at the time of writing,
the mean delay to Notify in production is roughly 1 second.

Note that, in order to run this with a large volume in Staging, we
will need to temporarily override a couple of environment variables:

- EMAIL_ADDRESS_OVERRIDE_WHITELIST_ONLY -> "" (so we actually attempt to
  send emails, which are mostly to addresses that are not allowed)

- DELIVERY_REQUEST_THRESHOLD -> "" (normally we want to impose a strict
  limit on Staging, as it's running against Notify's test environment)