### PR TITLE
Fix 'limit' argument for rake task

### DIFF
--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -52,7 +52,7 @@ namespace :manage do
   desc "View most recent email delivery attempts for a subscriber"
   task :view_emails, %i[email_address limit] => :environment do |_t, args|
     email_address = args[:email_address]
-    limit = args[:limit] || 10
+    limit = args[:limit].to_i || 10
     subscriber = Subscriber.find_by_address(email_address)
     abort("Cannot find any subscriber with email address #{email_address}.") if subscriber.nil?
 


### PR DESCRIPTION
Arguments are treated as strings by default, so we need to
cast this to an integer.

See https://github.com/alphagov/email-alert-api/pull/1310#pullrequestreview-440718985