### PR TITLE
Fix Zeitwerk loading EmailAlertAPI constant

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,5 +1,6 @@
 Rails.autoloaders.each do |autoloader|
   autoloader.inflector.inflect(
     "symbolize_json" => "SymbolizeJSON",
+    "email_alert_api" => "EmailAlertAPI",
   )
 end


### PR DESCRIPTION
This resolves a problem where the Email Alert API application was not
starting when using the Zeitwerk autoloader. The application wasn't
starting because it couldn't find the EmailAlertAPI constant and was
triggering this error:

```
/Users/kevindew/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/zeitwerk-2.4.0/lib/zeitwerk/loader.rb:392:in `const_get': uninitialized constant EmailAlertApi::Config (NameError)
```

The autoloader would expect to find a class named EmailAlertApi rather
than EmailAlertAPI at the location of email_alert_api.