### PR TITLE
Handle SocketErrors for comms with Notify

### DIFF
--- a/app/services/send_email_service/notify_provider.rb
+++ b/app/services/send_email_service/notify_provider.rb
@@ -21,7 +21,7 @@ class SendEmailService::NotifyProvider
 
     Metrics.sent_to_notify_successfully
     :sent
-  rescue Notifications::Client::RequestError, Net::OpenTimeout, Net::ReadTimeout => e
+  rescue Notifications::Client::RequestError, Net::OpenTimeout, Net::ReadTimeout, SocketError => e
     Metrics.failed_to_send_to_notify
 
     Rails.logger.warn(

--- a/spec/services/send_email_service/notify_provider_spec.rb
+++ b/spec/services/send_email_service/notify_provider_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe SendEmailService::NotifyProvider do
       expect(described_class.call(**arguments)).to be(:provider_communication_failure)
     end
 
+    it "returns a provider_communication_failure status for temporary DNS errors" do
+      allow(Notifications::Client).to receive(:new).and_return(notify_client)
+
+      allow(notify_client).to receive(:send_email).and_raise(SocketError)
+      expect(described_class.call(**arguments)).to be(:provider_communication_failure)
+    end
+
     it "returns a provider_communication_failure status for a Notify rejecting an email address" do
       error_response = double(
         code: 400,


### PR DESCRIPTION
https://sentry.io/organizations/govuk/issues/2010669159/?project=202220&referrer=slack

Previously we saw this raise a single error to Sentry, which is
likely due to a transient DNS failure. Although the SocketError
class may represent other kinds of error, this variant is most
likely [1], and we should avoid shouting about it, since it's not
actionable. This updates the NotifyProvider to handle these errors
graefully, noting we can always make the handling more specific if
in future we find we want to expose other variants.

SentryAPP Today at 12:46 AM
SocketError
Failed to open TCP connection to api.notifications.service.gov.uk:443 (getaddrinfo: Name or service not known)
environment
production
APP-EMAIL-ALERT-API-17Q via <https://sentry.io/organizations/govuk/alerts/rules/app-email-alert-api/283774/|Send a notification for new events>APP-EMAIL-ALERT-API-17Q via Send a notification for new events | Today at 12:46 AM

[1]: https://www.exceptionalcreatures.com/bestiary/SocketError.html