### PR TITLE
Tweak task to view recent emails

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -31,7 +31,7 @@ $ bundle exec rake manage:change_email_address[<old_email_address>, <new_email_a
 
 ## View subscriber's recent emails
 
-This task shows the most recent email delivery attempts made to the given user.
+This task shows the most recent emails for the given user.
 It takes two parameters: `email_address` (required), and `limit` (optional).
 `limit` defaults to 10, but you can override this if you need to see more of
 the user's history.

--- a/lib/tasks/manage.rake
+++ b/lib/tasks/manage.rake
@@ -49,7 +49,7 @@ namespace :manage do
     puts hash_to_table(results)
   end
 
-  desc "View most recent email delivery attempts for a subscriber"
+  desc "View most recent email emails for a subscriber"
   task :view_emails, %i[email_address limit] => :environment do |_t, args|
     email_address = args[:email_address]
     limit = args[:limit].to_i || 10
@@ -65,7 +65,6 @@ namespace :manage do
       {
         created_at: email.created_at,
         status: email.status,
-        delivery_attempts: DeliveryAttempt.where(email_id: email.id).count,
         email_subject: email.subject,
         email_uuid: email.id,
         # Confirmation emails have no corresponding subscription at this point. `subscription_slug: nil`


### PR DESCRIPTION
https://trello.com/c/Xd47oJKZ/415-remove-the-deliveryattempt-model

- Accurately refer to emails (not delivery attempts)
- Stop reporting a count of attempts, which is at most 1 [1]

[1]: https://github.com/alphagov/email-alert-api/pull/1341