### PR TITLE
Add report for matched content changes

### DIFF
--- a/lib/reports/matched_content_changes_report.rb
+++ b/lib/reports/matched_content_changes_report.rb
@@ -1,0 +1,46 @@
+class Reports::MatchedContentChangesReport
+  OUTPUT_ATTRIBUTES = {
+    created_at: :content_change,
+    base_path: :content_change,
+    change_note: :content_change,
+    document_type: :content_change,
+    publishing_app: :content_change,
+    priority: :content_change,
+    title: :subscriber_list,
+    subscription_count: :itself,
+  }.freeze
+
+  def call(start_time: nil, end_time: nil)
+    start_time = start_time ? Time.zone.parse(start_time) : 1.week.ago
+    end_time = end_time ? Time.zone.parse(end_time) : Time.zone.now
+
+    subscription_count_query = Subscription
+      .select("count(*)")
+      .where("subscriptions.created_at <= content_changes.created_at")
+      .where("subscriptions.ended_at is null or subscriptions.ended_at > content_changes.created_at")
+      .where("subscriptions.subscriber_list_id = subscriber_lists.id")
+      .where(frequency: "immediately")
+      .arel
+      .as("subscription_count")
+
+    query = MatchedContentChange
+      .select("*")
+      .select(subscription_count_query)
+      .includes(:subscriber_list, :content_change) # for efficient "row.content_change"
+      .joins(:subscriber_list, :content_change) # for the nested query
+      .where("content_changes.created_at": start_time..end_time)
+      .order(subscription_count: :desc)
+
+    CSV.generate do |csv|
+      csv << OUTPUT_ATTRIBUTES.keys
+
+      query.each do |row|
+        next if row.subscription_count.zero?
+
+        csv << OUTPUT_ATTRIBUTES.map do |sub_field, field|
+          row.public_send(field).public_send(sub_field)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,7 @@
+namespace :report do
+  desc "Outputs a CSV of content changes by subscriber list"
+  task matched_content_changes: :environment do
+    puts Reports::MatchedContentChangesReport.new.call(start_time: ENV["START_DATE"],
+                                                       end_time: ENV["END_DATE"])
+  end
+end

--- a/spec/lib/reports/matched_content_changes_report_spec.rb
+++ b/spec/lib/reports/matched_content_changes_report_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Reports::MatchedContentChangesReport do
+  describe "#call" do
+    it "outputs a CSV of matched content changes" do
+      subscriber_list = create :subscriber_list_with_subscribers
+      match = create :matched_content_change, subscriber_list: subscriber_list
+      expect(described_class.new.call).to eq report_for([{ match: match, count: 5 }])
+    end
+
+    it "only reports on immediate subscriptions" do
+      subscriber_list = create :subscriber_list
+      subscriber_list.subscriptions << create(:subscription, frequency: :daily)
+      create :matched_content_change, subscriber_list: subscriber_list
+      expect(described_class.new.call).to eq report_for([])
+    end
+
+    it "orders the output by subscription count" do
+      subscriber_list1 = create :subscriber_list_with_subscribers
+      subscriber_list2 = create :subscriber_list
+      subscriber_list2.subscriptions << create(:subscription)
+      match1 = create :matched_content_change, subscriber_list: subscriber_list1
+      match2 = create :matched_content_change, subscriber_list: subscriber_list2
+
+      expect(described_class.new.call).to eq report_for([
+        { match: match1, count: 5 }, { match: match2, count: 1 }
+      ])
+    end
+
+    it "ignores lists that had no subscriptions" do
+      subscriber_list = create :subscriber_list
+      subscriber_list.subscriptions << create(:subscription, ended_at: 1.day.ago)
+      create :matched_content_change, subscriber_list: subscriber_list
+      expect(described_class.new.call).to eq report_for([])
+    end
+
+    it "includes subscriptions that ended later" do
+      subscriber_list = create :subscriber_list
+      subscriber_list.subscriptions << create(:subscription, ended_at: 1.day.from_now)
+      match = create :matched_content_change, subscriber_list: subscriber_list
+      expect(described_class.new.call).to eq report_for([{ match: match, count: 1 }])
+    end
+
+    it "allows specifying the date range to report" do
+      subscriber_list = create :subscriber_list_with_subscribers
+      create :matched_content_change, subscriber_list: subscriber_list
+      output = described_class.new.call(start_time: 1.day.from_now.to_s, end_time: 2.days.from_now.to_s)
+      expect(output).to eq report_for([])
+    end
+
+    def report_for(rows)
+      headers = described_class::OUTPUT_ATTRIBUTES.keys.join(",")
+
+      rows = [headers] + rows.map do |row|
+        "#{row[:match].content_change.created_at}," \
+          "government/base_path,change note,document type,publishing app,normal," \
+          "#{row[:match].subscriber_list.title},#{row[:count]}"
+      end
+
+      rows.join("\n") + "\n"
+    end
+  end
+end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "report" do
+  describe "matched_content_changes" do
+    it "outputs a CSV of matched content changes" do
+      expect { Rake::Task["report:matched_content_changes"].invoke }
+        .to output.to_stdout
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/IAj6XWFo/309-create-a-report-to-show-the-content-changes-that-have-triggered-notifications

    This adds a report to output content changes by matching subscriber
    list over a given period, calculating the number of emails each match
    would have generated using a similar technique to the "active_on" scope
    on the Subscription model. We want to use this report to see clusters of
    changes that contribute to high email volume.