### PR TITLE
Fix typo in "non-existent"

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,7 +6,7 @@ class Subscription < ApplicationRecord
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
   enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2, subscriber_list_changed: 3 }, _prefix: true
-  enum ended_reason: { unsubscribed: 0, non_existant_email: 1, frequency_changed: 2, subscriber_list_changed: 3, marked_as_spam: 4, unpublished: 5 }, _prefix: :ended
+  enum ended_reason: { unsubscribed: 0, non_existent_email: 1, frequency_changed: 2, subscriber_list_changed: 3, marked_as_spam: 4, unpublished: 5 }, _prefix: :ended
 
   validates :subscriber, uniqueness: { scope: :subscriber_list, conditions: -> { active } }
 

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -34,7 +34,7 @@ class StatusUpdateService
     end
 
     if delivery_attempt.permanent_failure? && subscriber
-      UnsubscribeService.subscriber!(subscriber, :non_existant_email)
+      UnsubscribeService.subscriber!(subscriber, :non_existent_email)
     # We check for a status of nil here too in case email hasn't had a status set
     elsif delivery_attempt.temporary_failure? && ["pending", nil].include?(email.status)
       DeliveryRequestWorker.perform_in(TEMPORARY_FAILURE_RETRY_DELAY, email.id, :default)

--- a/docs/arch/adr-003-data-retention.md
+++ b/docs/arch/adr-003-data-retention.md
@@ -261,7 +261,7 @@ numerical id.
 - Replace the `deleted_at` field with an `ended_at` field.
 - Create an enum field for source (ideas are imported, user_signup,
   frequency_change)
-- Create an enum field for end (ideas are user_unsubscribe, non_existant_email,
+- Create an enum field for end (ideas are user_unsubscribe, non_existent_email,
   frequency_change)
 - Create an active boolean field
 - Drop the current unique key and replace it with one that incorporates active


### PR DESCRIPTION
We were spelling "non-existent" as "non-existant", which is incorrect.