### PR TITLE
Backfill ended subscriptions updated_at

### DIFF
--- a/db/migrate/20201111122823_backfill_updated_at_of_ended_subscriptions.rb
+++ b/db/migrate/20201111122823_backfill_updated_at_of_ended_subscriptions.rb
@@ -1,0 +1,13 @@
+class BackfillUpdatedAtOfEndedSubscriptions < ActiveRecord::Migration[6.0]
+  class Subscription < ApplicationRecord; end
+
+  disable_ddl_transaction!
+
+  def change
+    ended_subscriptions = Subscription.where("ended_at > updated_at")
+
+    ended_subscriptions.find_each do |sub|
+      sub.update!(updated_at: sub.ended_at)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_10_163036) do
+ActiveRecord::Schema.define(version: 2020_11_11_122823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
In [this PR] a bug was introduced which stopped updating the
`updated_at` when all of a users subscriptions were ended. This had a
knock on effect of breaking a [report].

[this PR]: https://github.com/alphagov/email-alert-api/pull/1462#discussion_r519839598
[report]: https://github.com/alphagov/email-alert-api/blob/master/lib/reports/subscription_changes_after_switch_to_daily_digest_report.rb#L17