### PR TITLE
Add historical data deletion worker

### DIFF
--- a/app/workers/historical_data_deletion_worker.rb
+++ b/app/workers/historical_data_deletion_worker.rb
@@ -1,0 +1,32 @@
+class HistoricalDataDeletionWorker < ApplicationWorker
+  def perform
+    # cascades matched content changes
+    ContentChange.where("created_at < ?", retention_period).delete_all
+
+    # cascades matched messages
+    Message.where("created_at < ?", retention_period).delete_all
+
+    # cascades digest run subscribers
+    DigestRun.where("created_at < ?", retention_period).delete_all
+
+    # deleting subscriptions must be done before deleting subscriber lists or subscribers
+    Subscription.where("ended_at < ?", retention_period).delete_all
+
+    empty_subscriber_lists.delete_all
+
+    # restricts deletion if emails are present
+    Subscriber.where("deactivated_at < ?", retention_period).delete_all
+  end
+
+private
+
+  def retention_period
+    @retention_period ||= 1.year.ago
+  end
+
+  def empty_subscriber_lists
+    SubscriberList.left_outer_joins(:subscriptions)
+                  .where("subscriber_lists.created_at < ?", retention_period)
+                  .where("subscriptions.id": nil)
+  end
+end

--- a/spec/workers/historical_data_deletion_worker.rb
+++ b/spec/workers/historical_data_deletion_worker.rb
@@ -1,0 +1,93 @@
+RSpec.describe HistoricalDataDeletionWorker do
+  describe "#perform" do
+    let(:historic_date) { 2.years.ago }
+
+    def perform
+      described_class.new.perform
+    end
+
+    context "when deleting content changes" do
+      it "should remove all old content changes" do
+        create(:content_change, created_at: historic_date)
+        expect { perform }.to change(ContentChange, :count).by(-1)
+      end
+
+      it "shouldn't remove recent content changes" do
+        create(:content_change)
+        expect { perform }.to_not change(ContentChange, :count)
+      end
+    end
+
+    context "when deleting messages" do
+      it "should remove all old messages" do
+        create(:message, created_at: historic_date)
+        expect { perform }.to change(Message, :count).by(-1)
+      end
+
+      it "shouldn't remove recent messages" do
+        create(:content_change)
+        expect { perform }.to_not change(Message, :count)
+      end
+    end
+
+    context "when deleting digest runs" do
+      it "should remove all old digest runs" do
+        create(:digest_run, created_at: historic_date)
+        expect { perform }.to change(DigestRun, :count).by(-1)
+      end
+
+      it "shouldn't remove recent digest runs" do
+        create(:digest_run)
+        expect { perform }.to_not change(DigestRun, :count)
+      end
+    end
+
+    context "when deleting subscriptions" do
+      it "should remove all old subscriptions which have ended" do
+        create(:subscription, ended_at: historic_date)
+        expect { perform }.to change(Subscription, :count).by(-1)
+      end
+
+      it "shouldn't remove active subscriptions" do
+        create(:subscription)
+        expect { perform }.to_not change(Subscription, :count)
+      end
+    end
+
+    context "when deleting subscriber lists" do
+      it "should remove all old subscriber lists which have no subscriptions" do
+        create(:subscriber_list, created_at: historic_date)
+        expect { perform }.to change(SubscriberList, :count).by(-1)
+      end
+
+      it "should remove all old subscriber lists which have no recent active subscriptions" do
+        subscriber_list = create(:subscriber_list, created_at: historic_date)
+        create(:subscription, ended_at: historic_date, subscriber_list: subscriber_list)
+        expect { perform }.to change(SubscriberList, :count).by(-1)
+      end
+
+      it "shouldn't remove subscriber lists which have active subscriptions" do
+        create(:subscription)
+        expect { perform }.to_not change(SubscriberList, :count)
+      end
+
+      it "shouldn't remove subscriber lists which have recent active subscriptions" do
+        subscriber_list = create(:subscriber_list, created_at: historic_date)
+        create(:subscription, ended_at: 1.week.ago, subscriber_list: subscriber_list)
+        expect { perform }.to_not change(SubscriberList, :count)
+      end
+    end
+
+    context "when deleting subscribers" do
+      it "should remove all old deactivated subscribers" do
+        create(:subscriber, deactivated_at: historic_date)
+        expect { perform }.to change(Subscriber, :count).by(-1)
+      end
+
+      it "shouldn't remove active subscribers" do
+        create(:subscriber)
+        expect { perform }.to_not change(Subscriber, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses the cleanup of redundant records from our database.

Currently we don't have a process to remove historic unused data for a
number of our models. This commit adds a worker which will remove this
data when a retention period has been reached (1 year).

After merging the PR's above we can run the historic data deletion worker. The index PR speeds this deletion up which is shown in the run in integration (total time ~7 minutes 20 seconds):

```
2020-10-19T13:52:36.037Z 22058 TID-yye INFO: Deleted 148294 content changes in 14.65 seconds
2020-10-19T13:52:36.253Z 22058 TID-yye INFO: Deleted 15 messages in 0.22 seconds
2020-10-19T13:56:37.579Z 22058 TID-yye INFO: Deleted 674 digest runs in 241.33 seconds
2020-10-19T13:58:39.073Z 22058 TID-yye INFO: Deleted 1043947 subscription in 121.49 seconds
2020-10-19T13:58:52.231Z 22058 TID-yye INFO: Deleted 11470 subscriber lists in 13.16 seconds
2020-10-19T13:59:45.886Z 22058 TID-yye INFO: Deleted 195432 subscribers in 53.66 seconds
```

Previously the query got stuck when deleting subscribers and didn't complete due to slow constraint checks (went on for hours before forcefully exiting the query). Other model deletions were also slow but have been made to be more efficient through the [index PR](https://github.com/alphagov/email-alert-api/pull/1442).

More info in the commits ->

Depends on:   

- [ ] [Restrict subscriber deletion if emails present](https://github.com/alphagov/email-alert-api/pull/1437)
- [ ] [Delete lingering subscription contents](https://github.com/alphagov/email-alert-api/pull/1440)
- [ ] [Adding foreign key indexes for certain tables](https://github.com/alphagov/email-alert-api/pull/1442)
- [ ] [Make emails deleteable after a week](https://github.com/alphago/email-alert-api/pull/1439) 

Trello:
https://trello.com/c/tfu9zXuy/534-delete-unused-data-after-a-year