### PR TITLE
Replace Sidekiq queue weights with priorities

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,18 +3,17 @@
 :concurrency: 32
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
-
 # Any changes to the queues should be reflected in `docs/queues.md`.
+# https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
 :queues:
   - delivery_transactional
-  - [delivery_immediate_high, 10]
-  - [delivery_immediate, 5]
-  - [process_and_generate_emails, 4]
-  - [default, 3]
-  - [delivery_digest, 2]
-  - [email_generation_digest, 1]
+  - delivery_immediate_high
+  - delivery_digest
+  - delivery_immediate
+  - process_and_generate_emails
+  - email_generation_digest
+  - default
   - cleanup
-
 :schedule:
   daily_digest_initiator:
     cron: '30 8 * * * Europe/London' # every day at 8:30am


### PR DESCRIPTION
Previously we had an incompatible mixture of ordering [1] and weights,
which were often set arbitrarily and misread as priorities [2]. This
removes all the weights, so that the configuration simply prioritises
the queues based on the order they are listed.

This also groups similar queues together: for delivery and generation;
we should prioritise digest email above cleanup and 'default' jobs.

[1]: 9473c38a4e7eb989cc39c84fd15fe9e0ffc4c136
[2]: 21dcb06850bb6ccbe857bc04d05f5b476bba96ea