### PR TITLE
Fix sending emails to migrated subscribers

### DIFF
--- a/app/services/bulk_email_sender_service.rb
+++ b/app/services/bulk_email_sender_service.rb
@@ -1,6 +1,6 @@
 class BulkEmailSenderService
-  def self.call(subject:, body:, subscriber_lists:, queue: :delivery_immediate)
-    email_ids = BulkEmailBuilder.call(subject: subject, body: body, subscriber_lists: subscriber_lists).ids
+  def self.call(bulk_email_builder:, queue: :delivery_immediate)
+    email_ids = bulk_email_builder.ids
 
     email_ids.each do |email_id|
       DeliveryRequestWorker.perform_async(email_id, queue)

--- a/lib/subscriber_list_mover.rb
+++ b/lib/subscriber_list_mover.rb
@@ -22,7 +22,7 @@ class SubscriberListMover
     puts "#{sub_count} active subscribers moving from #{from_slug} to #{to_slug}"
 
     if send_email
-      email_change_to_subscribers(source_subscriber_list)
+      emails_for_subscribed = build_emails(source_subscriber_list)
     end
 
     subscribers.each do |subscriber|
@@ -54,10 +54,15 @@ class SubscriberListMover
       end
     end
 
-    puts "#{sub_count} active subscribers moved from #{from_slug} to #{to_slug}"
+    puts "#{sub_count} active subscribers moved from #{from_slug} to #{to_slug}."
+
+    if send_email
+      puts "Sending emails to subscribers about change"
+      email_change_to_subscribers(emails_for_subscribed)
+    end
   end
 
-  def email_change_to_subscribers(source_subscriber_list)
+  def build_emails(source_subscriber_list)
     email_subject = "Changes to GOV.UK emails"
     email_utm_parameters = {
       utm_source: from_slug,
@@ -71,19 +76,23 @@ class SubscriberListMover
       Hello,
 
       You’ve subscribed to get emails about #{list_title}.
-      
+
       GOV.UK is changing the way we send emails, so you may notice a difference in the number and type of updates you get.
-      
+
       You can [manage your subscription](#{email_redirect}) to choose how often you want to receive emails.
-      
+
       Thanks,
       GOV.UK
     BODY
 
-    BulkEmailSenderService.call(
+    BulkEmailBuilder.call(
       subject: email_subject,
       body: bulk_move_template,
       subscriber_lists: source_subscriber_list,
     )
+  end
+
+  def email_change_to_subscribers(emails_for_subscribed)
+    BulkEmailSenderService.call(emails_for_subscribed)
   end
 end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -1,10 +1,12 @@
 namespace :bulk do
   desc "Send a bulk email to many subscriber lists"
   task :email, [] => :environment do |_t, args|
-    BulkEmailSenderService.call(
+    emails = BulkEmailBuilder.call(
       subject: ENV.fetch("SUBJECT"),
       body: ENV.fetch("BODY"),
       subscriber_lists: SubscriberList.where(id: args.extras),
     )
+
+    BulkEmailSenderService.call(bulk_email_builder: emails)
   end
 end

--- a/spec/lib/tasks/bulk_spec.rb
+++ b/spec/lib/tasks/bulk_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "bulk" do
+  describe "email" do
+    before do
+      Rake::Task["bulk:email"].reenable
+    end
+
+    around(:each) do |example|
+      ClimateControl.modify(SUBJECT: "subject", BODY: "body") do
+        example.run
+      end
+    end
+
+    it "sends emails to a subscription list" do
+      subscriber_list = create(:subscriber_list)
+
+      expect(BulkEmailSenderService).to receive(:call).with(
+        bulk_email_builder: BulkEmailBuilder.call(
+          subject: "subject",
+          body: "body",
+          subscriber_lists: subscriber_list,
+        ),
+      )
+
+      Rake::Task["bulk:email"].invoke(subscriber_list.id)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ require "db/seeds"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 
+Rails.application.load_tasks
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.use_transactional_fixtures = true

--- a/spec/services/bulk_email_sender_service_spec.rb
+++ b/spec/services/bulk_email_sender_service_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe BulkEmailSenderService do
   let(:email_subject) { "email subject" }
   let(:body) { "body" }
   let(:subscriber_lists) { [create(:subscription).subscriber_list] }
+  let(:bulk_email_builder) { BulkEmailBuilder.call(subject: email_subject, body: body, subscriber_lists: subscriber_lists) }
 
   describe ".call" do
     it "adds a delivery request to the queue" do
@@ -10,7 +11,7 @@ RSpec.describe BulkEmailSenderService do
       ).and_call_original
 
       Sidekiq::Testing.fake! do
-        described_class.call(subject: email_subject, body: body, subscriber_lists: subscriber_lists)
+        described_class.call(bulk_email_builder: bulk_email_builder)
       end
 
       expect(DeliveryRequestWorker.jobs.size).to eq(1)


### PR DESCRIPTION
The rake task for migrating subscribers to a different subscriber list
sent emails before the migration was completed. Especially for large
lists of users, this caused a confusing experience as emails were
received while the migration was still happening.

This change allows to to generate the emails to send, make the
migration, and then send the emails after the migration has
completed.

https://trello.com/c/HYqY4ZHw