### PR TITLE
Pending ADR for new approach to monitoring and alerting

### DIFF
--- a/docs/adr/adr-007-monitoring-and-alerting.md
+++ b/docs/adr/adr-007-monitoring-and-alerting.md
@@ -7,11 +7,11 @@ Date: 2020-11-13
 Email Alert API has acquired the undesirable reputation of an application that
 produces a high volume of unactionable alerts and is a frequent source of
 GOV.UK incidents. The monitoring and alerting approach no longer appears to
-be sufficient for the application behaviour as the volume of work for the
-application has changed in the past 2 years. In previous years, the application
+be sufficient for the application behaviour as the application's volume of
+work has changed in the past 2 years. In previous years, the application
 would reach a peak of sending 1 million emails a day whereas now it can be
-sending over 10 million emails a day. This increased volume of work has
-increased system latency which has impacting alerts and contributed to
+sending over 10 million emails a day. This elevated volume of work has
+increased system latency which has impacted alerts and contributed to
 incidents.
 
 The approach used to monitoring the application and the wider email alert
@@ -19,43 +19,42 @@ system is two fold. One approach is to monitor Email Alert API's internal
 state to see if it is [completing tasks within a particular
 time frame][monitor-time-frame] or [whether there is a high quantity of work to
 do][monitor-workload]. The other approach is to use an [end-to-end
-test][email-alert-monitoring] which checks a Gmail account to identify that
-a particular address received an expected email within a time frame. Both of
-these approaches are flawed.
+check][email-alert-monitoring] which verifies that a Gmail account
+has received an email within a time frame. Both of these approaches are flawed.
 
-Monitoring for high quantities of work, and whether work was completed, in a
-time frame has left Email Alert API vulnerable to producing alerts when the
+Monitoring for high quantities of work, and whether work was completed in a
+time frame, has left Email Alert API vulnerable to producing alerts when the
 application is busy, yet fully operational. These alerts are unactionable for
 support engineers as the alerts resolve themselves once the work is completed
-and there is little to nothing an engineer can do to speed this process up.
-For example, if the application has accumulated 1,000,000 emails to send it
-raises a critical alert even if it is sending these at the fastest rate Notify
+and there is little an engineer can do to speed this process up. For example,
+if the application has accumulated 1,000,000 emails to send it raises a
+critical alert even if it is sending these at the fastest rate Notify
 would allow. These alerts, therefore, waste the time of support engineers and
 create a risk that a support engineer might miss an alert that requires their
 intervention.
 
-Since these alerts can't be relied upon to suggest the application is
-broken, they aren't used for any out-of-hours alerts. This means that if they
-did reflect a genuine problem no engineers would be contacted. An engineer
-instead learns of a problem out-of-hours due to the other type of monitoring
-approach: the end-to-end test. These alert when content published
-through [Travel Advice Publisher][] does not arrive in a Gmail inbox within a
-specified time period.
+Since these alerts can't be relied upon to reliably suggest the
+application is broken, they aren't used for any out-of-hours alerts. Therefore,
+even if they did reflect a genuine problem no engineers would be contacted.
+An engineer instead learns of a problem out-of-hours due to the other type
+of monitoring approach: the end-to-end checks. These alert when content
+published through [Travel Advice Publisher][] does not arrive in
+a particular Gmail inbox within a specified time period.
 
-Monitoring an inbox provided its own distinct flaws. If Email Alert API is
-broken out-of-hours engineers would not be notified unless travel advice
-content was published. This alert also monitor beyond the boundaries of
-the email alert system - considering whether GOV.UK publishing, Notify and
-Gmail are all working - leading to alerts representing problems outside the
-control of GOV.UK engineers. Finally, by nature of being time based, these
+Monitoring an inbox for a limited set of emails has its own distinct flaws.
+If Email Alert API breaks outside of office hours then engineers would not be
+notified unless travel advice content was published. This alert also monitors
+beyond the boundaries of the email alert system - considering whether
+GOV.UK publishing, Notify and Gmail are all working - leading to alerts
+representing problems outside the control of GOV.UK engineers (such as Gmail
+identifying an email as spam). Finally, by nature of being time based, these
 alerts are also vulnerable to the system being busy - where a sufficiently
-high volume of travel advice publishings guarantees that an alert will
-trigger.
+high volume of travel advice publishings guarantees that an alert will trigger.
 
-Reviewing these helped us understand the reputation for unactionable alerts and
-reviewing the GOV.UK incidents for Email Alert API helped us to identify
-patterns where incidents reflected ambiguity over whether the system
-was broken or not. We felt there was room for improvement.
+Reviewing this monitoring approach helped us understand the reputation for
+unactionable alerts and reviewing the GOV.UK incidents for Email Alert API
+helped us to identify patterns where incidents reflected ambiguity over whether
+the system was broken or not. We felt there was room for improvement.
 
 [monitor-time-frame]: https://github.com/alphagov/email-alert-api/blob/c70fcd7e5d64393074a3eebd83b3467fd8cc03b3/app/workers/digest_run_worker.rb#L6-L9
 [monitor-workload]: https://github.com/alphagov/govuk-puppet/blob/fac4b5163f10736bb19aa51a8eb7bc276dd2cb40/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp#L33-L44
@@ -64,7 +63,7 @@ was broken or not. We felt there was room for improvement.
 
 ## Decision
 
-Our decision is that the system should raise a critical alert
+We decided that the system should raise a critical alert
 [if and only if](https://en.wikipedia.org/wiki/If_and_only_if) the email alert
 system is broken. The majority of these alerts should contact engineers
 out-of-hours.
@@ -75,7 +74,7 @@ applications: Email Alert API,
 [Email Alert Service](https://github.com/alphagov/email-alert-service); this
 excludes the monitoring of whether GOV.UK publishing is working and whether
 Notify is working as they are independently monitored. The use of
-"if and only if" reflects a condition we're forming that the system will not
+"if and only if" reflects a condition we've formed that the system will not
 raise critical alerts unless we're highly confident it is broken, whereas
 warnings are appropriate for other situations. We decided that for the email
 alert system to be "broken" it represents a failing that will lead to a user
@@ -85,7 +84,8 @@ contact engineers out-of-hours for them as otherwise users will be
 experiencing issues.
 
 We decided that we will re-approach our alerting with this mindset and look to
-replace alerts that are vulnerable to reflecting a busy status.
+replace alerts that are vulnerable to reflecting a busy status, or which
+extend beyond the boundaries of the system.
 
 ## Status
 
@@ -96,9 +96,9 @@ Pending
 We will be changing the approaching to monitoring and alerting across the email
 alert system of applications in order to meet this new alerting criteria.
 
-## Monitoring Email Alert API
+### Monitoring Email Alert API
 
-### Sidekiq workers
+#### Sidekiq workers
 
 We will configure critical alerts, that contact engineers out-of-hours, if
 individual Sidekiq jobs fail multiple times for the following workers:
@@ -110,16 +110,25 @@ individual Sidekiq jobs fail multiple times for the following workers:
 - [SendEmailWorker][]
 - [WeeklyDigestInitiatorWorker][]
 
-These workers will use the database to store the amount of times we have
+These workers will use the database to store the number of times we have
 attempted to perform an action. An alert will be raised if the quantity of
-failed attempts reaches a threshold (the suggestion is 5).
+failed attempts reaches a threshold (the suggestion is 5). To ensure that these
+jobs actually run we will configure the [RecoverLostJobsWorker][] to identify
+any of these that need to run and attempt them, this protects from lost work
+problems such as [Sidekiq crashing][sidekiq-reliability].
 
-We will contact engineers out-of-hours if either [SendEmailWorker][] or
-[DigestEmailGenerationWorker][] have not completed at least one successful run
-within a time period (suggestion is 30 minutes) despite work existing. This
-reflects a concern that we would like support engineers to be notified quickly
-if all instances of these jobs are failing and the aforementioned retry method
-may take a long time to alert in a busy period.
+We expect [SendEmailWorker][] and [DigestEmailGenerationWorker][] jobs to run
+quickly (durations of up to a few seconds) and know that there can be high
+volumes of them to run (both can regularly reach volumes of > 100,000).
+Therefore, we are concerned about a scenario where these consistently fail
+because it could take a long time for sufficient retries to occur
+for an alert to be raised (as each retry is placed at the back of the queue).
+To reflect this concern we will contact engineers if either of these workers
+has not completed one successful run within a time period despite work
+existing (suggested time period is 30 minutes). The [Sidekiq retry
+cadence][sidekiq-retry] for these jobs will need to be updated to ensure they
+always retry within the time period, this is to ensure we don't alert while
+work isn't being attempted.
 
 Similarly, we will contact engineers out-of-hours if we determine that
 [DigestRuns][DigestRun] are not created within a reasonable time frame
@@ -132,7 +141,7 @@ We will also monitor that runs of [RecoverLostJobsWorker][] and
 (suggestion is 1 hour). These jobs should continue running even when the
 system is busy and the lack of them running indicates that we no longer have
 confidence the system is monitored or able to recover. Thus, an alert will be
-created that contacts engineers out-of-hours should these never succeed in a
+created that contacts engineers out-of-hours should these not succeed in a
 time frame.
 
 For Sidekiq workers that don't affect the user noticeable aspects of Email
@@ -140,14 +149,21 @@ Alert API, such as [EmailDeletionWorker][], we won't raise critical alerts if
 these are failing. Instead we will raise a warning if any Sidekiq workers
 exhaust all their retries and are placed in the [dead set][sidekiq-dead]. This
 approach was chosen as it was a pragmatic technique to monitor multiple workers
-without adding checks for individual workers.
+without adding alerts for individual workers. Workers will have their
+[retry cadence][sidekiq-retry] considered so that this will alert in a
+reasonable time frame of the retries being exhausted (the Sidekiq default of 21
+days is very long).
 
-We will modify the [latency checks for email queues][latency-checks] to be
-significantly less sensitive to latency for all email sending except
-[transactional emails][]. This is because transactional emails have an
-[expectation of a prompt delivery][transactional-delivery-expectation] and the
-lack of them blocks a user from progressing with their task. For the other
-queues we will change the time before a warning occurs to be in the measure of
+We will modify the [latency checks for email queues][latency-checks]. We
+will be treating [transactional emails][] different to other latency checks
+as these emails have have an [expectation of a prompt
+delivery][transactional-delivery-expectation] and the lack of them blocks a
+user from progressing with their task. These will raise a warning after 5 mins
+and go critical (with engineers contacted out-of-hours) should the latency
+reach 15 mins.
+
+The other latency checks will be made significantly less sensitive to latency
+and we will change the time before a warning occurs to be in the measure of
 multiple hours compared to minutes, with the intention that they serve to
 alert a support engineer only when the system is exceptionally busy and may be
 unhealthy. These alerts will only reach a critical status if they hit a 24 hour
@@ -155,7 +171,7 @@ point as this would indicate that we are consistently creating email faster
 than the application can send it, which may mean the system is perpetually
 backlogged.
 
-### Web application
+#### Web application
 
 We decided that there should be a mechanism that alerts people out-of-hours if
 the Email Alert API web application appears broken, noting that currently an
@@ -171,7 +187,7 @@ load balancer has no healthy instances of the application][aws-lb-check]. This
 represents that no instances of the web application are healthy and
 [no requests will succeed][aws-alb-health].
 
-### Alerts to be removed
+#### Alerts to be removed
 
 We will remove the following alerts that will become superseded:
 
@@ -179,35 +195,50 @@ We will remove the following alerts that will become superseded:
 - [Messages unprocessed after 2 hours][unprocessed-messages]
 - [Incomplete DigestRuns after 2 hours][incomplete-digest-runs]
 
-## Monitoring Email Alert Service
+### Monitoring Email Alert Service
 
 Email Alert Service listens for [Publishing API][] events and communicates
 these to Email Alert API. We currently [only have alerts][rabbitmq-alert] that
 occur in-hours if this system fails, so there is no visibility for any
 out-of-hours problems.
 
-We intend to improve this by raising an alert that contacts engineers
-out-of-hours if there is a pattern of failure in processing these events.
+We intend to improve and consolidate the existing alerts, and contact an
+engineer out-of-hours if there is a pattern of failure in processing these
+events.
 
-## Monitoring Email Alert Frontend
+### Monitoring Email Alert Frontend
 
 Email Alert Frontend acts as the public interface for subscriber interaction
 with the email alert system. This web application will be monitored in a
-[similar way to the Email Alert API web application][#web-application] by
+[similar way to the Email Alert API web application](#web-application) by
 considering whether the load balancer has any healthy instances.
 
-## Removal of Email Alert Monitoring
+### Removal of Email Alert Monitoring
 
 [Email Alert Monitoring][email-alert-monitoring] is the aforementioned
-end-to-end test that monitors whether travel advice and drug advice content
-changes send email to a Gmail inbox. The changes to alerting described in this
-ADR will render Email Alert Monitoring redundant, as the new alerts should
-capture real problems faster and cover a broader range of scenarios - this
-would leave Email Alert Monitoring capturing false positives and out-of-scope
-problems.
+end-to-end check that monitors whether travel advice and medical safety content
+changes result in an email received by a Gmail inbox. We intend to retire this
+check as we believe the new approach to monitoring the email alert system will
+cover the aspects of this check that are within scope of the email alert system.
+Broadly the Email Alert Monitoring verifies that:
 
-Once the new monitoring and alerting approaches have been implemented and
-tested we will remove Email Alert Monitoring from the GOV.UK stack.
+- content was published (out-of-scope for email alert system, this is a
+  Publishing API concern);
+- whether the publishing application successfully communicated with Email Alert
+  API (out-of-scope for email alert system, this is a publishing application
+  concern);
+- whether the content change is converted into emails (in-scope for email alert
+  system; monitored by identifying ProcessContentChangeWorker failures);
+- whether an email is sent to govuk_email_check@digital.cabinet-office.gov.uk
+  (in-scope for email alert system, monitored by identifying SendEmailWorker
+  failures);
+- whether Notify actually sends the email (out-of-scope for email alert system,
+  this is a Notify concern);
+- whether Gmail successfully receives the email (out-of-scope for email alert
+  system, this is Google's concern).
+
+Once we have completed configuring the alerts that cover the in-scope scenarios
+we will remove Email Alert Monitoring from the GOV.UK stack.
 
 [DailyDigestInitiatorWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/daily_digest_initiator_worker.rb
 [DigestEmailGenerationWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/digest_email_generation_worker.rb
@@ -215,9 +246,11 @@ tested we will remove Email Alert Monitoring from the GOV.UK stack.
 [ProcessMessageWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/process_message_worker.rb
 [SendEmailWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/send_email_worker.rb
 [WeeklyDigestInitiatorWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/weekly_digest_initiator_worker.rb
-[DigestRun]: https://github.com/alphagov/email-alert-api/blame/b92f9136230f9217e7877c6dbd6a049473ce7b35/README.md#L28-L29
-[digest-run-creation]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/services/digest_initiator_service.rb#L8
 [RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/recover_lost_jobs_worker.rb
+[sidekiq-reliability]: https://github.com/mperham/sidekiq/wiki/Reliability#using-super_fetch
+[DigestRun]: https://github.com/alphagov/email-alert-api/blame/b92f9136230f9217e7877c6dbd6a049473ce7b35/README.md#L28-L29
+[sidekiq-retry]: https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
+[digest-run-creation]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/services/digest_initiator_service.rb#L8
 [MetricsCollectionWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/metrics_collection_worker.rb
 [EmailDeletionWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/email_deletion_worker.rb
 [sidekiq-dead]: https://github.com/mperham/sidekiq/wiki/API#dead
@@ -226,7 +259,7 @@ tested we will remove Email Alert Monitoring from the GOV.UK stack.
 [transactional-delivery-expectation]: https://github.com/alphagov/email-alert-frontend/blob/de1caeea8098eccbb34d8768d7f2c95e455d901c/config/locales/subscriber_authentication.yml#L21
 [publishing-api-alert]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/publishing_api.pp#L168-L170
 [aws-lb-check]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/monitoring/manifests/checks/lb.pp
-[aws-alb-health]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html#introduction
+[aws-alb-health]: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-healthchecks.html
 [unprocessed-content-changes]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_api/checks.pp#L27-L36
 [unprocessed-messages]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_api/checks.pp#L49-L59
 [incomplete-digest-runs]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_api/checks.pp#L38-L47

--- a/docs/adr/adr-007-monitoring-and-alerting.md
+++ b/docs/adr/adr-007-monitoring-and-alerting.md
@@ -1,0 +1,234 @@
+# 7. Monitoring and alerting
+
+Date: 2020-11-13
+
+## Context
+
+Email Alert API has acquired the undesirable reputation of an application that
+produces a high volume of unactionable alerts and is a frequent source of
+GOV.UK incidents. The monitoring and alerting approach no longer appears to
+be sufficient for the application behaviour as the volume of work for the
+application has changed in the past 2 years. In previous years, the application
+would reach a peak of sending 1 million emails a day whereas now it can be
+sending over 10 million emails a day. This increased volume of work has
+increased system latency which has impacting alerts and contributed to
+incidents.
+
+The approach used to monitoring the application and the wider email alert
+system is two fold. One approach is to monitor Email Alert API's internal
+state to see if it is [completing tasks within a particular
+time frame][monitor-time-frame] or [whether there is a high quantity of work to
+do][monitor-workload]. The other approach is to use an [end-to-end
+test][email-alert-monitoring] which checks a Gmail account to identify that
+a particular address received an expected email within a time frame. Both of
+these approaches are flawed.
+
+Monitoring for high quantities of work, and whether work was completed, in a
+time frame has left Email Alert API vulnerable to producing alerts when the
+application is busy, yet fully operational. These alerts are unactionable for
+support engineers as the alerts resolve themselves once the work is completed
+and there is little to nothing an engineer can do to speed this process up.
+For example, if the application has accumulated 1,000,000 emails to send it
+raises a critical alert even if it is sending these at the fastest rate Notify
+would allow. These alerts, therefore, waste the time of support engineers and
+create a risk that a support engineer might miss an alert that requires their
+intervention.
+
+Since these alerts can't be relied upon to suggest the application is
+broken, they aren't used for any out-of-hours alerts. This means that if they
+did reflect a genuine problem no engineers would be contacted. An engineer
+instead learns of a problem out-of-hours due to the other type of monitoring
+approach: the end-to-end test. These alert when content published
+through [Travel Advice Publisher][] does not arrive in a Gmail inbox within a
+specified time period.
+
+Monitoring an inbox provided its own distinct flaws. If Email Alert API is
+broken out-of-hours engineers would not be notified unless travel advice
+content was published. This alert also monitor beyond the boundaries of
+the email alert system - considering whether GOV.UK publishing, Notify and
+Gmail are all working - leading to alerts representing problems outside the
+control of GOV.UK engineers. Finally, by nature of being time based, these
+alerts are also vulnerable to the system being busy - where a sufficiently
+high volume of travel advice publishings guarantees that an alert will
+trigger.
+
+Reviewing these helped us understand the reputation for unactionable alerts and
+reviewing the GOV.UK incidents for Email Alert API helped us to identify
+patterns where incidents reflected ambiguity over whether the system
+was broken or not. We felt there was room for improvement.
+
+[monitor-time-frame]: https://github.com/alphagov/email-alert-api/blob/c70fcd7e5d64393074a3eebd83b3467fd8cc03b3/app/workers/digest_run_worker.rb#L6-L9
+[monitor-workload]: https://github.com/alphagov/govuk-puppet/blob/fac4b5163f10736bb19aa51a8eb7bc276dd2cb40/modules/govuk/manifests/apps/email_alert_api/sidekiq_queue_check.pp#L33-L44
+[email-alert-monitoring]: https://github.com/alphagov/email-alert-monitoring
+[Travel Advice Publisher]: https://github.com/alphagov/travel-advice-publisher
+
+## Decision
+
+Our decision is that the system should raise a critical alert
+[if and only if](https://en.wikipedia.org/wiki/If_and_only_if) the email alert
+system is broken. The majority of these alerts should contact engineers
+out-of-hours.
+
+Unpacking this, we consider the email alert system to be comprised of 3
+applications: Email Alert API,
+[Email Alert Frontend](https://github.com/alphagov/email-alert-frontend) and
+[Email Alert Service](https://github.com/alphagov/email-alert-service); this
+excludes the monitoring of whether GOV.UK publishing is working and whether
+Notify is working as they are independently monitored. The use of
+"if and only if" reflects a condition we're forming that the system will not
+raise critical alerts unless we're highly confident it is broken, whereas
+warnings are appropriate for other situations. We decided that for the email
+alert system to be "broken" it represents a failing that will lead to a user
+noticeable issue unless an engineer intervenes. Since these alerts should
+represent a broken system requiring intervention, it should be suitable to
+contact engineers out-of-hours for them as otherwise users will be
+experiencing issues.
+
+We decided that we will re-approach our alerting with this mindset and look to
+replace alerts that are vulnerable to reflecting a busy status.
+
+## Status
+
+Pending
+
+## Consequences
+
+We will be changing the approaching to monitoring and alerting across the email
+alert system of applications in order to meet this new alerting criteria.
+
+## Monitoring Email Alert API
+
+### Sidekiq workers
+
+We will configure critical alerts, that contact engineers out-of-hours, if
+individual Sidekiq jobs fail multiple times for the following workers:
+
+- [DailyDigestInitiatorWorker][]
+- [DigestEmailGenerationWorker][]
+- [ProcessContentChangeWorker][]
+- [ProcessMessageWorker][]
+- [SendEmailWorker][]
+- [WeeklyDigestInitiatorWorker][]
+
+These workers will use the database to store the amount of times we have
+attempted to perform an action. An alert will be raised if the quantity of
+failed attempts reaches a threshold (the suggestion is 5).
+
+We will contact engineers out-of-hours if either [SendEmailWorker][] or
+[DigestEmailGenerationWorker][] have not completed at least one successful run
+within a time period (suggestion is 30 minutes) despite work existing. This
+reflects a concern that we would like support engineers to be notified quickly
+if all instances of these jobs are failing and the aforementioned retry method
+may take a long time to alert in a busy period.
+
+Similarly, we will contact engineers out-of-hours if we determine that
+[DigestRuns][DigestRun] are not created within a reasonable time frame
+(suggestion is 2 hours). Creating these is a [trivial][digest-run-creation],
+but essential, operation for producing a digest and the lack of these suggests
+the system is broken whether it is busy or not.
+
+We will also monitor that runs of [RecoverLostJobsWorker][] and
+[MetricsCollectionWorker][] are succeeding at least once within a time frame
+(suggestion is 1 hour). These jobs should continue running even when the
+system is busy and the lack of them running indicates that we no longer have
+confidence the system is monitored or able to recover. Thus, an alert will be
+created that contacts engineers out-of-hours should these never succeed in a
+time frame.
+
+For Sidekiq workers that don't affect the user noticeable aspects of Email
+Alert API, such as [EmailDeletionWorker][], we won't raise critical alerts if
+these are failing. Instead we will raise a warning if any Sidekiq workers
+exhaust all their retries and are placed in the [dead set][sidekiq-dead]. This
+approach was chosen as it was a pragmatic technique to monitor multiple workers
+without adding checks for individual workers.
+
+We will modify the [latency checks for email queues][latency-checks] to be
+significantly less sensitive to latency for all email sending except
+[transactional emails][]. This is because transactional emails have an
+[expectation of a prompt delivery][transactional-delivery-expectation] and the
+lack of them blocks a user from progressing with their task. For the other
+queues we will change the time before a warning occurs to be in the measure of
+multiple hours compared to minutes, with the intention that they serve to
+alert a support engineer only when the system is exceptionally busy and may be
+unhealthy. These alerts will only reach a critical status if they hit a 24 hour
+point as this would indicate that we are consistently creating email faster
+than the application can send it, which may mean the system is perpetually
+backlogged.
+
+### Web application
+
+We decided that there should be a mechanism that alerts people out-of-hours if
+the Email Alert API web application appears broken, noting that currently an
+engineer is unlikely to be contacted in the event of the whole Email Alert API
+application becoming unavailable - unless travel advice were published. We
+noted there wasn't a particularly consistent approach to this across GOV.UK
+([with some apps raising an out-of-hours alert when a single instance fails
+healthchecks][publishing-api-alert]) and felt it would be good to take a simple
+approach to avoid surprising engineers.
+
+We decided the most appropriate place to alert would be when [the application
+load balancer has no healthy instances of the application][aws-lb-check]. This
+represents that no instances of the web application are healthy and
+[no requests will succeed][aws-alb-health].
+
+### Alerts to be removed
+
+We will remove the following alerts that will become superseded:
+
+- [Content Changes unprocessed after 2 hours][unprocessed-content-changes]
+- [Messages unprocessed after 2 hours][unprocessed-messages]
+- [Incomplete DigestRuns after 2 hours][incomplete-digest-runs]
+
+## Monitoring Email Alert Service
+
+Email Alert Service listens for [Publishing API][] events and communicates
+these to Email Alert API. We currently [only have alerts][rabbitmq-alert] that
+occur in-hours if this system fails, so there is no visibility for any
+out-of-hours problems.
+
+We intend to improve this by raising an alert that contacts engineers
+out-of-hours if there is a pattern of failure in processing these events.
+
+## Monitoring Email Alert Frontend
+
+Email Alert Frontend acts as the public interface for subscriber interaction
+with the email alert system. This web application will be monitored in a
+[similar way to the Email Alert API web application][#web-application] by
+considering whether the load balancer has any healthy instances.
+
+## Removal of Email Alert Monitoring
+
+[Email Alert Monitoring][email-alert-monitoring] is the aforementioned
+end-to-end test that monitors whether travel advice and drug advice content
+changes send email to a Gmail inbox. The changes to alerting described in this
+ADR will render Email Alert Monitoring redundant, as the new alerts should
+capture real problems faster and cover a broader range of scenarios - this
+would leave Email Alert Monitoring capturing false positives and out-of-scope
+problems.
+
+Once the new monitoring and alerting approaches have been implemented and
+tested we will remove Email Alert Monitoring from the GOV.UK stack.
+
+[DailyDigestInitiatorWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/daily_digest_initiator_worker.rb
+[DigestEmailGenerationWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/digest_email_generation_worker.rb
+[ProcessContentChangeWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/process_content_change_worker.rb
+[ProcessMessageWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/process_message_worker.rb
+[SendEmailWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/send_email_worker.rb
+[WeeklyDigestInitiatorWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/weekly_digest_initiator_worker.rb
+[DigestRun]: https://github.com/alphagov/email-alert-api/blame/b92f9136230f9217e7877c6dbd6a049473ce7b35/README.md#L28-L29
+[digest-run-creation]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/services/digest_initiator_service.rb#L8
+[RecoverLostJobsWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/recover_lost_jobs_worker.rb
+[MetricsCollectionWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/metrics_collection_worker.rb
+[EmailDeletionWorker]: https://github.com/alphagov/email-alert-api/blob/b92f9136230f9217e7877c6dbd6a049473ce7b35/app/workers/email_deletion_worker.rb
+[sidekiq-dead]: https://github.com/mperham/sidekiq/wiki/API#dead
+[latency-checks]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_api/checks.pp#L9-L25
+[transactional emails]: https://github.com/alphagov/email-alert-api/blob/fe28935ae77137182ec713059b029d514a93bc2d/config/sidekiq.yml#L9
+[transactional-delivery-expectation]: https://github.com/alphagov/email-alert-frontend/blob/de1caeea8098eccbb34d8768d7f2c95e455d901c/config/locales/subscriber_authentication.yml#L21
+[publishing-api-alert]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/publishing_api.pp#L168-L170
+[aws-lb-check]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/monitoring/manifests/checks/lb.pp
+[aws-alb-health]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html#introduction
+[unprocessed-content-changes]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_api/checks.pp#L27-L36
+[unprocessed-messages]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_api/checks.pp#L49-L59
+[incomplete-digest-runs]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_api/checks.pp#L38-L47
+[Publishing API]: https://github.com/alphagov/publishing-api
+[rabbitmq-alert]: https://github.com/alphagov/govuk-puppet/blob/3922b4104e61e16e115e609a1f96fa19bffcfb0c/modules/govuk/manifests/apps/email_alert_service/rabbitmq.pp#L54-L60


### PR DESCRIPTION
Trello: https://trello.com/c/qHyEW6cE/585-record-the-architectural-decisions-for-email-alert-system-alerting

This is an ADR that tries to succinctly cover the major themes of the
23 page document on "How do we know the Email Alert System is broken"
[1]. It is a pending ADR as we have not yet started the development of
these new alerts which may lead to some of the consequences of the
decision being altered.

There's a few places where it could have appropriate to link to internal
Google Docs (such as incidents or the source document) however it felt
unconventional to link to internal documents in an ADR so I left this
out.

This was a tricky decision to portray as the work behind it was many
decisions. I tried to focus just on the major themes with the
expectation that future implementation documentation will convey more
granular information. In trying to make this succinct there were number
of avenues I chose not to go down, notably:

- Talking about why alerting is embedded in the system and the risks of that
  compared to entirely external alerting (it's hard to get sufficient
  information to call it).
- Aiming to alert about a problem with only a single alert even if it affects
  multiple machines. We're trying to avoid the situation where a problem occurs
  and an engineer gets ~10 alerts about the problem.
- Why it's not appropriate to monitor every content change to the granularity
  as is done in Email Alert monitoring.
- Talking about consistency across GOV.UK alerting approaches. They're mostly
  quite simplistic and there are pretty big gaps where things can break and
  no-one would get called automatically.
- Details as to why the stack boundaries are what they are, why Notify
  monitoring isn't our responsibility for instance.
- How we'd know if the monitoring machines stopped receiving data that powers
  alerts.
- How we may want to adjust retry schedules and attempts to reflect the
  new approaches.

As always in an ADR I ended up in a muddle over tense. I initially tried
to have this in past tense but that didn't flow right given the pending
nature of consequences, so I've instead opted for future tense.

[1]: https://docs.google.com/document/d/1HczXfKL6dJz1OqjJIqJSA8AohUiZJfZbVhsorCJdx0E/edit#