### PR TITLE
Expand Living In Europe report

### DIFF
--- a/lib/reports/data_exporter.rb
+++ b/lib/reports/data_exporter.rb
@@ -17,8 +17,8 @@ class Reports::DataExporter
     export_csv(SubscriberList.where(slug: slugs), at: date)
   end
 
-  def export_csv_from_living_in_europe
-    export_csv(living_in_europe_subscriber_lists)
+  def export_csv_from_living_in_europe(date)
+    export_detailed_csv(living_in_europe_subscriber_lists, at: date)
   end
 
   def export_csv_from_travel_advice_at(date)

--- a/lib/reports/data_exporter.rb
+++ b/lib/reports/data_exporter.rb
@@ -52,6 +52,7 @@ private
     netherlands
     poland
     portugal
+    romania
     slovakia
     slovenia
     spain

--- a/lib/reports/data_exporter.rb
+++ b/lib/reports/data_exporter.rb
@@ -22,7 +22,7 @@ class Reports::DataExporter
   end
 
   def export_csv_from_travel_advice_at(date)
-    travel_advice_csv(travel_advice_subscriber_lists, at: date)
+    export_detailed_csv(travel_advice_subscriber_lists, at: date)
   end
 
 private
@@ -93,7 +93,7 @@ private
     end
   end
 
-  def travel_advice_csv(subscriber_lists, at: nil)
+  def export_detailed_csv(subscriber_lists, at: nil)
     CSV($stdout, headers: %i[title subscribed unsubscribed immediately daily weekly], write_headers: true) do |csv|
       subscriber_lists.find_each do |subscriber_list|
         csv << present_travel_advice_report(subscriber_list, at: at)

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -61,9 +61,9 @@ namespace :report do
     Reports::DataExporter.new.export_csv_from_slugs_at(args.date, args.extras)
   end
 
-  desc "Export the number of subscriptions for the 'Living in' taxons for European countries"
-  task csv_from_living_in_europe: :environment do
-    Reports::DataExporter.new.export_csv_from_living_in_europe
+  desc "Export the number of subscriptions for the 'Living in' taxons for European countries as of a given date (format: 'yyyy-mm-dd')"
+  task :csv_from_living_in_europe, [:date] => :environment do |_, args|
+    Reports::DataExporter.new.export_csv_from_living_in_europe(args.date)
   end
 
   desc "Export the number of subscriptions to travel advice lists as of a given date (format: 'yyyy-mm-dd')"

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "report" do
 
   describe "csv_from_living_in_europe" do
     it "outputs a report of subscriptions to living in Europe lists" do
-      expect { Rake::Task["report:csv_from_living_in_europe"].invoke }
+      expect { Rake::Task["report:csv_from_living_in_europe"].invoke("2018-08-08") }
         .to output.to_stdout
     end
   end


### PR DESCRIPTION
## What
Expands the existing report for Living In guides to:

- Provide more detailed stats (new subscribers, unsubscribers, and a breakdown of immediate/daily/weekly)
- Ability to provide a date so the data is gathered from that point
- Adds Romania to the list of European countries

## Why
The FCO have requested this data on a weekly basis. As we were previously using this task to provide them with data, it makes sense to expand the existing task rather than create a new one.