### PR TITLE
Describe 'report:count_subscribers(_on)' tasks in support-tasks

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -31,28 +31,15 @@ Here are some example queries to pull out particular insights.
 ### How many subscribers does a list have
 
 ```ruby
+# total count right now
 SubscriberList.find(4194).active_subscriptions_count
-```
 
-There is a [rake task][rake-count-subscribers] that does this for you, and
-includes a breakdown of subscriptions that are Immediate, Daily or Weekly:
-
-```bash
-rake report:count_subscribers['subscriber-list-slug']
-```
-
-### How many subscribers did a list have at a particular point in time
-
-```ruby
+# total count at a particular point in time
 Subscription.active_on("2018-06-01").where(subscriber_list_id: 4194).count
 ```
 
-There is a [rake task][rake-count-subscribers-on] that does this for you, and
-includes a breakdown of subscriptions that are Immediate, Daily or Weekly:
-
-```bash
-rake report:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']
-```
+There are [rake tasks][support-tasks] that do this for you, and
+include a breakdown of subscriptions that are Immediate, Daily or Weekly.
 
 ### Lists with most new subscriptions in a time frame
 
@@ -203,6 +190,5 @@ LIMIT 10;
 [athena-queries]: https://docs.aws.amazon.com/athena/latest/ug/functions-operators-reference-section.html
 [aws]: https://aws.amazon.com
 [console-instructions]: https://docs.publishing.service.gov.uk/manual/seeing-things-in-the-aws-console.html
-[rake-count-subscribers]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:count_subscribers['subscriber-list-slug']
-[rake-count-subscribers-on]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']
 [schema.rb]: https://github.com/alphagov/email-alert-api/tree/master/db/schema.rb
+[support-tasks]: /apis/email-alert-api/support-tasks.html#count-subscriptions-to-a-subscriber-list

--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -153,6 +153,27 @@ Depending on the number of emails to send, the Rake task can take a few minutes 
 bundle exec rake 'troubleshoot:resend_failed_emails:by_id[<email_one_id>,<email_two_id>]'
 ```
 
+## Count subscriptions to a subscriber list
+
+This shows subscription counts by Immediate, Daily or Weekly:
+
+```bash
+rake report:count_subscribers['subscriber-list-slug']
+```
+
+[⚙ Run rake task on production][rake-count-subscribers]
+
+If you need to know the number of subscriptions on a particular day:
+
+```bash
+rake report:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']
+```
+
+[⚙ Run rake task on production][rake-count-subscribers-on]
+
+[rake-count-subscribers]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:count_subscribers['subscriber-list-slug']
+[rake-count-subscribers-on]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']
+
 ## Query for subscriptions by title
 
 This task will return subscriptions with titles containing the string provided


### PR DESCRIPTION
I knew the task existed, and was trying to find the documentation
for it. It took an embarrassingly long time to discover it was
documented in analytics.md rather than support-tasks.md, where
all the other rake tasks are documented.