### PR TITLE
Replace call to BulkEmailSenderService in manage rake task 

### DIFF
--- a/lib/subscriber_list_mover.rb
+++ b/lib/subscriber_list_mover.rb
@@ -93,6 +93,8 @@ class SubscriberListMover
   end
 
   def email_change_to_subscribers(emails_for_subscribed)
-    BulkEmailSenderService.call(emails_for_subscribed)
+    emails_for_subscribed.each do |id|
+      DeliveryRequestWorker.perform_async_in_queue(id, queue: :delivery_immediate)
+    end
   end
 end

--- a/lib/subscriber_list_mover.rb
+++ b/lib/subscriber_list_mover.rb
@@ -9,7 +9,6 @@ class SubscriberListMover
 
   def call
     source_subscriber_list = SubscriberList.find_by(slug: from_slug)
-    sub_count = source_subscriber_list.subscriptions.active.count
     raise "Source subscriber list #{from_slug} does not exist" if source_subscriber_list.nil?
 
     source_subscriptions = Subscription.active.find_by(subscriber_list_id: source_subscriber_list.id)
@@ -19,6 +18,7 @@ class SubscriberListMover
     raise "Destination subscriber list #{to_slug} does not exist" if destination_subscriber_list.nil?
 
     subscribers = source_subscriber_list.subscribers.activated
+    sub_count = source_subscriber_list.subscriptions.active.count
     puts "#{sub_count} active subscribers moving from #{from_slug} to #{to_slug}"
 
     if send_email

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -91,8 +91,6 @@ namespace :manage do
     end
   end
 
-  # TODO: this currently has an issue where emails are sent before
-  #       migrating users to the new subscriber list and causes confusion.
   desc "Move all subscribers from one subscriber list to another"
   task :move_all_subscribers, %i[from_slug to_slug] => :environment do |_t, args|
     if ENV["SEND_EMAIL"]

--- a/spec/lib/subscriber_list_mover_spec.rb
+++ b/spec/lib/subscriber_list_mover_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe SubscriberListMover do
+  let(:list_1) { create :subscriber_list }
+  let(:list_2) { create :subscriber_list }
+
+  before do
+    list_1.subscriptions << create_list(:subscription, 2)
+    list_2.subscriptions << create_list(:subscription, 1)
+
+    allow($stdout).to receive(:puts)
+    allow(DeliveryRequestWorker).to receive(:perform_async_in_queue)
+  end
+
+  describe "#with_send_email_false" do
+    it "raises an error if from_slug does not exist" do
+      expect { described_class.new(from_slug: "fake-list", to_slug: list_2.slug).call }
+        .to raise_error(RuntimeError, "Source subscriber list fake-list does not exist")
+    end
+
+    it "raises an error if to_slug does not exist" do
+      expect { described_class.new(from_slug: list_1.slug, to_slug: "fake-list-2").call }
+        .to raise_error(RuntimeError, "Destination subscriber list fake-list-2 does not exist")
+    end
+
+    it "raises an error if there are no active subscriptions" do
+      list_1.subscriptions = []
+
+      expect { described_class.new(from_slug: list_1.slug, to_slug: list_2.slug).call }
+        .to raise_error(RuntimeError, "No active subscriptions to move from #{list_1.slug}")
+    end
+
+    it "moves all subscriptions from the from_slug to the to_slug" do
+      expect(list_2.subscriptions.count).to eq 1
+
+      described_class.new(from_slug: list_1.slug, to_slug: list_2.slug).call
+
+      expect(list_2.subscriptions.count).to eq 3
+    end
+
+    it "ends from_slug subscriptions with reason: subscriber_list_changed" do
+      expect(list_1.subscriptions.count).to eq 2
+      expect(list_1.subscriptions[1].ended_reason).to eq nil
+
+      described_class.new(from_slug: list_1.slug, to_slug: list_2.slug).call
+
+      expect(list_1.subscriptions.count).to eq 2
+      expect(list_1.subscriptions[1].reload.ended_reason).to eq "subscriber_list_changed"
+    end
+  end
+
+  describe "#with_send_email_true" do
+    it "sends an email to all subscribers" do
+      allow(BulkEmailBuilder).to receive(:call).and_return([1, 2])
+      source_subscriber_list = SubscriberList.find_by(slug: list_1.slug)
+
+      expect(BulkEmailBuilder)
+      .to receive(:call)
+      .with(subject: "Changes to GOV.UK emails",
+            body: anything,
+            subscriber_lists: source_subscriber_list)
+
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(1, queue: :delivery_immediate)
+
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(2, queue: :delivery_immediate)
+
+      described_class.new(from_slug: list_1.slug, to_slug: list_2.slug, send_email: true).call
+    end
+  end
+end


### PR DESCRIPTION
# What

- The [BulkEmailSenderService has been removed](https://github.com/alphagov/email-alert-api/pull/1288/commits/03d616ee6c2f53ec8345f2f00e3c16328b3378bc). We can replace the call to BulkEmailSenderService with a call to DeliveryRequestWorker to send the emails
- Emails being sent before users were migrated has been fixed in https://github.com/alphagov/email-alert-api/pull/1261, so we can remove the comment now