### PR TITLE
Increase rate limit to 21,000

### DIFF
--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -50,8 +50,8 @@ class DeliveryRequestWorker
   end
 
   def rate_limit_threshold
-    per_minute_to_allow_250_per_second = "15000"
-    ENV.fetch("DELIVERY_REQUEST_THRESHOLD", per_minute_to_allow_250_per_second).to_i
+    per_minute_to_allow_350_per_second = "21000"
+    ENV.fetch("DELIVERY_REQUEST_THRESHOLD", per_minute_to_allow_350_per_second).to_i
   end
 
   def rate_limit_interval

--- a/spec/workers/delivery_request_worker_spec.rb
+++ b/spec/workers/delivery_request_worker_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe DeliveryRequestWorker do
         expect(subject.rate_limit_threshold).to eq(10)
       end
 
-      it "is 15000 by default" do
-        expect(subject.rate_limit_threshold).to eq(15_000)
+      it "is 21000 by default" do
+        expect(subject.rate_limit_threshold).to eq(21_000)
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe DeliveryRequestWorker do
 
     describe "rate_limit_exceeded?" do
       it "checks the delivery_request limit" do
-        default_threshold = 15_000
+        default_threshold = 21_000
         default_interval = 60
 
         expect(rate_limiter).to receive(:exceeded?).with(


### PR DESCRIPTION
Trello: https://trello.com/c/OfF8KVKq/338-increase-the-notify-rate-limit-back-to-25-26k-min

We previously temporarily reduced the rate limit to give Notify more breathing space to an investigate an issue they were seeing.
They've given us the go-ahead to increase again.

Our original limit was 360/s (21,600). This was weirdly just above Notify's limit, when really we want it to be just under or the same. Setting to 350/s for now so it's the same as Notify's. We can chat about getting Notify to increase things on their side in the future once they've confirmed the issue they were seeing has been resolved.