### PR TITLE
Add task to support renaming country tags

### DIFF
--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -95,4 +95,16 @@ namespace :data_migration do
       puts "Error updating subscriber list with title:#{new_title} and slug: #{new_slug}"
     end
   end
+
+  desc "Update one of the tags in a subscriber list"
+  task :update_subscriber_list_tag, %i[key old_criterion new_criterion] => :environment do |_t, args|
+    SubscriberList.where("tags->>'#{args[:key]}' IS NOT NULL").find_each do |list|
+      old_criteria = list.tags[args[:key].to_sym][:any]
+      next unless old_criteria.include?(args[:old_criterion])
+
+      new_criteria = old_criteria - [args[:old_criterion]] + [args[:new_criterion]]
+      list.update!(tags: list.tags.merge(args[:key].to_sym => { any: new_criteria }))
+      puts "Updated #{args[:key]} in #{list.title} to #{new_criteria}"
+    end
+  end
 end

--- a/spec/lib/tasks/data_migration_spec.rb
+++ b/spec/lib/tasks/data_migration_spec.rb
@@ -83,4 +83,26 @@ RSpec.describe "data_migration" do
       end
     end
   end
+
+  describe "update_subscriber_list_tag" do
+    before do
+      Rake::Task["data_migration:update_subscriber_list_tag"].reenable
+    end
+
+    it "renames a country in a 'destination_country' tag" do
+      list = create :subscriber_list, tags: { location: { any: %w[old other] } }
+
+      expect {
+        Rake::Task["data_migration:update_subscriber_list_tag"].invoke("location", "old", "new")
+      }.to output.to_stdout
+
+      expect(list.reload.tags[:location][:any]).to match_array %w[new other]
+    end
+
+    it "does not update a list without a matching tag" do
+      list = create :subscriber_list, tags: { location: { any: %w[other] } }
+      Rake::Task["data_migration:update_subscriber_list_tag"].invoke("location", "old", "new")
+      expect(list.reload.tags[:location][:any]).to match_array %w[other]
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/J6DOuBBp/569-2ndline-country-updates

Related to: https://github.com/alphagov/govuk-developer-docs/pull/2800

This adds a generic task (in keeping with the other tasks for this
purpose [1]) to support renaming a country on GOV.UK, when it exists
in the criteria for a specific tag. Examples:

- Export Health Certificates: tag is "destination_country"
- International Development Funds: tag is "location"

[1]: https://github.com/alphagov/govuk-developer-docs/blob/master/source/manual/rename-a-country.html.md#5-update-email-alert-api