### PR TITLE
Catch Net::ReadTimeout errors from Notify

### DIFF
--- a/app/services/send_email_service/notify_provider.rb
+++ b/app/services/send_email_service/notify_provider.rb
@@ -21,7 +21,7 @@ class SendEmailService::NotifyProvider
 
     Metrics.sent_to_notify_successfully
     :sent
-  rescue Notifications::Client::RequestError, Net::OpenTimeout => e
+  rescue Notifications::Client::RequestError, Net::OpenTimeout, Net::ReadTimeout => e
     Metrics.failed_to_send_to_notify
 
     Rails.logger.warn(

--- a/spec/services/send_email_service/notify_provider_spec.rb
+++ b/spec/services/send_email_service/notify_provider_spec.rb
@@ -43,12 +43,14 @@ RSpec.describe SendEmailService::NotifyProvider do
         .to be(:provider_communication_failure)
     end
 
-    it "returns a provider_communication_failure status for a Notify Timeout" do
+    it "returns a provider_communication_failure status for Notify timeouts" do
       allow(Notifications::Client).to receive(:new).and_return(notify_client)
-      allow(notify_client).to receive(:send_email).and_raise(Net::OpenTimeout)
 
-      expect(described_class.call(**arguments))
-        .to be(:provider_communication_failure)
+      allow(notify_client).to receive(:send_email).and_raise(Net::OpenTimeout)
+      expect(described_class.call(**arguments)).to be(:provider_communication_failure)
+
+      allow(notify_client).to receive(:send_email).and_raise(Net::ReadTimeout)
+      expect(described_class.call(**arguments)).to be(:provider_communication_failure)
     end
 
     it "returns a provider_communication_failure status for a Notify rejecting an email address" do


### PR DESCRIPTION
We saw one of these come through to our error handling today. I had
thought we had covered timeouts previously with checking for
Net::OpenTimeout and didn't realise it had a sibling.

I did consider whether to catch the superclass of these, Timeout::Error,
but decided that this wasn't the best approach as Timeout::Error seems
unrelated to Net communications and I felt that it would be strange to
either a) not test the exceptions we expect or b) test against different
exceptions than the code.