### PR TITLE
Remove redundant warning metric

### DIFF
--- a/lib/metrics/content_change_exporter.rb
+++ b/lib/metrics/content_change_exporter.rb
@@ -1,31 +1,18 @@
 class Metrics::ContentChangeExporter < Metrics::BaseExporter
   def call
-    GovukStatsd.gauge("content_changes.critical_total", critical_content_changes)
-    GovukStatsd.gauge("content_changes.warning_total", warning_content_changes)
+    GovukStatsd.gauge("content_changes.unprocessed_total", unprocessed_content_changes)
   end
 
 private
 
-  def critical_content_changes
-    @critical_content_changes ||= count_content_changes(critical_latency)
-  end
-
-  def warning_content_changes
-    @warning_content_changes ||= count_content_changes(warning_latency)
-  end
-
-  def count_content_changes(age)
+  def unprocessed_content_changes
     ContentChange
-      .where("created_at < ?", age.ago)
+      .where("created_at < ?", unprocessed_latency.ago)
       .where(processed_at: nil)
       .count
   end
 
-  def critical_latency
+  def unprocessed_latency
     120.minutes
-  end
-
-  def warning_latency
-    90.minutes
   end
 end

--- a/lib/metrics/message_exporter.rb
+++ b/lib/metrics/message_exporter.rb
@@ -1,31 +1,18 @@
 class Metrics::MessageExporter < Metrics::BaseExporter
   def call
-    GovukStatsd.gauge("messages.critical_total", critical_messages)
-    GovukStatsd.gauge("messages.warning_total", warning_messages)
+    GovukStatsd.gauge("messages.unprocessed_total", unprocessed_messages)
   end
 
 private
 
-  def critical_messages
-    @critical_messages ||= count_messages(critical_latency)
-  end
-
-  def warning_messages
-    @warning_messages ||= count_messages(warning_latency)
-  end
-
-  def count_messages(age)
+  def unprocessed_messages
     Message
-    .where("created_at < ?", age.ago)
+    .where("created_at < ?", unprocessed_latency.ago)
     .where(processed_at: nil)
     .count
   end
 
-  def critical_latency
+  def unprocessed_latency
     120.minutes
-  end
-
-  def warning_latency
-    90.minutes
   end
 end

--- a/spec/lib/metrics/content_change_exporter_spec.rb
+++ b/spec/lib/metrics/content_change_exporter_spec.rb
@@ -4,17 +4,11 @@ RSpec.describe Metrics::ContentChangeExporter do
 
     before do
       create(:content_change, created_at: 122.minutes.ago)
-      create(:content_change, created_at: 99.minutes.ago)
       allow(GovukStatsd).to receive(:gauge)
     end
 
-    it "records number of unprocessed content changes over 10 minutes old (critical)" do
-      expect(GovukStatsd).to receive(:gauge).with("content_changes.critical_total", 1)
-      described_class.call
-    end
-
-    it "records number of unprocessed content changes over 5 minutes old (warning)" do
-      expect(GovukStatsd).to receive(:gauge).with("content_changes.warning_total", 2)
+    it "records total number of unprocessed content changes over 120 minutes old" do
+      expect(GovukStatsd).to receive(:gauge).with("content_changes.unprocessed_total", 1)
       described_class.call
     end
   end

--- a/spec/lib/metrics/message_exporter_spec.rb
+++ b/spec/lib/metrics/message_exporter_spec.rb
@@ -3,20 +3,12 @@ RSpec.describe Metrics::MessageExporter do
     let(:statsd) { double }
 
     before do
-      3.times { create(:message, processed_at: nil, created_at: 122.minutes.ago) }
-      2.times { create(:message, processed_at: nil, created_at: 99.minutes.ago) }
+      3.times { create(:message, created_at: 122.minutes.ago) }
       allow(GovukStatsd).to receive(:gauge)
     end
 
-    it "records a metric for the total number of unprocessed messages created
-    over 10 minutes ago (critical)" do
-      expect(GovukStatsd).to receive(:gauge).with("messages.critical_total", 3)
-      described_class.call
-    end
-
-    it "records a metric for the total number of unprocessed messages created
-    over 5 minutes ago (warning)" do
-      expect(GovukStatsd).to receive(:gauge).with("messages.warning_total", 5)
+    it "records total number of unprocessed messages over 120 minutes old" do
+      expect(GovukStatsd).to receive(:gauge).with("messages.unprocessed_total", 3)
       described_class.call
     end
   end


### PR DESCRIPTION
Stop sending a warning latency metric for content changes and messages.
The use of this has been removed in this [puppet change].

As we've removed the warning alert then it makes sense to make the
actual metric more descriptive of what it's actually showing instead of
being concerened on whether it is specific to a critical or warning
state.

We should deploy this at the same time as the [puppet change].

Trello:
https://trello.com/c/BT5x4iAU/457-update-warning-critical-alerts-for-messages-and-content-changes

[puppet change]: https://github.com/alphagov/govuk-puppet/pull/10580