### PR TITLE
Revert "Try speeding things up with the spring gem"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,4 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails"
   gem "rubocop-govuk"
-  gem "spring"
-  gem "spring-commands-rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,9 +331,6 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 7.0)
       thor (~> 0)
-    spring (2.1.0)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -401,8 +398,6 @@ DEPENDENCIES
   rubocop-govuk
   sidekiq-scheduler
   sidekiq-unique-jobs
-  spring
-  spring-commands-rspec
   webmock
   with_advisory_lock
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ bundle exec rails server
 ### Running the test suite
 
 ```bash
-bundle exec spring rspec
+bundle exec rspec
 ```
 
 ## Documentation


### PR DESCRIPTION
This reverts commit 35e69853ecead13d0d9c080af65b84cdfc36dc6a.

Related to: https://github.com/alphagov/govuk-docker/pull/395

In practice I didn't find myself using this much. On the occasions
I did, one problem I encountered was that the code in the spring
server took some time to reload, such that the tests would report
some strange system-level error if I ran them too quickly after.