### PR TITLE
Rename completed_at to processed_at on DigestRun

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -11,7 +11,7 @@ class DigestRun < ApplicationRecord
   enum range: { daily: 0, weekly: 1 }
 
   def mark_as_completed
-    completed_time = digest_run_subscribers.maximum(:completed_at) || Time.zone.now
+    completed_time = digest_run_subscribers.maximum(:processed_at) || Time.zone.now
     update!(completed_at: completed_time)
   end
 

--- a/app/models/digest_run_subscriber.rb
+++ b/app/models/digest_run_subscriber.rb
@@ -5,7 +5,7 @@ class DigestRunSubscriber < ApplicationRecord
   belongs_to :digest_run
   belongs_to :subscriber
 
-  scope :incomplete_for_run, ->(digest_run_id) { where(digest_run_id: digest_run_id).where(completed_at: nil) }
+  scope :unprocessed_for_run, ->(digest_run_id) { where(digest_run_id: digest_run_id).where(processed_at: nil) }
 
   def self.populate(digest_run, subscriber_ids)
     now = Time.zone.now

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -12,7 +12,7 @@ class DigestEmailGenerationWorker
     )
 
     if subscription_content.empty?
-      digest_run_subscriber.update!(completed_at: Time.zone.now)
+      digest_run_subscriber.update!(processed_at: Time.zone.now)
     else
       create_and_send_email(digest_run_subscriber, subscription_content)
     end
@@ -27,7 +27,7 @@ private
     Metrics.digest_email_generation(digest_run.range) do
       email = nil
       Email.transaction do
-        digest_run_subscriber.update!(completed_at: Time.zone.now)
+        digest_run_subscriber.update!(processed_at: Time.zone.now)
         email = DigestEmailBuilder.call(
           address: subscriber.address,
           subscription_content: subscription_content,

--- a/app/workers/digest_run_completion_marker_worker.rb
+++ b/app/workers/digest_run_completion_marker_worker.rb
@@ -3,7 +3,7 @@ class DigestRunCompletionMarkerWorker
 
   def perform
     DigestRun.incomplete.find_each do |digest_run|
-      unless DigestRunSubscriber.incomplete_for_run(digest_run.id).exists?
+      unless DigestRunSubscriber.unprocessed_for_run(digest_run.id).exists?
         digest_run.mark_as_completed
       end
     end

--- a/db/migrate/20200818172715_rename_completed_at_digest_run_subscriber.rb
+++ b/db/migrate/20200818172715_rename_completed_at_digest_run_subscriber.rb
@@ -1,0 +1,5 @@
+class RenameCompletedAtDigestRunSubscriber < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :digest_run_subscribers, :completed_at, :processed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_150135) do
+ActiveRecord::Schema.define(version: 2020_08_18_172715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2020_08_18_150135) do
   create_table "digest_run_subscribers", force: :cascade do |t|
     t.integer "digest_run_id", null: false
     t.integer "subscriber_id", null: false
-    t.datetime "completed_at"
+    t.datetime "processed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["digest_run_id", "subscriber_id"], name: "index_digest_run_subscribers_on_digest_run_id_and_subscriber_id", unique: true

--- a/spec/models/digest_run_spec.rb
+++ b/spec/models/digest_run_spec.rb
@@ -124,13 +124,13 @@ RSpec.describe DigestRun do
 
     context "when there are digest_run_subscribers" do
       let(:digest_run_subscriber) do
-        create(:digest_run_subscriber, digest_run_id: digest_run.id, completed_at: Time.zone.now)
+        create(:digest_run_subscriber, digest_run_id: digest_run.id, processed_at: Time.zone.now)
       end
 
-      it "marks the digest run as completed based on the digest run subscriber time" do
+      it "marks the digest run as completed based on the digest run subscriber proceesed time" do
         expect { digest_run.mark_as_completed }
           .to change { digest_run.completed_at }
-          .to(digest_run_subscriber.reload.completed_at)
+          .to(digest_run_subscriber.reload.processed_at)
       end
     end
 

--- a/spec/models/digest_run_subscriber_spec.rb
+++ b/spec/models/digest_run_subscriber_spec.rb
@@ -33,27 +33,27 @@ RSpec.describe DigestRunSubscriber do
     end
   end
 
-  describe ".incomplete_for_run" do
-    it "returns records with the supplied digest_run_id that have completed_at nil" do
+  describe ".unprocessed_for_run" do
+    it "returns records with the supplied digest_run_id that have processed_at of nil" do
       create(:digest_run, id: 1)
       digest_run_subscriber = create(
         :digest_run_subscriber,
         digest_run_id: 1,
-        completed_at: nil,
+        processed_at: nil,
       )
 
-      expect(described_class.incomplete_for_run(1).first).to eq(digest_run_subscriber)
+      expect(described_class.unprocessed_for_run(1).first).to eq(digest_run_subscriber)
     end
 
-    it "doesn't return completed_records" do
+    it "doesn't return processed items" do
       create(:digest_run, id: 1)
       create(
         :digest_run_subscriber,
         digest_run_id: 1,
-        completed_at: Time.zone.now,
+        processed_at: Time.zone.now,
       )
 
-      expect(described_class.incomplete_for_run(1).count).to eq(0)
+      expect(described_class.unprocessed_for_run(1).count).to eq(0)
     end
 
     it "doesn't return records from other runs" do
@@ -61,10 +61,10 @@ RSpec.describe DigestRunSubscriber do
       create(
         :digest_run_subscriber,
         digest_run_id: 2,
-        completed_at: nil,
+        processed_at: nil,
       )
 
-      expect(described_class.incomplete_for_run(1).count).to eq(0)
+      expect(described_class.unprocessed_for_run(1).count).to eq(0)
     end
   end
 end

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -72,10 +72,10 @@ RSpec.describe DigestEmailGenerationWorker do
       subject.perform(digest_run_subscriber.id)
     end
 
-    it "marks the DigestRunSubscriber completed" do
+    it "marks the DigestRunSubscriber as processed" do
       freeze_time do
         expect { subject.perform(digest_run_subscriber.id) }
-          .to change { digest_run_subscriber.reload.completed_at }
+          .to change { digest_run_subscriber.reload.processed_at }
           .to(Time.zone.now)
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe DigestEmailGenerationWorker do
         .by(2)
     end
 
-    it "doesn't mark the digest run complete" do
+    it "doesn't mark the digest run as processed" do
       expect { subject.perform(digest_run_subscriber.id) }
         .not_to(change { digest_run.reload.completed_at })
     end
@@ -99,10 +99,10 @@ RSpec.describe DigestEmailGenerationWorker do
           .to_not change(Email, :count)
       end
 
-      it "marks the digest run subscriber completed" do
+      it "marks the digest run subscriber as processed" do
         freeze_time do
           expect { subject.perform(digest_run_subscriber.id) }
-            .to change { digest_run_subscriber.reload.completed_at }
+            .to change { digest_run_subscriber.reload.processed_at }
             .to(Time.zone.now)
         end
       end

--- a/spec/workers/digest_run_completion_marker_worker_spec.rb
+++ b/spec/workers/digest_run_completion_marker_worker_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe DigestRunCompletionMarkerWorker, type: :worker do
   describe "#perform" do
     let(:digest_run) { create(:digest_run) }
 
-    context "when a digest_run has incomplete subscribers" do
+    context "when a digest_run has unprocessed subscribers" do
       before do
         create(:digest_run_subscriber, digest_run: digest_run)
-        create(:digest_run_subscriber, digest_run: digest_run, completed_at: Time.zone.now)
+        create(:digest_run_subscriber, digest_run: digest_run, processed_at: Time.zone.now)
       end
 
       it "doesn't mark the digest run complete" do
@@ -14,12 +14,12 @@ RSpec.describe DigestRunCompletionMarkerWorker, type: :worker do
       end
     end
 
-    context "when a digest_run has complete subscribers" do
+    context "when a digest_run has processed subscribers" do
       let(:completed_time) { Date.yesterday.midday }
 
       before do
-        create(:digest_run_subscriber, digest_run: digest_run, completed_at: completed_time)
-        create(:digest_run_subscriber, digest_run: digest_run, completed_at: completed_time)
+        create(:digest_run_subscriber, digest_run: digest_run, processed_at: completed_time)
+        create(:digest_run_subscriber, digest_run: digest_run, processed_at: completed_time)
       end
 
       it "marks the digest run as complete at the most recent subscriber completion time" do


### PR DESCRIPTION
Trello: https://trello.com/c/DC7bXM5U/473-prepare-digests-so-they-can-be-safely-be-retried

This renames this column so that this model can be consistent with other
models that also use processed_at to indicate when the worker process
has completed for that model.

Normally the process to rename a column for a Rails app is rather
tricky, with the application raising errors at any points in time where
the code for the app is running a different version. This often means
renaming a column is a complex process of creating a new column and
backfilling it before deleting the old one. In this situation though I
determined that this could be done by a simple rename so long as this
was deployed outside the time that digests are running as that is the
only time this column is accessed. Thus, as long as this is deployed
carefully it, this can go out in a single step.

I tried running this on integration to see if the migration was fast and
it was very quick:

```
18:31:37 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] Migrating to RenameCompletedAtDigestRunSubscriber (20200818172715)
18:31:37 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] == 20200818172715 RenameCompletedAtDigestRunSubscriber: migrating =============
18:31:37 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] -- rename_column(:digest_run_subscribers, :completed_at, :processed_at)
18:31:37 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] -> 0.0109s
18:31:37 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal] == 20200818172715 RenameCompletedAtDigestRunSubscriber: migrated (0.0110s) ====
18:31:37 *** [err :: ip-10-1-5-9.eu-west-1.compute.internal]
```