### PR TITLE
Make the DigestInitiatorService retriable

### DIFF
--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -37,7 +37,7 @@ private
   end
 
   def enqueue_jobs(digest_run_subscriber_ids)
-    Array(digest_run_subscriber_ids).each do |digest_run_subscriber_id|
+    digest_run_subscriber_ids.each do |digest_run_subscriber_id|
       DigestEmailGenerationWorker.perform_async(digest_run_subscriber_id)
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/DC7bXM5U/473-prepare-digests-so-they-can-be-safely-be-retried

This updates this service so that it can support retrying a DigestRun
that didn't complete. This changes the approach for deciding whether to
abort a digest initiation from checking whether the digest run model
exists to instead checking whether that digest run model has a
populated processed_at field.

To prevent risks that could occur from this code being run concurrently
I've moved all of the service code inside the database lock.