### PR TITLE
Add task to switch users to daily digest emails

### DIFF
--- a/app/builders/switch_to_daily_digest_email_builder.rb
+++ b/app/builders/switch_to_daily_digest_email_builder.rb
@@ -1,0 +1,44 @@
+class SwitchToDailyDigestEmailBuilder
+  def initialize(subscriber, subscriptions)
+    @subscriber = subscriber
+    @subscriptions = subscriptions
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    Email.create!(
+      address: subscriber.address,
+      subject: "Your GOV.UK email subscriptions",
+      body: body,
+      subscriber_id: subscriber.id,
+    ).id
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscriber, :subscriptions
+
+  def body
+    <<~BODY
+      From now on, we'll group all the emails you get together into one digest when there's a change to content covered by one of these subscriptions:
+
+      #{subscriptions.map { |subscription| "- #{subscription.subscriber_list.title}" }.join("\n")}
+
+      If you need to keep receiving immediate emails you can change this by [managing your email subscriptions](#{manage_subscriptions_link}).
+    BODY
+  end
+
+  def manage_subscriptions_link
+    utm_source = "switch-to-daily-digest"
+    utm_medium = "email"
+    utm_campaign = "govuk-notifications"
+    utm_content = "initial-experiment"
+    base_url = PublicUrls.authenticate_url(address: subscriber.address)
+    "#{base_url}&utm_source=#{utm_source}&utm_medium=#{utm_medium}&utm_campaign=#{utm_campaign}&utm_content=#{utm_content}"
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,8 +5,8 @@ class Subscription < ApplicationRecord
   has_many :subscription_contents, dependent: :destroy
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
-  enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2, subscriber_list_changed: 3 }, _prefix: true
-  enum ended_reason: { unsubscribed: 0, non_existent_email: 1, frequency_changed: 2, subscriber_list_changed: 3, marked_as_spam: 4, unpublished: 5 }, _prefix: :ended
+  enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2, subscriber_list_changed: 3, bulk_immediate_to_digest: 4 }, _prefix: true
+  enum ended_reason: { unsubscribed: 0, non_existent_email: 1, frequency_changed: 2, subscriber_list_changed: 3, marked_as_spam: 4, unpublished: 5, bulk_immediate_to_digest: 6 }, _prefix: :ended
 
   validates :subscriber, uniqueness: { scope: :subscriber_list, conditions: -> { active } }
 

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -11,4 +11,81 @@ namespace :bulk do
       DeliveryRequestWorker.perform_async_in_queue(id, queue: :delivery_immediate)
     end
   end
+
+  desc "Switch immediate subscribers of the specified list slugs to daily digest"
+  task switch_to_daily_digest: :environment do |_t, args|
+    lists = SubscriberList.where(slug: args.extras)
+    raise "One or more lists were not found" if lists.count != args.extras.count
+
+    subscriptions = Subscription.active.immediately.where(subscriber_list: lists)
+    raise "No subscriptions to change" if subscriptions.none?
+
+    subscribers = Subscriber.where(id: subscriptions.pluck(:subscriber_id)).index_by(&:id)
+    subscriptions_by_subscriber = subscriptions.group_by(&:subscriber_id).transform_keys { |k| subscribers[k] }
+
+    subscriptions_by_subscriber.each do |subscriber, immediate_subscriptions|
+      email_id = nil
+
+      subscriber.with_lock do
+        immediate_subscriptions.each do |subscription|
+          subscription.end(reason: :bulk_immediate_to_digest)
+
+          Subscription.create!(
+            subscriber_id: subscription.subscriber_id,
+            subscriber_list_id: subscription.subscriber_list_id,
+            frequency: :daily,
+            source: :bulk_immediate_to_digest,
+          )
+        end
+
+        email_id = SwitchToDailyDigestEmailBuilder.call(subscriber, immediate_subscriptions)
+      end
+
+      DeliveryRequestWorker.perform_async_in_queue(email_id, queue: :default)
+    rescue StandardError => e
+      puts "Skipping subscriber: #{e}"
+    end
+  end
+
+  desc "Switch immediate subscribers of the following lists to daily digest (experiment)"
+  task switch_to_daily_digest_experiment: :environment do
+    Rake::Task["bulk:switch_to_daily_digest"].invoke(
+      "news-and-communications-2",
+      "guidance-and-regulation-2",
+      "guidance-and-regulation",
+      "guidance-about-all-topics-by-all-organisations",
+      "news-and-communications-3",
+      "news-and-communications",
+      "all-announcements-about-all-topics-by-all-organisations",
+      "business-and-industry",
+      "crime-justice-and-law",
+      "statistics",
+      "government-efficiency-transparency-and-accountability-2",
+      "press-releases-about-all-topics-by-all-organisations",
+      "environment-agency",
+      "corporate-information",
+      "all-types-of-document-about-all-topics-by-department-for-environment-food-rural-affairs",
+      "department-for-environment-food-rural-affairs",
+      "hm-revenue-customs",
+      "animal-and-plant-health-agency",
+      "ministry-of-defence",
+      "car-driving-tests",
+      "car-motorcycle-and-van-mot-tests",
+      "business-tax-self-employment",
+      "driving-and-motorcycle-tests",
+      "ofsted",
+      "rail-accident-investigation-branch",
+      "correspondence-related-to-education-and-education-and-skills-funding-agency-2",
+      "news-stories-about-all-topics-by-department-of-health-and-social-care",
+      "department-for-education",
+      "international-development-funding",
+      "the-charity-commission",
+      "theory-tests",
+      "standards-and-testing-agency",
+      "personal-tax-self-assessment",
+      "planning-and-development-planning-officer-guidance",
+      "civil-service-fast-track-apprenticeship",
+      "further-education-and-skills-apprenticeships",
+    )
+  end
 end

--- a/spec/lib/tasks/bulk_spec.rb
+++ b/spec/lib/tasks/bulk_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "bulk" do
+  include RequestHelpers
+
   describe "email" do
     before do
       Rake::Task["bulk:email"].reenable
@@ -38,6 +40,86 @@ RSpec.describe "bulk" do
         .with(2, queue: :delivery_immediate)
 
       Rake::Task["bulk:email"].invoke(subscriber_list.id)
+    end
+  end
+
+  describe "switch_to_daily_digest" do
+    let(:list1) { create :subscriber_list }
+    let(:list2) { create :subscriber_list }
+
+    before do
+      Rake::Task["bulk:switch_to_daily_digest"].reenable
+      stub_notify
+    end
+
+    it "switches immediate subscriptions to daily" do
+      subscription = create :subscription, subscriber_list: list1, frequency: :immediately
+
+      Rake::Task["bulk:switch_to_daily_digest"].invoke(list1.slug, list2.slug)
+      new_subscription = subscription.subscriber.subscriptions.active.first
+
+      expect(subscription.reload).to be_ended
+      expect(subscription.ended_reason).to eq "bulk_immediate_to_digest"
+
+      expect(new_subscription.frequency).to eq "daily"
+      expect(new_subscription.source).to eq "bulk_immediate_to_digest"
+    end
+
+    it "does not change other subscriptions" do
+      create :subscription, subscriber_list: list1, frequency: :daily
+      create :subscription, frequency: :immediately
+
+      expect { Rake::Task["bulk:switch_to_daily_digest"].invoke(list1.slug) }
+        .to raise_error("No subscriptions to change")
+    end
+
+    it "sends a summary email to affected subscribers" do
+      subscriber = create :subscriber
+      create :subscription, subscriber_list: list1, frequency: :immediately, subscriber: subscriber
+      create :subscription, subscriber_list: list2, frequency: :immediately, subscriber: subscriber
+
+      Rake::Task["bulk:switch_to_daily_digest"].invoke(list1.slug, list2.slug)
+      email_data = expect_an_email_was_sent
+
+      expect(email_data[:email_address]).to eq(subscriber.address)
+      expect(email_data[:personalisation][:subject]).to eq("Your GOV.UK email subscriptions")
+      expect(email_data[:personalisation][:body]).to include(list1.title)
+      expect(email_data[:personalisation][:body]).to include(list2.title)
+    end
+
+    context "when a list is not found" do
+      it "raises an error" do
+        expect { Rake::Task["bulk:switch_to_daily_digest"].invoke(list1.slug, "foo") }
+          .to raise_error("One or more lists were not found")
+      end
+    end
+
+    context "when the change fails for a subscriber" do
+      let!(:subscription1) { create :subscription, subscriber_list: list1, frequency: :immediately }
+      let!(:subscription2) { create :subscription, subscriber_list: list1, frequency: :immediately }
+
+      before do
+        allow(Subscription).to receive(:create!).and_call_original
+
+        allow(Subscription)
+          .to receive(:create!)
+          .with(hash_including(subscriber_id: subscription2.subscriber_id))
+          .and_raise("An error")
+      end
+
+      it "only sends an email to switched subscribers" do
+        expect { Rake::Task["bulk:switch_to_daily_digest"].invoke(list1.slug) }
+          .to output.to_stdout
+          .and change { Email.count }.by(1)
+      end
+
+      it "persists changes for other subscribers" do
+        expect { Rake::Task["bulk:switch_to_daily_digest"].invoke(list1.slug) }
+          .to output.to_stdout
+          .and change { Subscription.count }.by(1)
+
+        expect(subscription2.reload).to_not be_ended
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/RPBoOye6/440-start-the-switch-immediate-to-digest-experiment

This adds a new task as part of an experiment to switch immediate
subscribers of specific lists to daily digest emails. For each
subscriber, we send a summary email of the changes made. In order to
track the changes, we use a new reason for start/ending a subscription.

We process each subscriber individually, using the same locking approach
as when a subscriber is manually updating their subscriptions. I decided
to avoid doing a single, bulk change, as it's not clear that a roll back
would be possible in the presence of one or more race conditions.

The task is best effort: if a race condition causes the change to fail
for a particular subscriber, we can always rerun the task.

## Things left to do

- [ ] Update the content (separate PR, if this is ready to go in)
- [x] Test this works on Integration
- [ ] Decouple *Request*Helpers from requests
- [x] Rename BulkEmailBuilder to be more specific