### PR TITLE
Slightly drop Sidekiq concurrency

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 45
+:concurrency: 32
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :queues:


### PR DESCRIPTION
I'm thinking of adding more machines, which means will end up with
more workers even with this change. However, dropping the concurrency
reduces the chance of metrics being skewed by contention between
threads, so this might help investigate performance issues.