### PR TITLE
Backfill ended subscriptions updated_at

### DIFF
--- a/lib/tasks/backfill_updated_at_for_ended_subscriptions.rake
+++ b/lib/tasks/backfill_updated_at_for_ended_subscriptions.rake
@@ -1,0 +1,8 @@
+desc "Fix bug by backfilling updated at for ended subscriptions"
+task backfill_updated_at_for_ended_subscriptions: :environment do
+  ended_subscriptions = Subscription.where("ended_at > updated_at")
+
+  ended_subscriptions.find_each do |sub|
+    sub.update!(updated_at: sub.ended_at)
+  end
+end


### PR DESCRIPTION
In [this PR] a bug was introduced which stopped updating the
`updated_at` when all of a users subscriptions were ended. This had a
knock on effect of breaking a [report].

Also updates all the other instances where the ended_at time does not
match updated_at.

[this PR]: https://github.com/alphagov/email-alert-api/pull/1462#discussion_r519839598
[report]: https://github.com/alphagov/email-alert-api/blob/master/lib/reports/subscription_changes_after_switch_to_daily_digest_report.rb#L17