### PR TITLE
Add indexes for historical data deletion

### DIFF
--- a/db/migrate/20201016164726_add_foreign_key_indexes_for_subscriber_id.rb
+++ b/db/migrate/20201016164726_add_foreign_key_indexes_for_subscriber_id.rb
@@ -1,0 +1,8 @@
+class AddForeignKeyIndexesForSubscriberId < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :emails, :subscriber_id, algorithm: :concurrently
+    add_index :digest_run_subscribers, :subscriber_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20201019110929_add_index_for_digest_run_id_on_digest_run_subscribers.rb
+++ b/db/migrate/20201019110929_add_index_for_digest_run_id_on_digest_run_subscribers.rb
@@ -1,0 +1,7 @@
+class AddIndexForDigestRunIdOnDigestRunSubscribers < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :digest_run_subscribers, :digest_run_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20201019112513_add_index_for_message_id_on_subscription_contents.rb
+++ b/db/migrate/20201019112513_add_index_for_message_id_on_subscription_contents.rb
@@ -1,0 +1,7 @@
+class AddIndexForMessageIdOnSubscriptionContents < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :subscription_contents, :message_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_20_153450) do
+ActiveRecord::Schema.define(version: 2020_10_16_164726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_10_20_153450) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["digest_run_id", "subscriber_id"], name: "index_digest_run_subscribers_on_digest_run_id_and_subscriber_id", unique: true
+    t.index ["subscriber_id"], name: "index_digest_run_subscribers_on_subscriber_id"
   end
 
   create_table "digest_runs", force: :cascade do |t|
@@ -88,6 +89,7 @@ ActiveRecord::Schema.define(version: 2020_10_20_153450) do
     t.index ["address"], name: "index_emails_on_address"
     t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["created_at"], name: "index_emails_on_created_at"
+    t.index ["subscriber_id"], name: "index_emails_on_subscriber_id"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_19_110929) do
+ActiveRecord::Schema.define(version: 2020_10_20_153450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2020_10_19_110929) do
     t.index ["content_change_id"], name: "index_subscription_contents_on_content_change_id"
     t.index ["digest_run_subscriber_id"], name: "index_subscription_contents_on_digest_run_subscriber_id"
     t.index ["email_id"], name: "index_subscription_contents_on_email_id"
+    t.index ["message_id"], name: "index_subscription_contents_on_message_id"
     t.index ["subscription_id", "content_change_id"], name: "index_subscription_contents_on_subscription_and_content_change", unique: true
     t.index ["subscription_id", "message_id"], name: "index_subscription_contents_on_subscription_id_and_message_id", unique: true
     t.index ["subscription_id"], name: "index_subscription_contents_on_subscription_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_16_164726) do
+ActiveRecord::Schema.define(version: 2020_10_19_110929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_10_16_164726) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["digest_run_id", "subscriber_id"], name: "index_digest_run_subscribers_on_digest_run_id_and_subscriber_id", unique: true
+    t.index ["digest_run_id"], name: "index_digest_run_subscribers_on_digest_run_id"
     t.index ["subscriber_id"], name: "index_digest_run_subscribers_on_subscriber_id"
   end
 


### PR DESCRIPTION
These foreign key indexes are needed so we can efficiently delete [historic] data from the database. Previously we tried running the new worker without these indexes and certain queries took an obscene amount of time due to the constraints we have setup on certain tables.

One example of the improved run time was the total time of deleting 15 messages including its constraints (matched messages and subscription contents). Without an index for the message_id on the subscription contents table the query took 77 seconds vs 0.22 seconds which is a sizeable speed boost.

More info (before and afters) are found within the commits ->

Trello:
https://trello.com/c/tfu9zXuy/534-delete-unused-data-after-a-year

[historic]: https://github.com/alphagov/email-alert-api/pull/1432