### PR TITLE
Remove redundant "subscriber_count" for digest run

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -10,9 +10,6 @@ class DigestRun < ApplicationRecord
 
   enum range: { daily: 0, weekly: 1 }
 
-  # TEMPORARY (to remove once this column is dropped)
-  self.ignored_columns = %w[subscriber_count]
-
   def mark_complete!
     completed_at = digest_run_subscribers.maximum(:completed_at) || Time.zone.now
     update!(completed_at: completed_at)

--- a/db/migrate/20200810121128_remove_subscriber_count_from_digest_run.rb
+++ b/db/migrate/20200810121128_remove_subscriber_count_from_digest_run.rb
@@ -1,0 +1,5 @@
+class RemoveSubscriberCountFromDigestRun < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :digest_runs, :subscriber_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_04_143030) do
+ActiveRecord::Schema.define(version: 2020_08_10_121128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,7 +70,6 @@ ActiveRecord::Schema.define(version: 2020_08_04_143030) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "subscriber_count"
     t.index ["completed_at"], name: "index_digest_runs_on_completed_at"
     t.index ["created_at"], name: "index_digest_runs_on_created_at"
   end


### PR DESCRIPTION
We no longer populate this data [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1362