### PR TITLE
Remove transitionary code for #1438

### DIFF
--- a/app/workers/send_email_worker.rb
+++ b/app/workers/send_email_worker.rb
@@ -57,6 +57,3 @@ private
     end
   end
 end
-
-# For backwards compatibility
-DeliveryRequestWorker = SendEmailWorker

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,15 +6,11 @@
 :queues:
   # See here to understand priorities: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
   # Use powers of 2: higher priority groups are checked twice as often.
-  - [delivery_transactional, 8] # Legacy: To send one-off emails, such as subscription confirmation.
   - [send_email_transactional, 8] # To send one-off emails, such as subscription confirmation.
-  - [delivery_immediate_high, 8] # Legacy: To send high priority emails to users with immediate subscriptions e.g. travel advice.
   - [send_email_immediate_high, 8] # To send high priority emails to users with immediate subscriptions e.g. travel advice.
   - [process_and_generate_emails, 4] # To generate emails to users with immediate subscriptions for content changes and messages.
   - [email_generation_digest, 4] # To generate emails to users with daily or weekly subscriptions for content changes and messages.
-  - [delivery_immediate, 2] # Legacy: To send emails to users with immediate subscriptions.
   - [send_email_immediate, 2] # To send emails to users with immediate subscriptions.
-  - [delivery_digest, 2] # Legacy: To send digest emails to users with either daily or weekly subscriptions.
   - [send_email_digest, 2] # To send digest emails to users with either daily or weekly subscriptions.
   - [default, 1] # Miscellaneous operations e.g. initiating digest runs, monitoring, DB cleanup and recovering lost Sidekiq jobs.
 :schedule:

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -48,8 +48,6 @@ class Metrics
     def content_change_created_until_email_sent(created_time, sent_time)
       difference = (sent_time - created_time) * 1000
       timing("content_change_created_until_email_sent", difference)
-      # legacy - to be removed once dashboard is updated
-      timing("content_change_created_to_first_delivery_attempt", difference)
     end
 
   private


### PR DESCRIPTION
Trello: https://trello.com/c/Xd47oJKZ/535-remove-the-deliveryattempt-model

This removes code that was left for backwards compatibility during the
migration of the queue names, worker names and metrics in https://github.com/alphagov/email-alert-api/pull/1438