### PR TITLE
Add reporting list task

### DIFF
--- a/lib/reports/subscriber_lists_report.rb
+++ b/lib/reports/subscriber_lists_report.rb
@@ -1,0 +1,69 @@
+class Reports::SubscriberListsReport
+  attr_reader :date
+
+  CSV_HEADERS = %i[title
+                   slug
+                   matching_criteria
+                   created_at
+                   individual_subscribers
+                   daily_subscribers
+                   weekly_subscribers
+                   unsubscriptions
+                   matched_content_changes_for_date
+                   matched_messages_for_date].freeze
+
+  def initialize(date)
+    @date = Time.zone.parse(date)
+  end
+
+  def call
+    CSV do |csv|
+      csv << CSV_HEADERS
+
+      SubscriberList.where("created_at < ?", date.end_of_day).find_each do |list|
+        csv << export_list_row(list)
+      end
+    end
+  end
+
+private
+
+  def export_list_row(list)
+    unsubscriptions_count = list.subscriptions.where("ended_at <= ?", date.end_of_day).count
+    scope = list.subscriptions.active_on(date.end_of_day)
+
+    [list.title,
+     list.slug,
+     criteria(list),
+     list.created_at,
+     scope.immediately.count,
+     scope.daily.count,
+     scope.weekly.count,
+     unsubscriptions_count,
+     matched_content_changes_count(list),
+     matched_messages_count(list)]
+  end
+
+  def criteria(list)
+    list.as_json(root: false,
+                 only: %i[links
+                          tags
+                          email_document_supertype
+                          government_document_supertype
+                          document_type]).to_json
+  end
+
+  def matched_content_changes_count(list)
+    MatchedContentChange
+      .where(subscriber_list: list)
+      .where("created_at > ? AND created_at <= ?", date.beginning_of_day, date.end_of_day)
+      .count
+  end
+
+  def matched_messages_count(list)
+    MatchedMessage
+      .where(subscriber_list: list)
+      .where("created_at > ? AND created_at <= ?", date.beginning_of_day, date.end_of_day)
+      .count
+  end
+end

--- a/lib/reports/subscriber_lists_report.rb
+++ b/lib/reports/subscriber_lists_report.rb
@@ -17,6 +17,8 @@ class Reports::SubscriberListsReport
   end
 
   def call
+    validate_date
+
     CSV do |csv|
       csv << CSV_HEADERS
 
@@ -27,6 +29,12 @@ class Reports::SubscriberListsReport
   end
 
 private
+
+  def validate_date
+    raise "Invalid date" if date.blank?
+    raise "Date must be in the past" if date >= Time.zone.today
+    raise "Date must be within a year old" if date <= 1.year.ago
+  end
 
   def export_list_row(list)
     unsubscriptions_count = list.subscriptions.where("ended_at <= ?", date.end_of_day).count

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -40,4 +40,9 @@ namespace :report do
     end
     Reports::BrexitSubscribersReport.call(args[:date])
   end
+
+  desc "Outputs a CSV of information for each subscriber list within a year for a past date, format: 'yyyy-mm-dd'"
+  task :csv_subscriber_lists, [:date] => :environment do |_t, args|
+    Reports::SubscriberListsReport.new(args[:date]).call
+  end
 end

--- a/spec/lib/reports/subscriber_lists_report_spec.rb
+++ b/spec/lib/reports/subscriber_lists_report_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Reports::SubscriberListsReport do
+  before do
+    created_at = Time.zone.parse("2020-06-15").midday
+    list = create(:subscriber_list, created_at: created_at, title: "list 1", slug: "list-1")
+
+    create(:subscription, :immediately, subscriber_list: list, created_at: created_at)
+    create(:subscription, :daily, subscriber_list: list, created_at: created_at)
+    create(:subscription, :weekly, subscriber_list: list, created_at: created_at)
+    create(:subscription, :ended, ended_at: created_at, subscriber_list: list, created_at: created_at)
+
+    create(:matched_content_change, subscriber_list: list, created_at: created_at)
+    create(:matched_message, subscriber_list: list, created_at: created_at)
+  end
+
+  it "returns data around active lists for the given date" do
+    csv = <<~CSV
+      #{Reports::SubscriberListsReport::CSV_HEADERS.join(',')}
+      list 1,list-1,"{""document_type"":"""",""tags"":{""topics"":{""any"":[""motoring/road_rage""]}},""links"":{},""email_document_supertype"":"""",""government_document_supertype"":""""}",2020-06-15 12:00:00 +0100,1,1,1,1,1,1
+    CSV
+
+    expect { described_class.new("2020-06-15").call }.to output(csv).to_stdout
+  end
+
+  it "returns empty csv if there are no active subscriber lists for the given date" do
+    empty_csv = <<~CSV
+      #{Reports::SubscriberListsReport::CSV_HEADERS.join(',')}
+    CSV
+
+    expect { described_class.new("2020-05-01").call }.to output(empty_csv).to_stdout
+  end
+end

--- a/spec/lib/reports/subscriber_lists_report_spec.rb
+++ b/spec/lib/reports/subscriber_lists_report_spec.rb
@@ -28,4 +28,19 @@ RSpec.describe Reports::SubscriberListsReport do
 
     expect { described_class.new("2020-05-01").call }.to output(empty_csv).to_stdout
   end
+
+  it "raises an error if the date is invalid" do
+    expect { described_class.new("blahhh").call }
+      .to raise_error("Invalid date")
+  end
+
+  it "raises an error if the date isn't in the past" do
+    expect { described_class.new(Time.zone.today.to_s).call }
+      .to raise_error("Date must be in the past")
+  end
+
+  it "raises an error if the date isn't within a year old" do
+    expect { described_class.new("2019-05-01").call }
+      .to raise_error("Date must be within a year old")
+  end
 end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -44,4 +44,11 @@ RSpec.describe "report" do
         .to output.to_stdout
     end
   end
+
+  describe "csv_subscriber_lists" do
+    it "outputs a report of data concerning subscriber lists for a given date" do
+      expect { Rake::Task["report:csv_subscriber_lists"].invoke(6.months.ago.to_s) }
+        .to output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
Add task to report on subscriber lists. This task is needed so non devs (and devs tbf) can freely access metrics around subscriber lists without having to concoct queries every-time. This will also be a feed of information our new product dashboard.

Took ~5 mins to run in integration:
https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/190098/console

The task outputs as a CSV to stdout.

More info in the commits ->

Trello:
https://trello.com/c/PRXBoZBu/576-create-a-one-stop-data-shop-report-task-for-all-subscriber-lists