### PR TITLE
Add documentation on queues

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,6 +3,8 @@
 :concurrency: 32
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
+
+# Any changes to the queues should be reflected in `docs/queues.md`.
 :queues:
   - delivery_transactional
   - [delivery_immediate_high, 10]
@@ -12,6 +14,7 @@
   - [delivery_digest, 2]
   - [email_generation_digest, 1]
   - cleanup
+
 :schedule:
   daily_digest_initiator:
     cron: '30 8 * * * Europe/London' # every day at 8:30am

--- a/docs/queues.md
+++ b/docs/queues.md
@@ -1,0 +1,39 @@
+# Queues
+
+Email Alert API uses [Sidekiq] to process workers. There are numerous queues configured in the [config/sidekiq.yml] file.
+
+Each queue is assigned a priority and workers will be [picked from the queues according to their priority weighting](queue-priority). The queues listed below are in priority order, although for the specific weightings it's best to refer to the configuration file linked to above.
+
+[Sidekiq]: https://sidekiq.org/
+[config/sidekiq.yml]: https://github.com/alphagov/email-alert-api/blob/master/config/sidekiq.yml
+[queue-priority]: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
+
+## `delivery_transactional`
+
+Used to send one-off emails, such as subscription confirmation.
+
+## `delivery_immediate_high`
+
+Used to send high priority emails to users who have requested immediate updates to content. Foreign travel advice is an example of high priority content.
+
+## `delivery_immediate`
+
+Used to send emails to users who have requested immediate updates to content.
+
+## `process_and_generate_emails`
+
+Used to generate the emails for each content change to users who have requested immediate updates to content. Once the generation process is complete, delivery jobs are sent to either the high priority or normal priority delivery queues.
+
+## `delivery_digest`
+
+Used to send digest emails to users who have requested either daily or weekly updates to content.
+
+## `email_generation_digest`
+
+Used to generate the emails for each content change to users who have requested daily or weekly updates to content. The jobs on this queue are scheduled to run every day at 8:30am for daily updates and every Saturday at 8:30am for weekly updates.
+
+## `cleanup`
+
+Used to perform various operations related to monitoring or tidying up the database. There are jobs which [archives emails to Athena][analytics] and others which calculates the number of unprocessed content changes or subscription contents and sends that data to Statsd for monitoring.
+
+[analytics]: analytics.md


### PR DESCRIPTION
During incidents, it's often not clear to people what the various queues are used for (one specific example is the difference between `immediate` and `immediate_high_priority`).

This adds documentation on each of the queues, which will get picked up by the developer docs.

This work came from an incident we had recently related to the system being heavily overloaded.

[Trello Card](https://trello.com/c/y7nqDb94/2024-1-describe-each-of-the-email-queues-in-the-developer-docs) &middot; [Incident Report](https://docs.google.com/document/d/1rpHhLlbJQ-z7lu2RD88vpajUbxaolWvm3fG0Q9QAPYE/edit)