### PR TITLE
Remove import_ignoring_duplicates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node("postgresql-9.3") {
+node("postgresql-9.6") {
   govuk.setEnvar("TEST_DATABASE_URL", "postgresql://email-alert-api:email-alert-api@localhost/email-alert-api_test")
   govuk.buildProject(
     rubyLintDiff: false

--- a/app/models/subscription_content.rb
+++ b/app/models/subscription_content.rb
@@ -22,18 +22,4 @@ class SubscriptionContent < ApplicationRecord
       errors.add(:base, "must be associated with a content_change or a message")
     end
   end
-
-  # This method is needed whilst we continue using Postgres 9.4, from 9.5
-  # Postgres can suppoort a ON CONFLICT DO NOTHING and this can be called
-  # directly through activerecord-import: https://github.com/zdennis/activerecord-import#duplicate-key-ignore
-  def self.import_ignoring_duplicates(columns, rows, batch_size: 500)
-    rows.each_slice(batch_size).to_a.each do |batch|
-      transaction { import!(columns, batch) }
-    rescue ActiveRecord::RecordNotUnique
-      batch.each do |data|
-        attributes = columns.zip(data).to_h
-        create!(attributes) unless exists?(attributes)
-      end
-    end
-  end
 end

--- a/app/workers/process_content_change_and_generate_emails_worker.rb
+++ b/app/workers/process_content_change_and_generate_emails_worker.rb
@@ -29,9 +29,11 @@ private
 
   def import_subscription_content(content_change)
     ensure_subscription_content_import_running_only_once(content_change) do
-      SubscriptionContent.import_ignoring_duplicates(
+      SubscriptionContent.import!(
         %i[content_change_id subscription_id],
         subscription_ids(content_change).map { |id| [content_change.id, id] },
+        on_duplicate_key_ignore: true,
+        batch_size: 500,
       )
     end
   end

--- a/app/workers/process_message_and_generate_emails_worker.rb
+++ b/app/workers/process_message_and_generate_emails_worker.rb
@@ -30,9 +30,11 @@ private
 
   def import_subscription_content(message)
     ensure_subscription_content_import_running_only_once(message) do
-      SubscriptionContent.import_ignoring_duplicates(
+      SubscriptionContent.import!(
         %i[message_id subscription_id],
         subscription_ids(message).map { |id| [message.id, id] },
+        on_duplicate_key_ignore: true,
+        batch_size: 500,
       )
     end
   end

--- a/spec/models/subscription_content_spec.rb
+++ b/spec/models/subscription_content_spec.rb
@@ -27,14 +27,19 @@ RSpec.describe SubscriptionContent do
     end
   end
 
-  describe ".import_ignoring_duplicates" do
+  describe ".import!" do
     let(:content_changes) { create_list(:content_change, 15) }
     let(:subscription) { create(:subscription) }
     let(:columns) { %i[content_change_id subscription_id] }
     let(:rows) { content_changes.map { |c| [c.id, subscription.id] } }
 
     it "can import a lot of items" do
-      expect { described_class.import_ignoring_duplicates(columns, rows, batch_size: 5) }
+      expect {
+        described_class.import!(columns,
+                                rows,
+                                on_duplicate_key_ignore: true,
+                                batch_size: 5)
+      }
         .to change { SubscriptionContent.count }
         .by(15)
     end
@@ -48,7 +53,11 @@ RSpec.describe SubscriptionContent do
         )
       end
 
-      expect { described_class.import_ignoring_duplicates(columns, rows) }
+      expect {
+        described_class.import!(columns,
+                                rows,
+                                on_duplicate_key_ignore: true)
+      }
         .to change { SubscriptionContent.count }
         .by(10)
     end


### PR DESCRIPTION
Switch to using import! from the activerecord-import gem. We're now
using PostgreSQL 9.6, so we should be able to use the gem directly, as
described in the code comment.

I've updated the tests for this area, just to help demonstrate that
the behaviour is consistent. Maybe the tests are irrelevant now.