### PR TITLE
Remove config parameters unused in application code

### DIFF
--- a/app/providers/notify_provider.rb
+++ b/app/providers/notify_provider.rb
@@ -1,7 +1,7 @@
 class NotifyProvider
-  def initialize(config: EmailAlertAPI.config.notify, notify_client: EmailAlertAPI.config.notify_client)
-    @client = notify_client
-    @template_id = config.fetch(:template_id)
+  def initialize
+    @client = EmailAlertAPI.config.notify_client
+    @template_id = EmailAlertAPI.config.notify.fetch(:template_id)
   end
 
   def self.call(*args)

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -5,7 +5,8 @@ class DeliveryRequestService < ApplicationService
     "delay" => DelayProvider,
   }.freeze
 
-  def initialize(email:, metrics: {}, config: EmailAlertAPI.config.email_service)
+  def initialize(email:, metrics: {})
+    config = EmailAlertAPI.config.email_service
     @email = email
     @metrics = metrics
     @attempt_id = SecureRandom.uuid

--- a/lib/email_alert_api/config.rb
+++ b/lib/email_alert_api/config.rb
@@ -16,8 +16,8 @@ module EmailAlertAPI
     end
 
     def notify_client
-      api_key = @notify[:api_key]
-      base_url = @notify[:base_url]
+      api_key = notify[:api_key]
+      base_url = notify[:base_url]
       Notifications::Client.new(api_key, base_url)
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/es2Z8UV6/403-incident-action-investigate-automatically-retrying-on-technical-errors-with-notify

This removes a pattern that was somewhat confusing where we configured
classes to accept config options as arguments and didn't exercise these
at all.

This approach was likely used for testing but it seems that over time
the tests have moved on. As these config options are static methods it
would be more idiomatic to use mocking rather than injection.

My motivation for removing this was wondering what purpose these
arguments offered before concluding that there didn't seem to be any.