### PR TITLE
Remove smoke test conditional

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,7 +1,5 @@
 class SubscriptionsController < ApplicationController
   def create
-    return render json: { id: 0 }, status: :created if smoke_test_address?
-
     subscriber = Subscriber.resilient_find_or_create(
       address,
       signon_user_uid: current_user.uid,
@@ -84,10 +82,6 @@ class SubscriptionsController < ApplicationController
   end
 
 private
-
-  def smoke_test_address?
-    address.end_with?("@notifications.service.gov.uk")
-  end
 
   def address
     subscription_params.require(:address)

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -71,15 +71,6 @@ RSpec.describe "Creating a subscription", type: :request do
           end
         end
 
-        context "with a notify email address" do
-          it "returns a 201 but doesn't create a subscriber or subscription" do
-            params = JSON.dump(address: "simulate-delivered@notifications.service.gov.uk", subscriber_list_id: subscriber_list.id, frequency: "daily")
-            expect { post "/subscriptions", params: params, headers: json_headers }.to_not change(Subscriber, :count)
-
-            expect(response.status).to eq(201)
-          end
-        end
-
         context "with a deactivated subscriber" do
           before do
             create(:subscriber, :deactivated, address: "deactivated@example.com")


### PR DESCRIPTION
This code was included so that the app could be tested in a way that
does not produce side effects. Later the app was changed to email people
confirm their subscription and the smoke tests were changed to no longer
execute this code path [1], making it now redundant.

[1]: https://github.com/alphagov/smokey/commit/3384d3e295363f77ca7cfe3de4cd38dad69ab96d#diff-c85d3ae6ee27c858427c074e88044722