### PR TITLE
Rename conflicting "DataExporter" class

### DIFF
--- a/lib/reports/living_in_europe_report.rb
+++ b/lib/reports/living_in_europe_report.rb
@@ -1,7 +1,7 @@
 require "csv"
 
-class Reports::DataExporter
-  def export_csv_from_living_in_europe(date)
+class Reports::LivingInEuropeReport
+  def call(date)
     export_detailed_csv(living_in_europe_subscriber_lists, at: date)
   end
 

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -12,6 +12,6 @@ namespace :report do
 
   desc "Export the number of subscriptions for the 'Living in' taxons for European countries as of a given date (format: 'yyyy-mm-dd')"
   task :csv_from_living_in_europe, [:date] => :environment do |_, args|
-    Reports::DataExporter.new.export_csv_from_living_in_europe(args.date)
+    Reports::LivingInEuropeReport.new.call(args.date)
   end
 end


### PR DESCRIPTION
    Previously we removed almost all methods of the DataExporter class,
    such that it now represents a single report. The 'exporter' naming
    conflicts with that used for Graphite metrics. This renames the class
    to reflect its specific purpose, and avoid it having multiple
    responsibilities in future.