### PR TITLE
Index digest_run_subscribers by subscriber

### DIFF
--- a/db/migrate/20200811162222_add_subscriber_index_to_digest_run_subscriber.rb
+++ b/db/migrate/20200811162222_add_subscriber_index_to_digest_run_subscriber.rb
@@ -1,0 +1,7 @@
+class AddSubscriberIndexToDigestRunSubscriber < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :digest_run_subscribers, :subscriber_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_04_143030) do
+ActiveRecord::Schema.define(version: 2020_08_11_162222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2020_08_04_143030) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["subscriber_id"], name: "index_digest_run_subscribers_on_subscriber_id"
   end
 
   create_table "digest_runs", force: :cascade do |t|


### PR DESCRIPTION
https://trello.com/c/NvjAZOC8/454-get-the-data-needed-to-support-the-experiment

Currently it's impossible to query this model for a large number of
subscribers, since these records are not naturally ordered by this
column. This adds an index to facilitate a query we want to run, to
determine the number of digest emails sent to a set of subscribers.

Note that, although we wish to run this query of a time period, an
index on "created_at" has little added benefit, since the records
are naturally ordered by this column as-is.