### PR TITLE
Populate when we send an email request to Notify

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -1,7 +1,7 @@
 class DeliveryAttempt < ApplicationRecord
   belongs_to :email
 
-  enum status: { sending: 0, delivered: 1, undeliverable_failure: 3, provider_communication_failure: 4 }
+  enum status: { sent: 0, delivered: 1, undeliverable_failure: 3, provider_communication_failure: 4 }
   enum provider: { pseudo: 0, notify: 1, delay: 2 }
 
   def finished_sending_at

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -22,12 +22,4 @@ class Email < ApplicationRecord
 
     Metrics.email_bulk_insert(batch_size) { insert_all!(records) }
   end
-
-  def mark_as_sent(finished_sending_at)
-    update!(status: :sent, finished_sending_at: finished_sending_at)
-  end
-
-  def mark_as_failed(finished_sending_at)
-    update!(status: :failed, finished_sending_at: finished_sending_at)
-  end
 end

--- a/app/providers/notify_provider.rb
+++ b/app/providers/notify_provider.rb
@@ -20,7 +20,7 @@ class NotifyProvider
     )
 
     Metrics.sent_to_notify_successfully
-    :sending
+    :sent
   rescue Notifications::Client::RequestError, Net::OpenTimeout => e
     Metrics.failed_to_send_to_notify
 

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -37,9 +37,11 @@ class DeliveryRequestService < ApplicationService
         email.update!(status: :sent, sent_at: Time.zone.now)
       when :delivered
         record_metric_and_update_attempt(attempt, status)
+        # Deprecated: finished_sending_at is deprecated and soon to be removed due to the introduction of sent_at
         email.update!(status: :sent, finished_sending_at: attempt.finished_sending_at, sent_at: Time.zone.now)
       when :undeliverable_failure
         record_metric_and_update_attempt(attempt, status)
+        # Deprecated: finished_sending_at is deprecated and soon to be removed due to the introduction of sent_at
         email.update!(status: :failed, finished_sending_at: attempt.finished_sending_at)
       when :provider_communication_failure
         record_metric_and_update_attempt(attempt, status)

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -31,13 +31,19 @@ class DeliveryRequestService < ApplicationService
 
     status = Metrics.email_send_request(provider_name) { send_email }
 
-    return attempt if status == :sent
-
     ActiveRecord::Base.transaction do
-      attempt.update!(status: status, completed_at: Time.zone.now)
-      Metrics.delivery_attempt_status_changed(status)
-      email.mark_as_sent(attempt.finished_sending_at) if attempt.delivered?
-      email.mark_as_failed(attempt.finished_sending_at) if attempt.undeliverable_failure?
+      case status
+      when :sent
+        email.update!(status: :sent, sent_at: Time.zone.now)
+      when :delivered
+        record_metric_and_update_attempt(attempt, status)
+        email.update!(status: :sent, finished_sending_at: attempt.finished_sending_at, sent_at: Time.zone.now)
+      when :undeliverable_failure
+        record_metric_and_update_attempt(attempt, status)
+        email.update!(status: :failed, finished_sending_at: attempt.finished_sending_at)
+      when :provider_communication_failure
+        record_metric_and_update_attempt(attempt, status)
+      end
     end
 
     attempt
@@ -75,5 +81,10 @@ private
       metrics[:content_change_created_at],
       now,
     )
+  end
+
+  def record_metric_and_update_attempt(attempt, status)
+    Metrics.delivery_attempt_status_changed(status)
+    attempt.update!(status: status, completed_at: Time.zone.now)
   end
 end

--- a/app/services/delivery_request_service.rb
+++ b/app/services/delivery_request_service.rb
@@ -25,13 +25,13 @@ class DeliveryRequestService < ApplicationService
     attempt = Metrics.delivery_request_service_create_delivery_attempt do
       DeliveryAttempt.create!(id: attempt_id,
                               email: email,
-                              status: :sending,
+                              status: :sent,
                               provider: provider_name)
     end
 
     status = Metrics.email_send_request(provider_name) { send_email }
 
-    return attempt if status == :sending
+    return attempt if status == :sent
 
     ActiveRecord::Base.transaction do
       attempt.update!(status: status, completed_at: Time.zone.now)

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -18,6 +18,7 @@ class StatusUpdateService < ApplicationService
       )
     end
 
+    # Deprecated: finished_sending_at is deprecated and soon to be removed due to the introduction of sent_at
     email.update!(finished_sending_at: delivery_attempt.finished_sending_at)
 
     if status == "permanent-failure" && subscriber

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -48,7 +48,7 @@ private
                 .lock
                 .find(reference)
 
-    unless attempt.sending?
+    unless attempt.sent?
       raise DeliveryAttemptStatusConflictError, "Status update already received"
     end
 

--- a/app/services/status_update_service.rb
+++ b/app/services/status_update_service.rb
@@ -18,7 +18,7 @@ class StatusUpdateService < ApplicationService
       )
     end
 
-    update_email_status(delivery_attempt)
+    email.update!(finished_sending_at: delivery_attempt.finished_sending_at)
 
     if status == "permanent-failure" && subscriber
       UnsubscribeAllService.call(subscriber, :non_existent_email)
@@ -67,12 +67,6 @@ private
       GovukError.notify(error)
       raise DeliveryAttemptInvalidStatusError, error
     end
-  end
-
-  def update_email_status(delivery_attempt)
-    finished_sending_at = delivery_attempt.finished_sending_at
-    email.mark_as_sent(finished_sending_at) if delivery_attempt.delivered?
-    email.mark_as_failed(finished_sending_at) if delivery_attempt.undeliverable_failure?
   end
 
   class DeliveryAttemptInvalidStatusError < RuntimeError; end

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -11,6 +11,7 @@ class DeliveryRequestWorker
                             .order(created_at: :desc)
                             .first
 
+    # Deprecated: finished_sending_at is deprecated and soon to be removed due to the introduction of sent_at
     email.update!(status: :failed, finished_sending_at: (delivery_attempt&.finished_sending_at || Time.zone.now))
   end
 

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -11,7 +11,7 @@ class DeliveryRequestWorker
                             .order(created_at: :desc)
                             .first
 
-    email.mark_as_failed(delivery_attempt&.finished_sending_at || Time.zone.now)
+    email.update!(status: :failed, finished_sending_at: (delivery_attempt&.finished_sending_at || Time.zone.now))
   end
 
   def perform(email_id, metrics, queue)

--- a/db/migrate/20200903094629_add_sent_at_to_emails.rb
+++ b/db/migrate/20200903094629_add_sent_at_to_emails.rb
@@ -1,0 +1,5 @@
+class AddSentAtToEmails < ActiveRecord::Migration[6.0]
+  def change
+    add_column :emails, :sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_172715) do
+ActiveRecord::Schema.define(version: 2020_09_03_094629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2020_08_18_172715) do
     t.datetime "archived_at"
     t.bigint "subscriber_id"
     t.integer "status", default: 0, null: false
+    t.datetime "sent_at"
     t.index ["address"], name: "index_emails_on_address"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["created_at"], name: "index_emails_on_created_at"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -63,9 +63,9 @@ FactoryBot.define do
     end
   end
 
-  factory :delivery_attempt, aliases: [:sending_delivery_attempt] do
+  factory :delivery_attempt, aliases: [:sent_delivery_attempt] do
     email
-    status { :sending }
+    status { :sent }
     provider { :notify }
 
     factory :delivered_delivery_attempt do

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Receiving a status update", type: :request do
-  let(:delivery_attempt) { create(:delivery_attempt, status: "sending") }
+  let(:delivery_attempt) { create(:delivery_attempt, status: "sent") }
   let(:reference) { delivery_attempt.id }
 
   let(:permissions) { %w[signin status_updates] }

--- a/spec/models/delivery_attempt_spec.rb
+++ b/spec/models/delivery_attempt_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe DeliveryAttempt, type: :model do
   describe ".finished_sending_at" do
     subject { delivery_attempt.finished_sending_at }
 
-    context "when email is sent" do
+    context "when email is delivered" do
       let(:delivery_attempt) { build(:delivered_delivery_attempt) }
       it { is_expected.to eq delivery_attempt.sent_at }
     end
@@ -12,8 +12,8 @@ RSpec.describe DeliveryAttempt, type: :model do
       it { is_expected.to eq delivery_attempt.completed_at }
     end
 
-    context "when email is sending" do
-      let(:delivery_attempt) { build(:sending_delivery_attempt) }
+    context "when email is sent" do
+      let(:delivery_attempt) { build(:sent_delivery_attempt) }
       it { is_expected.to be_nil }
     end
   end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -28,26 +28,4 @@ RSpec.describe Email do
       end
     end
   end
-
-  describe "#mark_as_sent" do
-    it "updates an email as sent with a finished_sending_at time" do
-      email = create(:email)
-      freeze_time do
-        expect { email.mark_as_sent(Time.zone.now) }
-          .to change { email.status }.to("sent")
-          .and change { email.finished_sending_at }.to(Time.zone.now)
-      end
-    end
-  end
-
-  describe "#mark_as_failed" do
-    it "updates an email as failed with a finished_sending_at time" do
-      email = create(:email)
-      freeze_time do
-        expect { email.mark_as_failed(Time.zone.now) }
-          .to change { email.status }.to("failed")
-          .and change { email.finished_sending_at }.to(Time.zone.now)
-      end
-    end
-  end
 end

--- a/spec/providers/notify_provider_spec.rb
+++ b/spec/providers/notify_provider_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe NotifyProvider do
       described_class.call(arguments)
     end
 
-    it "returns a sending status for a successful request" do
+    it "returns a sent status for a successful request" do
       stub_request(:post, /fake-notify/).to_return(body: {}.to_json)
       return_value = described_class.call(arguments)
-      expect(return_value).to be(:sending)
+      expect(return_value).to be(:sent)
     end
 
     it "returns a provider_communication_failure status for a Notify RequestError" do

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DeliveryRequestService do
                            body: email.body }
       expect(default_provider).to receive(:call)
                               .with(hash_including(email_parameters))
-                              .and_return(:sending)
+                              .and_return(:sent)
       described_class.call(email: email)
     end
 
@@ -26,7 +26,7 @@ RSpec.describe DeliveryRequestService do
         .to receive(:email_service)
         .and_return(email_service_config.merge(provider: "NOTIFY"))
 
-      expect(NotifyProvider).to receive(:call).and_return(:sending)
+      expect(NotifyProvider).to receive(:call).and_return(:sent)
       described_class.call(email: email)
     end
 
@@ -37,7 +37,7 @@ RSpec.describe DeliveryRequestService do
 
       expect(default_provider).to receive(:call)
                               .with(hash_including(subject: "[TEST] #{email.subject}"))
-                              .and_return(:sending)
+                              .and_return(:sent)
       described_class.call(email: email)
     end
 
@@ -49,7 +49,7 @@ RSpec.describe DeliveryRequestService do
 
       expect(default_provider).to receive(:call)
                               .with(hash_including(address: address))
-                              .and_return(:sending)
+                              .and_return(:sent)
       described_class.call(email: email)
     end
 
@@ -112,9 +112,9 @@ RSpec.describe DeliveryRequestService do
       end
     end
 
-    context "when sending the email returns a sending status" do
+    context "when sending the email returns a sent status" do
       it "doesn't update the email status" do
-        allow(default_provider).to receive(:call).and_return(:sending)
+        allow(default_provider).to receive(:call).and_return(:sent)
         expect { described_class.call(email: email) }
           .not_to(change { email.reload.status })
       end

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -113,10 +113,14 @@ RSpec.describe DeliveryRequestService do
     end
 
     context "when sending the email returns a sent status" do
-      it "doesn't update the email status" do
+      it "marks the email as sent and sets the sent_at time" do
         allow(default_provider).to receive(:call).and_return(:sent)
-        expect { described_class.call(email: email) }
-          .not_to(change { email.reload.status })
+
+        freeze_time do
+          expect { described_class.call(email: email) }
+            .to change { email.status }.to("sent")
+            .and change { email.sent_at }.to(Time.zone.now)
+        end
       end
     end
 
@@ -134,10 +138,20 @@ RSpec.describe DeliveryRequestService do
         end
       end
 
-      it "marks the email as sent" do
-        expect { described_class.call(email: email) }
-          .to change { email.reload.status }
-          .to("sent")
+      it "marks the email as sent and sets the sent_at and finished_sending_at time" do
+        freeze_time do
+          expect { described_class.call(email: email) }
+            .to change { email.status }.to("sent")
+            .and change { email.sent_at }.to(Time.zone.now)
+            .and change { email.finished_sending_at }.to(Time.zone.now)
+        end
+      end
+
+      it "records that the delivery attempt status has changed" do
+        expect(Metrics)
+          .to receive(:delivery_attempt_status_changed)
+          .with(:delivered)
+        described_class.call(email: email)
       end
     end
 
@@ -155,10 +169,19 @@ RSpec.describe DeliveryRequestService do
         end
       end
 
-      it "marks the email as failed" do
-        expect { described_class.call(email: email) }
-          .to change { email.reload.status }
-          .to("failed")
+      it "marks the email as failed and sets finished_sending_at time" do
+        freeze_time do
+          expect { described_class.call(email: email) }
+            .to change { email.status }.to("failed")
+            .and change { email.finished_sending_at }.to(Time.zone.now)
+        end
+      end
+
+      it "records that the delivery attempt status has changed" do
+        expect(Metrics)
+          .to receive(:delivery_attempt_status_changed)
+          .with(:undeliverable_failure)
+        described_class.call(email: email)
       end
     end
 
@@ -171,6 +194,13 @@ RSpec.describe DeliveryRequestService do
         scope = DeliveryAttempt.where(status: :provider_communication_failure)
         expect { described_class.call(email: email) }
           .to change(scope, :count).by(1)
+      end
+
+      it "records that the delivery attempt status has changed" do
+        expect(Metrics)
+          .to receive(:delivery_attempt_status_changed)
+          .with(:provider_communication_failure)
+        described_class.call(email: email)
       end
     end
   end

--- a/spec/services/status_update_service_spec.rb
+++ b/spec/services/status_update_service_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe StatusUpdateService do
       end
     end
 
-    context "when the delivery attempt isn't in a sending state" do
+    context "when the delivery attempt isn't in a sent state" do
       let!(:delivery_attempt) do
         create(:delivered_delivery_attempt, id: reference, email: email)
       end


### PR DESCRIPTION
This PR is the first stage of work to do with reducing our reliance on status updates from notify to archive emails. 

Included in this PR:

* Created a new `sent_at` column on Email model
* Updated the `sending` enum to `sent` for the DeliveryAttempt model
* We now populate the new column (sent_at) and mark the email as sent when we successfully make an email request to Notify. 
* Stop updating the email's status from the status update

Future work to do:

* Remove sent_at and completed_at from the DeliveryAttempt model
* Remove finished_sending_at from the Email model
* Delete all emails older than 14 days old

Trello:
https://trello.com/c/15eVh9Qg/482-stop-relying-on-notify-status-updates-to-archive-delete-emails