### PR TITLE
Archive emails pt3

### DIFF
--- a/app/models/delivery_attempt.rb
+++ b/app/models/delivery_attempt.rb
@@ -1,6 +1,4 @@
 class DeliveryAttempt < ApplicationRecord
-  self.ignored_columns = %w[sent_at completed_at]
-
   belongs_to :email
 
   enum status: { sent: 0, delivered: 1, undeliverable_failure: 3, provider_communication_failure: 4 }

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -2,8 +2,6 @@ class Email < ApplicationRecord
   # Any validations added this to this model won't be applied on record
   # creation as this table is populated by the #insert_all bulk method
 
-  self.ignored_columns = %w[finished_sending_at]
-
   COURTESY_EMAIL = "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk".freeze
   has_many :delivery_attempts
 

--- a/db/migrate/20200916163844_remove_sent_at_and_completed_at_from_delivery_attempts.rb
+++ b/db/migrate/20200916163844_remove_sent_at_and_completed_at_from_delivery_attempts.rb
@@ -1,0 +1,14 @@
+class RemoveSentAtAndCompletedAtFromDeliveryAttempts < ActiveRecord::Migration[6.0]
+  def up
+    change_table :delivery_attempts, bulk: true do |t|
+      t.remove :sent_at, :completed_at
+    end
+  end
+
+  def down
+    change_table :delivery_attempts, bulk: true do |t|
+      t.column :sent_at, :datetime
+      t.column :completed_at, :datetime
+    end
+  end
+end

--- a/db/migrate/20200916164443_remove_finished_sending_at_from_emails.rb
+++ b/db/migrate/20200916164443_remove_finished_sending_at_from_emails.rb
@@ -1,0 +1,6 @@
+class RemoveFinishedSendingAtFromEmails < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :emails, :finished_sending_at
+    remove_column :emails, :finished_sending_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_16_095316) do
+ActiveRecord::Schema.define(version: 2020_09_16_163844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,8 +47,6 @@ ActiveRecord::Schema.define(version: 2020_09_16_095316) do
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
     t.uuid "email_id", null: false
-    t.datetime "completed_at"
-    t.datetime "sent_at"
     t.index ["created_at"], name: "index_delivery_attempts_on_created_at"
     t.index ["email_id", "updated_at"], name: "index_delivery_attempts_on_email_id_and_updated_at"
     t.index ["email_id"], name: "index_delivery_attempts_on_email_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_16_163844) do
+ActiveRecord::Schema.define(version: 2020_09_16_164443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,6 @@ ActiveRecord::Schema.define(version: 2020_09_16_163844) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
-    t.datetime "finished_sending_at"
     t.datetime "archived_at"
     t.bigint "subscriber_id"
     t.integer "status", default: 0, null: false
@@ -89,7 +88,6 @@ ActiveRecord::Schema.define(version: 2020_09_16_163844) do
     t.index ["address"], name: "index_emails_on_address"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["created_at"], name: "index_emails_on_created_at"
-    t.index ["finished_sending_at"], name: "index_emails_on_finished_sending_at"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|


### PR DESCRIPTION
These use of these columns will have been removed [here][PR] so they will be safe to remove.

**Warning:** this PR will need to be merged into master, currently it will merge into `archive-emails-pt2`.

Dependant on:
[ this PR][PR]

Trello:
 https://trello.com/c/15eVh9Qg/482-stop-relying-on-notify-status-updates-to-archive-delete-emails

[PR]: https://github.com/alphagov/email-alert-api/pull/1408
[6th]: https://github.com/alphagov/email-alert-api/pull/1410/commits/27f3bbf9b837982914c36c30c81b885b949bf396
[7th]: https://github.com/alphagov/email-alert-api/pull/1410/commits/a69de39776de61d31cbc50654e8f3f482badcb88