### PR TITLE
Prepare to migrate non-migrated subscribers

### DIFF
--- a/app/builders/switch_to_daily_digest_email_builder.rb
+++ b/app/builders/switch_to_daily_digest_email_builder.rb
@@ -42,7 +42,7 @@ private
   end
 
   def manage_subscriptions_link
-    utm_campaign = "govuk-notifications-switch-to-daily-experiment-3"
+    utm_campaign = "govuk-notifications-switch-to-daily-covid-transition"
     utm_medium = "email"
     utm_source = "gov.uk"
     utm_content = "manage-subscriptions"

--- a/app/builders/switch_to_daily_digest_email_builder.rb
+++ b/app/builders/switch_to_daily_digest_email_builder.rb
@@ -1,0 +1,52 @@
+class SwitchToDailyDigestEmailBuilder
+  def initialize(subscriber, subscriptions)
+    @subscriber = subscriber
+    @subscriptions = subscriptions
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    Email.create!(
+      address: subscriber.address,
+      subject: "Your GOV.UK email subscriptions",
+      body: body,
+      subscriber_id: subscriber.id,
+    ).id
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscriber, :subscriptions
+
+  def body
+    <<~BODY
+      We've changed how often you get some emails from GOV.UK. We've done this to make the number of emails you get more manageable.
+
+      You'll now get one email a day that will list any changes to:
+
+      #{subscriptions.map { |subscription| "- #{subscription.subscriber_list.title}" }.join("\n")}
+
+      If you do not get an email about those topics, it's because there have been no changes.
+
+      We’ve not changed how often you get emails for any other GOV.UK subscriptions you may have. We’ve only changed the subscriptions listed in this email.
+
+      # If you want to go back to immediate emails
+
+      You can go back to getting immediate updates about these topics by [managing your subscriptions](#{manage_subscriptions_link}).
+    BODY
+  end
+
+  def manage_subscriptions_link
+    utm_campaign = "govuk-notifications-switch-to-daily-experiment-3"
+    utm_medium = "email"
+    utm_source = "gov.uk"
+    utm_content = "manage-subscriptions"
+    base_url = PublicUrls.authenticate_url(address: subscriber.address)
+    "#{base_url}&utm_source=#{utm_source}&utm_medium=#{utm_medium}&utm_campaign=#{utm_campaign}&utm_content=#{utm_content}"
+  end
+end

--- a/config/daily_digest_migration_lists.csv
+++ b/config/daily_digest_migration_lists.csv
@@ -1,0 +1,3 @@
+slug
+transition-p
+coronavirus-covid-19

--- a/lib/reports/subscription_changes_after_switch_to_daily_digest_report.rb
+++ b/lib/reports/subscription_changes_after_switch_to_daily_digest_report.rb
@@ -1,0 +1,30 @@
+require "csv"
+
+class Reports::SubscriptionChangesAfterSwitchToDailyDigestReport
+  def self.call
+    list_slugs = CSV.read(Rails.root.join("config/daily_digest_migration_lists.csv"), headers: true)
+                    .map { |c| c.fetch("slug") }
+
+    ended_subscriptions = Subscription
+      .joins(:subscriber_list)
+      .where(source: :bulk_immediate_to_digest, "subscriber_lists.slug": list_slugs)
+      .where.not(ended_at: nil)
+
+    most_recent_subscriptions = ended_subscriptions.map do |s|
+      Subscription
+        .includes(:subscriber_list)
+        .where(subscriber_id: s.subscriber_id, subscriber_list_id: s.subscriber_list_id)
+        .where("updated_at > ?", s.created_at)
+        .order(updated_at: :desc)
+        .first
+    end
+
+    puts(CSV.generate do |csv|
+      csv << %w[created_at ended_at frequency subscriber_id subscriber_list_slug]
+
+      most_recent_subscriptions.each do |s|
+        csv << [s.created_at, s.ended_at, s.frequency, s.subscriber_id, s.subscriber_list.slug]
+      end
+    end)
+  end
+end

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -1,6 +1,75 @@
 require "csv"
 
 namespace :data_migration do
+  desc "Experiment 3 in switching immediate subscribers to daily digest"
+  task switch_to_daily_digest_experiment: :environment do
+    lists = CSV.read(Rails.root.join("config/experiment_3_lists.csv"), headers: true)
+
+    list_count = SubscriberList.where(slug: lists.map { |l| l.fetch("slug") }).count
+    raise "One or more lists were not found" if lists.size != list_count
+
+    subscriber_and_subscription_ids = lists.each_with_object({}) do |list, memo|
+      subscription_scope = Subscription.active
+                                       .immediately
+                                       .joins(:subscriber_list)
+                                       .where("subscriber_lists.slug": list.fetch("slug"))
+
+      total = subscription_scope.count
+      to_migrate = (total * list.fetch("proportion").to_f).round
+      random_subscriptions = subscription_scope.limit(to_migrate)
+                                               .order("RANDOM()")
+                                               .pluck(:id, :subscriber_id)
+
+      random_subscriptions.each do |(subscription_id, subscriber_id)|
+        memo[subscriber_id] ||= []
+        memo[subscriber_id] << subscription_id
+      end
+
+      puts "Migrating #{random_subscriptions.size} of #{total} immediate subscribers of #{list.fetch('slug')}"
+    end
+
+    subscribers = Subscriber.where(id: subscriber_and_subscription_ids.keys)
+    subscribers.find_each.with_index do |subscriber, index|
+      email_id = nil
+      now = Time.zone.now
+      subscription_ids = subscriber_and_subscription_ids.fetch(subscriber.id)
+
+      subscriber.with_lock do
+        immediate_subscriptions = Subscription.active.immediately.where(id: subscription_ids)
+
+        new_subscriptions = immediate_subscriptions.map do |subscription|
+          {
+            subscriber_id: subscriber.id,
+            subscriber_list_id: subscription.subscriber_list_id,
+            frequency: :daily,
+            source: :bulk_immediate_to_digest,
+            created_at: now,
+            updated_at: now,
+          }
+        end
+
+        Subscription.where(id: immediate_subscriptions.map(&:id)).update_all(
+          ended_reason: :bulk_immediate_to_digest,
+          ended_at: now,
+        )
+
+        Subscription.insert_all!(new_subscriptions)
+
+        email_id = SwitchToDailyDigestEmailBuilder.call(
+          subscriber, immediate_subscriptions
+        )
+      end
+
+      DeliveryRequestWorker.perform_async_in_queue(email_id, queue: :default)
+
+      progress = index + 1
+      total = subscriber_and_subscription_ids.size
+      puts "Processed #{progress} of #{total} subscribers" if (progress % 1000).zero?
+    rescue StandardError => e
+      puts "Skipping subscriber #{subscriber.id}: #{e}"
+    end
+  end
+
   desc "Move all subscribers from one subscriber list to another"
   task :move_all_subscribers, %i[from_slug to_slug] => :environment do |_t, args|
     if ENV["SEND_EMAIL"]

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -1,8 +1,8 @@
 require "csv"
 
 namespace :data_migration do
-  desc "Experiment 3 in switching immediate subscribers to daily digest"
-  task switch_to_daily_digest_experiment: :environment do
+  desc "Switch immediate subscribers to daily digest"
+  task switch_to_daily_digest: :environment do
     lists = CSV.read(Rails.root.join("config/daily_digest_migration_lists.csv"), headers: true)
 
     list_count = SubscriberList.where(slug: lists.map { |l| l.fetch("slug") }).count

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -45,4 +45,9 @@ namespace :report do
   task :csv_subscriber_lists, [:date] => :environment do |_t, args|
     Reports::SubscriberListsReport.new(args[:date]).call
   end
+
+  desc "Temporary report for subscribers taking action in switching immediate subscribers to daily digest"
+  task subscription_changes_after_switch_to_daily_digest: :environment do
+    Reports::SubscriptionChangesAfterSwitchToDailyDigestReport.call
+  end
 end

--- a/spec/lib/tasks/data_migration_spec.rb
+++ b/spec/lib/tasks/data_migration_spec.rb
@@ -1,4 +1,113 @@
 RSpec.describe "data_migration" do
+  include NotifyRequestHelpers
+
+  describe "switch_to_daily_digest_experiment" do
+    let!(:list1) { create :subscriber_list }
+    let!(:list2) { create :subscriber_list }
+    let(:list_data) do
+      [
+        { "slug" => list1.slug, "proportion" => "1" },
+        { "slug" => list2.slug, "proportion" => "0.5" },
+      ]
+    end
+
+    before do
+      allow(CSV).to receive(:open).and_return(list_data)
+      Rake::Task["data_migration:switch_to_daily_digest_experiment"].reenable
+      stub_notify
+    end
+
+    it "switches immediate subscriptions to daily" do
+      subscription = create :subscription, subscriber_list: list1, frequency: :immediately
+
+      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+        .to output.to_stdout
+
+      new_subscription = subscription.subscriber.subscriptions.active.first
+
+      expect(subscription.reload).to be_ended
+      expect(subscription.ended_reason).to eq "bulk_immediate_to_digest"
+
+      expect(new_subscription.frequency).to eq "daily"
+      expect(new_subscription.source).to eq "bulk_immediate_to_digest"
+    end
+
+    it "does not change other subscriptions" do
+      digest = create :subscription, subscriber_list: list1, frequency: :daily
+      non_list = create :subscription, frequency: :immediately
+
+      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+        .to output.to_stdout
+
+      expect(digest.reload).not_to be_ended
+      expect(non_list.reload).not_to be_ended
+    end
+
+    it "can change a proportion of subscriptions" do
+      create_list :subscription, 4, subscriber_list: list2, frequency: :immediately
+
+      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+        .to output.to_stdout
+        .and change { Subscription.active.immediately.where(subscriber_list: list2).count }
+        .from(4)
+        .to(2)
+    end
+
+    it "sends a summary email to affected subscribers" do
+      subscriber = create :subscriber
+      create :subscription, subscriber_list: list1, frequency: :immediately, subscriber: subscriber
+      create :subscription, subscriber_list: list2, frequency: :immediately, subscriber: subscriber
+
+      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+        .to output.to_stdout
+
+      email_data = expect_an_email_was_sent
+      expect(email_data[:email_address]).to eq(subscriber.address)
+      expect(email_data[:personalisation][:subject]).to eq("Your GOV.UK email subscriptions")
+      expect(email_data[:personalisation][:body]).to include(list1.title)
+      expect(email_data[:personalisation][:body]).to include(list2.title)
+    end
+
+    context "when a list is not found" do
+      let(:list_data) do
+        [{ "slug" => "missing-list", "proportion" => "1" }]
+      end
+
+      it "raises an error" do
+        expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+          .to raise_error("One or more lists were not found")
+      end
+    end
+
+    context "when the change fails for a subscriber" do
+      let!(:subscription1) { create :subscription, subscriber_list: list1, frequency: :immediately }
+      let!(:subscription2) { create :subscription, subscriber_list: list1, frequency: :immediately }
+
+      before do
+        allow(Subscription).to receive(:insert_all!).and_call_original
+
+        allow(Subscription)
+          .to receive(:insert_all!)
+          .with(array_including([hash_including(subscriber_id: subscription2.subscriber_id)]))
+          .and_raise("An error")
+      end
+
+      it "only sends an email to switched subscribers" do
+        expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+          .to output.to_stdout
+          .and change { Email.count }.by(1)
+      end
+
+      it "persists changes for other subscribers" do
+        expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+          .to output.to_stdout
+          .and change { Subscription.count }.by(1)
+
+        expect(subscription2.reload).to_not be_ended
+      end
+    end
+  end
+
   describe "update_subscriber_list_tag" do
     before do
       Rake::Task["data_migration:update_subscriber_list_tag"].reenable

--- a/spec/lib/tasks/data_migration_spec.rb
+++ b/spec/lib/tasks/data_migration_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "data_migration" do
     let!(:list2) { create :subscriber_list }
     let(:list_data) do
       [
-        { "slug" => list1.slug, "proportion" => "1" },
-        { "slug" => list2.slug, "proportion" => "0.5" },
+        { "slug" => list1.slug },
+        { "slug" => list2.slug },
       ]
     end
 
@@ -43,16 +43,6 @@ RSpec.describe "data_migration" do
       expect(non_list.reload).not_to be_ended
     end
 
-    it "can change a proportion of subscriptions" do
-      create_list :subscription, 4, subscriber_list: list2, frequency: :immediately
-
-      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
-        .to output.to_stdout
-        .and change { Subscription.active.immediately.where(subscriber_list: list2).count }
-        .from(4)
-        .to(2)
-    end
-
     it "sends a summary email to affected subscribers" do
       subscriber = create :subscriber
       create :subscription, subscriber_list: list1, frequency: :immediately, subscriber: subscriber
@@ -70,7 +60,7 @@ RSpec.describe "data_migration" do
 
     context "when a list is not found" do
       let(:list_data) do
-        [{ "slug" => "missing-list", "proportion" => "1" }]
+        [{ "slug" => "missing-list" }]
       end
 
       it "raises an error" do

--- a/spec/lib/tasks/data_migration_spec.rb
+++ b/spec/lib/tasks/data_migration_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "data_migration" do
   include NotifyRequestHelpers
 
-  describe "switch_to_daily_digest_experiment" do
+  describe "switch_to_daily_digest" do
     let!(:list1) { create :subscriber_list }
     let!(:list2) { create :subscriber_list }
     let(:list_data) do
@@ -13,14 +13,14 @@ RSpec.describe "data_migration" do
 
     before do
       allow(CSV).to receive(:open).and_return(list_data)
-      Rake::Task["data_migration:switch_to_daily_digest_experiment"].reenable
+      Rake::Task["data_migration:switch_to_daily_digest"].reenable
       stub_notify
     end
 
     it "switches immediate subscriptions to daily" do
       subscription = create :subscription, subscriber_list: list1, frequency: :immediately
 
-      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+      expect { Rake::Task["data_migration:switch_to_daily_digest"].invoke }
         .to output.to_stdout
 
       new_subscription = subscription.subscriber.subscriptions.active.first
@@ -36,7 +36,7 @@ RSpec.describe "data_migration" do
       digest = create :subscription, subscriber_list: list1, frequency: :daily
       non_list = create :subscription, frequency: :immediately
 
-      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+      expect { Rake::Task["data_migration:switch_to_daily_digest"].invoke }
         .to output.to_stdout
 
       expect(digest.reload).not_to be_ended
@@ -49,7 +49,7 @@ RSpec.describe "data_migration" do
       reverted_subscription = create :subscription, subscriber_list: list1, frequency: :immediately, subscriber: subscriber
       other_subscription = create :subscription, subscriber_list: list2, frequency: :immediately, subscriber: subscriber
 
-      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+      expect { Rake::Task["data_migration:switch_to_daily_digest"].invoke }
         .to output.to_stdout
 
       expect(reverted_subscription.reload).not_to be_ended
@@ -61,7 +61,7 @@ RSpec.describe "data_migration" do
       create :subscription, subscriber_list: list1, frequency: :immediately, subscriber: subscriber
       create :subscription, subscriber_list: list2, frequency: :immediately, subscriber: subscriber
 
-      expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+      expect { Rake::Task["data_migration:switch_to_daily_digest"].invoke }
         .to output.to_stdout
 
       email_data = expect_an_email_was_sent
@@ -77,7 +77,7 @@ RSpec.describe "data_migration" do
       end
 
       it "raises an error" do
-        expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+        expect { Rake::Task["data_migration:switch_to_daily_digest"].invoke }
           .to raise_error("One or more lists were not found")
       end
     end
@@ -96,13 +96,13 @@ RSpec.describe "data_migration" do
       end
 
       it "only sends an email to switched subscribers" do
-        expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+        expect { Rake::Task["data_migration:switch_to_daily_digest"].invoke }
           .to output.to_stdout
           .and change { Email.count }.by(1)
       end
 
       it "persists changes for other subscribers" do
-        expect { Rake::Task["data_migration:switch_to_daily_digest_experiment"].invoke }
+        expect { Rake::Task["data_migration:switch_to_daily_digest"].invoke }
           .to output.to_stdout
           .and change { Subscription.count }.by(1)
 

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -51,4 +51,11 @@ RSpec.describe "report" do
         .to output.to_stdout
     end
   end
+
+  describe "subscription_changes_after_switch_to_daily_digest" do
+    it "outputs a report" do
+      expect { Rake::Task["report:subscription_changes_after_switch_to_daily_digest"].invoke }
+        .to output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/mZjpPawg/605-switch-remaining-80-of-coronavirus-and-transition-subscribers

This resurrects and modifies the task to migrate subscribers
to daily digest emails for a specified bunch of lists.

Please see the commits for more details.