### PR TITLE
Rake task to bulk email all Brexit subscribers

### DIFF
--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -6,9 +6,14 @@ namespace :bulk_email do
       body: ENV.fetch("BODY"),
       subscriber_lists: SubscriberList.where(id: args.extras),
     )
-
     email_ids.each do |id|
       DeliveryRequestWorker.perform_async_in_queue(id, queue: :delivery_immediate)
     end
+  end
+
+  desc "Email all subscribers of the Brexit checker"
+  task brexit_subscribers: :environment do
+    brexit_lists = SubscriberList.where("subscriber_lists.tags->>'brexit_checklist_criteria' IS NOT NULL")
+    Rake::Task["bulk_email:for_lists"].invoke(*brexit_lists)
   end
 end

--- a/spec/lib/tasks/bulk_email_spec.rb
+++ b/spec/lib/tasks/bulk_email_spec.rb
@@ -1,4 +1,45 @@
 RSpec.describe "bulk_email" do
+  describe "brexit_subscribers" do
+    let(:tags) { { brexit_checklist_criteria: { any: %w[visiting-eu] } } }
+    let!(:list) { create(:subscriber_list, tags: tags) }
+    before do
+      Rake::Task["bulk_email:brexit_subscribers"].reenable
+      Rake::Task["bulk_email:for_lists"].reenable
+    end
+
+    around(:each) do |example|
+      ClimateControl.modify(SUBJECT: "subject", BODY: "body") do
+        example.run
+      end
+    end
+
+    it "builds emails for a subscriber list" do
+      expect(BulkSubscriberListEmailBuilder)
+        .to receive(:call)
+        .with(subject: "subject",
+              body: "body",
+              subscriber_lists: [list])
+        .and_call_original
+
+      Rake::Task["bulk_email:brexit_subscribers"].invoke
+    end
+
+    it "enqueues the emails for delivery" do
+      allow(BulkSubscriberListEmailBuilder).to receive(:call)
+        .and_return([1, 2])
+
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(1, queue: :delivery_immediate)
+
+      expect(DeliveryRequestWorker)
+        .to receive(:perform_async_in_queue)
+        .with(2, queue: :delivery_immediate)
+
+      Rake::Task["bulk_email:brexit_subscribers"].invoke
+    end
+  end
+
   describe "for_lists" do
     before do
       Rake::Task["bulk_email:for_lists"].reenable


### PR DESCRIPTION
## What

A rake task that will email all subscribers of the Brexit checker.


trello https://trello.com/c/o8NIyi3H/322-check-if-we-can-email-existing-subscribers-about-new-campaign-actions-to-encourage-users-to-revisit-the-checker