### PR TITLE
Stop populating subscriber count for digest runs

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -10,6 +10,9 @@ class DigestRun < ApplicationRecord
 
   enum range: { daily: 0, weekly: 1 }
 
+  # TEMPORARY (to remove once this column is dropped)
+  self.ignored_columns = %w[subscriber_count]
+
   def mark_complete!
     completed_at = digest_run_subscribers.maximum(:completed_at) || Time.zone.now
     update!(completed_at: completed_at)

--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -15,8 +15,6 @@ class DigestInitiatorService < ApplicationService
 
         enqueue_jobs(digest_run_subscriber_ids)
       end
-
-      digest_run.update!(subscriber_count: subscriber_ids.count)
     end
   end
 

--- a/spec/services/digest_initiator_service_spec.rb
+++ b/spec/services/digest_initiator_service_spec.rb
@@ -53,11 +53,6 @@ RSpec.describe DigestInitiatorService do
 
           described_class.call(range: range)
         end
-
-        it "sets the digest_run_subscriber_count" do
-          described_class.call(range: range)
-          expect(DigestRun.last.subscriber_count).to eq(2)
-        end
       end
 
       it "records a metric for the delivery attempt" do


### PR DESCRIPTION
This data isn't used anywhere, and we have no current need for it.
Once we have stopped populating the field, we can remove the column.