### PR TITLE
Add a metric to record first_delivery_attempt

### DIFF
--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -67,7 +67,9 @@ private
   end
 
   def create_delivery_attempt(email, reference)
-    MetricsService.first_delivery_attempt(email, Time.now.utc)
+    MetricsService.delivery_request_service_first_delivery_attempt do
+      MetricsService.first_delivery_attempt(email, Time.now.utc)
+    end
 
     MetricsService.delivery_request_service_create_delivery_attempt do
       DeliveryAttempt.create!(

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -69,7 +69,7 @@ private
   def create_delivery_attempt(email, reference)
     MetricsService.first_delivery_attempt(email, Time.now.utc)
 
-    MetricsService.delivery_request_service_create_deliver_attempt do
+    MetricsService.delivery_request_service_create_delivery_attempt do
       DeliveryAttempt.create!(
         id: reference,
         email: email,

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -40,6 +40,10 @@ class MetricsService
       time("delivery_request_worker_find_email.timing", &block)
     end
 
+    def delivery_request_service_first_delivery_attempt(&block)
+      time("delivery_request_service_first_delivery_attempt.timing", &block)
+    end
+
     def delivery_request_service_create_delivery_attempt(&block)
       time("delivery_request_service_create_delivery_attempt.timing", &block)
     end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -40,7 +40,7 @@ class MetricsService
       time("delivery_request_worker_find_email.timing", &block)
     end
 
-    def delivery_request_service_create_deliver_attempt(&block)
+    def delivery_request_service_create_delivery_attempt(&block)
       time("delivery_request_service_create_delivery_attempt.timing", &block)
     end
 


### PR DESCRIPTION
This change is rather bonkers as it adds a metric to record how long it
takes to record another metric in some sort of weird metric-ception.
From digging into where the time is going when trying to send emails the
queries involved in pulling out this metric appear to be where the
majority of time goes when trying to send an email.

This is being recorded in the hope it helps fill in our picture of where
the time goes when sending emails. It's a bit unclear at this stage what
we're going to do to resolve this lost time.