### PR TITLE
Remove marked as spam field on email

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -17,9 +17,6 @@ class Email < ApplicationRecord
 
   enum status: { pending: 0, sent: 1, failed: 2 }
 
-  # This can be removed once the column is deleted.
-  self.ignored_columns = %i[marked_as_spam]
-
   def self.timed_bulk_insert(records, batch_size)
     return insert_all!(records) unless records.size == batch_size
 

--- a/db/migrate/20200804143030_remove_marked_as_spam_from_email.rb
+++ b/db/migrate/20200804143030_remove_marked_as_spam_from_email.rb
@@ -1,0 +1,5 @@
+class RemoveMarkedAsSpamFromEmail < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :emails, :marked_as_spam, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_172117) do
+ActiveRecord::Schema.define(version: 2020_08_04_143030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,7 +85,6 @@ ActiveRecord::Schema.define(version: 2020_07_30_172117) do
     t.datetime "archived_at"
     t.bigint "subscriber_id"
     t.integer "status", default: 0, null: false
-    t.boolean "marked_as_spam"
     t.index ["address"], name: "index_emails_on_address"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["created_at"], name: "index_emails_on_created_at"


### PR DESCRIPTION
The limited retention period for emails make recording this not
very useful, especially that we now chart spam reports to a
Grafana dashboard.

Dependent on https://github.com/alphagov/email-alert-api/pull/1336.

Related:

* https://github.com/alphagov/email-alert-api/pull/1336
* https://github.com/alphagov/govuk-puppet/pull/10529

Trello:

https://trello.com/c/alIJoEDk/408-chart-emails-marked-as-spam-and-subscriptions-ended-due-to-this