### PR TITLE
Delete unique job digest when a job is marked as dead

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,9 @@
-Sidekiq.configure_server do
+Sidekiq.configure_server do |config|
   # Calls to Rails.logger in a sidekiq process will use Sidekiq's logger
   Rails.logger = Sidekiq::Logging.logger
+
+  config.death_handlers << lambda { |job, _error|
+    digest = job["unique_digest"]
+    SidekiqUniqueJobs::Digests.delete_by_digest(digest) if digest
+  }
 end


### PR DESCRIPTION
Without this any unique jobs cannot be re-enqueued to retry them as they
will be marked as already existing.