### PR TITLE
Gems cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,27 +1,24 @@
 source "https://rubygems.org"
 
-gem "pg", "~> 1.2"
-gem "rails", "~> 6.0"
-
+gem "aws-sdk-s3"
 gem "bootsnap", require: false
-gem "with_advisory_lock", "~> 4.6"
-
-gem "aws-sdk-s3", "~> 1"
-gem "faraday", "1.0.1"
-gem "gds-api-adapters", "~> 67.0"
-gem "gds-sso", "~> 15.0"
-gem "govuk_app_config", "~> 2.2"
-gem "govuk_document_types", "~> 0.9.2"
-gem "json-schema", "~> 2.8"
-gem "jwt", "~> 2.2"
-gem "nokogiri", "~> 1.10"
-gem "notifications-ruby-client", "~> 5.1"
-gem "plek", "~> 3.0"
-gem "redcarpet", "~> 3.5"
-
-gem "govuk_sidekiq", "~> 3.0"
-gem "ratelimit", "~> 1.0"
-gem "sidekiq-scheduler", "~> 3.0"
+gem "faraday"
+gem "gds-api-adapters"
+gem "gds-sso"
+gem "govuk_app_config"
+gem "govuk_document_types"
+gem "govuk_sidekiq"
+gem "json-schema"
+gem "jwt"
+gem "nokogiri"
+gem "notifications-ruby-client"
+gem "pg"
+gem "plek"
+gem "rails"
+gem "ratelimit"
+gem "redcarpet"
+gem "sidekiq-scheduler"
+gem "with_advisory_lock"
 
 group :test do
   gem "climate_control"
@@ -32,8 +29,8 @@ group :test do
 end
 
 group :development, :test do
-  gem "listen", "3.2.1"
+  gem "listen"
   gem "pry-byebug"
-  gem "rspec-rails", "4.0.1"
+  gem "rspec-rails"
   gem "rubocop-govuk"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,4 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails", "4.0.1"
   gem "rubocop-govuk"
-  gem "ruby-prof", "~> 1.4"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "with_advisory_lock", "~> 4.6"
 
 gem "aws-sdk-s3", "~> 1"
 gem "faraday", "1.0.1"
-gem "foreman", "~> 0.87"
 gem "gds-api-adapters", "~> 67.0"
 gem "gds-sso", "~> 15.0"
 gem "govuk_app_config", "~> 2.2"

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "sidekiq-scheduler", "~> 3.0"
 
 group :test do
   gem "climate_control"
-  gem "database_cleaner"
   gem "equivalent-xml"
   gem "factory_bot_rails"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,6 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
-    foreman (0.87.1)
     fugit (1.3.3)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
@@ -378,7 +377,6 @@ DEPENDENCIES
   equivalent-xml
   factory_bot_rails
   faraday (= 1.0.1)
-  foreman (~> 0.87)
   gds-api-adapters (~> 67.0)
   gds-sso (~> 15.0)
   govuk_app_config (~> 2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,6 @@ GEM
       rubocop
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
-    ruby-prof (1.4.1)
     ruby-progressbar (1.10.1)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
@@ -398,7 +397,6 @@ DEPENDENCIES
   redcarpet (~> 3.5)
   rspec-rails (= 4.0.1)
   rubocop-govuk
-  ruby-prof (~> 1.4)
   sidekiq-scheduler (~> 3.0)
   timecop
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
     aws-eventstream (1.1.0)
-    aws-partitions (1.331.0)
+    aws-partitions (1.332.0)
     aws-sdk-core (3.100.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -78,11 +78,11 @@ GEM
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
-    byebug (11.1.1)
+    byebug (11.1.3)
     climate_control (0.2.0)
-    coderay (1.1.2)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -93,19 +93,19 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.9.0)
-    et-orbi (1.2.2)
+    et-orbi (1.2.4)
       tzinfo
-    factory_bot (6.0.0)
+    factory_bot (6.0.2)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.0.0)
       factory_bot (~> 6.0.0)
       railties (>= 5.0.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.3)
-    fugit (1.3.3)
+    ffi (1.13.1)
+    fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.1)
+      raabro (~> 1.3)
     gds-api-adapters (67.0.0)
       addressable
       link_header
@@ -198,21 +198,21 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.19.1)
-    parser (2.7.1.3)
-      ast (~> 2.4.0)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     pg (1.2.3)
     plek (3.0.0)
-    pry (0.13.0)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.5)
-    raabro (1.1.6)
+    raabro (1.3.1)
     rack (2.2.3)
-    rack-cache (1.11.1)
+    rack-cache (1.12.0)
       rack (>= 0.4)
     rack-protection (2.0.8.1)
       rack
@@ -250,11 +250,11 @@ GEM
     ratelimit (1.0.3)
       redis (>= 2.0.0)
       redis-namespace (>= 1.0.0)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
-    redis (4.1.3)
+    redis (4.1.4)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     regexp_parser (1.7.1)
@@ -313,11 +313,11 @@ GEM
     safe_yaml (1.0.5)
     sentry-raven (3.0.0)
       faraday (>= 1.0)
-    sidekiq (5.2.7)
+    sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
-      rack (>= 1.5.0)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (>= 3.3.5, < 4.2)
     sidekiq-logging-json (0.0.19)
       sidekiq (>= 3)
     sidekiq-scheduler (3.0.1)
@@ -371,34 +371,34 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-s3 (~> 1)
+  aws-sdk-s3
   bootsnap
   climate_control
   equivalent-xml
   factory_bot_rails
-  faraday (= 1.0.1)
-  gds-api-adapters (~> 67.0)
-  gds-sso (~> 15.0)
-  govuk_app_config (~> 2.2)
-  govuk_document_types (~> 0.9.2)
-  govuk_sidekiq (~> 3.0)
-  json-schema (~> 2.8)
-  jwt (~> 2.2)
-  listen (= 3.2.1)
-  nokogiri (~> 1.10)
-  notifications-ruby-client (~> 5.1)
-  pg (~> 1.2)
-  plek (~> 3.0)
+  faraday
+  gds-api-adapters
+  gds-sso
+  govuk_app_config
+  govuk_document_types
+  govuk_sidekiq
+  json-schema
+  jwt
+  listen
+  nokogiri
+  notifications-ruby-client
+  pg
+  plek
   pry-byebug
-  rails (~> 6.0)
-  ratelimit (~> 1.0)
-  redcarpet (~> 3.5)
-  rspec-rails (= 4.0.1)
+  rails
+  ratelimit
+  redcarpet
+  rspec-rails
   rubocop-govuk
-  sidekiq-scheduler (~> 3.0)
+  sidekiq-scheduler
   timecop
   webmock
-  with_advisory_lock (~> 4.6)
+  with_advisory_lock
 
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,6 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
-    database_cleaner (1.8.5)
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -377,7 +376,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   bootsnap
   climate_control
-  database_cleaner
   equivalent-xml
   factory_bot_rails
   faraday (= 1.0.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,15 +28,6 @@ RSpec.configure do |config|
   config.after type: :request do
     logout
   end
-
-  config.around(:each, testing_transactions: true) do |example|
-    DatabaseCleaner.allow_remote_database_url = true
-    self.use_transactional_tests = false
-    DatabaseCleaner.strategy = :truncation
-    example.run
-    DatabaseCleaner.clean
-    self.use_transactional_tests = true
-  end
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 
+gem install foreman --conservative
 bundle install
-PORT=${PORT:-3088} bundle exec foreman start
+PORT=${PORT:-3088} foreman start


### PR DESCRIPTION
This removes a few gems that aren't needed and applies a consistent approach to the Gemfile.

Since all the gems for this repo are at the latest version I thought we could apply an approach of specifying no gem versions which makes this file a lot cleaner. I'm pondering this as a convention that could be applied across GOV.UK where we only specify a pinned version where we've got a reason to do so. It's early days on that idea though.

