### PR TITLE
Only stub $stdout where we need to

### DIFF
--- a/spec/lib/clean/empty_subscriber_lists_spec.rb
+++ b/spec/lib/clean/empty_subscriber_lists_spec.rb
@@ -11,14 +11,20 @@ RSpec.describe Clean::EmptySubscriberLists do
       end
     end
 
-    context "during a dry run" do
-      it "wont remove the list" do
-        expect { subject.remove_empty_subscriberlists }.not_to(change { SubscriberList.count })
+    describe "#remove_empty_subscriber_lists" do
+      before do
+        allow($stdout).to receive(:puts)
       end
-    end
 
-    it "removes the list" do
-      expect { subject.remove_empty_subscriberlists(dry_run: false) }.to(change { SubscriberList.count })
+      context "during a dry run" do
+        it "wont remove the list" do
+          expect { subject.remove_empty_subscriberlists }.not_to(change { SubscriberList.count })
+        end
+      end
+
+      it "removes the list" do
+        expect { subject.remove_empty_subscriberlists(dry_run: false) }.to(change { SubscriberList.count })
+      end
     end
   end
 

--- a/spec/lib/clean/invalid_subscriber_lists_spec.rb
+++ b/spec/lib/clean/invalid_subscriber_lists_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Clean::InvalidSubscriberLists do
     let!(:subscriber) { create(:subscriber) }
     let!(:subscription) { create(:subscription, :ended, subscriber: subscriber, subscriber_list: invalid_list1) }
 
+    before do
+      allow($stdout).to receive(:puts)
+    end
+
     it "deletes invalid subscriber lists which don't have active subscriptions" do
       expect {
         subject.destroy_invalid_subscriber_lists(dry_run: false)

--- a/spec/lib/clean/invalid_subscribers_spec.rb
+++ b/spec/lib/clean/invalid_subscribers_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe Clean::InvalidSubscribers do
+  before do
+    allow($stdout).to receive(:puts)
+  end
+
   context "There are four subscribers" do
     before :each do
       @subscriber1 = FactoryBot.create(:subscriber, id: 1)

--- a/spec/lib/clean/migrate_specialist_subscriber_lists_spec.rb
+++ b/spec/lib/clean/migrate_specialist_subscriber_lists_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Clean::MigrateSpecialistSubscriberLists do
       subject(:migration) { cleaner.migrate_subscribers_to_working_lists(dry_run: dry_run) }
       let(:dry_run) { false }
 
+      before do
+        allow($stdout).to receive(:puts)
+      end
+
       context "during a dry run" do
         let(:dry_run) { true }
         it "wont migrate subscribers" do

--- a/spec/lib/notifications_from_notify_spec.rb
+++ b/spec/lib/notifications_from_notify_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe NotificationsFromNotify do
         notification = notifications_collection.collection.first
         allow(client).to receive(:get_notifications).and_return(notifications_collection)
 
-        described_class.call(reference)
-
         expect { described_class.call(reference) }
         .to output(
           <<~TEXT,
@@ -60,8 +58,6 @@ RSpec.describe NotificationsFromNotify do
         client = instance_double("Notifications::Client")
         allow(client).to receive(:get_notifications).and_return(empty_client_notifications_collection)
 
-        described_class.call(reference)
-
         expect { described_class.call(reference) }
         .to output(
           <<~TEXT,
@@ -94,7 +90,6 @@ RSpec.describe NotificationsFromNotify do
         client = instance_double("Notifications::Client")
         error = client_request_error
         allow(client).to receive(:get_notifications).and_raise(client_request_error)
-        described_class.call(reference)
 
         expect { described_class.call(reference) }
         .to output(

--- a/spec/lib/overloader_spec.rb
+++ b/spec/lib/overloader_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Overloader do
   before do
     list_1.subscriptions << create_list(:subscription, 2)
     list_2.subscriptions << create_list(:subscription, 1)
+    allow($stdout).to receive(:puts)
   end
 
   describe "#with_big_lists" do

--- a/spec/lib/reports/find_delivery_attempts_report_spec.rb
+++ b/spec/lib/reports/find_delivery_attempts_report_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Reports::FindDeliveryAttemptsReport do
     let(:end_date) { "2019-03-23" }
 
     it "throws an error if invalid date is used" do
+      allow($stdout).to receive(:puts)
       expect { described_class.new("xyz", end_date).report }.to raise_error(ArgumentError, "Date(s) entered need to be of date/time format")
     end
 
@@ -43,6 +44,7 @@ RSpec.describe Reports::FindDeliveryAttemptsReport do
     end
 
     it "does not output the average time if there are no delivery attempts within date range" do
+      allow($stdout).to receive(:puts)
       expect { described_class.new("2019-02-02", "2019-02-01").report }.to raise_error(RuntimeError, "No data for dates provided")
     end
   end

--- a/spec/lib/reports/unpublishing_report_spec.rb
+++ b/spec/lib/reports/unpublishing_report_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Reports::UnpublishingReport do
 
   context "generates report" do
     it "generates a report showing unpublishing activity and new subscriptions being made" do
-      described_class.call("2018/08/28", "2018/08/30")
       expect { described_class.call("2018/08/28", "2018/08/30") }.to output(
         <<~TEXT,
           Unpublishing activity between 2018-08-28 00:00:00 and 2018-08-30 00:00:00
@@ -62,7 +61,6 @@ RSpec.describe Reports::UnpublishingReport do
     end
 
     it "generates a report showing unpublishing activity but no new subscriptions being created" do
-      described_class.call("2018/08/31", "2018/09/01")
       expect { described_class.call("2018/08/31", "2018/09/01") }.to output(
         <<~TEXT,
           Unpublishing activity between 2018-08-31 00:00:00 and 2018-09-01 00:00:00

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,10 +21,6 @@ RSpec.configure do |config|
   config.include RequestHelpers, type: :request
   config.include FactoryBot::Syntax::Methods
 
-  config.before do
-    allow($stdout).to receive(:puts)
-  end
-
   config.before(:each) do
     Sidekiq::Worker.clear_all
   end


### PR DESCRIPTION
https://trello.com/c/IAj6XWFo/309-create-a-report-to-show-the-content-changes-that-have-triggered-notifications

Previously we swallowed calls to 'puts' in any test, which created
confusion for people trying to use an interactive debugger. Since
RuboCop prevents uses of 'puts' outside of 'lib/', it should not be
necessary to swallow calls to this method in general.

This removes the stub and applies it in the specific places where it's
necessary to avoid noisy test output. Note that some of the calls to
'puts' were due to the test running the code twice, with the instance
correctly swallowing the output already.