### PR TITLE
Requeue lost content change and email work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "rails"
 gem "ratelimit"
 gem "redcarpet"
 gem "sidekiq-scheduler"
+gem "sidekiq-unique-jobs"
 gem "with_advisory_lock"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,10 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
+    sidekiq-unique-jobs (6.0.22)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      sidekiq (>= 4.0, < 7.0)
+      thor (~> 0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -338,7 +342,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
-    thor (1.0.1)
+    thor (0.20.3)
     thread_safe (0.3.6)
     thwait (0.1.0)
     tilt (2.0.10)
@@ -395,6 +399,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sidekiq-scheduler
+  sidekiq-unique-jobs
   webmock
   with_advisory_lock
 

--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -18,6 +18,8 @@ class ContentChange < ApplicationRecord
 
   enum priority: { normal: 0, high: 1 }
 
+  scope :unprocessed, -> { where(processed_at: nil) }
+
   def mark_processed!
     update!(processed_at: Time.zone.now)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -21,6 +21,8 @@ class Message < ApplicationRecord
 
   enum priority: { normal: 0, high: 1 }
 
+  scope :unprocessed, -> { where(processed_at: nil) }
+
   def mark_processed!
     update!(processed_at: Time.zone.now)
   end

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -1,7 +1,10 @@
 class ProcessContentChangeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :process_and_generate_emails
+  sidekiq_options queue: :process_and_generate_emails,
+                  lock: :until_executed,
+                  lock_args: ->(args) { [args.first] },
+                  on_conflict: :log
 
   def perform(content_change_id)
     content_change = ContentChange.find(content_change_id)

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -1,7 +1,10 @@
 class ProcessMessageWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :process_and_generate_emails
+  sidekiq_options queue: :process_and_generate_emails,
+                  lock: :until_executed,
+                  lock_args: ->(args) { [args.first] },
+                  on_conflict: :log
 
   def perform(message_id)
     message = Message.find(message_id)

--- a/app/workers/recover_lost_jobs_worker.rb
+++ b/app/workers/recover_lost_jobs_worker.rb
@@ -1,0 +1,13 @@
+class RecoverLostJobsWorker
+  include Sidekiq::Worker
+
+  def perform
+    ContentChange.unprocessed.where("created_at <= ?", 1.hour.ago).pluck(:id).map do |content_change_id|
+      ProcessContentChangeWorker.perform_async(content_change_id)
+    end
+
+    Message.unprocessed.where("created_at <= ?", 1.hour.ago).pluck(:id).map do |message_id|
+      ProcessMessageWorker.perform_async(message_id)
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -37,3 +37,6 @@
   metrics_collection:
     every: '1m'
     class: MetricsCollectionWorker
+  recover_lost_jobs:
+    every: '30m'
+    class: RecoverLostJobsWorker

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,8 @@ end
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
+SidekiqUniqueJobs.config.enabled = false
+
 Sidekiq::Testing.inline!
 Sidekiq::Worker.clear_all
 Sidekiq::Logging.logger = nil

--- a/spec/workers/recover_lost_jobs_worker_spec.rb
+++ b/spec/workers/recover_lost_jobs_worker_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe RecoverLostJobsWorker do
+  describe ".perform" do
+    describe "ContentChange recovery" do
+      it "does not requeue incomplete content changes that are under 1-hour old" do
+        create(:content_change, created_at: 59.minutes.ago)
+        expect(ProcessContentChangeWorker).not_to receive(:perform_async)
+        subject.perform
+      end
+
+      it "requeues incomplete content changes that are over 1-hour old" do
+        create(:content_change, created_at: 1.hour.ago)
+        expect(ProcessContentChangeWorker).to receive(:perform_async)
+        subject.perform
+      end
+    end
+
+    describe "Message recovery" do
+      it "does not requeue incomplete messages that are under 1-hour old" do
+        create(:message, created_at: 59.minutes.ago)
+        expect(ProcessMessageWorker).not_to receive(:perform_async)
+        subject.perform
+      end
+
+      it "requeues incomplete messages that are over 1-hour old" do
+        create(:message, created_at: 1.hour.ago)
+        expect(ProcessMessageWorker).to receive(:perform_async)
+        subject.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What and why

We had [an incident](https://docs.google.com/document/d/1GYiQr_06HsXO5Nm_zsoXCBRlhDJvTEzLsJX5rIeXqAc/edit) where travel advice emails were not sent due to the original Content Change jobs being lost from our queueing system. 

This is [a general problem with the queuing system](https://github.com/mperham/sidekiq/wiki/Error-Handling#process-crashes) across GOV.UK. Since we're not going to change the system, we need to make our software resilient to this flaw.

## Solution

This PR creates a sweeper job that requeues incomplete work that is over 1 hour old, for the following models:

* ContentChange (where `processed_at: nil`)
* Message (where `processed_at: nil`)

We chose 1 hour somewhat arbitrarily. That roughly matches the worst case time for some content change processing.

This PR makes use of the [sidekiq-unique-jobs](https://github.com/mhenrixon/sidekiq-unique-jobs#until-executed) gem to enforce job uniqueness, with `sidekiq_options lock: :until_executed`:

> Locks from when the client pushes the job to the queue. Will be unlocked when the server has successfully processed the job.

## Trello cards

https://trello.com/c/WYQDff8u/223-automatically-requeue-email-work-that-has-been-lost
https://trello.com/c/JD9CohHz/356-incident-action-automatically-requeue-content-changes-and-messages-that-have-been-lost