### PR TITLE
Remove ignore marked_as_spam column

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -17,9 +17,6 @@ class Email < ApplicationRecord
 
   enum status: { pending: 0, sent: 1, failed: 2 }
 
-  # This can be removed once the column is deleted.
-  self.ignored_columns = %i[marked_as_spam]
-
   def self.timed_bulk_insert(records, batch_size)
     return insert_all!(records) unless records.size == batch_size
 


### PR DESCRIPTION
Now that the marked_as_spam column has been removed in
https://github.com/alphagov/email-alert-api/pull/1353, we can safely delete this code.