### PR TITLE
Introduce ApplicationService to DRY-up services

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -62,6 +62,6 @@ private
     url = subscriber_list.url
     tracked_url = url + (url.include?("?") ? "&" : "?") + query
 
-    PublicUrlService.url_for(base_path: tracked_url)
+    PublicUrls.url_for(base_path: tracked_url)
   end
 end

--- a/app/controllers/spam_reports_controller.rb
+++ b/app/controllers/spam_reports_controller.rb
@@ -3,7 +3,7 @@ class SpamReportsController < ApplicationController
 
   def create
     delivery_attempt = DeliveryAttempt.find(params[:reference])
-    UnsubscribeService.spam_report!(delivery_attempt)
+    SpamReportService.call(delivery_attempt)
     head :no_content
   end
 

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -1,21 +1,15 @@
 class UnsubscribeController < ApplicationController
   def unsubscribe
-    UnsubscribeService.subscription!(subscription, :unsubscribed)
+    subscription = Subscription.active.find(id)
+    UnsubscribeService.unsubscribe!(subscription.subscriber, [subscription], :unsubscribed)
   end
 
   def unsubscribe_all
-    UnsubscribeService.subscriber!(subscriber, :unsubscribed)
+    subscriber = Subscriber.activated.find(id)
+    UnsubscribeService.unsubscribe!(subscriber, subscriber.active_subscriptions, :unsubscribed)
   end
 
 private
-
-  def subscription
-    Subscription.active.find(id)
-  end
-
-  def subscriber
-    Subscriber.activated.find(id)
-  end
 
   def id
     params.fetch(:id)

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -6,7 +6,7 @@ class UnsubscribeController < ApplicationController
 
   def unsubscribe_all
     subscriber = Subscriber.activated.find(id)
-    UnsubscribeService.call(subscriber, subscriber.active_subscriptions, :unsubscribed)
+    UnsubscribeAllService.call(subscriber, :unsubscribed)
   end
 
 private

--- a/app/controllers/unsubscribe_controller.rb
+++ b/app/controllers/unsubscribe_controller.rb
@@ -1,12 +1,12 @@
 class UnsubscribeController < ApplicationController
   def unsubscribe
     subscription = Subscription.active.find(id)
-    UnsubscribeService.unsubscribe!(subscription.subscriber, [subscription], :unsubscribed)
+    UnsubscribeService.call(subscription.subscriber, [subscription], :unsubscribed)
   end
 
   def unsubscribe_all
     subscriber = Subscriber.activated.find(id)
-    UnsubscribeService.unsubscribe!(subscriber, subscriber.active_subscriptions, :unsubscribed)
+    UnsubscribeService.call(subscriber, subscriber.active_subscriptions, :unsubscribed)
   end
 
 private

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -22,7 +22,7 @@ class ContentItem
   end
 
   def url
-    @url ||= PublicUrlService.absolute_url(path: @path)
+    @url ||= PublicUrls.absolute_url(path: @path)
   end
 
   def content_store_data

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -21,6 +21,6 @@ class Email < ApplicationRecord
   def self.timed_bulk_insert(records, batch_size)
     return insert_all!(records) unless records.size == batch_size
 
-    MetricsService.email_bulk_insert(batch_size) { insert_all!(records) }
+    Metrics.email_bulk_insert(batch_size) { insert_all!(records) }
   end
 end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -46,7 +46,7 @@ class SubscriberList < ApplicationRecord
         }
 
   def subscription_url
-    PublicUrlService.subscription_url(slug: slug)
+    PublicUrls.subscription_url(slug: slug)
   end
 
   def gov_delivery_id

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -35,7 +35,7 @@ private
     utm_campaign = "govuk-notifications"
     utm_content = frequency
     base_path = "#{content_change.base_path}?utm_source=#{utm_source}&utm_medium=#{utm_medium}&utm_campaign=#{utm_campaign}&utm_content=#{utm_content}"
-    PublicUrlService.url_for(base_path: base_path)
+    PublicUrls.url_for(base_path: base_path)
   end
 
   def public_updated_at_header

--- a/app/presenters/manage_subscriptions_link_presenter.rb
+++ b/app/presenters/manage_subscriptions_link_presenter.rb
@@ -18,6 +18,6 @@ private
   attr_reader :address
 
   def url
-    PublicUrlService.authenticate_url(address: address)
+    PublicUrls.authenticate_url(address: address)
   end
 end

--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -20,6 +20,6 @@ private
 
   def url
     base_path = "/email/unsubscribe/#{id}"
-    PublicUrlService.url_for(base_path: base_path)
+    PublicUrls.url_for(base_path: base_path)
   end
 end

--- a/app/providers/delay_provider.rb
+++ b/app/providers/delay_provider.rb
@@ -5,7 +5,7 @@ class DelayProvider
 
   def call(**_args)
     Kernel.sleep 0.1
-    MetricsService.sent_to_notify_successfully
+    Metrics.sent_to_notify_successfully
     :delivered
   end
 

--- a/app/providers/notify_provider.rb
+++ b/app/providers/notify_provider.rb
@@ -19,10 +19,10 @@ class NotifyProvider
       },
     )
 
-    MetricsService.sent_to_notify_successfully
+    Metrics.sent_to_notify_successfully
     :sending
   rescue Notifications::Client::RequestError => e
-    MetricsService.failed_to_send_to_notify
+    Metrics.failed_to_send_to_notify
     unless e.message.end_with?("Not a valid email address")
       GovukError.notify(e, tags: { provider: "notify" })
     end

--- a/app/providers/pseudo_provider.rb
+++ b/app/providers/pseudo_provider.rb
@@ -13,7 +13,7 @@ class PseudoProvider
       Reference: #{reference}
     INFO
 
-    MetricsService.sent_to_pseudo_successfully
+    Metrics.sent_to_pseudo_successfully
     :delivered
   end
 

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,7 @@
+class ApplicationService
+  def self.call(*args)
+    new(*args).call
+  end
+
+  private_class_method :new
+end

--- a/app/services/auth_token_generator_service.rb
+++ b/app/services/auth_token_generator_service.rb
@@ -1,20 +1,21 @@
-class AuthTokenGeneratorService
+class AuthTokenGeneratorService < ApplicationService
   CIPHER = "aes-256-gcm".freeze
   OPTIONS = { cipher: CIPHER, serializer: JSON }.freeze
 
-  def self.call(*args)
-    new.call(*args)
+  attr_reader :data, :expiry
+
+  def initialize(data, expiry: 1.week)
+    @data = data
+    @expiry = expiry
   end
 
-  def call(data, expiry: 1.week)
+  def call
     len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
     key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
     crypt = ActiveSupport::MessageEncryptor.new(key, OPTIONS)
     token = crypt.encrypt_and_sign(data, expires_in: expiry)
     CGI.escape(token)
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/content_change_handler_service.rb
+++ b/app/services/content_change_handler_service.rb
@@ -11,7 +11,7 @@ class ContentChangeHandlerService
 
   def call
     content_change = ContentChange.create!(content_change_params)
-    MetricsService.content_change_created
+    Metrics.content_change_created
     ProcessContentChangeWorker.perform_async(content_change.id)
   end
 

--- a/app/services/content_change_handler_service.rb
+++ b/app/services/content_change_handler_service.rb
@@ -1,12 +1,8 @@
-class ContentChangeHandlerService
+class ContentChangeHandlerService < ApplicationService
   def initialize(params:, govuk_request_id:, user: nil)
     @params = params
     @govuk_request_id = govuk_request_id
     @user = user
-  end
-
-  def self.call(*args)
-    new(*args).call
   end
 
   def call
@@ -14,8 +10,6 @@ class ContentChangeHandlerService
     Metrics.content_change_created
     ProcessContentChangeWorker.perform_async(content_change.id)
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -1,4 +1,4 @@
-class DeliveryRequestService
+class DeliveryRequestService < ApplicationService
   PROVIDERS = {
     "notify" => NotifyProvider,
     "pseudo" => PseudoProvider,
@@ -12,10 +12,6 @@ class DeliveryRequestService
     @provider_name = config.fetch(:provider).downcase
     @subject_prefix = config.fetch(:email_subject_prefix)
     @overrider = EmailAddressOverrider.new(config)
-  end
-
-  def self.call(*args)
-    new(*args).call
   end
 
   def call

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -21,24 +21,24 @@ class DeliveryRequestService
   def call
     return false if address.nil?
 
-    MetricsService.delivery_request_service_first_delivery_attempt do
+    Metrics.delivery_request_service_first_delivery_attempt do
       record_first_attempt_metrics unless DeliveryAttempt.exists?(email: email)
     end
 
-    delivery_attempt = MetricsService.delivery_request_service_create_delivery_attempt do
+    delivery_attempt = Metrics.delivery_request_service_create_delivery_attempt do
       DeliveryAttempt.create!(id: attempt_id,
                               email: email,
                               status: :sending,
                               provider: provider_name)
     end
 
-    status = MetricsService.email_send_request(provider_name) { send_email }
+    status = Metrics.email_send_request(provider_name) { send_email }
 
     return true if status == :sending
 
     ActiveRecord::Base.transaction do
       delivery_attempt.update!(status: status, completed_at: Time.zone.now)
-      MetricsService.delivery_attempt_status_changed(status)
+      Metrics.delivery_attempt_status_changed(status)
       UpdateEmailStatusService.call(delivery_attempt)
     end
 
@@ -69,11 +69,11 @@ private
 
   def record_first_attempt_metrics
     now = Time.now.utc
-    MetricsService.email_created_to_first_delivery_attempt(email.created_at, now)
+    Metrics.email_created_to_first_delivery_attempt(email.created_at, now)
 
     return unless metrics[:content_change_created_at]
 
-    MetricsService.content_change_created_to_first_delivery_attempt(
+    Metrics.content_change_created_to_first_delivery_attempt(
       metrics[:content_change_created_at],
       now,
     )

--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -11,7 +11,7 @@ class DigestInitiatorService
     digest_run = create_digest_run
     return if digest_run.nil?
 
-    MetricsService.digest_initiator_service(range) do
+    Metrics.digest_initiator_service(range) do
       subscriber_ids = DigestRunSubscriberQuery.call(digest_run: digest_run).pluck(:id)
 
       subscriber_ids.each_slice(1000) do |subscriber_ids_chunk|

--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -1,10 +1,6 @@
-class DigestInitiatorService
+class DigestInitiatorService < ApplicationService
   def initialize(range:)
     @range = range
-  end
-
-  def self.call(*args)
-    new(*args).call
   end
 
   def call
@@ -23,8 +19,6 @@ class DigestInitiatorService
       digest_run.update(subscriber_count: subscriber_ids.count)
     end
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/immediate_email_generation_service.rb
+++ b/app/services/immediate_email_generation_service.rb
@@ -1,9 +1,5 @@
-class ImmediateEmailGenerationService
+class ImmediateEmailGenerationService < ApplicationService
   BATCH_SIZE = 5000
-
-  def self.call(*args)
-    new(*args).call
-  end
 
   def initialize(content)
     @content = content
@@ -21,8 +17,6 @@ class ImmediateEmailGenerationService
       end
     end
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/immediate_email_generation_service/batch.rb
+++ b/app/services/immediate_email_generation_service/batch.rb
@@ -17,7 +17,7 @@ class ImmediateEmailGenerationService
         SubscriptionContent.populate_for_content(content, records)
       end
 
-      MetricsService.content_change_emails(content_change, email_parameters.count) if content_change
+      Metrics.content_change_emails(content_change, email_parameters.count) if content_change
       email_ids
     end
 

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -1,10 +1,6 @@
-class MatchedContentChangeGenerationService
+class MatchedContentChangeGenerationService < ApplicationService
   def initialize(content_change)
     @content_change = content_change
-  end
-
-  def self.call(*args)
-    new(*args).call
   end
 
   def call
@@ -24,8 +20,6 @@ class MatchedContentChangeGenerationService
 
     MatchedContentChange.insert_all!(records)
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/matched_message_generation_service.rb
+++ b/app/services/matched_message_generation_service.rb
@@ -1,10 +1,6 @@
-class MatchedMessageGenerationService
+class MatchedMessageGenerationService < ApplicationService
   def initialize(message)
     @message = message
-  end
-
-  def self.call(*args)
-    new(*args).call
   end
 
   def call
@@ -24,8 +20,6 @@ class MatchedMessageGenerationService
 
     MatchedMessage.insert_all!(records)
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -1,12 +1,8 @@
-class MessageHandlerService
+class MessageHandlerService < ApplicationService
   def initialize(params:, govuk_request_id:, user: nil)
     @params = params
     @govuk_request_id = govuk_request_id
     @user = user
-  end
-
-  def self.call(*args)
-    new(*args).call
   end
 
   def call
@@ -14,8 +10,6 @@ class MessageHandlerService
     Metrics.message_created
     ProcessMessageWorker.perform_async(message.id)
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/message_handler_service.rb
+++ b/app/services/message_handler_service.rb
@@ -11,7 +11,7 @@ class MessageHandlerService
 
   def call
     message = Message.create!(message_params)
-    MetricsService.message_created
+    Metrics.message_created
     ProcessMessageWorker.perform_async(message.id)
   end
 

--- a/app/services/s3_email_archive_service.rb
+++ b/app/services/s3_email_archive_service.rb
@@ -1,15 +1,15 @@
-class S3EmailArchiveService
-  def self.call(*args)
-    new.call(*args)
-  end
+class S3EmailArchiveService < ApplicationService
+  attr_reader :batch
 
   # For batch we expect an array of hashes containing email data in the format
   # from EmailArchivePresenter
-  def call(batch)
-    group_by_date(batch).map { |prefix, records| send_to_s3(prefix, records) }
+  def initialize(batch)
+    @batch = batch
   end
 
-  private_class_method :new
+  def call
+    group_by_date(batch).map { |prefix, records| send_to_s3(prefix, records) }
+  end
 
 private
 

--- a/app/services/spam_report_service.rb
+++ b/app/services/spam_report_service.rb
@@ -1,0 +1,26 @@
+class SpamReportService
+  attr_reader :delivery_attempt
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  private_class_method :new
+
+  def initialize(delivery_attempt)
+    @delivery_attempt = delivery_attempt
+  end
+
+  def call
+    subscriber_id = delivery_attempt.email.subscriber_id
+    subscriber = Subscriber.find(subscriber_id)
+
+    UnsubscribeService.unsubscribe!(
+      subscriber,
+      subscriber.active_subscriptions,
+      :marked_as_spam,
+    )
+
+    delivery_attempt.email.update!(marked_as_spam: true)
+  end
+end

--- a/app/services/spam_report_service.rb
+++ b/app/services/spam_report_service.rb
@@ -1,11 +1,5 @@
-class SpamReportService
+class SpamReportService < ApplicationService
   attr_reader :delivery_attempt
-
-  def self.call(*args)
-    new(*args).call
-  end
-
-  private_class_method :new
 
   def initialize(delivery_attempt)
     @delivery_attempt = delivery_attempt

--- a/app/services/spam_report_service.rb
+++ b/app/services/spam_report_service.rb
@@ -8,13 +8,7 @@ class SpamReportService < ApplicationService
   def call
     subscriber_id = delivery_attempt.email.subscriber_id
     subscriber = Subscriber.find(subscriber_id)
-
-    UnsubscribeService.call(
-      subscriber,
-      subscriber.active_subscriptions,
-      :marked_as_spam,
-    )
-
+    UnsubscribeAllService.call(subscriber, :marked_as_spam)
     delivery_attempt.email.update!(marked_as_spam: true)
   end
 end

--- a/app/services/spam_report_service.rb
+++ b/app/services/spam_report_service.rb
@@ -15,7 +15,7 @@ class SpamReportService
     subscriber_id = delivery_attempt.email.subscriber_id
     subscriber = Subscriber.find(subscriber_id)
 
-    UnsubscribeService.unsubscribe!(
+    UnsubscribeService.call(
       subscriber,
       subscriber.active_subscriptions,
       :marked_as_spam,

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -34,7 +34,7 @@ class StatusUpdateService
     end
 
     if delivery_attempt.permanent_failure? && subscriber
-      UnsubscribeService.subscriber!(subscriber, :non_existent_email)
+      UnsubscribeService.call(subscriber, subscriber.active_subscriptions, :non_existent_email)
     # We check for a status of nil here too in case email hasn't had a status set
     elsif delivery_attempt.temporary_failure? && ["pending", nil].include?(email.status)
       DeliveryRequestWorker.perform_in(TEMPORARY_FAILURE_RETRY_DELAY, email.id, :default)

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -1,4 +1,4 @@
-class StatusUpdateService
+class StatusUpdateService < ApplicationService
   TEMPORARY_FAILURE_RETRY_DELAY = 6.hours
   TEMPORARY_FAILURE_RETRY_TIMEOUT = 24.hours
 
@@ -11,12 +11,8 @@ class StatusUpdateService
     @delivery_attempt = find_delivery_attempt(reference)
   end
 
-  def self.call(*args)
-    DeliveryAttempt.transaction { new(*args).call }
-  end
-
   def call
-    begin
+    DeliveryAttempt.transaction do
       delivery_attempt.update!(
         sent_at: sent_at,
         completed_at: completed_at,
@@ -46,8 +42,6 @@ class StatusUpdateService
     GovukStatsd.increment("status_update.failure")
     raise
   end
-
-  private_class_method :new
 
 private
 

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -30,7 +30,7 @@ class StatusUpdateService < ApplicationService
     end
 
     if delivery_attempt.permanent_failure? && subscriber
-      UnsubscribeService.call(subscriber, subscriber.active_subscriptions, :non_existent_email)
+      UnsubscribeAllService.call(subscriber, :non_existent_email)
     # We check for a status of nil here too in case email hasn't had a status set
     elsif delivery_attempt.temporary_failure? && ["pending", nil].include?(email.status)
       DeliveryRequestWorker.perform_in(TEMPORARY_FAILURE_RETRY_DELAY, email.id, :default)

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -40,7 +40,7 @@ class StatusUpdateService
       DeliveryRequestWorker.perform_in(TEMPORARY_FAILURE_RETRY_DELAY, email.id, :default)
     end
 
-    MetricsService.delivery_attempt_status_changed(status.underscore)
+    Metrics.delivery_attempt_status_changed(status.underscore)
     GovukStatsd.increment("status_update.success")
   rescue StandardError
     GovukStatsd.increment("status_update.failure")

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -1,4 +1,4 @@
-class UnpublishHandlerService
+class UnpublishHandlerService < ApplicationService
   TAXON_TEMPLATE = <<~BODY.freeze
     Your subscription to email updates about '<%=subject%>' has ended because this topic no longer exists on GOV.UK.
 
@@ -11,11 +11,14 @@ class UnpublishHandlerService
     taxon_tree: TAXON_TEMPLATE,
   }.freeze
 
-  def self.call(*args)
-    new.call(*args)
+  attr_reader :content_id, :redirect
+
+  def initialize(content_id, redirect)
+    @content_id = content_id
+    @redirect = redirect
   end
 
-  def call(content_id, redirect)
+  def call
     subscriber_lists = SubscriberList
                          .find_by_links_value(content_id)
                          .includes(:subscribers)

--- a/app/services/unsubscribe_all_service.rb
+++ b/app/services/unsubscribe_all_service.rb
@@ -1,0 +1,12 @@
+class UnsubscribeAllService < ApplicationService
+  attr_reader :subscriber, :reason
+
+  def initialize(subscriber, reason)
+    @subscriber = subscriber
+    @reason = reason
+  end
+
+  def call
+    UnsubscribeService.call(subscriber, subscriber.active_subscriptions, reason)
+  end
+end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -8,28 +8,14 @@ module UnsubscribeService
       unsubscribe!(subscription.subscriber, [subscription], reason)
     end
 
-    def subscriptions!(subscriber, subscriptions, reason, ended_email_id: nil)
-      subscription_subscriber_ids = subscriptions.map(&:subscriber_id).uniq
-      raise "Can't process subscriptions for multiple subscribers" unless subscription_subscriber_ids.length == 1
-      raise "Subscriptions don't match subscriber" unless subscription_subscriber_ids.first == subscriber.id
-
-      unsubscribe!(
-        subscriber,
-        subscriptions,
-        reason,
-        ended_email_id: ended_email_id,
-      )
-    end
-
     def unsubscribe!(
       subscriber,
       subscriptions,
-      reason,
-      ended_email_id: nil
+      reason
     )
       ActiveRecord::Base.transaction do
         subscriptions.each do |subscription|
-          subscription.end(reason: reason, ended_email_id: ended_email_id)
+          subscription.end(reason: reason)
         end
 
         if !subscriber.deactivated? && no_other_subscriptions?(subscriber, subscriptions)

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -1,18 +1,6 @@
 module UnsubscribeService
   class << self
-    def subscriber!(subscriber, reason)
-      unsubscribe!(subscriber, subscriber.active_subscriptions, reason)
-    end
-
-    def subscription!(subscription, reason)
-      unsubscribe!(subscription.subscriber, [subscription], reason)
-    end
-
-    def unsubscribe!(
-      subscriber,
-      subscriptions,
-      reason
-    )
+    def unsubscribe!(subscriber, subscriptions, reason)
       ActiveRecord::Base.transaction do
         subscriptions.each do |subscription|
           subscription.end(reason: reason)

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -1,19 +1,33 @@
-module UnsubscribeService
-  class << self
-    def unsubscribe!(subscriber, subscriptions, reason)
-      ActiveRecord::Base.transaction do
-        subscriptions.each do |subscription|
-          subscription.end(reason: reason)
-        end
+class UnsubscribeService
+  attr_reader :subscriber, :subscriptions, :reason
 
-        if !subscriber.deactivated? && no_other_subscriptions?(subscriber, subscriptions)
-          subscriber.deactivate!
-        end
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(subscriber, subscriptions, reason)
+    @subscriber = subscriber
+    @subscriptions = subscriptions
+    @reason = reason
+  end
+
+  private_class_method :new
+
+  def call
+    ActiveRecord::Base.transaction do
+      subscriptions.each do |subscription|
+        subscription.end(reason: reason)
+      end
+
+      if !subscriber.deactivated? && no_other_subscriptions?(subscriber, subscriptions)
+        subscriber.deactivate!
       end
     end
+  end
 
-    def no_other_subscriptions?(subscriber, subscriptions)
-      (subscriber.subscriptions - subscriptions).empty?
-    end
+private
+
+  def no_other_subscriptions?(subscriber, subscriptions)
+    (subscriber.subscriptions - subscriptions).empty?
   end
 end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -1,17 +1,11 @@
-class UnsubscribeService
+class UnsubscribeService < ApplicationService
   attr_reader :subscriber, :subscriptions, :reason
-
-  def self.call(*args)
-    new(*args).call
-  end
 
   def initialize(subscriber, subscriptions, reason)
     @subscriber = subscriber
     @subscriptions = subscriptions
     @reason = reason
   end
-
-  private_class_method :new
 
   def call
     ActiveRecord::Base.transaction do

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -21,32 +21,16 @@ module UnsubscribeService
       )
     end
 
-    def spam_report!(delivery_attempt)
-      subscriber_id = delivery_attempt.email.subscriber_id
-      subscriber = Subscriber.find(subscriber_id)
-      unsubscribe!(
-        subscriber,
-        subscriber.active_subscriptions,
-        :marked_as_spam,
-        email_marked_as_spam: delivery_attempt.email,
-      )
-    end
-
-  private
-
     def unsubscribe!(
       subscriber,
       subscriptions,
       reason,
-      email_marked_as_spam: nil,
       ended_email_id: nil
     )
       ActiveRecord::Base.transaction do
         subscriptions.each do |subscription|
           subscription.end(reason: reason, ended_email_id: ended_email_id)
         end
-
-        email_marked_as_spam.update!(marked_as_spam: true) if email_marked_as_spam && reason == :marked_as_spam
 
         if !subscriber.deactivated? && no_other_subscriptions?(subscriber, subscriptions)
           subscriber.deactivate!

--- a/app/services/update_email_status_service.rb
+++ b/app/services/update_email_status_service.rb
@@ -1,10 +1,6 @@
-class UpdateEmailStatusService
+class UpdateEmailStatusService < ApplicationService
   def initialize(delivery_attempt)
     @delivery_attempt = delivery_attempt
-  end
-
-  def self.call(*args)
-    new(*args).call
   end
 
   def call
@@ -13,8 +9,6 @@ class UpdateEmailStatusService
     handle_permanent_failure if delivery_attempt.permanent_failure?
     handle_delivered if delivery_attempt.delivered?
   end
-
-  private_class_method :new
 
 private
 

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -22,7 +22,7 @@ class DeliveryRequestWorker
 
     check_rate_limit_exceeded
 
-    email = MetricsService.delivery_request_worker_find_email do
+    email = Metrics.delivery_request_worker_find_email do
       Email.find(email_id)
     end
 

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -24,7 +24,7 @@ private
     digest_run = digest_run_subscriber.digest_run
     subscriber = digest_run_subscriber.subscriber
 
-    MetricsService.digest_email_generation(digest_run.range) do
+    Metrics.digest_email_generation(digest_run.range) do
       email = nil
       Email.transaction do
         digest_run_subscriber.mark_complete!

--- a/lib/clean/invalid_subscribers.rb
+++ b/lib/clean/invalid_subscribers.rb
@@ -18,7 +18,7 @@ module Clean
       subscribers_to_remove =  Subscriber.where(id: subscriber_ids_to_remove).activated
       puts "Removing the following email subscriptions"
       puts subscribers_to_remove.pluck(:address)
-      subscribers_to_remove.each { |s| UnsubscribeService.subscriber!(s, :unsubscribed) } unless dry_run
+      subscribers_to_remove.each { |s| UnsubscribeService.unsubscribe!(s, s.active_subscriptions, :unsubscribed) } unless dry_run
     end
 
   private

--- a/lib/clean/invalid_subscribers.rb
+++ b/lib/clean/invalid_subscribers.rb
@@ -18,7 +18,7 @@ module Clean
       subscribers_to_remove =  Subscriber.where(id: subscriber_ids_to_remove).activated
       puts "Removing the following email subscriptions"
       puts subscribers_to_remove.pluck(:address)
-      subscribers_to_remove.each { |s| UnsubscribeService.unsubscribe!(s, s.active_subscriptions, :unsubscribed) } unless dry_run
+      subscribers_to_remove.each { |s| UnsubscribeService.call(s, s.active_subscriptions, :unsubscribed) } unless dry_run
     end
 
   private

--- a/lib/clean/invalid_subscribers.rb
+++ b/lib/clean/invalid_subscribers.rb
@@ -18,7 +18,7 @@ module Clean
       subscribers_to_remove =  Subscriber.where(id: subscriber_ids_to_remove).activated
       puts "Removing the following email subscriptions"
       puts subscribers_to_remove.pluck(:address)
-      subscribers_to_remove.each { |s| UnsubscribeService.call(s, s.active_subscriptions, :unsubscribed) } unless dry_run
+      subscribers_to_remove.each { |s| UnsubscribeAllService.call(s, :unsubscribed) } unless dry_run
     end
 
   private

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -1,4 +1,4 @@
-class MetricsService
+class Metrics
   class << self
     def content_change_emails(content_change, count)
       count("content_change_emails.publishing_app.#{content_change.publishing_app}.immediate", count)

--- a/lib/public_urls.rb
+++ b/lib/public_urls.rb
@@ -1,4 +1,4 @@
-module PublicUrlService
+module PublicUrls
   class << self
     def url_for(base_path:)
       URI.join(website_root, base_path).to_s

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -108,7 +108,7 @@ namespace :manage do
       if active_subscriptions.empty?
         puts "Subscriber #{email_address} already unsubscribed from #{subscriber_list_slug}"
       else
-        UnsubscribeService.subscription!(active_subscriptions.last, :unsubscribed)
+        UnsubscribeService.unsubscribe!(subscriber, [active_subscriptions.last], :unsubscribed)
         puts "Unsubscribing from #{email_address} from #{subscriber_list_slug}"
       end
     end
@@ -122,7 +122,7 @@ namespace :manage do
       puts "Subscriber #{email_address} not found"
     else
       puts "Unsubscribing #{email_address}"
-      UnsubscribeService.subscriber!(subscriber, :unsubscribed)
+      UnsubscribeService.unsubscribe!(subscriber, subscriber.active_subscriptions, :unsubscribed)
     end
   end
 

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -122,7 +122,7 @@ namespace :manage do
       puts "Subscriber #{email_address} not found"
     else
       puts "Unsubscribing #{email_address}"
-      UnsubscribeService.call(subscriber, subscriber.active_subscriptions, :unsubscribed)
+      UnsubscribeAllService.call(subscriber, :unsubscribed)
     end
   end
 

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -108,7 +108,7 @@ namespace :manage do
       if active_subscriptions.empty?
         puts "Subscriber #{email_address} already unsubscribed from #{subscriber_list_slug}"
       else
-        UnsubscribeService.unsubscribe!(subscriber, [active_subscriptions.last], :unsubscribed)
+        UnsubscribeService.call(subscriber, [active_subscriptions.last], :unsubscribed)
         puts "Unsubscribing from #{email_address} from #{subscriber_list_slug}"
       end
     end
@@ -122,7 +122,7 @@ namespace :manage do
       puts "Subscriber #{email_address} not found"
     else
       puts "Unsubscribing #{email_address}"
-      UnsubscribeService.unsubscribe!(subscriber, subscriber.active_subscriptions, :unsubscribed)
+      UnsubscribeService.call(subscriber, subscriber.active_subscriptions, :unsubscribed)
     end
   end
 

--- a/spec/integration/spam_reports_spec.rb
+++ b/spec/integration/spam_reports_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Receiving a spam report", type: :request do
   let(:subscriber) { create(:subscriber) }
   let(:email) { create(:email, subscriber_id: subscriber.id) }
-  let(:delivery_attempt) { create(:delivery_attempt, email_id: email.id) }
+  let!(:delivery_attempt) { create(:delivery_attempt, email_id: email.id) }
   let(:reference) { delivery_attempt.id }
 
   let(:permissions) { %w[signin status_updates] }
@@ -12,10 +12,9 @@ RSpec.describe "Receiving a spam report", type: :request do
     let(:params) { { reference: reference } }
     let(:permissions) { %w[signin status_updates] }
 
-    it "calls the unsubscribe service" do
-      expect(UnsubscribeService).to receive(:spam_report!).with(delivery_attempt)
-
+    it "unsubscribes the user" do
       post "/spam-reports", params: params
+      expect(subscriber.active_subscriptions).to be_empty
     end
 
     it "renders 204 no content" do

--- a/spec/lib/metrics_spec.rb
+++ b/spec/lib/metrics_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe MetricsService do
+RSpec.describe Metrics do
   before do
     allow(GovukStatsd).to receive(:count)
   end

--- a/spec/lib/public_urls_spec.rb
+++ b/spec/lib/public_urls_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PublicUrlService do
+RSpec.describe PublicUrls do
   describe ".url_for" do
     it "returns the GOV.UK url for the content item" do
       result = subject.url_for(base_path: "/foo/bar")

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Email do
 
     context "when we're inserting a full batch of emails" do
       it "times the insert" do
-        expect(MetricsService).to receive(:email_bulk_insert).and_call_original
+        expect(Metrics).to receive(:email_bulk_insert).and_call_original
         expect(described_class).to receive(:insert_all!).with(records)
         described_class.timed_bulk_insert(records, 3)
       end
@@ -22,7 +22,7 @@ RSpec.describe Email do
 
     context "when we're not inserting a full batch of emails" do
       it "doesn't time the insert" do
-        expect(MetricsService).not_to receive(:email_bulk_insert)
+        expect(Metrics).not_to receive(:email_bulk_insert)
         expect(described_class).to receive(:insert_all!).with(records)
         described_class.timed_bulk_insert(records, 5)
       end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe DeliveryRequestService do
       around { |example| freeze_time { example.run } }
 
       it "records the time of the delivery attempt" do
-        expect(MetricsService)
+        expect(Metrics)
           .to receive(:email_created_to_first_delivery_attempt)
           .with(email.created_at, Time.zone.now)
         described_class.call(email: email)
@@ -85,7 +85,7 @@ RSpec.describe DeliveryRequestService do
       it "records the time from content change created until this delivery attempt" do
         content_change_created_at = 1.hour.ago
         metrics = { content_change_created_at: content_change_created_at }
-        expect(MetricsService)
+        expect(Metrics)
           .to receive(:content_change_created_to_first_delivery_attempt)
           .with(content_change_created_at, Time.zone.now)
 
@@ -97,7 +97,7 @@ RSpec.describe DeliveryRequestService do
       before { create(:delivery_attempt, email: email) }
 
       it "doesn't record the time of the delivery attempt" do
-        expect(MetricsService).not_to receive(:email_created_to_first_delivery_attempt)
+        expect(Metrics).not_to receive(:email_created_to_first_delivery_attempt)
         described_class.call(email: email)
       end
     end

--- a/spec/services/digest_initiator_service_spec.rb
+++ b/spec/services/digest_initiator_service_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe DigestInitiatorService do
       end
 
       it "records a metric for the delivery attempt" do
-        expect(MetricsService).to receive(:digest_initiator_service)
+        expect(Metrics).to receive(:digest_initiator_service)
           .with("daily")
 
         described_class.call(range: range)

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
       end
 
       it "sends stats about the generated emails" do
-        expect(MetricsService).to receive(:content_change_emails)
+        expect(Metrics).to receive(:content_change_emails)
                               .with(content_change, 2)
         instance.generate_emails
       end

--- a/spec/services/message_handler_service_spec.rb
+++ b/spec/services/message_handler_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe MessageHandlerService do
     end
 
     it "records a metric" do
-      expect(MetricsService).to receive(:message_created)
+      expect(Metrics).to receive(:message_created)
       described_class.call(params: params, govuk_request_id: govuk_request_id)
     end
 

--- a/spec/services/spam_report_service_spec.rb
+++ b/spec/services/spam_report_service_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe SpamReportService do
+  describe ".call" do
+    let(:subscription) { create(:subscription) }
+    let(:subscriber) { subscription.subscriber }
+    let(:email) { create(:email, subscriber_id: subscriber.id) }
+    let(:delivery_attempt) { create(:delivery_attempt, email: email) }
+
+    it "delegates to the UnsubscribeService" do
+      expect(UnsubscribeService).to receive(:unsubscribe!)
+        .with(subscriber, [subscription], :marked_as_spam)
+
+      described_class.call(delivery_attempt)
+    end
+
+    it "marks the email as spam" do
+      described_class.call(delivery_attempt)
+      expect(email.marked_as_spam).to be_truthy
+    end
+  end
+end

--- a/spec/services/spam_report_service_spec.rb
+++ b/spec/services/spam_report_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SpamReportService do
     let(:delivery_attempt) { create(:delivery_attempt, email: email) }
 
     it "delegates to the UnsubscribeService" do
-      expect(UnsubscribeService).to receive(:unsubscribe!)
+      expect(UnsubscribeService).to receive(:call)
         .with(subscriber, [subscription], :marked_as_spam)
 
       described_class.call(delivery_attempt)

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -74,46 +74,4 @@ RSpec.describe UnsubscribeService do
       end
     end
   end
-
-  describe ".subscriptions!" do
-    let(:subscriber) { create(:subscriber) }
-    let(:subscriptions) { create_list(:subscription, 3, subscriber: subscriber) }
-
-    context "when passed inconsistent subscriptions" do
-      it "raises an exception" do
-        expect {
-          subject.subscriptions!(subscriber, [create(:subscription)], :unpublished)
-        }.to raise_error "Subscriptions don't match subscriber"
-      end
-    end
-
-    context "when passed subscriptions for multiple subscribers" do
-      it "raises an exception" do
-        expect {
-          subject.subscriptions!(
-            subscriber,
-            subscriptions + [create(:subscription)],
-            :unpublished,
-          )
-        }.to raise_error "Can't process subscriptions for multiple subscribers"
-      end
-    end
-
-    context "when an ended_email_id is provided" do
-      it "gets passed through to Subscription#end" do
-        email = create(:email)
-
-        subject.subscriptions!(
-          subscriber,
-          subscriptions,
-          :unpublished,
-          ended_email_id: email.id,
-        )
-
-        subscriptions.each do |subscription|
-          expect(subscription.ended_email_id).to eq(email.id)
-        end
-      end
-    end
-  end
 end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -116,25 +116,4 @@ RSpec.describe UnsubscribeService do
       end
     end
   end
-
-  describe "spam_report" do
-    let!(:subscription) { create(:subscription) }
-    let(:subscriber) { subscription.subscriber }
-    let(:email) { create(:email, subscriber_id: subscriber.id) }
-    let(:delivery_attempt) { create(:delivery_attempt, email: email) }
-
-    it "unsubscribes the subscriber" do
-      expect { subject.spam_report!(delivery_attempt) }
-        .to change { email.reload.marked_as_spam }
-        .from(nil)
-        .to(true)
-    end
-
-    it "marks the subscription as ended" do
-      expect { subject.spam_report!(delivery_attempt) }
-        .to change { subscription.reload.ended_reason }
-        .from(nil)
-        .to("marked_as_spam")
-    end
-  end
 end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -1,76 +1,37 @@
 RSpec.describe UnsubscribeService do
-  describe ".subscriber!" do
-    let!(:subscriber) { create(:subscriber, address: "foo@bar.com") }
+  describe ".unsubscribe!" do
+    let(:subscriber) { create(:subscriber, address: "foo@bar.com") }
+    let(:subscriptions) { create_list(:subscription, 2, subscriber: subscriber) }
 
-    it "deactivates the subscriber" do
-      expect { subject.subscriber!(subscriber, :unsubscribed) }
-        .to change { subscriber.reload.deactivated? }
-        .from(false)
-        .to(true)
+    it "ends the specified subscriptions" do
+      described_class.unsubscribe!(subscriber, [subscriptions.first], :unsubscribed)
+      expect(subscriber.active_subscriptions.count).to eq 1
     end
 
-    context "when the subscriber has subscriptions" do
+    context "when the email address is invalid" do
       before do
-        create_list(:subscription, 3, subscriber: subscriber)
+        allow(subscriber).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
       end
 
-      it "removes them" do
-        expect { subject.subscriber!(subscriber, :unsubscribed) }
-          .to change(subscriber.active_subscriptions, :count)
-          .from(3)
-          .to(0)
-      end
+      it "does not remove the subscriptions" do
+        expect { described_class.unsubscribe!(subscriber, subscriptions, :unsubscribed) }
+          .to raise_error(ActiveRecord::RecordInvalid)
 
-      it "does not remove them if the email address update fails" do
-        allow_any_instance_of(Subscriber)
-          .to receive(:valid?).and_raise("failed")
-
-        expect { subject.subscriber!(subscriber, :unsubscribed) }
-          .to raise_error("failed")
-          .and change(subscriber.active_subscriptions, :count)
-          .by(0)
+        expect(subscriber.active_subscriptions).to be_present
       end
     end
-  end
 
-  describe ".subscription!" do
-    let!(:subscription) { create(:subscription) }
-    let(:subscriber) { subscription.subscriber }
-
-    it "removes the subscription" do
-      subject.subscription!(subscription, :unsubscribed)
-      expect(Subscription.active.find_by(id: subscription.id)).to be_nil
+    context "when other subscriptions remain" do
+      it "does not deactivate the subscriber" do
+        described_class.unsubscribe!(subscriber, [subscriptions.first], :unsubscribed)
+        expect(subscriber.reload.deactivated?).to be_falsey
+      end
     end
 
-    it "does not remove the subscription if the email address update fails" do
-      allow_any_instance_of(Subscriber)
-        .to receive(:valid?).and_raise("failed")
-
-      expect { subject.subscriber!(subscriber, :unsubscribed) }
-        .to raise_error("failed")
-        .and change(subscriber.active_subscriptions, :count)
-        .by(0)
-    end
-
-    context "when it is the only remaining subscription for the subscriber" do
+    context "when all subscriptions are ended" do
       it "deactivates the subscriber" do
-        expect { subject.subscription!(subscription, :unsubscribed) }
-          .to change { subscriber.reload.deactivated? }
-          .from(false)
-          .to(true)
-      end
-    end
-
-    context "when there are other subscriptions for the subscriber" do
-      before do
-        create_list(:subscription, 3, subscriber: subscription.subscriber)
-      end
-
-      it "does not nullify the email address of the subscriber" do
-        subscriber = subscription.subscriber
-
-        subject.subscription!(subscription, :unsubscribed)
-        expect(subscriber.reload.address).not_to be_nil
+        described_class.unsubscribe!(subscriber, subscriptions, :unsubscribed)
+        expect(subscriber.reload.deactivated?).to be_truthy
       end
     end
   end

--- a/spec/services/unsubscribe_service_spec.rb
+++ b/spec/services/unsubscribe_service_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe UnsubscribeService do
-  describe ".unsubscribe!" do
+  describe ".call" do
     let(:subscriber) { create(:subscriber, address: "foo@bar.com") }
     let(:subscriptions) { create_list(:subscription, 2, subscriber: subscriber) }
 
     it "ends the specified subscriptions" do
-      described_class.unsubscribe!(subscriber, [subscriptions.first], :unsubscribed)
+      described_class.call(subscriber, [subscriptions.first], :unsubscribed)
       expect(subscriber.active_subscriptions.count).to eq 1
     end
 
@@ -14,7 +14,7 @@ RSpec.describe UnsubscribeService do
       end
 
       it "does not remove the subscriptions" do
-        expect { described_class.unsubscribe!(subscriber, subscriptions, :unsubscribed) }
+        expect { described_class.call(subscriber, subscriptions, :unsubscribed) }
           .to raise_error(ActiveRecord::RecordInvalid)
 
         expect(subscriber.active_subscriptions).to be_present
@@ -23,14 +23,14 @@ RSpec.describe UnsubscribeService do
 
     context "when other subscriptions remain" do
       it "does not deactivate the subscriber" do
-        described_class.unsubscribe!(subscriber, [subscriptions.first], :unsubscribed)
+        described_class.call(subscriber, [subscriptions.first], :unsubscribed)
         expect(subscriber.reload.deactivated?).to be_falsey
       end
     end
 
     context "when all subscriptions are ended" do
       it "deactivates the subscriber" do
-        described_class.unsubscribe!(subscriber, subscriptions, :unsubscribed)
+        described_class.call(subscriber, subscriptions, :unsubscribed)
         expect(subscriber.reload.deactivated?).to be_truthy
       end
     end

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe DigestEmailGenerationWorker do
     end
 
     it "records a metric for the delivery attempt" do
-      expect(MetricsService).to receive(:digest_email_generation)
+      expect(Metrics).to receive(:digest_email_generation)
         .with("daily")
 
       subject.perform(digest_run_subscriber.id)


### PR DESCRIPTION
This moves and refactors a few services in order to adopt
a consistent interface for classes in app/services.

UnsubscribeService was the main blocker for doing this, and
had some major issues with it:

- The interface was really unclear (the method names did not
indicate the outcome).

- The class had multiple responsibilities: single, bulk and
spam-related unsubscribes.

Please see the commits for more details.