### PR TITLE
Reenable cleanup workers following locking changes

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -21,17 +21,15 @@
   weekly_digest_initiator:
     cron: '30 8 * * 6 Europe/London' # every Saturday at 8:30am
     class: WeeklyDigestInitiatorWorker
-  # TEMPORARY: disable these workers while we change the ID used
-  # for their advisory locks
-  #nullify_deactivated_subscribers:
-    #every: '1h'
-    #class: NullifyDeactivatedSubscribersWorker
-  #email_archiver:
-    #every: '1h'
-    #class: EmailArchiveWorker
-  #email_deleter:
-    #every: '1h'
-    #class: EmailDeletionWorker
+  nullify_deactivated_subscribers:
+    every: '1h'
+    class: NullifyDeactivatedSubscribersWorker
+  email_archiver:
+    every: '1h'
+    class: EmailArchiveWorker
+  email_deleter:
+    every: '1h'
+    class: EmailDeletionWorker
   digest_run_completion_marker:
     every: '1m'
     class: DigestRunCompletionMarkerWorker


### PR DESCRIPTION
https://trello.com/c/3ixGroQO/469-apply-retry-logic-for-digest-runs

Now that we've deployed [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1419