### PR TITLE
Add temporary task to remove dead records

### DIFF
--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -95,4 +95,9 @@ namespace :data_migration do
       puts "Error updating subscriber list with title:#{new_title} and slug: #{new_slug}"
     end
   end
+
+  desc "Remove ancient, unprocessed digest run subscribers"
+  task remove_ancient_unprocessed_digest_run_subscribers: :environment do
+    DigestRunSubscriber.where("created_at < ?", 1.week.ago).where(processed_at: nil).delete_all
+  end
 end


### PR DESCRIPTION
https://trello.com/c/3ixGroQO/469-apply-retry-logic-for-digest-runs

This is a prerequisite to automatic recovery of digest runs, for
which the primary period of concern is 1 week (hence the threshold)
here. A quick check shows all such digests are c. 2018.