### PR TITLE
Remove extra comments about queues

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,11 +3,9 @@
 :concurrency: 32
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
-# Any changes to the queues should be reflected in `docs/queues.md`.
-# See https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
-# Use powers of 2: higher priority groups are checked twice as often.
 :queues:
   # See here to understand priorities: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
+  # Use powers of 2: higher priority groups are checked twice as often.
   - [delivery_transactional, 8] # To send one-off emails, such as subscription confirmation.
   - [delivery_immediate_high, 8] # To send high priority emails to users with immediate subscriptions e.g. travel advice.
   - [process_and_generate_emails, 4] # To generate emails to users with immediate subscriptions for content changes and messages.


### PR DESCRIPTION
I missed these when inlining the documentation in 21166658.