### PR TITLE
Increase log level for test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,9 @@ Rails.application.configure do
     "Cache-Control" => "public, max-age=#{1.hour.seconds.to_i}",
   }
 
+  # Use a higher log level to avoid unnecessary clutter and disk IO.
+  config.log_level = :warn
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
https://trello.com/c/iwhQbAaE/383-incident-action-fix-the-world-of-email

This shaves off 12 seconds when running tests for the last PR I
worked on [1]. We take a similar approach in Content Publisher [2].

[1]: https://github.com/alphagov/email-alert-api/pull/1332
[2]: https://github.com/alphagov/content-publisher/pull/1730