### PR TITLE
Fix prematurely marking DigestRuns as complete

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -6,8 +6,6 @@ class DigestRun < ApplicationRecord
   has_many :digest_run_subscribers, dependent: :destroy
   has_many :subscribers, through: :digest_run_subscribers
 
-  scope :incomplete, -> { where(completed_at: nil) }
-
   enum range: { daily: 0, weekly: 1 }
 
   def mark_as_completed

--- a/app/workers/digest_run_completion_marker_worker.rb
+++ b/app/workers/digest_run_completion_marker_worker.rb
@@ -2,7 +2,8 @@ class DigestRunCompletionMarkerWorker
   include Sidekiq::Worker
 
   def perform
-    DigestRun.incomplete.find_each do |digest_run|
+    candidates = DigestRun.where.not(processed_at: nil).where(completed_at: nil)
+    candidates.find_each do |digest_run|
       unless DigestRunSubscriber.unprocessed_for_run(digest_run.id).exists?
         digest_run.mark_as_completed
       end


### PR DESCRIPTION
Trello: https://trello.com/c/DC7bXM5U/473-prepare-digests-so-they-can-be-safely-be-retried

As the worker to check if DigestRun objects are complete runs every
minute it can mark a DigestRun as complete before it is created any
DigestRunSubscriber objects and thus mark the digest complete before
this has actually occurred.

This can be resolved by using the new processed_at field to check that a
DigestRun is also processed before making this check.

I started this change hoping that I could actually remove the
completed_at field as it seemed a bit of a smell that we run a worker
every minute of every day for it. However doing so would sacrifice some
of the relevance of the Metrics::DigestRunExporter and thus I have left
it. I'm hoping that in the not too distant future we can see an
opportunity to remove it.