### PR TITLE
Rake task to view email delivery attempts

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -29,6 +29,21 @@ $ bundle exec rake manage:change_email_address[<old_email_address>, <new_email_a
 
 [change]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:change_email_address[from@example.org,to@example.org]
 
+## View subscriber's recent emails
+
+This task shows the most recent email delivery attempts made to the given user.
+It takes two parameters: `email_address` (required), and `limit` (optional).
+`limit` defaults to 10, but you can override this if you need to see more of
+the user's history.
+
+```bash
+$ bundle exec rake manage:view_emails[<email_address>,<limit>]
+```
+
+[⚙ Run rake task on production][view_emails]
+
+[view_emails]: https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=manage:view_emails[email@example.org]
+
 ## View subscriber's subscriptions
 
 This task shows you all of the active and inactive subscriptions for a given user.

--- a/spec/lib/tasks/manage_spec.rb
+++ b/spec/lib/tasks/manage_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "manage" do
+  describe "hash_to_table" do
+    it "converts a hash to table markdown" do
+      hash = [{ foo: "bar", baz: 12_345 }, { foo: "Long bar", baz: 12 }]
+      expected_markdown = <<~MARKDOWN
+        | Foo      | Baz   |
+        | bar      | 12345 |
+        | Long bar | 12    |
+      MARKDOWN
+      expect(hash_to_table(hash)).to eq(expected_markdown)
+    end
+
+    it "converts non-string values to string" do
+      hash = [{ timestamp: Time.zone.parse("2020-06-29 15:18:48") }]
+      expected_markdown = <<~MARKDOWN
+        | Timestamp                 |
+        | 2020-06-29 15:18:48 +0100 |
+      MARKDOWN
+      expect(hash_to_table(hash)).to eq(expected_markdown)
+    end
+  end
+end


### PR DESCRIPTION
We sometimes get queries from users complaining about emails they have not received.

To enable us to help them more easily, the `manage:view_emails` rake task attempts to pull together all email delivery attempts made to the given email address.