### PR TITLE
Rename BulkEmailBuilder to be more specific

### DIFF
--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -1,4 +1,4 @@
-class BulkEmailBuilder
+class BulkSubscriberListEmailBuilder
   def initialize(subject:, body:, subscriber_lists:)
     @subject = subject
     @body = body

--- a/lib/subscriber_list_mover.rb
+++ b/lib/subscriber_list_mover.rb
@@ -85,7 +85,7 @@ class SubscriberListMover
       GOV.UK
     BODY
 
-    BulkEmailBuilder.call(
+    BulkSubscriberListEmailBuilder.call(
       subject: email_subject,
       body: bulk_move_template,
       subscriber_lists: source_subscriber_list,

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -1,7 +1,7 @@
 namespace :bulk do
   desc "Send a bulk email to many subscriber lists"
   task :email, [] => :environment do |_t, args|
-    email_ids = BulkEmailBuilder.call(
+    email_ids = BulkSubscriberListEmailBuilder.call(
       subject: ENV.fetch("SUBJECT"),
       body: ENV.fetch("BODY"),
       subscriber_lists: SubscriberList.where(id: args.extras),

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe BulkEmailBuilder do
+RSpec.describe BulkSubscriberListEmailBuilder do
   let(:email_subject) { "email subject" }
   let(:body) { "email body" }
 

--- a/spec/lib/subscriber_list_mover_spec.rb
+++ b/spec/lib/subscriber_list_mover_spec.rb
@@ -49,10 +49,10 @@ RSpec.describe SubscriberListMover do
 
   describe "#with_send_email_true" do
     it "sends an email to all subscribers" do
-      allow(BulkEmailBuilder).to receive(:call).and_return([1, 2])
+      allow(BulkSubscriberListEmailBuilder).to receive(:call).and_return([1, 2])
       source_subscriber_list = SubscriberList.find_by(slug: list_1.slug)
 
-      expect(BulkEmailBuilder)
+      expect(BulkSubscriberListEmailBuilder)
       .to receive(:call)
       .with(subject: "Changes to GOV.UK emails",
             body: anything,

--- a/spec/lib/tasks/bulk_spec.rb
+++ b/spec/lib/tasks/bulk_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "bulk" do
     it "builds emails for a subscriber list" do
       subscriber_list = create(:subscriber_list)
 
-      expect(BulkEmailBuilder)
+      expect(BulkSubscriberListEmailBuilder)
         .to receive(:call)
         .with(subject: "subject",
               body: "body",
@@ -26,8 +26,8 @@ RSpec.describe "bulk" do
     it "enqueues the emails for delivery" do
       subscriber_list = create(:subscriber_list)
 
-      allow(BulkEmailBuilder).to receive(:call)
-                              .and_return([1, 2])
+      allow(BulkSubscriberListEmailBuilder).to receive(:call)
+        .and_return([1, 2])
 
       expect(DeliveryRequestWorker)
         .to receive(:perform_async_in_queue)


### PR DESCRIPTION
https://trello.com/c/RPBoOye6/440-start-the-switch-immediate-to-digest-experiment

This was a pain point when adding another builder associated with
sending emails in bulk [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1352