### PR TITLE
Update `updated_at` when using `update_all`

### DIFF
--- a/app/services/unsubscribe_all_service.rb
+++ b/app/services/unsubscribe_all_service.rb
@@ -7,8 +7,10 @@ class UnsubscribeAllService < ApplicationService
   end
 
   def call
+    ended_time = Time.zone.now
     ended_count = subscriber.active_subscriptions
-                            .update_all(ended_at: Time.zone.now,
+                            .update_all(ended_at: ended_time,
+                                        updated_at: ended_time,
                                         ended_reason: reason)
 
     Metrics.unsubscribed(reason, ended_count)


### PR DESCRIPTION
`update_all` doesn't update timestamps when used and so left the
'updated_at' column unchanged. This indirectly created a bug as we use
the `updated_at` field as filter for [one of our reports] which resulted
in nils being passed around.

[one of our reports]: https://github.com/alphagov/email-alert-api/blob/master/lib/reports/subscription_changes_after_switch_to_daily_digest_report.rb#L17