### PR TITLE
Avoid overlapping experiment UTM with other emails

### DIFF
--- a/app/builders/switch_to_daily_digest_email_builder.rb
+++ b/app/builders/switch_to_daily_digest_email_builder.rb
@@ -34,10 +34,10 @@ private
   end
 
   def manage_subscriptions_link
-    utm_source = "switch-to-daily-digest"
+    utm_campaign = "govuk-notifications-switch-to-daily-experiment"
     utm_medium = "email"
-    utm_campaign = "govuk-notifications"
-    utm_content = "initial-experiment"
+    utm_source = "gov.uk"
+    utm_content = "manage-subscriptions"
     base_url = PublicUrls.authenticate_url(address: subscriber.address)
     "#{base_url}&utm_source=#{utm_source}&utm_medium=#{utm_medium}&utm_campaign=#{utm_campaign}&utm_content=#{utm_content}"
   end


### PR DESCRIPTION
https://trello.com/c/RPBoOye6/440-start-the-switch-immediate-to-digest-experiment

This is more consistent with the way these parameters should be used
[1]. Note that 'utm_content' is an optional parameter, but may be
useful for distinguishing other links we add in future.

- [ ] Send test email and check tracking works on Integration

[1]: https://en.wikipedia.org/wiki/UTM_parameters#UTM_parameters