### PR TITLE
Namespace rate limiter to support multiple tenants

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -4,6 +4,6 @@ module Services
   end
 
   def self.rate_limiter
-    @rate_limiter ||= Ratelimit.new("deliveries")
+    @rate_limiter ||= Ratelimit.new("email-alert-api:deliveries")
   end
 end


### PR DESCRIPTION
https://trello.com/c/fCrWTqFj/372-incident-action-rate-limit-email-authentication-emails-by-address

Previously we assumed the rate limiter was unique to this app, with
no risk of name clashes. This prefixes the original key with the name
of this app, to avoid future, accidental name clashes [1].

[1]: https://github.com/alphagov/email-alert-frontend/pull/832