### PR TITLE
Increase critical alert time for incomplete digest

### DIFF
--- a/app/workers/metrics_collection_worker/digest_run_exporter.rb
+++ b/app/workers/metrics_collection_worker/digest_run_exporter.rb
@@ -17,6 +17,6 @@ private
   end
 
   def critical_latency
-    1.hour
+    2.hours
   end
 end


### PR DESCRIPTION
Over the last 7 days there have been two runs which have exceeded the
hour mark to process at 73 minutes and 90 minutes (today). The one today
processed on it's own fine with no intervention so I think we should amp
up the threshold time to allow for longer digest runs so 2nd line
doesn't have to investigate problems destined to be fixed on their own.

This is also consistent with the thresholds for messages and content
changes.

Related PR:
https://github.com/alphagov/govuk-puppet/pull/10746