### PR TITLE
[DO NOT MERGE] Stop ignoring failure reason column

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -17,9 +17,6 @@ class Email < ApplicationRecord
 
   enum status: { pending: 0, sent: 1, failed: 2 }
 
-  # This can be removed once the column is deleted.
-  self.ignored_columns = %i[failure_reason]
-
   def self.timed_bulk_insert(records, batch_size)
     return insert_all!(records) unless records.size == batch_size
 


### PR DESCRIPTION
Trello: https://trello.com/c/es2Z8UV6/403-incident-action-investigate-automatically-retrying-on-technical-errors-with-notify

Once a deployment has been made to delete this column we can merge this
change in.