### PR TITLE
Update `updated_at` when we use `update_all`

### DIFF
--- a/app/workers/email_archive_worker.rb
+++ b/app/workers/email_archive_worker.rb
@@ -35,7 +35,7 @@ private
   end
 
   def mark_emails_as_archived(ids, archived_at)
-    Email.where(id: ids).update_all(archived_at: archived_at)
+    Email.where(id: ids).update_all(archived_at: archived_at, updated_at: archived_at)
   end
 
   def log_complete(archived, start_time, end_time)

--- a/app/workers/nullify_subscribers_worker.rb
+++ b/app/workers/nullify_subscribers_worker.rb
@@ -1,7 +1,7 @@
 class NullifySubscribersWorker < ApplicationWorker
   def perform
     run_with_advisory_lock(Subscriber, "nullify") do
-      nullifyable_subscribers.update_all(address: nil)
+      nullifyable_subscribers.update_all(address: nil, updated_at: Time.zone.now)
     end
   end
 


### PR DESCRIPTION
update_all doesn't update timestamps when used and so leaves the
'updated_at' timestamp unchanged. This indirectly created a bug as we
use the updated_at field as filter for one of [our reports] which resulted
in nils being passed around.

This updates the other uses of `update_all` in the email system.

[our reports]: https://github.com/alphagov/email-alert-api/blob/master/lib/reports/subscription_changes_after_switch_to_daily_digest_report.rb#L17