### PR TITLE
Replace sidekiq-unique-jobs with non-blocking lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem "plek"
 gem "ratelimit"
 gem "redcarpet"
 gem "sidekiq-scheduler"
-gem "sidekiq-unique-jobs"
 gem "with_advisory_lock"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,10 +328,6 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
-    sidekiq-unique-jobs (6.0.22)
-      concurrent-ruby (~> 1.0, >= 1.0.5)
-      sidekiq (>= 4.0, < 7.0)
-      thor (~> 0)
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -402,7 +398,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sidekiq-scheduler
-  sidekiq-unique-jobs
   simplecov
   webmock
   with_advisory_lock

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,12 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.try_lock
+    transaction do
+      lock("FOR UPDATE NOWAIT")
+      yield
+    rescue ActiveRecord::LockWaitTimeout => e
+      Rails.logger.warn(e)
+    end
+  end
 end

--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -37,7 +37,7 @@ private
   end
 
   def run_with_advisory_lock
-    DigestRun.with_advisory_lock("#{range}_digest_initiator-#{date}", timeout_seconds: 0) do
+    ApplicationRecord.with_advisory_lock("#{range}_digest_initiator-#{date}", timeout_seconds: 0) do
       yield
     end
   end

--- a/app/workers/daily_digest_initiator_worker.rb
+++ b/app/workers/daily_digest_initiator_worker.rb
@@ -5,14 +5,7 @@ class DailyDigestInitiatorWorker
     60 * (count + 1)
   end
 
-  sidekiq_options retry: 3,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first || Date.current.to_s]
-  end
+  sidekiq_options retry: 3
 
   def perform(date = Date.current.to_s)
     DigestInitiatorService.call(date: Date.parse(date), range: Frequency::DAILY)

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -1,20 +1,13 @@
 class DigestEmailGenerationWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :email_generation_digest,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first]
-  end
+  sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)
     email = nil
-    DigestRun.transaction do
-      digest_run_subscriber = DigestRunSubscriber.lock.find(digest_run_subscriber_id)
 
+    ApplicationRecord.try_lock do
+      digest_run_subscriber = DigestRunSubscriber.find(digest_run_subscriber_id)
       return if digest_run_subscriber.processed_at
 
       digest_items = DigestItemsQuery.call(

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -1,24 +1,19 @@
 class ProcessContentChangeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :process_and_generate_emails,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first]
-  end
+  sidekiq_options queue: :process_and_generate_emails
 
   def perform(content_change_id)
-    content_change = ContentChange.find(content_change_id)
-    return if content_change.processed_at
+    ApplicationRecord.try_lock do
+      content_change = ContentChange.find(content_change_id)
+      return if content_change.processed_at
 
-    MatchedContentChangeGenerationService.call(content_change)
-    ImmediateEmailGenerationService.call(content_change)
+      MatchedContentChangeGenerationService.call(content_change)
+      ImmediateEmailGenerationService.call(content_change)
 
-    queue_courtesy_email(content_change)
-    content_change.update!(processed_at: Time.zone.now)
+      queue_courtesy_email(content_change)
+      content_change.update!(processed_at: Time.zone.now)
+    end
   end
 
 private

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -1,24 +1,19 @@
 class ProcessMessageWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :process_and_generate_emails,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first]
-  end
+  sidekiq_options queue: :process_and_generate_emails
 
   def perform(message_id)
-    message = Message.find(message_id)
-    return if message.processed_at
+    ApplicationRecord.try_lock do
+      message = Message.find(message_id)
+      return if message.processed_at
 
-    MatchedMessageGenerationService.call(message)
-    ImmediateEmailGenerationService.call(message)
+      MatchedMessageGenerationService.call(message)
+      ImmediateEmailGenerationService.call(message)
 
-    queue_courtesy_email(message)
-    message.update!(processed_at: Time.zone.now)
+      queue_courtesy_email(message)
+      message.update!(processed_at: Time.zone.now)
+    end
   end
 
 private

--- a/app/workers/weekly_digest_initiator_worker.rb
+++ b/app/workers/weekly_digest_initiator_worker.rb
@@ -5,14 +5,7 @@ class WeeklyDigestInitiatorWorker
     60 * (count + 1)
   end
 
-  sidekiq_options retry: 3,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first || Date.current.to_s]
-  end
+  sidekiq_options retry: 3
 
   def perform(date = Date.current.to_s)
     DigestInitiatorService.call(date: Date.parse(date), range: Frequency::WEEKLY)

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ApplicationRecord do
+  describe ".try_lock" do
+    it "silently skips if the record is already being processed" do
+      allow(ApplicationRecord).to receive(:lock).and_raise(ActiveRecord::LockWaitTimeout)
+      duplicate_work_attempt = proc { ContentChange.try_lock { ContentChange.find(1) } }
+      expect { duplicate_work_attempt.call }.to_not raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,8 +37,6 @@ end
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
-SidekiqUniqueJobs.config.enabled = false
-
 Sidekiq::Testing.inline!
 Sidekiq::Worker.clear_all
 Sidekiq::Logging.logger = nil

--- a/spec/workers/process_content_change_worker_spec.rb
+++ b/spec/workers/process_content_change_worker_spec.rb
@@ -58,20 +58,4 @@ RSpec.describe ProcessContentChangeWorker do
       described_class.new.perform(processed_content.id)
     end
   end
-
-  describe ".perform_async" do
-    # We're expecting redis-namespace to raise a warning unfortunately
-    before { allow_any_instance_of(Redis::Namespace).to receive(:warn) }
-
-    around do |example|
-      SidekiqUniqueJobs.use_config(enabled: true, logger: Logger.new("/dev/null")) do
-        example.run
-      end
-    end
-
-    it "enforces job uniqueness with the correct sidekiq-unique-jobs option" do
-      expect(described_class).to receive(:uniqueness_with).with([content_change.id])
-      described_class.perform_async(content_change.id)
-    end
-  end
 end

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -59,20 +59,4 @@ RSpec.describe ProcessMessageWorker do
       described_class.new.perform(processed_message.id)
     end
   end
-
-  describe ".perform_async" do
-    # We're expecting redis-namespace to raise a warning unfortunately
-    before { allow_any_instance_of(Redis::Namespace).to receive(:warn) }
-
-    around do |example|
-      SidekiqUniqueJobs.use_config(enabled: true, logger: Logger.new("/dev/null")) do
-        example.run
-      end
-    end
-
-    it "enforces job uniqueness with the correct sidekiq-unique-jobs option" do
-      expect(described_class).to receive(:uniqueness_with).with([message.id])
-      described_class.perform_async(message.id)
-    end
-  end
 end


### PR DESCRIPTION
https://trello.com/c/3ixGroQO/469-apply-retry-logic-for-digest-runs

    Previously we added sidekiq-unique-jobs as a way to prevent duplicate
    jobs executing concurrently. However, we've since learned the gem is
    flawed for the main scenario we're trying to prevent: a worker being
    killed due to memory issues [1]. An non-blocking lock [2] can be used
    to get the same no-wait-noop effect, similarly to an advisory lock, but
    without the need to define a unique namespace [3]. This replaces the
    use of the gem with non-blocking locks, which are more robust.
    
    Note this replaces the use of specific models with ApplicationRecord
    where the specific model class is not relevant.
    
    Note that, while we could use "SKIP LOCKED" instead of "NOWAIT", this
    would still result in a "not found" error later on, due to the record
    being invisible to all but the process holding the lock [2]. I think
    it's better to use "NOWAIT", so the error we catch (to avoid a failure
    / retry) is explicitly related to locking.
    
    [1]: https://github.com/alphagov/email-alert-api/pull/1412#issuecomment-695999823
    [2]: https://www.postgresql.org/docs/9.5/sql-select.html
    [3]: https://github.com/alphagov/email-alert-api/pull/1405/commits/e2b85f9e1223d3af386a6c20029962445e6ac0c3