### PR TITLE
Extend stats for immediate content changes

### DIFF
--- a/app/services/immediate_email_generation_service/batch.rb
+++ b/app/services/immediate_email_generation_service/batch.rb
@@ -17,6 +17,7 @@ class ImmediateEmailGenerationService
         SubscriptionContent.populate_for_content(content, records)
       end
 
+      MetricsService.content_change_emails(content_change, email_parameters.count) if content_change
       email_ids
     end
 

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -1,5 +1,10 @@
 class MetricsService
   class << self
+    def content_change_emails(content_change, count)
+      count("content_change_emails.publishing_app.#{content_change.publishing_app}.immediate", count)
+      count("content_change_emails.document_type.#{content_change.document_type}.immediate", count)
+    end
+
     def sent_to_notify_successfully
       increment("notify.email_send_request.success")
     end
@@ -74,6 +79,10 @@ class MetricsService
 
     def timing(namespace, difference)
       GovukStatsd.timing(namespace, difference)
+    end
+
+    def count(namespace, value)
+      GovukStatsd.count(namespace, value)
     end
   end
 end

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
         instance.generate_emails
       end
 
+      it "sends stats about the generated emails" do
+        expect(MetricsService).to receive(:content_change_emails)
+                              .with(content_change, 2)
+        instance.generate_emails
+      end
+
       it "doesn't use MessageEmailBuilder" do
         expect(MessageEmailBuilder).not_to receive(:call)
         instance.generate_emails

--- a/spec/services/metrics_service_spec.rb
+++ b/spec/services/metrics_service_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe MetricsService do
+  before do
+    allow(GovukStatsd).to receive(:count)
+  end
+
+  describe ".content_change_emails" do
+    it "sends stats for a batch of content change emails" do
+      content_change = build(:content_change, publishing_app: "app", document_type: "type")
+      expect(GovukStatsd).to receive(:count).with("content_change_emails.publishing_app.app.immediate", 1)
+      expect(GovukStatsd).to receive(:count).with("content_change_emails.document_type.type.immediate", 1)
+      described_class.content_change_emails(content_change, 1)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/hTAPWQfE/360-chart-email-backlog-by-publishing-app-and-document-type-in-grafana

Previously we could only see the realtime number of emails being
processed by the system, noting that almost all email we send is
due to a content change. This changes the processing of immediate
emails for a content change to send a breakdown of the generated
email by document type and publishing app, to improve visibility
of the effect of publishing on the volume of email we send, and to
help reassure ourselves about its source.

Note that this metric is not applicable for digest emails, because
of the many-to-one link between content changes and the email that
is sent. For digest emails, the number of subscriptions is a better
(maximum) indicator of the volume of email we expect to send.

## Example of what this could look like in a dashboard

<img width="1280" alt="Screenshot 2020-07-15 at 12 08 17" src="https://user-images.githubusercontent.com/9029009/87538310-ec968100-c693-11ea-896d-32304e5bb9f9.png">
