### PR TITLE
Ensure the correct sidekiq-unique-jobs option is used

### DIFF
--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -3,8 +3,12 @@ class ProcessContentChangeWorker
 
   sidekiq_options queue: :process_and_generate_emails,
                   lock: :until_executed,
-                  lock_args: ->(args) { [args.first] },
+                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
                   on_conflict: :log
+
+  def self.uniqueness_with(args)
+    [args.first]
+  end
 
   def perform(content_change_id)
     content_change = ContentChange.find(content_change_id)

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -3,8 +3,12 @@ class ProcessMessageWorker
 
   sidekiq_options queue: :process_and_generate_emails,
                   lock: :until_executed,
-                  lock_args: ->(args) { [args.first] },
+                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
                   on_conflict: :log
+
+  def self.uniqueness_with(args)
+    [args.first]
+  end
 
   def perform(message_id)
     message = Message.find(message_id)

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -57,4 +57,20 @@ RSpec.describe ProcessMessageWorker do
       described_class.new.perform(processed_message.id)
     end
   end
+
+  describe ".perform_async" do
+    # We're expecting redis-namespace to raise a warning unfortunately
+    before { allow_any_instance_of(Redis::Namespace).to receive(:warn) }
+
+    around do |example|
+      SidekiqUniqueJobs.use_config(enabled: true, logger: Logger.new("/dev/null")) do
+        example.run
+      end
+    end
+
+    it "enforces job uniqueness with the correct sidekiq-unique-jobs option" do
+      expect(described_class).to receive(:uniqueness_with).with([message.id])
+      described_class.perform_async(message.id)
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/alphagov/email-alert-api/pull/1318 mistakenly shipped specifying the `lock_args` option from the upcoming version 7 of sidekiq-unique-jobs, rather than the currently used version's (6.0.22) `unique_args`.

Compare:

* https://github.com/mhenrixon/sidekiq-unique-jobs/tree/v6.0.22#finer-control-over-uniqueness
* https://github.com/mhenrixon/sidekiq-unique-jobs/tree/v7.0.0.beta22#finer-control-over-uniqueness

This ensures we use the version's correct sidekiq-unique-jobs option to enforce uniqueness.

Once the gem has been upgraded to version 7, it should be ok to remove the tests.