### PR TITLE
Remove code for non-existant warning alert

### DIFF
--- a/app/workers/metrics_collection_worker/digest_run_exporter.rb
+++ b/app/workers/metrics_collection_worker/digest_run_exporter.rb
@@ -1,17 +1,12 @@
 class MetricsCollectionWorker::DigestRunExporter < MetricsCollectionWorker::BaseExporter
   def call
     GovukStatsd.gauge("digest_runs.critical_total", critical_digest_runs)
-    GovukStatsd.gauge("digest_runs.warning_total", warning_digest_runs)
   end
 
 private
 
   def critical_digest_runs
     @critical_digest_runs ||= count_digest_runs(critical_latency)
-  end
-
-  def warning_digest_runs
-    @warning_digest_runs ||= count_digest_runs(warning_latency)
   end
 
   def count_digest_runs(age)
@@ -23,9 +18,5 @@ private
 
   def critical_latency
     1.hour
-  end
-
-  def warning_latency
-    20.minutes
   end
 end

--- a/spec/workers/metrics_collection_worker/digest_run_exporter_spec.rb
+++ b/spec/workers/metrics_collection_worker/digest_run_exporter_spec.rb
@@ -12,10 +12,5 @@ RSpec.describe MetricsCollectionWorker::DigestRunExporter do
       expect(GovukStatsd).to receive(:gauge).with("digest_runs.critical_total", 1)
       described_class.call
     end
-
-    it "records number of unprocessed digest runs over 20 minutes old (warning)" do
-      expect(GovukStatsd).to receive(:gauge).with("digest_runs.warning_total", 2)
-      described_class.call
-    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/seBH6Dhz/470-update-warning-critical-digest-runs-check

This was removed in https://github.com/alphagov/govuk-puppet/pull/10710