### PR TITLE
Create worker to recover lost jobs

### DIFF
--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -18,6 +18,8 @@ class ContentChange < ApplicationRecord
 
   enum priority: { normal: 0, high: 1 }
 
+  scope :unprocessed, -> { where(processed_at: nil) }
+
   def mark_processed!
     update!(processed_at: Time.zone.now)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,6 +8,8 @@ class Message < ApplicationRecord
   validates :criteria_rules, criteria_schema: true, allow_blank: true
   validates :sender_message_id, uuid: true, uniqueness: true, allow_nil: true
 
+  scope :unprocessed, -> { where(processed_at: nil) }
+
   validates_each :url, allow_nil: true do |record, attribute, value|
     parsed = URI.parse(value)
     if parsed.absolute? && parsed.scheme != "https"

--- a/app/workers/recover_lost_jobs_worker.rb
+++ b/app/workers/recover_lost_jobs_worker.rb
@@ -1,0 +1,27 @@
+class RecoverLostJobsWorker
+  include Sidekiq::Worker
+
+  def perform(model, worker)
+    orphan_records(model).each do |record|
+      worker.perform_async(record.id)
+    end
+  end
+
+private
+
+  def orphan_records(model)
+    model.unprocessed.where("created_at <= ?", 1.hour.ago).select { |record| orphan?(record) }
+  end
+
+  def orphan?(record)
+    !queued?(record) || !retrying?(record)
+  end
+
+  def queued?(record)
+    Sidekiq::Queue.new("process_and_generate_emails").any? { |job| job.args[0] == record.id }
+  end
+
+  def retrying?(record)
+    Sidekiq::RetrySet.new.any? { |job| job.args[0] == record.id }
+  end
+end

--- a/lib/recovery/recover_lost_jobs.rb
+++ b/lib/recovery/recover_lost_jobs.rb
@@ -1,0 +1,8 @@
+module Recovery
+  class RecoverLostJobs
+    def self.run
+      RecoverLostJobsWorker.perform_async(ContentChange, ProcessContentChangeWorker)
+      RecoverLostJobsWorker.perform_async(Message, ProcessMessageWorker)
+    end
+  end
+end

--- a/spec/workers/recover_lost_jobs_worker_spec.rb
+++ b/spec/workers/recover_lost_jobs_worker_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe RecoverLostJobsWorker do
+  before do
+    Sidekiq::Worker.clear_all
+  end
+
+  describe ".perform" do
+    it "does not requeue incomplete content changes that are under 1-hour old" do
+      travel_to(59.minutes.ago) do
+        2.times { create(:content_change) }
+      end
+
+      travel_to(Time.zone.now) do
+        expect(ProcessContentChangeWorker).not_to receive(:perform_async)
+        subject.perform(ContentChange, ProcessContentChangeWorker)
+      end
+    end
+
+    it "requeues incomplete content changes that are over 1-hour old" do
+      travel_to(1.hour.ago) do
+        2.times { create(:content_change) }
+      end
+
+      travel_to(Time.zone.now) do
+        expect(ProcessContentChangeWorker).to receive(:perform_async).twice
+        subject.perform(ContentChange, ProcessContentChangeWorker)
+      end
+    end
+
+    it "does not requeue incomplete messages that are under 1-hour old" do
+      travel_to(59.minutes.ago) do
+        2.times { create(:message) }
+      end
+
+      travel_to(Time.zone.now) do
+        expect(ProcessMessageWorker).not_to receive(:perform_async)
+        subject.perform(Message, ProcessMessageWorker)
+      end
+    end
+
+    it "requeues incomplete messages that are over 1-hour old" do
+      travel_to(1.hour.ago) do
+        2.times { create(:message) }
+      end
+
+      travel_to(Time.zone.now) do
+        expect(ProcessMessageWorker).to receive(:perform_async).twice
+        subject.perform(Message, ProcessMessageWorker)
+      end
+    end
+  end
+end

--- a/spec/workers/recover_lost_jobs_worker_spec.rb
+++ b/spec/workers/recover_lost_jobs_worker_spec.rb
@@ -4,47 +4,85 @@ RSpec.describe RecoverLostJobsWorker do
   end
 
   describe ".perform" do
-    it "does not requeue incomplete content changes that are under 1-hour old" do
-      travel_to(59.minutes.ago) do
-        2.times { create(:content_change) }
+    describe "ContentChange recovery" do
+      it "does not requeue incomplete content changes that are under 1-hour old" do
+        travel_to(59.minutes.ago) do
+          2.times { create(:content_change) }
+        end
+
+        travel_to(Time.zone.now) do
+          expect(ProcessContentChangeWorker).not_to receive(:perform_async)
+          subject.perform(ContentChange, ProcessContentChangeWorker)
+        end
       end
 
-      travel_to(Time.zone.now) do
-        expect(ProcessContentChangeWorker).not_to receive(:perform_async)
-        subject.perform(ContentChange, ProcessContentChangeWorker)
+      it "does not requeue incomplete content changes that are still in the queue" do
+        travel_to(1.hour.ago) do
+          create(:content_change)
+
+          ContentChange.all do |content_change|
+            ProcessContentChangeWorker.perform(content_change.id)
+          end
+
+          expect(ProcessContentChangeWorker).to receive(:perform_async)
+        end
+
+        travel_to(Time.zone.now) do
+          expect(ProcessContentChangeWorker).not_to receive(:perform_async)
+          subject.perform(ContentChange, ProcessContentChangeWorker)
+        end
+      end
+
+      it "requeues incomplete content changes that are over 1-hour old" do
+        travel_to(1.hour.ago) do
+          2.times { create(:content_change) }
+        end
+
+        travel_to(Time.zone.now) do
+          expect(ProcessContentChangeWorker).to receive(:perform_async).twice
+          subject.perform(ContentChange, ProcessContentChangeWorker)
+        end
       end
     end
 
-    it "requeues incomplete content changes that are over 1-hour old" do
-      travel_to(1.hour.ago) do
-        2.times { create(:content_change) }
+    describe "Message recovery" do
+      it "does not requeue incomplete messages that are under 1-hour old" do
+        travel_to(59.minutes.ago) do
+          2.times { create(:message) }
+        end
+
+        travel_to(Time.zone.now) do
+          expect(ProcessMessageWorker).not_to receive(:perform_async)
+          subject.perform(Message, ProcessMessageWorker)
+        end
       end
 
-      travel_to(Time.zone.now) do
-        expect(ProcessContentChangeWorker).to receive(:perform_async).twice
-        subject.perform(ContentChange, ProcessContentChangeWorker)
-      end
-    end
+      it "does not requeue incomplete messages that are still in the queue" do
+        travel_to(1.hour.ago) do
+          create(:message)
 
-    it "does not requeue incomplete messages that are under 1-hour old" do
-      travel_to(59.minutes.ago) do
-        2.times { create(:message) }
-      end
+          Message.all do |message|
+            ProcessMessageWorker.perform(message.id)
+          end
 
-      travel_to(Time.zone.now) do
-        expect(ProcessMessageWorker).not_to receive(:perform_async)
-        subject.perform(Message, ProcessMessageWorker)
-      end
-    end
+          expect(ProcessMessageWorker).to receive(:perform_async)
+        end
 
-    it "requeues incomplete messages that are over 1-hour old" do
-      travel_to(1.hour.ago) do
-        2.times { create(:message) }
+        travel_to(Time.zone.now) do
+          expect(ProcessMessageWorker).not_to receive(:perform_async)
+          subject.perform(Message, ProcessMessageWorker)
+        end
       end
 
-      travel_to(Time.zone.now) do
-        expect(ProcessMessageWorker).to receive(:perform_async).twice
-        subject.perform(Message, ProcessMessageWorker)
+      it "requeues incomplete messages that are over 1-hour old" do
+        travel_to(1.hour.ago) do
+          2.times { create(:message) }
+        end
+
+        travel_to(Time.zone.now) do
+          expect(ProcessMessageWorker).to receive(:perform_async).twice
+          subject.perform(Message, ProcessMessageWorker)
+        end
       end
     end
   end


### PR DESCRIPTION
Automatically re-enqueue content changes and messages that have been lost.

There is [a general problem with the queuing system](https://github.com/mperham/sidekiq/wiki/Error-Handling#process-crashes) that means in-progress jobs can be permanently lost, which leads to alerts and call-outs. We experience the most pain from the loss of [jobs to process content changes](https://github.com/alphagov/email-alert-api/blob/fdec17c576963f0f67e82bd02cd829ca4debe122/app/workers/process_content_change_worker.rb). We want to recover these lost jobs automatically.

https://trello.com/c/JD9CohHz/356-incident-action-automatically-requeue-content-changes-and-messages-that-have-been-lost