### PR TITLE
Match content changes in a worker

### DIFF
--- a/app/services/content_change_handler_service.rb
+++ b/app/services/content_change_handler_service.rb
@@ -10,12 +10,8 @@ class ContentChangeHandlerService
   end
 
   def call
-    content_change = nil
-    ActiveRecord::Base.transaction do
-      content_change = ContentChange.create!(content_change_params)
-      MetricsService.content_change_created
-      MatchedContentChangeGenerationService.call(content_change: content_change)
-    end
+    content_change = ContentChange.create!(content_change_params)
+    MetricsService.content_change_created
     ProcessContentChangeAndGenerateEmailsWorker.perform_async(content_change.id)
   end
 

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -8,7 +8,7 @@ class MatchedContentChangeGenerationService
   end
 
   def call
-    # if we already have any records already we expect the process completed
+    # if we have records already, then we expect the process completed
     # successfully previously since the insert is an atomic operation
     return if MatchedContentChange.exists?(content_change: content_change)
 

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -1,5 +1,5 @@
 class MatchedContentChangeGenerationService
-  def initialize(content_change:)
+  def initialize(content_change)
     @content_change = content_change
   end
 

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -8,6 +8,10 @@ class MatchedContentChangeGenerationService
   end
 
   def call
+    # if we already have any records already we expect the process completed
+    # successfully previously since the insert is an atomic operation
+    return if MatchedContentChange.exists?(content_change: content_change)
+
     MatchedContentChange.import!(columns, records)
   end
 

--- a/app/services/matched_message_generation_service.rb
+++ b/app/services/matched_message_generation_service.rb
@@ -8,7 +8,7 @@ class MatchedMessageGenerationService
   end
 
   def call
-    # if we already have any records already we expect the process completed
+    # if we already have records already, then we expect the process completed
     # successfully previously since the insert is an atomic operation
     return if MatchedMessage.exists?(message: message)
 

--- a/app/services/matched_message_generation_service.rb
+++ b/app/services/matched_message_generation_service.rb
@@ -8,6 +8,10 @@ class MatchedMessageGenerationService
   end
 
   def call
+    # if we already have any records already we expect the process completed
+    # successfully previously since the insert is an atomic operation
+    return if MatchedMessage.exists?(message: message)
+
     MatchedMessage.import!(columns, records)
   end
 

--- a/app/workers/process_content_change_and_generate_emails_worker.rb
+++ b/app/workers/process_content_change_and_generate_emails_worker.rb
@@ -7,6 +7,8 @@ class ProcessContentChangeAndGenerateEmailsWorker < ProcessAndGenerateEmailsWork
     content_change = ContentChange.find(content_change_id)
     return if content_change.processed?
 
+    MatchedContentChangeGenerationService.call(content_change)
+
     import_subscription_content(content_change)
 
     SubscribersForImmediateEmailQuery.call(content_change_id: content_change_id, message_id: nil).find_in_batches(batch_size: BATCH_SIZE) do |group|

--- a/spec/services/content_change_handler_service_spec.rb
+++ b/spec/services/content_change_handler_service_spec.rb
@@ -56,11 +56,6 @@ RSpec.describe ContentChangeHandlerService do
         .to change { ContentChange.count }.by(1)
     end
 
-    it "creates a MatchedContentChange" do
-      expect { described_class.call(params: params, govuk_request_id: govuk_request_id) }
-        .to change { MatchedContentChange.count }.by(1)
-    end
-
     let(:content_change) { create(:content_change) }
 
     it "adds GovukDocumentTypes to the content_change tags" do

--- a/spec/services/matched_content_change_generation_service_spec.rb
+++ b/spec/services/matched_content_change_generation_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MatchedContentChangeGenerationService do
 
   describe ".call" do
     it "creates a MatchedContentChange" do
-      expect { described_class.call(content_change: content_change) }
+      expect { described_class.call(content_change) }
         .to change { MatchedContentChange.count }.by(1)
     end
   end

--- a/spec/services/matched_content_change_generation_service_spec.rb
+++ b/spec/services/matched_content_change_generation_service_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe MatchedContentChangeGenerationService do
     create(:content_change, tags: { topics: ["oil-and-gas/licensing"] })
   end
 
-  before do
+  let!(:subscriber_list) do
     create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
   end
 
@@ -11,6 +11,14 @@ RSpec.describe MatchedContentChangeGenerationService do
     it "creates a MatchedContentChange" do
       expect { described_class.call(content_change) }
         .to change { MatchedContentChange.count }.by(1)
+    end
+
+    it "copes and does nothing when the MatchedContentChange records already exists" do
+      MatchedContentChange.create!(content_change: content_change,
+                                   subscriber_list: subscriber_list)
+
+      expect { described_class.call(content_change) }
+        .to_not(change { MatchedContentChange.count })
     end
   end
 end

--- a/spec/services/matched_message_generation_service_spec.rb
+++ b/spec/services/matched_message_generation_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MatchedMessageGenerationService do
     )
   end
 
-  before do
+  let!(:subscriber_list) do
     create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
   end
 
@@ -16,6 +16,13 @@ RSpec.describe MatchedMessageGenerationService do
     it "creates a MatchedMessage" do
       expect { described_class.call(message) }
         .to change { MatchedMessage.count }.by(1)
+    end
+
+    it "copes and does nothing when the MatchedMessage records already exists" do
+      MatchedMessage.create!(message: message, subscriber_list: subscriber_list)
+
+      expect { described_class.call(message) }
+        .to_not(change { MatchedMessage.count })
     end
   end
 end

--- a/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
+++ b/spec/workers/process_content_change_and_generate_emails_worker_spec.rb
@@ -1,11 +1,10 @@
 RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
-  let(:content_change) { create(:content_change, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
+  let(:content_change) { create(:content_change, tags: { topics: ["oil-and-gas/licensing"] }) }
   let(:email) { create(:email) }
 
   context "with a subscription" do
     let(:subscriber) { create(:subscriber) }
     let(:subscriber_list) { create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
-    let!(:matched_content_change) { create(:matched_content_change, subscriber_list: subscriber_list, content_change: content_change) }
     let!(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list) }
 
     it "creates subscription content for the content change" do
@@ -18,6 +17,11 @@ RSpec.describe ProcessContentChangeAndGenerateEmailsWorker do
       expect { subject.perform(content_change.id) }
         .to change { content_change.reload.processed? }
         .to(true)
+    end
+
+    it "creates a MatchedContentChange" do
+      expect { subject.perform(content_change.id) }
+        .to change { MatchedContentChange.count }.by(1)
     end
 
     context "when the subscription content has already been imported" do


### PR DESCRIPTION
This change is to resolve a long running inconsistency between content
changes and messages. Both of these need to match subscription lists to
their content model. Message has performed this action asynchronously in
the worker whereas ContentChange has performed this during the HTTP
request.

This is an action that is unnecessary for the HTTP request and thus
risks these being slower than necessary (From looking over last 24 hours
I can see the request maxed at 5s and averages 1.1s).

It also adds a check in both of the MatchContentChangeGenerationService
and MatchedMessageGenerationService to handle cases where the service
is called after already matching. This serves to allow us to transition from
web request to worker and also serves as a means to not re-run this when
resuming any retried workers.