### PR TITLE
Archive emails pt4

### DIFF
--- a/lib/tasks/delete_old_emails.rake
+++ b/lib/tasks/delete_old_emails.rake
@@ -1,7 +1,9 @@
 desc "Deletes all emails older than 14 days old"
 task delete_old_emails: :environment do
-  two_weeks_ago = 14.days.ago
-  deleted_count = Email.where("created_at < ?", two_weeks_ago).delete_all
-
-  "#{deleted_count} pending emails deleted older than #{two_weeks_ago}"
+  count = 0
+  two_weeks_ago = 2.weeks.ago
+  Email.where("created_at < ?", two_weeks_ago).in_batches(of: 10_000) do |batch|
+    count += batch.delete_all
+    puts "#{count} emails deleted"
+  end
 end

--- a/lib/tasks/delete_old_emails.rake
+++ b/lib/tasks/delete_old_emails.rake
@@ -1,0 +1,7 @@
+desc "Deletes all emails older than 14 days old"
+task delete_old_emails: :environment do
+  two_weeks_ago = 14.days.ago
+  deleted_count = Email.where("created_at < ?", two_weeks_ago).delete_all
+
+  "#{deleted_count} pending emails deleted older than #{two_weeks_ago}"
+end


### PR DESCRIPTION
Delete all emails older than 14 days old.

**warning** we can't run this rake task until at least 2 weeks
have past from the deployment of [this PR] which occurred on the 15th
September at 3:52pm. This is so all non deleted emails will have a
populated sent_at value on the Email model (emails get deleted after 2
weeks).

This temp rake task deletes all emails older than 2 weeks old. All these
emails are in a pending state so I've dropped that from the query to
hopefully reduce the time take it takes to run.

In aws prod:
```
irb(main):001:0> Email.where(status: :pending).where("created_at < ?", 14.days.ago).count
=> 8448165
irb(main):002:0> Email.where.not(status: :pending).where("created_at < ?", 14.days.ago).count
=> 0
```

Trello:
https://trello.com/c/15eVh9Qg/482-stop-relying-on-notify-status-updates-to-archive-delete-emails

[this PR]: https://github.com/alphagov/email-alert-api/pull/1402