### PR TITLE
Fix backfill rake task

### DIFF
--- a/lib/tasks/backfill_updated_at_for_ended_subscriptions.rake
+++ b/lib/tasks/backfill_updated_at_for_ended_subscriptions.rake
@@ -3,6 +3,6 @@ task backfill_updated_at_for_ended_subscriptions: :environment do
   ended_subscriptions = Subscription.where("ended_at > updated_at")
 
   ended_subscriptions.find_each do |sub|
-    sub.update!(updated_at: sub.ended_at)
+    sub.update_attribute(:updated_at, sub.ended_at) # rubocop:disable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
We've had to use `update_attribute` to skip validations as the
[uniqueness validation] concerning subscribers on the subscriptions
model was triggerining causing the following error:

```
ActiveRecord::RecordInvalid (Validation failed: Subscriber has already been taken)
```

The task is _currently_ running in Staging -> https://deploy.blue.staging.govuk.digital/job/run-rake-task/104022/console

[uniqueness validation]: https://github.com/alphagov/email-alert-api/blob/master/app/models/subscription.rb#L11