### PR TITLE
Swap sidekiq-unique-jobs for PG advisory locks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem "plek"
 gem "ratelimit"
 gem "redcarpet"
 gem "sidekiq-scheduler"
-gem "sidekiq-unique-jobs"
 gem "with_advisory_lock"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,10 +328,6 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
-    sidekiq-unique-jobs (6.0.22)
-      concurrent-ruby (~> 1.0, >= 1.0.5)
-      sidekiq (>= 4.0, < 7.0)
-      thor (~> 0)
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -402,7 +398,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sidekiq-scheduler
-  sidekiq-unique-jobs
   simplecov
   webmock
   with_advisory_lock

--- a/app/services/digest_initiator_service.rb
+++ b/app/services/digest_initiator_service.rb
@@ -5,13 +5,11 @@ class DigestInitiatorService < ApplicationService
   end
 
   def call
-    run_with_advisory_lock do
-      digest_run = DigestRun.find_or_create_by!(date: date, range: range)
-      return if digest_run.processed_at
+    digest_run = DigestRun.find_or_create_by!(date: date, range: range)
+    return if digest_run.processed_at
 
-      create_digest_run_subscribers(digest_run)
-      digest_run.update!(processed_at: Time.zone.now)
-    end
+    create_digest_run_subscribers(digest_run)
+    digest_run.update!(processed_at: Time.zone.now)
   end
 
 private
@@ -33,12 +31,6 @@ private
   def enqueue_jobs(digest_run_subscriber_ids)
     digest_run_subscriber_ids.each do |digest_run_subscriber_id|
       DigestEmailGenerationWorker.perform_async(digest_run_subscriber_id)
-    end
-  end
-
-  def run_with_advisory_lock
-    DigestRun.with_advisory_lock("#{range}_digest_initiator-#{date}", timeout_seconds: 0) do
-      yield
     end
   end
 end

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,0 +1,9 @@
+class ApplicationWorker
+  include Sidekiq::Worker
+
+private
+
+  def run_with_advisory_lock(model, unique_ref)
+    ApplicationRecord.with_advisory_lock("#{model}-#{unique_ref}", timeout_seconds: 0) { yield }
+  end
+end

--- a/app/workers/daily_digest_initiator_worker.rb
+++ b/app/workers/daily_digest_initiator_worker.rb
@@ -5,14 +5,7 @@ class DailyDigestInitiatorWorker
     60 * (count + 1)
   end
 
-  sidekiq_options retry: 3,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first || Date.current.to_s]
-  end
+  sidekiq_options retry: 3
 
   def perform(date = Date.current.to_s)
     DigestInitiatorService.call(date: Date.parse(date), range: Frequency::DAILY)

--- a/app/workers/delivery_request_worker.rb
+++ b/app/workers/delivery_request_worker.rb
@@ -1,7 +1,5 @@
-class DeliveryRequestWorker
+class DeliveryRequestWorker < ApplicationWorker
   class ProviderCommunicationFailureError < RuntimeError; end
-
-  include Sidekiq::Worker
 
   sidekiq_options retry: 9
 

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -1,14 +1,7 @@
 class DigestEmailGenerationWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :email_generation_digest,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first]
-  end
+  sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)
     email = nil

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -1,6 +1,4 @@
-class DigestEmailGenerationWorker
-  include Sidekiq::Worker
-
+class DigestEmailGenerationWorker < ApplicationWorker
   sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)

--- a/app/workers/digest_run_completion_marker_worker.rb
+++ b/app/workers/digest_run_completion_marker_worker.rb
@@ -1,6 +1,4 @@
-class DigestRunCompletionMarkerWorker
-  include Sidekiq::Worker
-
+class DigestRunCompletionMarkerWorker < ApplicationWorker
   def perform
     candidates = DigestRun.where.not(processed_at: nil).where(completed_at: nil)
     candidates.find_each do |digest_run|

--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -1,13 +1,10 @@
-class EmailArchiveWorker
-  include Sidekiq::Worker
-
-  LOCK_NAME = "email_archive_worker".freeze
+class EmailArchiveWorker < ApplicationWorker
   BATCH_SIZE = 1000
 
   def perform
     return unless ENV.include?("EMAIL_ARCHIVE_S3_ENABLED")
 
-    Email.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
+    run_with_advisory_lock(Email, "archive") do
       start_time = Time.zone.now
       archived_count = 0
 

--- a/app/workers/email_deletion_worker.rb
+++ b/app/workers/email_deletion_worker.rb
@@ -1,10 +1,6 @@
-class EmailDeletionWorker
-  include Sidekiq::Worker
-
-  LOCK_NAME = "email_deletion_worker".freeze
-
+class EmailDeletionWorker < ApplicationWorker
   def perform
-    Email.with_advisory_lock(LOCK_NAME, timeout_seconds: 0) do
+    run_with_advisory_lock(Email, "delete") do
       start_time = Time.zone.now
       deleted_count = Email.deleteable.delete_all
       log_complete(deleted_count, start_time, Time.zone.now)

--- a/app/workers/metrics_collection_worker.rb
+++ b/app/workers/metrics_collection_worker.rb
@@ -1,6 +1,4 @@
-class MetricsCollectionWorker
-  include Sidekiq::Worker
-
+class MetricsCollectionWorker < ApplicationWorker
   def perform
     ContentChangeExporter.call
     DigestRunExporter.call

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -1,24 +1,19 @@
 class ProcessContentChangeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :process_and_generate_emails,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first]
-  end
+  sidekiq_options queue: :process_and_generate_emails
 
   def perform(content_change_id)
-    content_change = ContentChange.find(content_change_id)
-    return if content_change.processed_at
+    run_with_advisory_lock(content_change_id) do
+      content_change = ContentChange.find(content_change_id)
+      return if content_change.processed_at
 
-    MatchedContentChangeGenerationService.call(content_change)
-    ImmediateEmailGenerationService.call(content_change)
+      MatchedContentChangeGenerationService.call(content_change)
+      ImmediateEmailGenerationService.call(content_change)
 
-    queue_courtesy_email(content_change)
-    content_change.update!(processed_at: Time.zone.now)
+      queue_courtesy_email(content_change)
+      content_change.update!(processed_at: Time.zone.now)
+    end
   end
 
 private
@@ -37,5 +32,10 @@ private
     ]).first
 
     DeliveryRequestWorker.perform_async_in_queue(id, queue: content_change.queue)
+  end
+
+  def run_with_advisory_lock(content_change_id)
+    key = "content-change-#{content_change_id}"
+    ApplicationRecord.with_advisory_lock(key, timeout_seconds: 0) { yield }
   end
 end

--- a/app/workers/recover_lost_jobs_worker.rb
+++ b/app/workers/recover_lost_jobs_worker.rb
@@ -1,6 +1,4 @@
-class RecoverLostJobsWorker
-  include Sidekiq::Worker
-
+class RecoverLostJobsWorker < ApplicationWorker
   def perform
     RecoverLostJobsWorker::UnprocessedCheck.new.call
     RecoverLostJobsWorker::MissingDigestRunsCheck.new.call

--- a/app/workers/subscriber_deactivation_worker.rb
+++ b/app/workers/subscriber_deactivation_worker.rb
@@ -1,6 +1,4 @@
-class SubscriberDeactivationWorker
-  include Sidekiq::Worker
-
+class SubscriberDeactivationWorker < ApplicationWorker
   sidekiq_options retry: 3
 
   def perform(subscriber_ids)

--- a/app/workers/weekly_digest_initiator_worker.rb
+++ b/app/workers/weekly_digest_initiator_worker.rb
@@ -1,6 +1,4 @@
-class WeeklyDigestInitiatorWorker
-  include Sidekiq::Worker
-
+class WeeklyDigestInitiatorWorker < ApplicationWorker
   sidekiq_retry_in do |count|
     60 * (count + 1)
   end
@@ -8,13 +6,8 @@ class WeeklyDigestInitiatorWorker
   sidekiq_options retry: 3
 
   def perform(date = Date.current.to_s)
-    run_with_advisory_lock(date) do
+    run_with_advisory_lock(DigestRun, "#{date}-#{Frequency::WEEKLY}") do
       DigestInitiatorService.call(date: Date.parse(date), range: Frequency::WEEKLY)
     end
-  end
-
-  def run_with_advisory_lock(date)
-    key = "#{Frequency::WEEKLY}_digest_initiator-#{date}"
-    ApplicationRecord.with_advisory_lock(key, timeout_seconds: 0) { yield }
   end
 end

--- a/app/workers/weekly_digest_initiator_worker.rb
+++ b/app/workers/weekly_digest_initiator_worker.rb
@@ -8,6 +8,13 @@ class WeeklyDigestInitiatorWorker
   sidekiq_options retry: 3
 
   def perform(date = Date.current.to_s)
-    DigestInitiatorService.call(date: Date.parse(date), range: Frequency::WEEKLY)
+    run_with_advisory_lock(date) do
+      DigestInitiatorService.call(date: Date.parse(date), range: Frequency::WEEKLY)
+    end
+  end
+
+  def run_with_advisory_lock(date)
+    key = "#{Frequency::WEEKLY}_digest_initiator-#{date}"
+    ApplicationRecord.with_advisory_lock(key, timeout_seconds: 0) { yield }
   end
 end

--- a/app/workers/weekly_digest_initiator_worker.rb
+++ b/app/workers/weekly_digest_initiator_worker.rb
@@ -5,14 +5,7 @@ class WeeklyDigestInitiatorWorker
     60 * (count + 1)
   end
 
-  sidekiq_options retry: 3,
-                  lock: :until_executed,
-                  unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args
-                  on_conflict: :log
-
-  def self.uniqueness_with(args)
-    [args.first || Date.current.to_s]
-  end
+  sidekiq_options retry: 3
 
   def perform(date = Date.current.to_s)
     DigestInitiatorService.call(date: Date.parse(date), range: Frequency::WEEKLY)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -21,15 +21,17 @@
   weekly_digest_initiator:
     cron: '30 8 * * 6 Europe/London' # every Saturday at 8:30am
     class: WeeklyDigestInitiatorWorker
-  nullify_deactivated_subscribers:
-    every: '1h'
-    class: NullifyDeactivatedSubscribersWorker
-  email_archiver:
-    every: '1h'
-    class: EmailArchiveWorker
-  email_deleter:
-    every: '1h'
-    class: EmailDeletionWorker
+  # TEMPORARY: disable these workers while we change the ID used
+  # for their advisory locks
+  #nullify_deactivated_subscribers:
+    #every: '1h'
+    #class: NullifyDeactivatedSubscribersWorker
+  #email_archiver:
+    #every: '1h'
+    #class: EmailArchiveWorker
+  #email_deleter:
+    #every: '1h'
+    #class: EmailDeletionWorker
   digest_run_completion_marker:
     every: '1m'
     class: DigestRunCompletionMarkerWorker

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,8 +39,6 @@ end
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
-SidekiqUniqueJobs.config.enabled = false
-
 Sidekiq::Testing.inline!
 Sidekiq::Worker.clear_all
 Sidekiq::Logging.logger = nil

--- a/spec/workers/process_content_change_worker_spec.rb
+++ b/spec/workers/process_content_change_worker_spec.rb
@@ -58,20 +58,4 @@ RSpec.describe ProcessContentChangeWorker do
       described_class.new.perform(processed_content.id)
     end
   end
-
-  describe ".perform_async" do
-    # We're expecting redis-namespace to raise a warning unfortunately
-    before { allow_any_instance_of(Redis::Namespace).to receive(:warn) }
-
-    around do |example|
-      SidekiqUniqueJobs.use_config(enabled: true, logger: Logger.new("/dev/null")) do
-        example.run
-      end
-    end
-
-    it "enforces job uniqueness with the correct sidekiq-unique-jobs option" do
-      expect(described_class).to receive(:uniqueness_with).with([content_change.id])
-      described_class.perform_async(content_change.id)
-    end
-  end
 end

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -59,20 +59,4 @@ RSpec.describe ProcessMessageWorker do
       described_class.new.perform(processed_message.id)
     end
   end
-
-  describe ".perform_async" do
-    # We're expecting redis-namespace to raise a warning unfortunately
-    before { allow_any_instance_of(Redis::Namespace).to receive(:warn) }
-
-    around do |example|
-      SidekiqUniqueJobs.use_config(enabled: true, logger: Logger.new("/dev/null")) do
-        example.run
-      end
-    end
-
-    it "enforces job uniqueness with the correct sidekiq-unique-jobs option" do
-      expect(described_class).to receive(:uniqueness_with).with([message.id])
-      described_class.perform_async(message.id)
-    end
-  end
 end


### PR DESCRIPTION
https://trello.com/c/3ixGroQO/469-apply-retry-logic-for-digest-runs

This PR makes a couple of changes to the way we avoid repeating work:

- Replaces the use of sidekiq-unique-jobs with advisory locks as the
primary mechanism to prevent duplicate work.

- Standardises the location and ID structure of our locks. This means
we need to deploy the change when affected worker code is not in use.

- DRYs-up the worker classes by introducing a new base class.

More detail is in the commits. We could consider making the changes to
the advisory lock IDs in a separate, smaller deployment. I think it's
more coherent if we keep all the changes together in one PR, unless this
proves hard to review.