### PR TITLE
Improve resend troubleshooting tasks

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -117,12 +117,25 @@ To send a test email to an email address (doesn't have to be subscribed to anyth
 $ bundle exec rake deliver:deliver_to_test_email[<email_address>]
 ```
 
-## Resend emails
+## Resend failed emails
 
-This task takes an array of email ids and re-sends them.
+There are two Rake tasks available to resend emails which didn't send for
+whatever reason and ended up in the failed state. This is most useful after
+an incident to resend all emails that failed with a technical failure.
+
+### Using a date range
 
 ```bash
-bundle exec rake troubleshoot:resend_failed_emails:by_id[<email_one_id>, <email_two_id>]
+bundle exec rake 'troubleshoot:resend_failed_emails:by_date[<from_date>,<to_date>]'
+```
+
+The date format should be in ISO8601 format, for example `2020-01-01T10:00:00Z`.
+Depending on the number of emails to send, the Rake task can take a few minutes to run.
+
+### Using email IDs
+
+```bash
+bundle exec rake 'troubleshoot:resend_failed_emails:by_id[<email_one_id>,<email_two_id>]'
 ```
 
 ## Query for subscriptions by title

--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -122,7 +122,7 @@ $ bundle exec rake deliver:deliver_to_test_email[<email_address>]
 This task takes an array of email ids and re-sends them.
 
 ```bash
-bundle exec rake deliver:resend_failed_emails[<email_one_id>, <email_two_id>]
+bundle exec rake troubleshoot:resend_failed_emails:by_id[<email_one_id>, <email_two_id>]
 ```
 
 ## Query for subscriptions by title

--- a/lib/tasks/troubleshoot.rake
+++ b/lib/tasks/troubleshoot.rake
@@ -59,6 +59,6 @@ def resend_failed_emails(scope)
   puts "Resending #{ids.length} emails"
 
   ids.each do |id|
-    DeliveryRequestWorker.perform_async_in_queue(id, queue: :delivery_immediate)
+    DeliveryRequestWorker.perform_async_in_queue(id, queue: :delivery_immediate_high)
   end
 end

--- a/lib/tasks/troubleshoot.rake
+++ b/lib/tasks/troubleshoot.rake
@@ -44,6 +44,13 @@ namespace :troubleshoot do
     task by_id: [:environment] do |_, args|
       resend_failed_emails(Email.where(id: args.to_a))
     end
+
+    desc "Re-send failed emails by date range"
+    task :by_date, %i[from to] => [:environment] do |_, args|
+      from = Time.iso8601(args.fetch(:from))
+      to = Time.iso8601(args.fetch(:to))
+      resend_failed_emails(Email.where(created_at: from..to))
+    end
   end
 end
 

--- a/lib/tasks/troubleshoot.rake
+++ b/lib/tasks/troubleshoot.rake
@@ -39,13 +39,19 @@ namespace :troubleshoot do
     DeliveryRequestWorker.perform_async_in_queue(email.id, queue: :delivery_immediate)
   end
 
-  desc "Re-send failed emails by email ids"
-  task resend_failed_emails: [:environment] do |_, args|
-    failed_email_ids = Email.where(id: args.to_a, status: "failed").pluck(:id)
-
-    failed_email_ids.each do |email_id|
-      puts "Resending email: #{email_id}"
-      DeliveryRequestWorker.perform_async_in_queue(email_id, queue: :delivery_immediate)
+  namespace :resend_failed_emails do
+    desc "Re-send failed emails by email ids"
+    task by_id: [:environment] do |_, args|
+      resend_failed_emails(Email.where(id: args.to_a))
     end
+  end
+end
+
+def resend_failed_emails(scope)
+  ids = scope.where(status: :failed).pluck(:id)
+  puts "Resending #{ids.length} emails"
+
+  ids.each do |id|
+    DeliveryRequestWorker.perform_async_in_queue(id, queue: :delivery_immediate)
   end
 end

--- a/spec/lib/tasks/troubleshoot_spec.rb
+++ b/spec/lib/tasks/troubleshoot_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe "troubleshoot" do
     end
   end
 
-  describe "resend_failed_emails" do
+  describe "resend_failed_emails:by_id" do
     it "queues specified failed emails to resend" do
       email = create :email, status: :failed
 
       expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
         .with(email.id, queue: :delivery_immediate)
 
-      expect { Rake::Task["troubleshoot:resend_failed_emails"].invoke(email.id.to_s) }
+      expect { Rake::Task["troubleshoot:resend_failed_emails:by_id"].invoke(email.id.to_s) }
         .to output.to_stdout
     end
   end

--- a/spec/lib/tasks/troubleshoot_spec.rb
+++ b/spec/lib/tasks/troubleshoot_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "troubleshoot" do
       email = create :email, status: :failed
 
       expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-        .with(email.id, queue: :delivery_immediate)
+        .with(email.id, queue: :delivery_immediate_high)
 
       expect { Rake::Task["troubleshoot:resend_failed_emails:by_id"].invoke(email.id.to_s) }
         .to output.to_stdout
@@ -52,7 +52,7 @@ RSpec.describe "troubleshoot" do
       email = create :email, status: :failed
 
       expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
-        .with(email.id, queue: :delivery_immediate)
+        .with(email.id, queue: :delivery_immediate_high)
 
       from = (email.created_at - 1.day).iso8601
       to = (email.created_at + 1.day).iso8601

--- a/spec/lib/tasks/troubleshoot_spec.rb
+++ b/spec/lib/tasks/troubleshoot_spec.rb
@@ -46,4 +46,18 @@ RSpec.describe "troubleshoot" do
         .to output.to_stdout
     end
   end
+
+  describe "resend_failed_emails:by_date" do
+    it "queues specified failed emails to resend" do
+      email = create :email, status: :failed
+
+      expect(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+        .with(email.id, queue: :delivery_immediate)
+
+      from = (email.created_at - 1.day).iso8601
+      to = (email.created_at + 1.day).iso8601
+      expect { Rake::Task["troubleshoot:resend_failed_emails:by_date"].invoke(from, to) }
+        .to output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
This expands on the existing tasks for resending failed emails to support providing either an email ID or a date range. The change came from a recent incident where a task accepting a date range would have been useful.

[Trello Card](https://trello.com/c/hBOhkenb/2026-3-investigate-improving-task-to-resend-email-when-theres-been-a-failure)