### PR TITLE
Reinstate simplified report for content changes

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -109,24 +109,3 @@ Depending on the number of emails to send, the Rake task can take a few minutes 
 ```bash
 bundle exec rake 'support:resend_failed_emails:by_id[<email_one_id>,<email_two_id>]'
 ```
-
-## Count subscriptions to a subscriber list
-
-This shows subscription counts by Immediate, Daily or Weekly:
-
-```bash
-rake report:count_subscribers['subscriber-list-slug']
-```
-
-[⚙ Run rake task on production][rake-count-subscribers]
-
-If you need to know the number of subscriptions on a particular day:
-
-```bash
-rake report:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']
-```
-
-[⚙ Run rake task on production][rake-count-subscribers-on]
-
-[rake-count-subscribers]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:count_subscribers['subscriber-list-slug']
-[rake-count-subscribers-on]: https://deploy.blue.production.govuk.digital//job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:count_subscribers_on[yyyy-mm-dd,'subscriber-list-slug']

--- a/lib/reports/matched_content_changes_report.rb
+++ b/lib/reports/matched_content_changes_report.rb
@@ -1,0 +1,33 @@
+class Reports::MatchedContentChangesReport
+  OUTPUT_ATTRIBUTES = {
+    created_at: :content_change,
+    base_path: :content_change,
+    change_note: :content_change,
+    document_type: :content_change,
+    publishing_app: :content_change,
+    priority: :content_change,
+    title: :subscriber_list,
+    slug: :subscriber_list,
+  }.freeze
+
+  def call(start_time: nil, end_time: nil)
+    start_time = start_time ? Time.zone.parse(start_time) : 1.week.ago
+    end_time = end_time ? Time.zone.parse(end_time) : Time.zone.now
+
+    query = MatchedContentChange
+      .includes(:subscriber_list, :content_change) # for efficient "row.content_change"
+      .joins(:content_change) # for the next query
+      .where("content_changes.created_at": start_time..end_time)
+      .order("matched_content_changes.created_at desc")
+
+    CSV.generate do |csv|
+      csv << OUTPUT_ATTRIBUTES.keys
+
+      query.each do |row|
+        csv << OUTPUT_ATTRIBUTES.map do |sub_field, field|
+          row.public_send(field).public_send(sub_field)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -10,6 +10,12 @@ namespace :report do
                                                date: args[:date])
   end
 
+  desc "Outputs a CSV of content changes by subscriber list"
+  task matched_content_changes: :environment do
+    puts Reports::MatchedContentChangesReport.new.call(start_time: ENV["START_DATE"],
+                                                       end_time: ENV["END_DATE"])
+  end
+
   desc "Export the number of subscriptions for the 'Living in' taxons for European countries as of a given date (format: 'yyyy-mm-dd')"
   task :csv_from_living_in_europe, [:date] => :environment do |_, args|
     Reports::LivingInEuropeReport.new.call(args.date)

--- a/spec/lib/reports/matched_content_changes_report_spec.rb
+++ b/spec/lib/reports/matched_content_changes_report_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Reports::MatchedContentChangesReport do
+  describe "#call" do
+    it "outputs a CSV of matched content changes" do
+      subscriber_list = create :subscriber_list
+      match = create :matched_content_change, subscriber_list: subscriber_list
+      expect(described_class.new.call).to eq report_for([{ match: match }])
+    end
+
+    it "allows specifying the date range to report" do
+      subscriber_list = create :subscriber_list
+      create :matched_content_change, subscriber_list: subscriber_list
+      output = described_class.new.call(start_time: 1.day.from_now.to_s, end_time: 2.days.from_now.to_s)
+      expect(output).to eq report_for([])
+    end
+
+    def report_for(rows)
+      headers = described_class::OUTPUT_ATTRIBUTES.keys.join(",")
+
+      rows = [headers] + rows.map do |row|
+        "#{row[:match].content_change.created_at}," \
+          "government/base_path,change note,document type,publishing app,normal," \
+          "#{row[:match].subscriber_list.title}," \
+          "#{row[:match].subscriber_list.slug}" \
+      end
+
+      rows.join("\n") + "\n"
+    end
+  end
+end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe "report" do
     end
   end
 
+  describe "matched_content_changes" do
+    it "outputs a CSV of matched content changes" do
+      expect { Rake::Task["report:matched_content_changes"].invoke }
+        .to output.to_stdout
+    end
+  end
+
   describe "csv_from_living_in_europe" do
     it "outputs a report of subscriptions to living in Europe lists" do
       expect { Rake::Task["report:csv_from_living_in_europe"].invoke("2018-08-08") }


### PR DESCRIPTION
https://trello.com/c/bKAemKqV/517-review-the-emails-that-users-have-received-for-driving-subscription-lists

Previously we had a report for content changes matched against each
subscriber list with its immediate subscribers, as a way to discover
the origin of email volume [1]. Since then, we have begun reporting
email volume by publishing app and document type [2], and have done
migrations to increase the use of daily digest emails, to the extent
that immediate subscriber numbers are no longer meaningful as a way
to estimate volume, and are time consuming to include. This reinstates
a report of just the matched content changes, in the spirit of making
this data more easily available [3], and to support our research into
the behaviour of specific lists.

[1]: https://github.com/alphagov/email-alert-api/pull/1265
[2]: https://github.com/alphagov/email-alert-api/pull/1323
[3]: https://trello.com/c/Izm4d6NM/454-epic-make-data-about-email-notifications-easily-available