### PR TITLE
Schedule the deletion of historical data

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,6 +20,9 @@
   weekly_digest_initiator:
     cron: '30 8 * * 6 Europe/London' # every Saturday at 8:30am
     class: WeeklyDigestInitiatorWorker
+  historical_data_deletion:
+    cron: '0 12 * * * Europe/London' # every day at midday
+    class: HistoricalDataDeletionWorker
   nullify_deactivated_subscribers:
     every: '1h'
     class: NullifyDeactivatedSubscribersWorker


### PR DESCRIPTION
Schedule HistoricalDataDeletionWorker to run every day at midday.

The bulk of records to be deleted are digest run subscribers which we
are currently producing at around ~400,000 per day, these on average are
created within 30 minutes in the morning of each digest run.

The combined amount of the rest deletions per day from the other models
comes to under 10k per day.

We could delete in batches for digest run subscribers but wasn't sure
that was necessary as in integration it only took around 13 seconds to
delete 400k digest run subscribers which is fairly quick (this is likely to 
be even faster now indexes have been added [here]).

Depends on:
https://github.com/alphagov/email-alert-api/pull/1432

[here]: https://github.com/alphagov/email-alert-api/pull/1442/files

Trello:
https://trello.com/c/tfu9zXuy/534-delete-unused-data-after-a-year