### PR TITLE
Add processed_at field to DigestRun

### DIFF
--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -16,6 +16,8 @@ class DigestInitiatorService < ApplicationService
         enqueue_jobs(digest_run_subscriber_ids)
       end
     end
+
+    digest_run.update!(processed_at: Time.zone.now)
   end
 
 private

--- a/db/migrate/20200817151547_add_processed_at_to_digest_runs.rb
+++ b/db/migrate/20200817151547_add_processed_at_to_digest_runs.rb
@@ -1,0 +1,5 @@
+class AddProcessedAtToDigestRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column :digest_runs, :processed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2020_08_18_150135) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "processed_at"
     t.index ["completed_at"], name: "index_digest_runs_on_completed_at"
     t.index ["created_at"], name: "index_digest_runs_on_created_at"
   end

--- a/spec/services/digest_initiator_service_spec.rb
+++ b/spec/services/digest_initiator_service_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe DigestInitiatorService do
           expect { described_class.call(range: range) }
             .to change { DigestRun.daily.count }.from(0).to(1)
         end
+
+        it "marks the digest run as processed" do
+          described_class.call(range: range)
+          digest_run = DigestRun.last
+          expect(digest_run.processed_at).to eq(Time.zone.now)
+        end
       end
 
       context "when a DigestRun already exists" do

--- a/spec/services/digest_initiator_service_spec.rb
+++ b/spec/services/digest_initiator_service_spec.rb
@@ -1,103 +1,50 @@
 RSpec.describe DigestInitiatorService do
   describe ".call" do
-    around { |example| travel_to(Time.zone.parse("08:30")) { example.run } }
+    let(:subscribers) { create_list(:subscriber, 2) }
 
-    context "daily" do
-      let(:range) { Frequency::DAILY }
+    before do
+      allow(DigestRunSubscriberQuery).to receive(:call).and_return(subscribers)
+      allow(DigestEmailGenerationWorker).to receive(:perform_async)
+    end
 
-      context "when there is no daily DigestRun for the date" do
-        it "creates one" do
-          expect { described_class.call(range: range) }
-            .to change { DigestRun.daily.count }.from(0).to(1)
-        end
+    context "when a digest run doesn't exist" do
+      it "creates a digest run for the current data with the specified range" do
+        expect { described_class.call(range: Frequency::DAILY) }
+          .to change { DigestRun.daily.where(date: Date.current).count }
+          .by(1)
 
-        it "marks the digest run as processed" do
-          described_class.call(range: range)
+        expect { described_class.call(range: Frequency::WEEKLY) }
+          .to change { DigestRun.weekly.where(date: Date.current).count }
+          .by(1)
+      end
+
+      it "marks the digest run as processed" do
+        freeze_time do
+          described_class.call(range: Frequency::DAILY)
           digest_run = DigestRun.last
           expect(digest_run.processed_at).to eq(Time.zone.now)
         end
       end
 
-      context "when a DigestRun already exists" do
-        it "doesn't create another one" do
-          create(:digest_run, :daily, date: Date.current)
-
-          described_class.call(range: range)
-
-          expect(DigestRun.count).to eq(1)
-        end
+      it "creates a DigestRunSubscriber for each subscription" do
+        expect { described_class.call(range: Frequency::DAILY) }
+          .to change { DigestRunSubscriber.exists?(subscriber: subscribers) }
+          .to(true)
       end
 
-      context "when the service is called multiple times" do
-        it "only creates one DigestRun" do
-          described_class.call(range: range)
-          described_class.call(range: range)
-          described_class.call(range: range)
-          described_class.call(range: range)
-
-          expect(DigestRun.count).to eq(1)
-        end
-      end
-
-      context "with matched content" do
-        let(:subscribers) { [create(:subscriber, id: 1), create(:subscriber, id: 2)] }
-
-        before do
-          allow(DigestRunSubscriberQuery).to receive(:call).and_return(subscribers)
-          allow(DigestEmailGenerationWorker).to receive(:perform_async)
-        end
-
-        it "creates a DigestRunSubscriber for each subscriber" do
-          described_class.call(range: range)
-          expect(DigestRunSubscriber.all.map(&:subscriber_id)).to match([1, 2])
-        end
-
-        it "enqueues a DigestEmailGenerationWorker job" do
-          expect(DigestEmailGenerationWorker)
-            .to receive(:perform_async)
-            .exactly(2).times
-
-          described_class.call(range: range)
-        end
-      end
-
-      it "records a metric for the delivery attempt" do
-        expect(Metrics).to receive(:digest_initiator_service)
-          .with("daily")
-
-        described_class.call(range: range)
+      it "enqueues DigestEmailGenerationWorker for each DigestRunSubscriber" do
+        described_class.call(range: Frequency::DAILY)
+        ids = DigestRunSubscriber.last(2).pluck(:id)
+        expect(DigestEmailGenerationWorker).to have_received(:perform_async).with(ids[0])
+        expect(DigestEmailGenerationWorker).to have_received(:perform_async).with(ids[1])
       end
     end
 
-    context "weekly" do
-      let(:range) { Frequency::WEEKLY }
-
-      context "when there is no daily DigestRun for the date" do
-        it "creates one" do
-          expect { described_class.call(range: range) }
-            .to change { DigestRun.weekly.count }.from(0).to(1)
-        end
-      end
-
-      context "when a DigestRun already exists" do
-        it "doesn't create another one" do
-          create(:digest_run, :weekly, date: Date.current)
-
-          described_class.call(range: range)
-
-          expect(DigestRun.count).to eq(1)
-        end
-      end
-
-      context "when the service is called multiple times" do
-        it "only creates one DigestRun" do
-          described_class.call(range: range)
-          described_class.call(range: range)
-          described_class.call(range: range)
-          described_class.call(range: range)
-
-          expect(DigestRun.count).to eq(1)
-        end
+    context "when a digest run already exists" do
+      it "exits without creating any DigestRunSubscribers" do
+        create(:digest_run, range: Frequency::DAILY, date: Date.current)
+        expect { described_class.call(range: Frequency::DAILY) }
+          .not_to(change { DigestRunSubscriber.count })
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/DC7bXM5U/473-prepare-digests-so-they-can-be-safely-be-retried

This is one of the early steps to adapt DigestRun models to support retrying a partially successful one. This introduces a processed_at value which will be used to record whether a DigestRun had completed processing or not (in a similar manner to ContentChange and Message). This initial PR introduces the column and starts populating it for new records. Once we've done a migration to populate this on old records we can then write the code to make use of it.