### PR TITLE
Unique index on digest_run_subscribers

### DIFF
--- a/app/models/digest_run_subscriber.rb
+++ b/app/models/digest_run_subscriber.rb
@@ -18,7 +18,7 @@ class DigestRunSubscriber < ApplicationRecord
       }
     end
 
-    insert_all!(records).pluck("id")
+    insert_all(records).pluck("id")
   end
 
   def mark_complete!

--- a/db/migrate/20200818150135_unique_index_on_digest_run_subscribers.rb
+++ b/db/migrate/20200818150135_unique_index_on_digest_run_subscribers.rb
@@ -1,0 +1,10 @@
+class UniqueIndexOnDigestRunSubscribers < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :digest_run_subscribers,
+              %i[digest_run_id subscriber_id],
+              unique: true,
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_121128) do
+ActiveRecord::Schema.define(version: 2020_08_18_150135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2020_08_10_121128) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["digest_run_id", "subscriber_id"], name: "index_digest_run_subscribers_on_digest_run_id_and_subscriber_id", unique: true
   end
 
   create_table "digest_runs", force: :cascade do |t|


### PR DESCRIPTION
Trello: https://trello.com/c/DC7bXM5U/473-prepare-digests-so-they-can-be-safely-be-retried

This applies a unique index to digest_run_subscribers columns (at the time of writing there are no duplicates so it can be safely applied).

This is done so that we can resume the processing of a digest run were one to fail part way through.

I was worried this might slow down inserts for digest_run_subscribers significantly but much to my surprise it showed a performance improvement. Before todays DigestRun took 1291 seconds on integration whereas after it took 918 seconds. 