### PR TITLE
Use Ruby 2.7 argument forwarding operator

### DIFF
--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -5,8 +5,8 @@ class BulkSubscriberListEmailBuilder
     @subscriber_lists = subscriber_lists
   end
 
-  def self.call(**args)
-    new(**args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -3,8 +3,8 @@ class ContentChangeEmailBuilder
     @recipients_and_content = recipients_and_content
   end
 
-  def self.call(*args)
-    new(*args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -6,8 +6,8 @@ class DigestEmailBuilder
     @subscriber_id = subscriber_id
   end
 
-  def self.call(**args)
-    new(**args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/builders/message_email_builder.rb
+++ b/app/builders/message_email_builder.rb
@@ -3,8 +3,8 @@ class MessageEmailBuilder
     @recipients_and_messages = recipients_and_messages
   end
 
-  def self.call(*args)
-    new(*args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/builders/subscriber_auth_email_builder.rb
+++ b/app/builders/subscriber_auth_email_builder.rb
@@ -5,8 +5,8 @@ class SubscriberAuthEmailBuilder
     @token = token
   end
 
-  def self.call(**args)
-    new(**args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/builders/subscription_auth_email_builder.rb
+++ b/app/builders/subscription_auth_email_builder.rb
@@ -6,8 +6,8 @@ class SubscriptionAuthEmailBuilder
     @frequency = frequency
   end
 
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -3,8 +3,8 @@ class SubscriptionConfirmationEmailBuilder
     @subscription = subscription
   end
 
-  def self.call(**args)
-    new(**args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/builders/unpublish_email_builder.rb
+++ b/app/builders/unpublish_email_builder.rb
@@ -1,6 +1,6 @@
 class UnpublishEmailBuilder
-  def self.call(*args)
-    new.call(*args)
+  def self.call(...)
+    new.call(...)
   end
 
   def call(emails, template)

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -8,8 +8,8 @@ class ContentChangePresenter
     @frequency = frequency
   end
 
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/presenters/email_archive_presenter.rb
+++ b/app/presenters/email_archive_presenter.rb
@@ -3,8 +3,8 @@ class EmailArchivePresenter
 
   # This is expected to be called with a JSON representation of a record
   # returned from EmailArchiveQuery
-  def self.for_s3(*args)
-    new.for_s3(*args)
+  def self.for_s3(...)
+    new.for_s3(...)
   end
 
   def for_s3(record, archived_at)

--- a/app/presenters/manage_subscriptions_link_presenter.rb
+++ b/app/presenters/manage_subscriptions_link_presenter.rb
@@ -3,8 +3,8 @@ class ManageSubscriptionsLinkPresenter
     @address = address
   end
 
-  def self.call(*args)
-    new(*args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -4,8 +4,8 @@ class MessagePresenter
     @frequency = frequency
   end
 
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/presenters/unsubscribe_link_presenter.rb
+++ b/app/presenters/unsubscribe_link_presenter.rb
@@ -4,8 +4,8 @@ class UnsubscribeLinkPresenter
     @title = title
   end
 
-  def self.call(*args)
-    new(*args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/queries/digest_items_query.rb
+++ b/app/queries/digest_items_query.rb
@@ -6,8 +6,8 @@ class DigestItemsQuery
     @digest_run = digest_run
   end
 
-  def self.call(*args)
-    new(*args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/queries/subscriber_lists_by_criteria_query.rb
+++ b/app/queries/subscriber_lists_by_criteria_query.rb
@@ -1,6 +1,6 @@
 class SubscriberListsByCriteriaQuery
-  def self.call(*args)
-    new(*args).call
+  def self.call(...)
+    new(...).call
   end
 
   def initialize(initial_scope, criteria_rules)

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,6 +1,6 @@
 class ApplicationService
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
+  def self.call(...)
+    new(...).call
   end
 
   private_class_method :new

--- a/app/services/auth_token_generator_service.rb
+++ b/app/services/auth_token_generator_service.rb
@@ -9,8 +9,8 @@ class AuthTokenGeneratorService < ApplicationService
     @expiry = expiry
   end
 
-  def self.call(*args)
-    new(*args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call

--- a/app/services/immediate_email_generation_service.rb
+++ b/app/services/immediate_email_generation_service.rb
@@ -1,7 +1,7 @@
 class ImmediateEmailGenerationService < ApplicationService
   BATCH_SIZE = 5000
 
-  def initialize(content, **)
+  def initialize(content)
     @content = content
   end
 

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -1,5 +1,5 @@
 class MatchedContentChangeGenerationService < ApplicationService
-  def initialize(content_change, **)
+  def initialize(content_change)
     @content_change = content_change
   end
 

--- a/app/services/matched_message_generation_service.rb
+++ b/app/services/matched_message_generation_service.rb
@@ -1,5 +1,5 @@
 class MatchedMessageGenerationService < ApplicationService
-  def initialize(message, **)
+  def initialize(message)
     @message = message
   end
 

--- a/app/services/s3_email_archive_service.rb
+++ b/app/services/s3_email_archive_service.rb
@@ -3,7 +3,7 @@ class S3EmailArchiveService < ApplicationService
 
   # For batch we expect an array of hashes containing email data in the format
   # from EmailArchivePresenter
-  def initialize(batch, **)
+  def initialize(batch)
     @batch = batch
   end
 

--- a/app/services/send_email_service/delay_provider.rb
+++ b/app/services/send_email_service/delay_provider.rb
@@ -1,6 +1,6 @@
 class SendEmailService::DelayProvider
-  def self.call(**args)
-    new.call(**args)
+  def self.call(...)
+    new.call(...)
   end
 
   def call(**_args)

--- a/app/services/send_email_service/notify_provider.rb
+++ b/app/services/send_email_service/notify_provider.rb
@@ -4,8 +4,8 @@ class SendEmailService::NotifyProvider
     @template_id = EmailAlertAPI.config.notify.fetch(:template_id)
   end
 
-  def self.call(**args)
-    new.call(**args)
+  def self.call(...)
+    new.call(...)
   end
 
   def call(address:, subject:, body:, reference:)

--- a/app/services/send_email_service/pseudo_provider.rb
+++ b/app/services/send_email_service/pseudo_provider.rb
@@ -1,8 +1,8 @@
 class SendEmailService::PseudoProvider
   LOG_PATH = Rails.root.join("log/pseudo_email.log").freeze
 
-  def self.call(**args)
-    new.call(**args)
+  def self.call(...)
+    new.call(...)
   end
 
   def call(address:, subject:, body:, reference:)

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -13,7 +13,7 @@ class UnpublishHandlerService < ApplicationService
 
   attr_reader :content_id, :redirect
 
-  def initialize(content_id, redirect, **)
+  def initialize(content_id, redirect)
     @content_id = content_id
     @redirect = redirect
   end

--- a/app/services/unsubscribe_all_service.rb
+++ b/app/services/unsubscribe_all_service.rb
@@ -1,7 +1,7 @@
 class UnsubscribeAllService < ApplicationService
   attr_reader :subscriber, :reason
 
-  def initialize(subscriber, reason, **)
+  def initialize(subscriber, reason)
     @subscriber = subscriber
     @reason = reason
   end

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -1,7 +1,7 @@
 class UnsubscribeService < ApplicationService
   attr_reader :subscriber, :subscriptions, :reason
 
-  def initialize(subscriber, subscriptions, reason, **)
+  def initialize(subscriber, subscriptions, reason)
     @subscriber = subscriber
     @subscriptions = subscriptions
     @reason = reason

--- a/lib/notifications_from_notify.rb
+++ b/lib/notifications_from_notify.rb
@@ -4,8 +4,8 @@ class NotificationsFromNotify
     @template_id = config.fetch(:template_id)
   end
 
-  def self.call(*args)
-    new.call(*args)
+  def self.call(...)
+    new.call(...)
   end
 
   def call(reference)

--- a/lib/reports/brexit_subscribers_report.rb
+++ b/lib/reports/brexit_subscribers_report.rb
@@ -8,13 +8,12 @@ class Reports::BrexitSubscribersReport
     @date = date
   end
 
-  def self.call(*args)
-    new(args).call
+  def self.call(...)
+    new(...).call
   end
 
   def call
-    subscriber_lists =
-      date.empty? ? brexit_lists : brexit_lists_before_date
+    subscriber_lists = date ? brexit_lists_before_date : brexit_lists
     CSV.instance($stdout, headers: CSV_HEADERS, write_headers: true) do |csv|
       subscriber_lists.each do |list|
         csv << row_data(list)
@@ -23,12 +22,6 @@ class Reports::BrexitSubscribersReport
   end
 
 private
-
-  def parsed_date
-    unless date.empty?
-      @parsed_date ||= Date.parse(date.to_s)
-    end
-  end
 
   def brexit_lists
     @brexit_lists ||= SubscriberList.where("subscriber_lists.tags->>'brexit_checklist_criteria' IS NOT NULL")
@@ -39,11 +32,9 @@ private
   end
 
   def subscribed_to_before_date(list)
-    subscriptions =
-      list.subscribers.select do |subscriber|
-        subscriber.created_at <= parsed_date
-      end
-    subscriptions.any?
+    list.subscribers.any? do |subscriber|
+      subscriber.created_at <= date
+    end
   end
 
   def row_data(list)

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -33,12 +33,13 @@ namespace :report do
   task :csv_brexit_subscribers_on_or_before, [:date] => [:environment] do |_task, args|
     raise "Enter a date" if args[:date].empty?
 
-    begin
-      Date.parse(args[:date].to_s)
-    rescue ArgumentError
-      puts 'Invalid date. Please use "yyyy-mm-dd"'
-    end
-    Reports::BrexitSubscribersReport.call(args[:date])
+    date = begin
+             Date.parse(args[:date].to_s)
+           rescue ArgumentError
+             raise 'Invalid date. Please use "yyyy-mm-dd"'
+           end
+
+    Reports::BrexitSubscribersReport.call(date)
   end
 
   desc "Temporary report for subscribers taking action in switching immediate subscribers to daily digest"


### PR DESCRIPTION
This applies the `...` operator in this app. This feature was introduced in Ruby 2.7 and is the equivalent to `def method(*args, **kwargs, &block)`. This has been done to reduce the clutter we've acquired in places where we do in argument forwarding with various usages of empty double splats to satisfy method definitions.

More info in the commits.