### PR TITLE
Temporarily reduce rate limit from 21600 to 15000

### DIFF
--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -50,8 +50,8 @@ class DeliveryRequestWorker
   end
 
   def rate_limit_threshold
-    per_minute_to_allow_360_per_second = "21600"
-    ENV.fetch("DELIVERY_REQUEST_THRESHOLD", per_minute_to_allow_360_per_second).to_i
+    per_minute_to_allow_250_per_second = "15000"
+    ENV.fetch("DELIVERY_REQUEST_THRESHOLD", per_minute_to_allow_250_per_second).to_i
   end
 
   def rate_limit_interval

--- a/spec/workers/delivery_request_worker_spec.rb
+++ b/spec/workers/delivery_request_worker_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe DeliveryRequestWorker do
         expect(subject.rate_limit_threshold).to eq(10)
       end
 
-      it "is 21600 by default" do
-        expect(subject.rate_limit_threshold).to eq(21_600)
+      it "is 15000 by default" do
+        expect(subject.rate_limit_threshold).to eq(15_000)
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe DeliveryRequestWorker do
 
     describe "rate_limit_exceeded?" do
       it "checks the delivery_request limit" do
-        default_threshold = 21_600
+        default_threshold = 15_000
         default_interval = 60
 
         expect(rate_limiter).to receive(:exceeded?).with(


### PR DESCRIPTION
Reduce from ~360/s to ~250/s as Notify are having issues.
This is a temporary change, we should revert as soon as Notify confirm that's ok to do.