### PR TITLE
Fix validation message for digests

### DIFF
--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -24,7 +24,9 @@ private
   end
 
   def ends_at_is_in_the_past
-    errors.add(:date, "must be after #{DIGEST_RANGE_HOUR}:00") if ends_at >= Time.zone.now
+    return if ends_at < Time.zone.now
+
+    errors.add(:date, "must be in the past, or today if after #{DIGEST_RANGE_HOUR}:00")
   end
 
   def weekly_digest_is_on_a_saturday

--- a/spec/models/digest_run_spec.rb
+++ b/spec/models/digest_run_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DigestRun do
         instance = described_class.new(date: Date.current + 1.day, range: "daily")
         instance.validate
         expected_time = "#{DigestRun::DIGEST_RANGE_HOUR}:00"
-        expect(instance.errors[:date]).to eq(["must be after #{expected_time}"])
+        expect(instance.errors[:date]).to eq(["must be in the past, or today if after #{expected_time}"])
       end
 
       it "fails if a weekly digest does not end on a Saturday" do


### PR DESCRIPTION
https://trello.com/c/6NVuDOF5/525-make-it-possible-to-fix-digest-emails-if-they-break-over-the-weekend

It didn't make sense to say "Date must be in the past"...today.