### PR TITLE
Remove deactivated concept - part 2

### DIFF
--- a/db/migrate/20201110163036_remove_deactivated_at_from_subscribers.rb
+++ b/db/migrate/20201110163036_remove_deactivated_at_from_subscribers.rb
@@ -1,0 +1,5 @@
+class RemoveDeactivatedAtFromSubscribers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :subscribers, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_153802) do
+ActiveRecord::Schema.define(version: 2020_11_10_163036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -145,7 +145,6 @@ ActiveRecord::Schema.define(version: 2020_10_21_153802) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
-    t.datetime "deactivated_at"
     t.index "lower((address)::text)", name: "index_subscribers_on_lower_address", unique: true
   end
 


### PR DESCRIPTION
Removes `deactivated_at` column from subscribers which was retired in
[this PR].

Trello:
https://trello.com/c/tfu9zXuy/534-delete-unused-data-after-a-year

[this PR]: https://github.com/alphagov/email-alert-api/pull/1462