### PR TITLE
Co-locate metrics worker code with the worker

### DIFF
--- a/app/services/delivery_request_service/delay_provider.rb
+++ b/app/services/delivery_request_service/delay_provider.rb
@@ -1,4 +1,4 @@
-class DelayProvider
+class DeliveryRequestService::DelayProvider
   def self.call(*args)
     new.call(*args)
   end

--- a/app/services/delivery_request_service/email_address_overrider.rb
+++ b/app/services/delivery_request_service/email_address_overrider.rb
@@ -1,21 +1,19 @@
-class DeliveryRequestService
-  class EmailAddressOverrider
-    attr_reader :override_address, :whitelist_addresses, :whitelist_only
+class DeliveryRequestService::EmailAddressOverrider
+  attr_reader :override_address, :whitelist_addresses, :whitelist_only
 
-    def initialize(config)
-      @override_address = config[:email_address_override]
-      @whitelist_addresses = Array(config[:email_address_override_whitelist])
-      @whitelist_only = config[:email_address_override_whitelist_only]
-    end
+  def initialize(config)
+    @override_address = config[:email_address_override]
+    @whitelist_addresses = Array(config[:email_address_override_whitelist])
+    @whitelist_only = config[:email_address_override_whitelist_only]
+  end
 
-    def destination_address(address)
-      return address unless override_address
+  def destination_address(address)
+    return address unless override_address
 
-      if whitelist_addresses.include?(address)
-        address
-      else
-        whitelist_only ? nil : override_address
-      end
+    if whitelist_addresses.include?(address)
+      address
+    else
+      whitelist_only ? nil : override_address
     end
   end
 end

--- a/app/services/delivery_request_service/notify_provider.rb
+++ b/app/services/delivery_request_service/notify_provider.rb
@@ -1,4 +1,4 @@
-class NotifyProvider
+class DeliveryRequestService::NotifyProvider
   def initialize
     @client = EmailAlertAPI.config.notify_client
     @template_id = EmailAlertAPI.config.notify.fetch(:template_id)

--- a/app/services/delivery_request_service/pseudo_provider.rb
+++ b/app/services/delivery_request_service/pseudo_provider.rb
@@ -1,4 +1,4 @@
-class PseudoProvider
+class DeliveryRequestService::PseudoProvider
   LOG_PATH = Rails.root.join("log/pseudo_email.log").freeze
 
   def self.call(*args)

--- a/app/workers/metrics_collection_worker.rb
+++ b/app/workers/metrics_collection_worker.rb
@@ -2,8 +2,8 @@ class MetricsCollectionWorker
   include Sidekiq::Worker
 
   def perform
-    Metrics::ContentChangeExporter.call
-    Metrics::DigestRunExporter.call
-    Metrics::MessageExporter.call
+    ContentChangeExporter.call
+    DigestRunExporter.call
+    MessageExporter.call
   end
 end

--- a/app/workers/metrics_collection_worker/base_exporter.rb
+++ b/app/workers/metrics_collection_worker/base_exporter.rb
@@ -1,4 +1,4 @@
-class Metrics::BaseExporter
+class MetricsCollectionWorker::BaseExporter
   def self.call
     new.call
   end

--- a/app/workers/metrics_collection_worker/content_change_exporter.rb
+++ b/app/workers/metrics_collection_worker/content_change_exporter.rb
@@ -1,4 +1,4 @@
-class Metrics::ContentChangeExporter < Metrics::BaseExporter
+class MetricsCollectionWorker::ContentChangeExporter < MetricsCollectionWorker::BaseExporter
   def call
     GovukStatsd.gauge("content_changes.unprocessed_total", unprocessed_content_changes)
   end

--- a/app/workers/metrics_collection_worker/digest_run_exporter.rb
+++ b/app/workers/metrics_collection_worker/digest_run_exporter.rb
@@ -1,4 +1,4 @@
-class Metrics::DigestRunExporter < Metrics::BaseExporter
+class MetricsCollectionWorker::DigestRunExporter < MetricsCollectionWorker::BaseExporter
   def call
     GovukStatsd.gauge("digest_runs.critical_total", critical_digest_runs)
     GovukStatsd.gauge("digest_runs.warning_total", warning_digest_runs)

--- a/app/workers/metrics_collection_worker/message_exporter.rb
+++ b/app/workers/metrics_collection_worker/message_exporter.rb
@@ -1,4 +1,4 @@
-class Metrics::MessageExporter < Metrics::BaseExporter
+class MetricsCollectionWorker::MessageExporter < MetricsCollectionWorker::BaseExporter
   def call
     GovukStatsd.gauge("messages.unprocessed_total", unprocessed_messages)
   end

--- a/spec/services/delivery_request_service/delay_provider_spec.rb
+++ b/spec/services/delivery_request_service/delay_provider_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DelayProvider do
+RSpec.describe DeliveryRequestService::DelayProvider do
   describe ".call" do
     let(:args) do
       {

--- a/spec/services/delivery_request_service/notify_provider_spec.rb
+++ b/spec/services/delivery_request_service/notify_provider_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe NotifyProvider do
+RSpec.describe DeliveryRequestService::NotifyProvider do
   describe ".call" do
     let(:template_id) { EmailAlertAPI.config.notify.fetch(:template_id) }
     let(:arguments) do

--- a/spec/services/delivery_request_service/pseudo_provider_spec.rb
+++ b/spec/services/delivery_request_service/pseudo_provider_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PseudoProvider do
+RSpec.describe DeliveryRequestService::PseudoProvider do
   describe ".call" do
     it "logs to a file" do
       allow(Logger).to receive(:new).and_return(logger = double)

--- a/spec/services/delivery_request_service_spec.rb
+++ b/spec/services/delivery_request_service_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe DeliveryRequestService do
   describe ".call" do
     let(:email) { create(:email) }
     let(:default_provider_name) { "pseudo" }
-    let(:default_provider) { PseudoProvider }
+    let(:default_provider) { DeliveryRequestService::PseudoProvider }
     let(:email_service_config) { EmailAlertAPI.config.email_service }
 
     it "creates a delivery attempt" do
@@ -26,7 +26,7 @@ RSpec.describe DeliveryRequestService do
         .to receive(:email_service)
         .and_return(email_service_config.merge(provider: "NOTIFY"))
 
-      expect(NotifyProvider).to receive(:call).and_return(:sent)
+      expect(DeliveryRequestService::NotifyProvider).to receive(:call).and_return(:sent)
       described_class.call(email: email)
     end
 

--- a/spec/workers/metrics_collection_worker/content_change_exporter_spec.rb
+++ b/spec/workers/metrics_collection_worker/content_change_exporter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metrics::ContentChangeExporter do
+RSpec.describe MetricsCollectionWorker::ContentChangeExporter do
   describe ".call" do
     let(:statsd) { double }
 

--- a/spec/workers/metrics_collection_worker/digest_run_exporter_spec.rb
+++ b/spec/workers/metrics_collection_worker/digest_run_exporter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metrics::DigestRunExporter do
+RSpec.describe MetricsCollectionWorker::DigestRunExporter do
   describe ".call" do
     let(:statsd) { double }
 

--- a/spec/workers/metrics_collection_worker/message_exporter_spec.rb
+++ b/spec/workers/metrics_collection_worker/message_exporter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metrics::MessageExporter do
+RSpec.describe MetricsCollectionWorker::MessageExporter do
   describe ".call" do
     let(:statsd) { double }
 

--- a/spec/workers/metrics_collection_worker_spec.rb
+++ b/spec/workers/metrics_collection_worker_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe MetricsCollectionWorker do
   describe ".perform" do
     it "delegates to collect metrics" do
-      expect(Metrics::ContentChangeExporter).to receive(:call)
-      expect(Metrics::DigestRunExporter).to receive(:call)
-      expect(Metrics::MessageExporter).to receive(:call)
+      expect(MetricsCollectionWorker::ContentChangeExporter).to receive(:call)
+      expect(MetricsCollectionWorker::DigestRunExporter).to receive(:call)
+      expect(MetricsCollectionWorker::MessageExporter).to receive(:call)
 
       subject.perform
     end


### PR DESCRIPTION
https://trello.com/c/3ixGroQO/469-apply-retry-logic-for-digest-runs

This repeats a similar refactoring of the RecoverLostJobsWorker [1],
which has the benefit of keeping the 'lib' directory lean.

[1]: https://github.com/alphagov/email-alert-api/pull/1405/commits/482153f3b2d4d5c2a6f5700046bde96b1c26cf04