### PR TITLE
Fix missing enum definition for DelayProvider

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -6,7 +6,7 @@ class DeliveryAttempt < ApplicationRecord
   FINAL_STATUSES = %i[delivered permanent_failure].freeze
 
   enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4, internal_failure: 5 }
-  enum provider: { pseudo: 0, notify: 1 }
+  enum provider: { pseudo: 0, notify: 1, delay: 2 }
 
   def has_final_status?
     self.class.final_status?(status)


### PR DESCRIPTION
https://trello.com/c/fjn6HcTn/329-investigate-redis-as-a-bottleneck-during-high-load

ArgumentError: 'delay' is not a valid provider
  from active_record/enum.rb:142:in `assert_valid_value'