### PR TITLE
Remove aws-sdk-kms-1.34 dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.34.0)
+    aws-sdk-kms (1.33.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.68.0)


### PR DESCRIPTION
This gem has been yanked. See
https://github.com/aws/aws-sdk-ruby/issues/2327 and
https://github.com/aws/aws-sdk-ruby/issues/2329