### PR TITLE
Revert "Stop suggesting individual emails are "immediate""

### DIFF
--- a/app/builders/switch_to_daily_digest_email_builder.rb
+++ b/app/builders/switch_to_daily_digest_email_builder.rb
@@ -35,9 +35,9 @@ private
 
       We’ve not changed how often you get emails for any other GOV.UK subscriptions you may have. We’ve only changed the subscriptions listed in this email.
 
-      # If you want to go back to individual emails
+      # If you want to go back to immediate emails
 
-      You can go back to getting individual updates about these topics by [managing your subscriptions](#{manage_subscriptions_link}).
+      You can go back to getting immediate updates about these topics by [managing your subscriptions](#{manage_subscriptions_link}).
     BODY
   end
 


### PR DESCRIPTION
Reverts alphagov/email-alert-api#1377

In later discussion we decided neither wording is ideal, because 
it's different to that used in the signup / management journeys. 
While "immediate" may be a less true than "individual", we think 
the impact of this wording for users will be minimal.