### PR TITLE
Revert "Remove redundant email uniqueness validation"

### DIFF
--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,7 +1,10 @@
 class Subscriber < ApplicationRecord
   self.ignored_columns = %w[deactivated_at]
 
-  validates :address, email_address: true, allow_nil: true
+  with_options allow_nil: true do
+    validates :address, email_address: true
+    validates :address, uniqueness: { case_sensitive: false }
+  end
 
   has_many :subscriptions
   has_many :active_subscriptions, -> { active }, class_name: "Subscription"

--- a/spec/integration/subscribers_spec.rb
+++ b/spec/integration/subscribers_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe "Subscriptions", type: :request do
           patch "/subscribers/#{subscriber.id}", params: { new_address: "invalid" }
           expect(response.status).to eq(422)
         end
+
+        it "returns an error message if the new email address is not unique" do
+          create :subscriber, address: "new-test@example.com"
+          patch "/subscribers/#{subscriber.id}", params: { new_address: "new-test@example.com" }
+          expect(response.status).to eq(422)
+        end
       end
 
       context "without an existing subscriber" do

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -78,9 +78,7 @@ RSpec.describe Subscriber, type: :model do
       subject.address = "foo@bar.com"
       expect(subject).to be_invalid
 
-      expect {
-        subject.save!(validate: false)
-      }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect { subject.save! }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "is invalid if an email address is already taken but with a different case" do
@@ -89,9 +87,7 @@ RSpec.describe Subscriber, type: :model do
       subject.address = "foo@bar.com"
       expect(subject).to be_invalid
 
-      expect {
-        subject.save!(validate: false)
-      }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect { subject.save! }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe Subscriber, type: :model do
 
       expect(subject).to be_invalid
     end
+
+    it "is invalid if an email address is already taken" do
+      create(:subscriber, address: "foo@bar.com")
+
+      subject.address = "foo@bar.com"
+      expect(subject).to be_invalid
+
+      expect {
+        subject.save!(validate: false)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "is invalid if an email address is already taken but with a different case" do
+      create(:subscriber, address: "FOO@BAR.com")
+
+      subject.address = "foo@bar.com"
+      expect(subject).to be_invalid
+
+      expect {
+        subject.save!(validate: false)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
   end
 
   context "with a subscription" do
@@ -171,7 +193,7 @@ RSpec.describe Subscriber, type: :model do
 
         allow(described_class).to receive(:find_by_address).and_return(nil)
         expect { described_class.resilient_find_or_create(subscriber.address) }
-          .to raise_error(ActiveRecord::RecordNotUnique)
+          .to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end


### PR DESCRIPTION
This reverts commit c118d2c40496eb1e898935062a5dc1dc68d254b7.

Previously we removed this validation on the basis that it was
covered by a DB/schema-level validation. However, it turns out
the specific exception had an impact on the response code, which
changed from a 422 to a 500. This reverts the validations, and
adds a request-level spec to properly document it.