### PR TITLE
Prevent Sentry alerts for PG::Errors during data sync

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,17 @@
+GovukError.configure do |config|
+  # Don't capture postgres errors that occur during the time that the data sync
+  # is running in integration and staging environments
+  # This lambda is called with Ruby Exception objects, Raven::Event objects
+  # and may be called with other types.
+  config.should_capture = lambda do |error_or_event|
+    data_sync_ignored_error = error_or_event.is_a?(PG::Error) ||
+      (error_or_event.respond_to?(:cause) && error_or_event.cause.is_a?(PG::Error))
+
+    data_sync_environment = ENV.fetch("SENTRY_CURRENT_ENV", "")
+                               .match(/integration|staging/)
+
+    data_sync_time = Time.zone.now.hour <= 8
+
+    !(data_sync_ignored_error && data_sync_environment && data_sync_time)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/koo6gJov/355-increase-visibility-of-sentry-alerts-for-email-apps-and-services

This ports over code from Content Publisher [1] that prevents Sentry
from being notified of PostgreSQL errors during a time period in
integration and staging environment.

Looking in Sentry there is _a lot_ of errors sent during the data sync.
In integration there were ~56k errors during the last 14 days and in
staging there were in the region of ~42k.

Arguably, this reveals a bunch of flaws in our data sync process as it
looks like we produce errors for a number of hours each night.

The tricky thing in this PR is deciding on what is a reasonable time to
start reporting errors again, as outside of data syncs we do want to
be informed of DB errors in integration and staging. Looking at recent
data I can see the data syncs occur until around 6am, so I felt 8am
should provide sufficient buffer and be unlikely to intrude on many
peoples working days. However this may need tweaking if we find
ourselves alerted.

[1]: https://github.com/alphagov/content-publisher/blob/2406ab6fc7bf5bdb2bd7d05c7f585b745c2ad061/config/initializers/govuk_error.rb