### PR TITLE
Add an endpoint to get a subscriber's details from an account token

### DIFF
--- a/app/controllers/subscribers_account_jwt_controller.rb
+++ b/app/controllers/subscribers_account_jwt_controller.rb
@@ -1,0 +1,57 @@
+class SubscribersAccountJwtController < ApplicationController
+  before_action :validate_params
+
+  class TokenInvalid < RuntimeError; end
+
+  rescue_from TokenInvalid do |exception|
+    render json: { error: "Could not fetch subscriber",
+                   details: exception.message },
+           status: :forbidden
+  end
+
+  def account_jwt
+    jwt = expected_params.require(:jwt)
+    address = validate_token(jwt)
+    subscriber = find_subscriber(address)
+
+    render json: { subscriber: subscriber }
+  end
+
+private
+
+  def validate_token(jwt)
+    payload, = JWT.decode jwt, public_key, true, { algorithm: "ES256" }
+    raise TokenInvalid, "email address not verified" unless payload["email_verified"]
+
+    payload["email"]
+  rescue JWT::DecodeError
+    raise TokenInvalid, "could not decode jwt"
+  end
+
+  def public_key
+    OpenSSL::PKey::EC.new(Rails.application.secrets.accounts_jwt_public_key)
+  end
+
+  def find_subscriber(address)
+    Subscriber.resilient_find_or_create(
+      address,
+      signon_user_uid: current_user.uid,
+    ).tap do |subscriber|
+      subscriber.activate if subscriber.deactivated?
+    end
+  end
+
+  def expected_params
+    params.permit(:jwt)
+  end
+
+  def validate_params
+    ParamsValidator.new(expected_params).validate!
+  end
+
+  class ParamsValidator < OpenStruct
+    include ActiveModel::Validations
+
+    validates :jwt, presence: true
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
     post "/subscribers/auth-token", to: "subscribers_auth_token#auth_token"
     post "/subscriptions/auth-token", to: "subscriptions_auth_token#auth_token"
 
+    post "/subscribers/account-jwt", to: "subscribers_account_jwt#account_jwt"
+
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
 
     get "/healthcheck", to: "healthcheck#index"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,6 +22,7 @@
 development:
   secret_key_base: 68c093e39d8ac8ecbaca8cc09dc573c3fd7d6942a9cd1a88474c50f028cb85f653a2d2d7c0579da6e172519518e77fc557d5dca7920bae925a6e2e8f3ad7c514
   email_alert_auth_token: b132e4dde18854890516866be3ef3a2885addd6a47fc1d6173f3069290b6753ec28ccbe9dee580837f9027be18b36f8983dc03d1230e4d23818049b1777c8a2b
+  accounts_jwt_public_key: <%= ENV["ACCOUNTS_JWT_PUBLIC_KEY"] %>
 
 test:
   secret_key_base: 8bcfe54ee0999f12fc3a57eb369fc010788e3e4335ea8a7d85dea34859265260b9bfdce6bc92296c2e8d4af1ca534276759b14de510de9347b67b0b1c8532bee
@@ -35,3 +36,4 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   email_alert_auth_token: <%= ENV["EMAIL_ALERT_AUTH_TOKEN"] %>
+  accounts_jwt_public_key: <%= ENV["ACCOUNTS_JWT_PUBLIC_KEY"] %>

--- a/spec/integration/subscribers_account_jwt_spec.rb
+++ b/spec/integration/subscribers_account_jwt_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe "Subscribers from account JWT", type: :request do
+  let(:private_key) { OpenSSL::PKey::EC.new("prime256v1").tap(&:generate_key) }
+  let(:public_key) { OpenSSL::PKey::EC.new(private_key).tap { |key| key.private_key = nil } }
+
+  let(:email) { "text@example.com" }
+  let(:email_verified) { true }
+
+  let(:jwt) do
+    payload = { email: email, email_verified: email_verified }
+    JWT.encode payload.compact, private_key, "ES256"
+  end
+
+  let(:params) { { jwt: jwt }.compact }
+  let(:path) { "/subscribers/account-jwt" }
+
+  before do
+    allow(Rails.application.secrets).to receive(:accounts_jwt_public_key).and_return(public_key)
+  end
+
+  context "with authentication and authorisation" do
+    before do
+      login_with_internal_app
+    end
+
+    it "returns the subscriber details" do
+      post path, params: params
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)["subscriber"]).to_not be_nil
+    end
+
+    context "JWT signature does not match" do
+      let(:public_key) do
+        bad_private_key = OpenSSL::PKey::EC.new("prime256v1").tap(&:generate_key)
+        OpenSSL::PKey::EC.new(bad_private_key).tap { |key| key.private_key = nil }
+      end
+
+      it "returns a 403" do
+        post path, params: params
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)["details"]).to eq("could not decode jwt")
+      end
+    end
+
+    context "address is not verified" do
+      let(:email_verified) { false }
+
+      it "returns a 403" do
+        post path, params: params
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)["details"]).to eq("email address not verified")
+      end
+    end
+
+    context "missing the JWT" do
+      let(:jwt) { nil }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+
+  context "without authentication" do
+    it "returns a 401" do
+      without_login do
+        post path
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For at least our initial experiment, we want to be able to manage
email subscriptions from the account manager.  All email-alert-api
interaction is done in terms of subscriber IDs, rather than addresses,
and the only way to turn an address into a subscriber ID is by sending
a verification email with a magic link in it.

We don't want to have a "double verification email" scenario, where we
ask a user to verify their account and then also to verify we can
manage their subscriptions.  So add this endpoint which:

1. Accepts a JWT over POST containing the fields `email` and `email_verified`
2. Checks that the JWT has a valid signature from the account system
3. Checks that the `email_verified` is true
4. Returns either an error or the subscriber details

With the ID and the address all the other endpoints work.  We can:

- List a user's subscriptions
- Change a user's address
- Unsubscribe a user from one or all of their subscriptions
- Subscribe a user to a list (which sends them a confirmation, but not
  verification, email)
- Update the frequency of a subscription

---

[Trello card](https://trello.com/c/VOHkLg9s/319-figure-out-what-changes-we-need-in-email-alert-api)