### PR TITLE
Fix test that fails before 8am

### DIFF
--- a/app/workers/metrics_collection_worker/digest_run_exporter.rb
+++ b/app/workers/metrics_collection_worker/digest_run_exporter.rb
@@ -1,22 +1,9 @@
 class MetricsCollectionWorker::DigestRunExporter < MetricsCollectionWorker::BaseExporter
   def call
+    critical_digest_runs = DigestRun.where("created_at < ?", 2.hours.ago)
+                                    .where(completed_at: nil)
+                                    .count
+
     GovukStatsd.gauge("digest_runs.critical_total", critical_digest_runs)
-  end
-
-private
-
-  def critical_digest_runs
-    @critical_digest_runs ||= count_digest_runs(critical_latency)
-  end
-
-  def count_digest_runs(age)
-    DigestRun
-      .where("created_at < ?", age.ago)
-      .where(completed_at: nil)
-      .count
-  end
-
-  def critical_latency
-    2.hours
   end
 end

--- a/spec/workers/metrics_collection_worker/digest_run_exporter_spec.rb
+++ b/spec/workers/metrics_collection_worker/digest_run_exporter_spec.rb
@@ -1,16 +1,13 @@
 RSpec.describe MetricsCollectionWorker::DigestRunExporter do
   describe ".call" do
-    let(:statsd) { double }
-
-    before do
-      create(:digest_run, created_at: 2.days.ago, date: 2.days.ago)
-      create(:digest_run, created_at: 21.minutes.ago, date: Time.zone.today)
-      allow(GovukStatsd).to receive(:gauge)
-    end
-
-    it "records number of unprocessed digest runs over 1 hour old (critical)" do
-      expect(GovukStatsd).to receive(:gauge).with("digest_runs.critical_total", 1)
-      described_class.call
+    it "records number of unprocessed digest runs over 2 hours old (critical)" do
+      # Digest runs must be created after 8am to validate
+      travel_to("10:00") do
+        create(:digest_run, created_at: 2.days.ago, date: 2.days.ago)
+        create(:digest_run, created_at: 21.minutes.ago, date: Time.zone.today)
+        expect(GovukStatsd).to receive(:gauge).with("digest_runs.critical_total", 1)
+        described_class.call
+      end
     end
   end
 end


### PR DESCRIPTION
As DigestRun models only validate when they are created at 8am this test
will fail on any PR's raised before then (normally Dependabot, thankfully
none of us work through the night).

This also applies some minor refactoring where the class and test were
more fragmented than needed.