### PR TITLE
Delete all lingering subscription contents

### DIFF
--- a/db/migrate/20201019154701_delete_lingering_subscription_contents.rb
+++ b/db/migrate/20201019154701_delete_lingering_subscription_contents.rb
@@ -1,0 +1,7 @@
+class DeleteLingeringSubscriptionContents < ActiveRecord::Migration[6.0]
+  class SubscriptionContent < ApplicationRecord; end
+
+  def up
+    SubscriptionContent.where("created_at < '2020-06-23'").delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_16_164443) do
+ActiveRecord::Schema.define(version: 2020_10_19_154701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We need to delete existing lingering subscription contents to be able to
delete a few models in the cleanup worker as database restrictions limit
the deletion of subscriptions, content changes and messages if they have
associated subscription contents.

These lingering subscription contents exist due to a historic bug which
was fixed when we [reworked some workers] in email-alert-api, there are
around 34,283 of these.

We can see evidence of this when looking at the most recent lingering
subscription content and when this PR was deployed.

Deployed:
Mon Jun 22 09:45:47 2020 +0100 (8:45 UTC)

Most recent lingering subscription content: irb(main):002:0>
SubscriptionContent.where("created_at < ?",
2.weeks.ago).order(:created_at).last.created_at => Mon, 22 Jun 2020
09:51:31 BST +01:00

The reason for this is previously emails and subscription contents were
not both being created inside the same transaction which meant if there
were any issues with the worker (exiting midway through etc) then we
could be left in an inconsistent state where a subscription content has
no corresponding email as they were being created [first].

[Since 22 June] we’ve addressed this issue and both are now being
created inside a transaction and the locking behaviour has been rejigged
which means we don’t have any lingering subscriptions contents.

Count of subscription contents after 22nd: irb(main):004:0>
SubscriptionContent.where("created_at < ? AND created_at > ?",
9.days.ago, Time.zone.parse("2020/06/22 09:52:00")).count => 0

[reworked some workers]: https://github.com/alphagov/email-alert-api/pull/1284
[first]: https://github.com/alphagov/email-alert-api/blob/decc7b1d64937ec7ee1d5fc689c5b8def830c905/app/workers/process_content_change_and_generate_emails_worker.rb#L12
[Since 22 June]: https://github.com/alphagov/email-alert-api/commit/fdec17c576963f0f67e82bd02cd829ca4debe122#diff-17c86afb266aaf1f289b752880449c957a8653fa5a28f27e32d76f06fcdeee42R12-R18

Trello:
https://trello.com/c/tfu9zXuy/534-delete-unused-data-after-a-year