### PR TITLE
Rewrite content for subscription auth email

### DIFF
--- a/app/builders/subscription_auth_email_builder.rb
+++ b/app/builders/subscription_auth_email_builder.rb
@@ -1,8 +1,8 @@
 class SubscriptionAuthEmailBuilder
-  def initialize(address:, token:, topic_id:, frequency:)
+  def initialize(address:, token:, subscriber_list:, frequency:)
     @address = address
     @token = token
-    @topic_id = topic_id
+    @subscriber_list = subscriber_list
     @frequency = frequency
   end
 
@@ -22,7 +22,7 @@ class SubscriptionAuthEmailBuilder
 
 private
 
-  attr_reader :address, :token, :frequency, :topic_id
+  attr_reader :address, :token, :frequency, :subscriber_list
 
   def subject
     "Confirm your subscription"
@@ -30,26 +30,26 @@ private
 
   def body
     <<~BODY
-      # Click the link to confirm your subscription
+      # Click the link to confirm that you want to get emails from GOV.UK
 
-      ^ [Confirm your subscription](#{link})
+      # [Yes, I want emails about #{subscriber_list.title}](#{link})
 
-      This link will stop working in 7 days.
+      This link will stop working after 7 days.
 
-      # Didn’t request this email?
+      #{I18n.t!("emails.subscription_auth.frequency.#{frequency}")}. You can change this at any time.
 
-      Ignore or delete this email if you didn’t request it.
+      If you did not request this email, you can ignore it.
 
-      [Read our privacy policy (opens in a new tab)](https://www.gov.uk/help/privacy-notice) to find out how we use and protect your data.
-
-      [Contact GOV.UK](https://www.gov.uk/contact/govuk) if you have any problems with your email subscriptions.
+      Thanks 
+      GOV.UK emails 
+      [https://www.gov.uk/help/update-email-notifications](https://www.gov.uk/help/update-email-notifications)
     BODY
   end
 
   def link
     Plek.new.website_uri.tap do |uri|
       uri.path = "/email/subscriptions/authenticate"
-      uri.query = "token=#{token}&topic_id=#{topic_id}&frequency=#{frequency}"
+      uri.query = "token=#{token}&topic_id=#{subscriber_list.slug}&frequency=#{frequency}"
     end
   end
 end

--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -2,7 +2,7 @@ class SubscribersAuthTokenController < ApplicationController
   before_action :validate_params
 
   def auth_token
-    subscriber = Subscriber.find_by_address!(expected_params.require(:address))
+    subscriber = Subscriber.find_by_address!(expected_params[:address])
     token = generate_token(subscriber)
     email = build_email(subscriber, token)
 
@@ -24,7 +24,7 @@ private
   def build_email(subscriber, token)
     SubscriberAuthEmailBuilder.call(
       subscriber: subscriber,
-      destination: expected_params.require(:destination),
+      destination: expected_params[:destination],
       token: token,
     )
   end

--- a/app/controllers/subscriptions_auth_token_controller.rb
+++ b/app/controllers/subscriptions_auth_token_controller.rb
@@ -5,9 +5,16 @@ class SubscriptionsAuthTokenController < ApplicationController
     address = params.fetch(:address)
     topic_id = params.fetch(:topic_id)
     frequency = params.fetch(:frequency)
+    subscriber_list = SubscriberList.find_by!(slug: topic_id)
 
-    token = AuthTokenGeneratorService.call(address: address, topic_id: topic_id, frequency: frequency)
-    email = SubscriptionAuthEmailBuilder.call(address: address, token: token, topic_id: topic_id, frequency: frequency)
+    token = AuthTokenGeneratorService.call(address: address,
+                                           topic_id: topic_id,
+                                           frequency: frequency)
+
+    email = SubscriptionAuthEmailBuilder.call(address: address,
+                                              token: token,
+                                              subscriber_list: subscriber_list,
+                                              frequency: frequency)
 
     do_send email
     render json: {}, status: :ok

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,10 @@
 en:
   emails:
+    subscription_auth:
+      frequency:
+        daily: You’ll get one email a day
+        weekly: You’ll get one email a week
+        immediate: You’ll get an email each time we add or update a page
     message:
       subject: "Update from GOV.UK – %{title}"
       opening_line: Update on GOV.UK.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
       frequency:
         daily: You’ll get one email a day
         weekly: You’ll get one email a week
-        immediate: You’ll get an email each time we add or update a page
+        immediately: You’ll get an email each time we add or update a page
     message:
       subject: "Update from GOV.UK – %{title}"
       opening_line: Update on GOV.UK.

--- a/spec/builders/subscription_auth_email_builder_spec.rb
+++ b/spec/builders/subscription_auth_email_builder_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe SubscriptionAuthEmailBuilder do
     let(:address) { "test@gov.uk" }
     let(:token) { "secret" }
     let(:frequency) { "weekly" }
-    let(:topic_id) { "business-tax-corporation-tax" }
+    let(:subscriber_list) { create :subscriber_list, slug: "business-tax-corporation-tax" }
 
     subject(:call) do
       described_class.call(
         address: address,
         token: token,
-        topic_id: topic_id,
+        subscriber_list: subscriber_list,
         frequency: frequency,
       )
     end

--- a/spec/builders/subscription_auth_email_builder_spec.rb
+++ b/spec/builders/subscription_auth_email_builder_spec.rb
@@ -20,6 +20,29 @@ RSpec.describe SubscriptionAuthEmailBuilder do
       expect { call }.to change(Email, :count).by(1)
     end
 
+    it "has content for weekly subscriptions" do
+      email = call
+      expect(email.body).to include(I18n.t!("emails.subscription_auth.frequency.weekly"))
+    end
+
+    context "for daily subscriptions" do
+      let(:frequency) { "daily" }
+
+      it "has relevant content" do
+        email = call
+        expect(email.body).to include(I18n.t!("emails.subscription_auth.frequency.daily"))
+      end
+    end
+
+    context "for immediate subscriptions" do
+      let(:frequency) { "immediately" }
+
+      it "has relevant content" do
+        email = call
+        expect(email.body).to include(I18n.t!("emails.subscription_auth.frequency.immediately"))
+      end
+    end
+
     it "has a link to authenticate" do
       link = "http://www.dev.gov.uk/email/subscriptions/authenticate?token=#{token}&topic_id=business-tax-corporation-tax&frequency=weekly"
       email = call

--- a/spec/integration/subscriptions_auth_token_spec.rb
+++ b/spec/integration/subscriptions_auth_token_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe "Subscriptions auth token", type: :request do
   describe "creating an auth token" do
     let(:path) { "/subscriptions/auth-token" }
     let(:address) { "test@example.com" }
-    let(:topic_id) { "business-tax-corporation-tax" }
     let(:frequency) { "daily" }
+
+    let(:topic_id) do
+      create(:subscriber_list, slug: "business-tax-corporation-tax").slug
+    end
+
     let(:params) do
       {
         address: address,
@@ -29,6 +33,7 @@ RSpec.describe "Subscriptions auth token", type: :request do
         expect(response.status).to eq(422)
       end
     end
+
     context "when we're provided with a badly formatted email address" do
       let(:address) { "wrong.bad" }
 
@@ -37,6 +42,7 @@ RSpec.describe "Subscriptions auth token", type: :request do
         expect(response.status).to eq(422)
       end
     end
+
     context "when we're provided with no topic_id" do
       let(:topic_id) { nil }
 
@@ -45,6 +51,16 @@ RSpec.describe "Subscriptions auth token", type: :request do
         expect(response.status).to eq(422)
       end
     end
+
+    context "when the subscriber list does not exist" do
+      let(:topic_id) { "does-not-exist" }
+
+      it "returns a 404" do
+        post path, params: params
+        expect(response.status).to eq(404)
+      end
+    end
+
     context "when we're provided with no frequency" do
       let(:frequency) { nil }
 
@@ -53,6 +69,7 @@ RSpec.describe "Subscriptions auth token", type: :request do
         expect(response.status).to eq(422)
       end
     end
+
     context "when we're provided with a bad frequency" do
       let(:frequency) { "something_else" }
 


### PR DESCRIPTION
https://trello.com/c/g3cR5QGg/618-update-confirm-subscription-email-content

This is part of the new design for creating a new subscription.
Please see the commits for more details.

## Before

<img width="505" alt="Screenshot 2020-11-20 at 15 47 21" src="https://user-images.githubusercontent.com/9029009/99820004-1e3ebd80-2b48-11eb-93de-046db827aaf8.png">

## After

<img width="523" alt="Screenshot 2020-11-24 at 10 12 22" src="https://user-images.githubusercontent.com/9029009/100080312-943f6f00-2e3d-11eb-9df9-e0a8d4a70999.png">

