### PR TITLE
Increase latency time required for alert

### DIFF
--- a/lib/metrics/content_change_exporter.rb
+++ b/lib/metrics/content_change_exporter.rb
@@ -22,10 +22,10 @@ private
   end
 
   def critical_latency
-    10.minutes
+    120.minutes
   end
 
   def warning_latency
-    5.minutes
+    90.minutes
   end
 end

--- a/lib/metrics/message_exporter.rb
+++ b/lib/metrics/message_exporter.rb
@@ -22,10 +22,10 @@ private
   end
 
   def critical_latency
-    10.minutes
+    120.minutes
   end
 
   def warning_latency
-    5.minutes
+    90.minutes
   end
 end

--- a/spec/lib/metrics/content_change_exporter_spec.rb
+++ b/spec/lib/metrics/content_change_exporter_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Metrics::ContentChangeExporter do
     let(:statsd) { double }
 
     before do
-      create(:content_change, created_at: 11.minutes.ago)
-      create(:content_change, created_at: 6.minutes.ago)
+      create(:content_change, created_at: 122.minutes.ago)
+      create(:content_change, created_at: 99.minutes.ago)
       allow(GovukStatsd).to receive(:gauge)
     end
 

--- a/spec/lib/metrics/message_exporter_spec.rb
+++ b/spec/lib/metrics/message_exporter_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Metrics::MessageExporter do
     let(:statsd) { double }
 
     before do
-      3.times { create(:message, processed_at: nil, created_at: 10.minutes.ago) }
-      2.times { create(:message, processed_at: nil, created_at: 5.minutes.ago) }
+      3.times { create(:message, processed_at: nil, created_at: 122.minutes.ago) }
+      2.times { create(:message, processed_at: nil, created_at: 99.minutes.ago) }
       allow(GovukStatsd).to receive(:gauge)
     end
 


### PR DESCRIPTION
Currently we're in a situation where these warning / critical
thresholds are too low and our alerting system is raising these alerts
pretty frequently and causing quite a lot of noise for 2nd line.

We want to increase these latency thresholds to a point where
they're actually alerting when something is wrong rather than when
email-alert-api is processing a large batch of emails.

These increases also align with the work we're doing to automatically
re-queue content changes and messages if they haven't been processed
within 1 hour. Once this is implemented we want to give email-alert-api
a chance to sort it self out before these alert and manual intervention
is needed. The re-queue PR is [here](https://github.com/alphagov/email-alert-api/pull/1318).

---

Trello card:
https://trello.com/c/Li8Zo03f/381-relax-the-thresholds-for-content-change-and-message-alerts
https://trello.com/c/WYQDff8u/223-automatically-requeue-email-work-that-has-been-lost