### PR TITLE
Remove temporary rake task

### DIFF
--- a/lib/tasks/backfill_updated_at_for_ended_subscriptions.rake
+++ b/lib/tasks/backfill_updated_at_for_ended_subscriptions.rake
@@ -1,8 +1,0 @@
-desc "Fix bug by backfilling updated at for ended subscriptions"
-task backfill_updated_at_for_ended_subscriptions: :environment do
-  ended_subscriptions = Subscription.where("ended_at > updated_at")
-
-  ended_subscriptions.find_each do |sub|
-    sub.update_attribute(:updated_at, sub.ended_at) # rubocop:disable Rails/SkipsModelValidations
-  end
-end


### PR DESCRIPTION
The rake task has been run and all the ended subscriptions have been
backfilled.

Completed task -> https://deploy.blue.production.govuk.digital/job/run-rake-task/113597/console