### PR TITLE
Use default queue for cleanup jobs

### DIFF
--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -1,8 +1,6 @@
 class EmailArchiveWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :cleanup
-
   LOCK_NAME = "email_archive_worker".freeze
   BATCH_SIZE = 1000
 

--- a/app/workers/email_deletion_worker.rb
+++ b/app/workers/email_deletion_worker.rb
@@ -1,8 +1,6 @@
 class EmailDeletionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :cleanup
-
   LOCK_NAME = "email_deletion_worker".freeze
 
   def perform

--- a/app/workers/metrics_collection_worker.rb
+++ b/app/workers/metrics_collection_worker.rb
@@ -1,8 +1,6 @@
 class MetricsCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :cleanup
-
   def perform
     Metrics::ContentChangeExporter.call
     Metrics::DigestRunExporter.call

--- a/app/workers/nullify_deactivated_subscribers_worker.rb
+++ b/app/workers/nullify_deactivated_subscribers_worker.rb
@@ -1,8 +1,6 @@
 class NullifyDeactivatedSubscribersWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :cleanup
-
   def perform
     run_only_once do
       subscribers.find_each(&:nullify!)

--- a/docs/queues.md
+++ b/docs/queues.md
@@ -32,8 +32,8 @@ Used to send digest emails to users who have requested either daily or weekly up
 
 Used to generate the emails for each content change to users who have requested daily or weekly updates to content. The jobs on this queue are scheduled to run every day at 8:30am for daily updates and every Saturday at 8:30am for weekly updates.
 
-## `cleanup`
+## `default`
 
-Used to perform various operations related to monitoring or tidying up the database. There are jobs which [archives emails to Athena][analytics] and others which calculates the number of unprocessed content changes or subscription contents and sends that data to Statsd for monitoring.
+Default queue for Sidekiq which we use to perform various miscellaneous operations. This currently includes initiating digest runs (daily and weekly) and then marking them as complete, monitoring and tidying up the database and recovering lost Sidekiq jobs.
 
 [analytics]: analytics.md

--- a/spec/workers/nullify_deactivated_subscribers_worker_spec.rb
+++ b/spec/workers/nullify_deactivated_subscribers_worker_spec.rb
@@ -1,16 +1,4 @@
 RSpec.describe NullifyDeactivatedSubscribersWorker do
-  describe ".perform_async" do
-    before do
-      Sidekiq::Testing.fake! do
-        described_class.perform_async
-      end
-    end
-
-    it "gets added to the cleanup queue" do
-      expect(Sidekiq::Queues["cleanup"].size).to eq(1)
-    end
-  end
-
   describe ".perform" do
     context "with some subscribers" do
       before do


### PR DESCRIPTION
Use default queue for cleanup jobs and updates the queue doc. We'll
remove the `cleanup` queue in a seperate PR after the queue is drained
to avoid losing jobs.

Trello:
https://trello.com/c/HwvZx0V9/456-update-the-queue-latency-check