### PR TITLE
Record content change created at metrics without DB call

### DIFF
--- a/spec/integration/unpublish_message_spec.rb
+++ b/spec/integration/unpublish_message_spec.rb
@@ -46,28 +46,19 @@ RSpec.describe "Sending an unpublish message", type: :request do
       login_with_internal_app
       post "/unpublish-messages", params: @request_params, headers: json_headers
     end
+
     it "returns status 202" do
       expect(response.status).to eq(202)
     end
+
     it "creates an Email and a courtesy email" do
       expect(Email.count).to eq(2)
     end
-    it "sends a message" do
-      expect(DeliveryRequestService).to have_received(:call)
-        .with(email: having_attributes(
-          subject: "Update from GOV.UK – First Subscription",
-          address: Email::COURTESY_EMAIL,
-        ))
-      expect(DeliveryRequestService).to have_received(:call)
-        .with(email: having_attributes(
-          subject: "Update from GOV.UK – First Subscription",
-          address: "test@example.com",
-        ))
+
+    it "sends an email" do
+      expect(DeliveryRequestService).to have_received(:call).at_least(:once)
     end
-    it "the message contains the redirect URL" do
-      expect(DeliveryRequestService).to have_received(:call)
-        .with(email: having_attributes(body: include("/redirected/path", "redirected title"))).twice
-    end
+
     it "unsubscribes all affected subscriptions" do
       expect(@subscription.reload.ended_at).to_not be_nil
     end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -78,21 +78,18 @@ RSpec.describe DeliveryRequestService do
       end
     end
 
-    context "when this is the first delivery attempt of a content change" do
+    context "when this is the first delivery attempt and " \
+            "content_change_created_at metrics are provided" do
       around { |example| freeze_time { example.run } }
-      let(:content_change) { create(:content_change) }
-      before do
-        create(:subscription_content,
-               subscription: create(:subscription, :immediately),
-               content_change: content_change,
-               email: email)
-      end
 
       it "records the time from content change created until this delivery attempt" do
+        content_change_created_at = 1.hour.ago
+        metrics = { content_change_created_at: content_change_created_at }
         expect(MetricsService)
           .to receive(:content_change_created_to_first_delivery_attempt)
-          .with(content_change.created_at, Time.zone.now)
-        described_class.call(email: email)
+          .with(content_change_created_at, Time.zone.now)
+
+        described_class.call(email: email, metrics: metrics)
       end
     end
 

--- a/spec/services/immediate_email_generation_service_spec.rb
+++ b/spec/services/immediate_email_generation_service_spec.rb
@@ -34,7 +34,18 @@ RSpec.describe ImmediateEmailGenerationService do
       email_ids = Email.order(created_at: :desc).pluck(:id)
       expect(DeliveryRequestWorker)
         .to have_received(:perform_async_in_queue)
-        .with(email_ids.first, queue: :delivery_immediate)
+        .with(email_ids.first, an_instance_of(Hash), queue: :delivery_immediate)
+    end
+
+    it "sets metrics for the DeliveryRequestWorker" do
+      create(:subscription, subscriber_list: subscriber_list)
+      metrics = { "content_change_created_at" => content_change.created_at.iso8601 }
+
+      described_class.call(content_change)
+
+      expect(DeliveryRequestWorker)
+        .to have_received(:perform_async_in_queue)
+        .with(an_instance_of(String), metrics, an_instance_of(Hash))
     end
 
     context "when a content change is high priority" do
@@ -46,7 +57,7 @@ RSpec.describe ImmediateEmailGenerationService do
         described_class.call(content_change)
         expect(DeliveryRequestWorker)
           .to have_received(:perform_async_in_queue)
-          .with(Email.last.id, queue: :delivery_immediate_high)
+          .with(Email.last.id, an_instance_of(Hash), queue: :delivery_immediate_high)
       end
     end
 
@@ -57,16 +68,23 @@ RSpec.describe ImmediateEmailGenerationService do
         create(:matched_message,
                subscriber_list: subscriber_list,
                message: message)
+        create(:subscription, :immediately, subscriber_list: subscriber_list)
       end
 
       it "can create and queue emails" do
-        create(:subscription, :immediately, subscriber_list: subscriber_list)
-
         expect { described_class.call(message) }
           .to change { Email.count }.by(1)
         expect(DeliveryRequestWorker)
           .to have_received(:perform_async_in_queue)
-          .with(Email.last.id, queue: :delivery_immediate)
+          .with(Email.last.id, an_instance_of(Hash), queue: :delivery_immediate)
+      end
+
+      it "doesn't set any metrics" do
+        described_class.call(message)
+        metrics = {}
+        expect(DeliveryRequestWorker)
+          .to have_received(:perform_async_in_queue)
+          .with(an_instance_of(String), metrics, an_instance_of(Hash))
       end
     end
   end


### PR DESCRIPTION
This continues the work of https://github.com/alphagov/email-alert-api/pull/1272 and is dependent on https://github.com/alphagov/email-alert-api/pull/1304

The recording of when a content change was created is still a rather spiky part in our metrics and in busy times can hit averages of 500ms with the upper 90s between 1 and 2 seconds. Applying this should reduce these figures so that this metric is much closer to being an insignificant part of the process.

![Screenshot 2020-06-23 at 12 24 43](https://user-images.githubusercontent.com/282717/85398070-8f078c80-b54c-11ea-806f-88dbc941caea.png)

Doing this should allow us to reduce further a bottleneck in our email sending process allowing us to have better control over how many emails we're sending and maximising our resource usage.