### PR TITLE
Remove batch migration task

### DIFF
--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -52,13 +52,6 @@ namespace :data_migration do
     end
   end
 
-  desc "Switch immediate subscribers of the following lists to daily digest (experiment)"
-  task switch_to_daily_digest_experiment: :environment do
-    Rake::Task["data_migration:switch_to_daily_digest"].invoke(
-      *File.read(Rails.root.join("config/experiment_2_slugs.txt")).split("\n"),
-    )
-  end
-
   desc "Move all subscribers from one subscriber list to another"
   task :move_all_subscribers, %i[from_slug to_slug] => :environment do |_t, args|
     if ENV["SEND_EMAIL"]


### PR DESCRIPTION
https://trello.com/c/QF69iYHE/489-start-experiment-20

Note that the '.txt' file is still needed for reporting [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1376/files#diff-fa03edd65ae40ae3c0847fb56d37de70R4