### PR TITLE
Follow-up changes for #1341

### DIFF
--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -30,10 +30,6 @@ class StatusUpdateService < ApplicationService
 
     Metrics.delivery_attempt_status_changed(delivery_attempt_status)
     GovukStatsd.increment("status_update.status.#{status}")
-
-    # This statistic can be removed once we replace usage in monitoring
-    # with the status_update.status.* statistic
-    GovukStatsd.increment("status_update.success")
   end
 
 private

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -14,14 +14,7 @@ class DeliveryRequestWorker
     email.mark_as_failed(delivery_attempt&.finished_sending_at || Time.zone.now)
   end
 
-  # Once all existing jobs have been processed we can remove these default
-  # arguments
-  def perform(email_id, metrics = {}, queue = nil)
-    # existing jobs may have the second parameter set as a string, representing
-    # a queue and need their type changing. This can be removed once deployed
-    # and the queue is cleared
-    metrics = {} unless metrics.is_a?(Hash)
-
+  def perform(email_id, metrics, queue)
     if rate_limit_exceeded?
       logger.warn("Rescheduling email #{email_id} due to exceeding rate limit")
       GovukStatsd.increment("delivery_request_worker.rescheduled")

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -39,6 +39,3 @@ private
     DeliveryRequestWorker.perform_async_in_queue(id, queue: content_change.queue)
   end
 end
-
-# This can be deleted once there are no Sidekiq jobs queued to use this class
-ProcessContentChangeAndGenerateEmailsWorker = ProcessContentChangeWorker

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -39,6 +39,3 @@ private
     DeliveryRequestWorker.perform_async_in_queue(id, queue: message.queue)
   end
 end
-
-# This can be deleted once there are no Sidekiq jobs queued to use this class
-ProcessMessageAndGenerateEmailsWorker = ProcessMessageWorker

--- a/db/migrate/20200730170816_drop_failure_reason_from_emails.rb
+++ b/db/migrate/20200730170816_drop_failure_reason_from_emails.rb
@@ -1,0 +1,6 @@
+class DropFailureReasonFromEmails < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :emails, :failure_reason
+    remove_column :emails, :failure_reason, :integer
+  end
+end

--- a/db/migrate/20200730172117_migrate_delivery_attempt_statuses.rb
+++ b/db/migrate/20200730172117_migrate_delivery_attempt_statuses.rb
@@ -1,0 +1,15 @@
+class MigrateDeliveryAttemptStatuses < ActiveRecord::Migration[6.0]
+  class DeliveryAttempt < ApplicationRecord; end
+
+  def up
+    # we've changed from an enum of:
+    #  enum status: { sending: 0, delivered: 1, permanent_failure: 2, temporary_failure: 3, technical_failure: 4, internal_failure: 5 }
+    #
+    # to:
+    #   enum status: { sending: 0, delivered: 1, undeliverable_failure: 3, provider_communication_failure: 4 }
+    #
+    # This updates all records that fall outside these parameters
+    DeliveryAttempt.where(status: 2).update_all(status: 3)
+    DeliveryAttempt.where(status: 5).update_all(status: 4)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_06_094740) do
+ActiveRecord::Schema.define(version: 2020_07_30_170816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,12 +85,10 @@ ActiveRecord::Schema.define(version: 2020_04_06_094740) do
     t.datetime "archived_at"
     t.bigint "subscriber_id"
     t.integer "status", default: 0, null: false
-    t.integer "failure_reason"
     t.boolean "marked_as_spam"
     t.index ["address"], name: "index_emails_on_address"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["created_at"], name: "index_emails_on_created_at"
-    t.index ["failure_reason"], name: "index_emails_on_failure_reason"
     t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_170816) do
+ActiveRecord::Schema.define(version: 2020_07_30_172117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/es2Z8UV6/403-incident-action-investigate-automatically-retrying-on-technical-errors-with-notify

This applies backwards incompatible changes following the deployment of https://github.com/alphagov/email-alert-api/pull/1341, and as a bonus it removes the `Process*AndGenerateEmailsWorker` classes that haven't been needed for a while.

This should be deployed once https://github.com/alphagov/email-alert-api/pull/1341 is on production and we're happy we don't need to rollback (I'm expecting early next week).

There will also be a further follow-up PR to remove https://github.com/alphagov/email-alert-api/blob/95833cf348ae1446d7d190a59e9e4ae92b182c9c/app/models/email.rb#L21 I've not done that in this PR as I'm concerned the data migration may make the deploy time out and want the code to remain compatible with both iterations of the DB.