### PR TITLE
Try speeding things up with the spring gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,6 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails"
   gem "rubocop-govuk"
+  gem "spring"
+  gem "spring-commands-rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,9 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 7.0)
       thor (~> 0)
+    spring (2.1.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -400,6 +403,8 @@ DEPENDENCIES
   rubocop-govuk
   sidekiq-scheduler
   sidekiq-unique-jobs
+  spring
+  spring-commands-rspec
   webmock
   with_advisory_lock
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ ./startup.sh
 ### Running the test suite
 
 * Run `RAILS_ENV=test bundle exec rake db:setup` to load the database
-* Run `bundle exec rspec` to run the tests
+* Run `bundle exec spring rspec` to run the tests
 
 ### Using test email addresses for signup
 


### PR DESCRIPTION
https://trello.com/c/iwhQbAaE/383-incident-action-fix-the-world-of-email

Depends on: https://github.com/alphagov/govuk-docker/pull/377

This is an experiment: we can revert it if it causes problems.

Previously we incurred a startup delay each time we ran the tests,
in order for Rails to load all its files. I've found the delay to
be significant when using GOV.UK Docker, where disk accesses are
more expensive. This adds the 'spring' gem (and a corresponding
extension for RSpec commands) to intelligently cache the running
Rails app, so we don't waste time loading it over and again.

Locally (same when running via GOV.UK Docker):

- [before] bundle exec rspec/rails/rake <- you can still do this
- [after] bundle exec spring rspec/rails/rake <- fasterer

Performance stats from my machine when working on #1332:

time govuk-docker-run bundle exec rspec spec/lib/tasks/temp_fix_world_subs_spec.rb:38
govuk-docker-run bundle exec rspec   1.54s user 0.19s system 9% cpu 18.704 total
govuk-docker-run bundle exec rspec   1.55s user 0.19s system 9% cpu 19.094 total
govuk-docker-run bundle exec rspec   1.67s user 0.19s system 9% cpu 20.276 total

time govuk-docker-run spring rspec spec/lib/tasks/temp_fix_world_subs_spec.rb:38
govuk-docker-run bundle exec spring rspec   1.57s user 0.18s system 8% cpu 21.220 total
govuk-docker-run bundle exec spring rspec   1.56s user 0.18s system 19% cpu 8.889 total
govuk-docker-run bundle exec spring rspec   1.58s user 0.18s system 19% cpu 9.245 total
govuk-docker-run bundle exec spring rspec   1.56s user 0.18s system 20% cpu 8.621 total