### PR TITLE
[DNM] Update dfid_research_output subscriber lists

### DIFF
--- a/lib/tasks/update_dfid_subscriber_lists.rake
+++ b/lib/tasks/update_dfid_subscriber_lists.rake
@@ -1,0 +1,34 @@
+desc "Update DFID subscriber lists"
+task update_dfid_subscriber_lists: :environment do
+  # Update all subscriber lists subscribed to dfid_research_output document types
+  SubscriberList.where("links->'content_store_document_type'->>'any' LIKE '%dfid_research_output%'").each do |sl|
+    new_links = sl.links.merge(
+      content_store_document_type: {
+        any: (sl.links[:content_store_document_type][:any] - %w[dfid_research_output] + %w[research_for_development_output]),
+      },
+    )
+
+    sl.update!(links: new_links)
+  end
+
+  # Update all subscriber lists subscribed to dfid_research_output document types (no idea what makes these different to the links equivalent)
+  SubscriberList.where("tags->'content_store_document_type'->>'any' LIKE '%dfid_research_output%'").each do |sl|
+    new_tags = sl.tags.merge(
+      content_store_document_type: {
+        any: (sl.tags[:content_store_document_type][:any] - %w[dfid_research_output] + %w[research_for_development_output]),
+      },
+    )
+
+    sl.update!(tags: new_tags)
+  end
+
+  # Update subscriber list associated with the dfid_research_output finder
+  sl = SubscriberList.find_by("tags->'format'->>'any' LIKE '%dfid_research_output%'")
+  new_tags = sl.tags.merge(
+    format: {
+      any: (sl.tags[:format][:any] - %w[dfid_research_output] + %w[research_for_development_output]),
+    },
+  )
+
+  sl.update!(tags: new_tags)
+end


### PR DESCRIPTION
This temp rake tasks is to migrate dfid_research_output subscriber lists
over to research_for_development_output.

In email-alert-api there are a few different types of
dfid_research_output lists. We're migrating the dfid_research_output
finder and all lists associated with the dfid_research_output document
type.

I've tested this in integration and all the lists have been updated
successfully with no mention of dfid_research_output in any other
subscriber list. The rake task also only takes a few seconds to complete.

Trello:
https://trello.com/c/OxoDZj59/523-migrate-subscribers-for-dfid-finder