### PR TITLE
Close subscriptions for FCO/DFID lists

### DIFF
--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -5,4 +5,35 @@ namespace :clean do
     cleaner = Clean::EmptySubscriberLists.new
     cleaner.remove_empty_subscriberlists(dry_run: dry_run)
   end
+
+  desc "Temporary task to close subscriptions to FCO/DFID lists that will no " \
+       "longer receive emails"
+  task close_fco_dfid_subscriptions: :environment do
+    fco_content_id = "db994552-7644-404d-a770-a2fe659c661f"
+    dfid_content_id = "9adfc4ed-9f6c-4976-a6d8-18d34356367c"
+
+    lists = SubscriberList.where("links->'organisations'->>'any' LIKE ?", "%#{fco_content_id}%")
+      .or(SubscriberList.where("links->'organisations'->>'any' LIKE ?", "%#{dfid_content_id}%"))
+
+    stats = { lists: 0, subscriptions: 0 }
+
+    lists.find_each do |list|
+      other_organisations = list.links[:organisations][:any] - [fco_content_id, dfid_content_id]
+      # we won't close subscriptions for lists for other organisations
+      next if other_organisations.any?
+
+      list.subscriptions.active.includes(:subscriber).find_each do |subscription|
+        UnsubscribeService.call(subscription.subscriber,
+                                [subscription],
+                                :subscriber_list_changed)
+        stats[:subscriptions] += 1
+
+        puts "Processed #{stats[:subscriptions]} subscriptions" if (stats[:subscriptions] % 1000).zero?
+      end
+
+      stats[:lists] += 1
+    end
+
+    puts "Closed #{stats[:subscriptions]} subscriptions for #{stats[:lists]} lists"
+  end
 end

--- a/spec/lib/tasks/clean_spec.rb
+++ b/spec/lib/tasks/clean_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "clean" do
+  describe "close_fco_dfid_subscriptions" do
+    let(:fco_content_id) { "db994552-7644-404d-a770-a2fe659c661f" }
+    let(:dfid_content_id) { "9adfc4ed-9f6c-4976-a6d8-18d34356367c" }
+
+    before { Rake::Task["clean:close_fco_dfid_subscriptions"].reenable }
+
+    around do |example|
+      expect { example.run }.to output.to_stdout
+    end
+
+    it "closes subscriptions to FCO and DFID lists" do
+      fco_subscriber_list = create(
+        :subscriber_list_with_subscribers,
+        links: { organisations: { any: [fco_content_id] } },
+      )
+
+      dfid_subscriber_list = create(
+        :subscriber_list_with_subscribers,
+        links: { organisations: { any: [dfid_content_id] } },
+      )
+
+      fco_and_dfid_subscriber_list = create(
+        :subscriber_list_with_subscribers,
+        links: { organisations: { any: [fco_content_id, dfid_content_id] } },
+      )
+
+      scope = Subscription.active.where(
+        subscriber_list: [fco_subscriber_list,
+                          dfid_subscriber_list,
+                          fco_and_dfid_subscriber_list],
+      )
+
+      expect { Rake::Task["clean:close_fco_dfid_subscriptions"].invoke }
+        .to change { scope.count }.to(0)
+    end
+
+    it "doesn't close subscriptions to lists with other organisations" do
+      other_orgs_subscriber_list = create(
+        :subscriber_list_with_subscribers,
+        links: { organisations: { any: [fco_content_id, SecureRandom.uuid] } },
+      )
+
+      scope = Subscription.active.where(subscriber_list: [other_orgs_subscriber_list])
+
+      expect { Rake::Task["clean:close_fco_dfid_subscriptions"].invoke }
+        .not_to change { scope.exists? }.from(true)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/b5TF5mWv/499-migrate-fco-and-dfid-subscriptions-to-fcdo

This should not be merged until 8th September as per the schedule in the Trello card.

This adds a rake task which identifies lists that are associated with
FCO and DFID organisations and closes any subscriptions to them. It
filters out any lists that are associated with additional organisations.

This task has been put together to reflect that these lists will no
longer receive any emails now that the FCO and DFID organisations are
closed and that these subscriptions have become superfluous.

Once this has task has been run on September 8th (as per the current
schedule) it can be deleted from the code.