### PR TITLE
Restrict deleting subscribers if emails exist

### DIFF
--- a/db/migrate/20201020153450_change_foreign_key_constraint_for_emails.rb
+++ b/db/migrate/20201020153450_change_foreign_key_constraint_for_emails.rb
@@ -1,0 +1,6 @@
+class ChangeForeignKeyConstraintForEmails < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :emails, :subscribers
+    add_foreign_key :emails, :subscribers, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_19_154701) do
+ActiveRecord::Schema.define(version: 2020_10_20_153450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,7 +206,7 @@ ActiveRecord::Schema.define(version: 2020_10_19_154701) do
   add_foreign_key "delivery_attempts", "emails", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "digest_runs", on_delete: :cascade
   add_foreign_key "digest_run_subscribers", "subscribers", on_delete: :cascade
-  add_foreign_key "emails", "subscribers", name: "emails_subscriber_id_fk", on_delete: :cascade
+  add_foreign_key "emails", "subscribers", on_delete: :restrict
   add_foreign_key "matched_content_changes", "content_changes", on_delete: :cascade
   add_foreign_key "matched_content_changes", "subscriber_lists", on_delete: :cascade
   add_foreign_key "matched_messages", "messages", on_delete: :cascade


### PR DESCRIPTION
We want to change the behaviour of the db to restrict the deletion of
subscribers if they have associated emails, the previous behaviour was
to cascade the emails.

We don't want to do that anymore as we introduce a job to cleanup old
[subscribers] as emails shouldn't exist at the point of subscriber
deletion and if they do then we should raise an error.

I'm not sure why this foreign key was specifically named as I find no mention of it 
in the code so have removed.

Trello:
https://trello.com/c/tfu9zXuy/534-delete-unused-data-after-a-year

[subscribers]: https://github.com/alphagov/email-alert-api/pull/1432