### PR TITLE
Resolve concurrent request issues that cause 500 responses

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -81,13 +81,10 @@ private
   end
 
   def subscriber
-    @subscriber ||= begin
-                      found = Subscriber.find_by_address(address)
-                      found || Subscriber.create!(
-                        address: address,
-                        signon_user_uid: current_user.uid,
-                      )
-                    end
+    @subscriber ||= Subscriber.resilient_find_or_create(
+      address,
+      signon_user_uid: current_user.uid,
+    )
   end
 
   def address

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -54,6 +54,11 @@ class SubscriptionsController < ApplicationController
       subscription_params.require(:id),
     )
 
+    if frequency.to_s == existing_subscription.frequency.to_s
+      render json: { subscription: existing_subscription }
+      return
+    end
+
     new_subscription = existing_subscription.subscriber.with_lock do
       existing_subscription.end(reason: :frequency_changed)
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -16,7 +16,7 @@ class SubscriptionsController < ApplicationController
         subscriber_list: subscriber_list,
       )
 
-      create_new_subscription = frequency.to_s != existing_subscription&.frequency.to_s
+      create_new_subscription = frequency != existing_subscription&.frequency
 
       if create_new_subscription
         existing_subscription&.end(reason: :frequency_changed)
@@ -54,7 +54,7 @@ class SubscriptionsController < ApplicationController
       subscription_params.require(:id),
     )
 
-    if frequency.to_s == existing_subscription.frequency.to_s
+    if frequency == existing_subscription.frequency
       render json: { subscription: existing_subscription }
       return
     end
@@ -102,7 +102,7 @@ private
   end
 
   def frequency
-    subscription_params.fetch(:frequency, "immediately").to_sym
+    subscription_params.fetch(:frequency, "immediately")
   end
 
   def subscription_params

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -208,6 +208,12 @@ RSpec.describe "Subscriptions", type: :request do
             patch "/subscriptions/#{subscription.id}", params: { frequency: "monthly" }
             expect(response.status).to eq(422)
           end
+
+          it "returns the current subscription if the frequency is not changed" do
+            patch "/subscriptions/#{subscription.id}", params: { frequency: "immediately" }
+            expect(response.status).to eq(200)
+            expect(data[:subscription][:id]).to eq(subscription.id)
+          end
         end
 
         context "without an existing subscription" do


### PR DESCRIPTION
Trello: https://trello.com/c/koo6gJov/355-increase-visibility-of-sentry-alerts-for-email-apps-and-services

This card was inspired by a Sentry error that occurred: https://sentry.io/organizations/govuk/issues/356403617/?project=202221&query=&statsPeriod=14d which was due to Email Alert API accepting concurrent requests for the same new subscriber. This raised an error due to a find or create section of code that can fail on a unique key violation if executed concurrently.

It also looks at what other errors could occur for subscriptions creation when concurrent and prevents those by locking the request based on the subscriber.

Finally it edits the update subscription endpoint to check whether a subscription has changed before doing an update to save unnecessary work.

I found these endpoints rather baffling in their shared purpose (hopefully I didn't write them originally) so put in a [pain card](https://trello.com/c/Z8tTO9pr/368-the-subscription-create-endpoint-does-basically-everything-that-the-update-endpoint-does) for it.