### PR TITLE
Remove redundant SubscriberList question methods

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -63,14 +63,6 @@ class SubscriberList < ApplicationRecord
     super(options)
   end
 
-  def is_travel_advice?
-    self[:links].include?("countries")
-  end
-
-  def is_medical_safety_alert?
-    self[:tags].fetch("format", []).include?("medical_safety_alert")
-  end
-
 private
 
   def link_values_are_valid

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -74,14 +74,6 @@ RSpec.describe SubscriberList, type: :model do
       expect(subject.errors[:links]).to include("All link values must be sent as Arrays")
     end
 
-    it "is not recognised as travel advice" do
-      expect(subject.is_travel_advice?).to be false
-    end
-
-    it "is not recognised as medical safety alert" do
-      expect(subject.is_medical_safety_alert?).to be false
-    end
-
     describe "url" do
       it "is valid when url is nil" do
         expect(build(:subscriber_list, url: nil)).to be_valid
@@ -145,22 +137,6 @@ RSpec.describe SubscriberList, type: :model do
 
     it "can access the subscribers" do
       expect(subject.subscribers.size).to eq(1)
-    end
-  end
-
-  context "with a travel advice subscriber list" do
-    subject { build(:subscriber_list, :travel_advice) }
-
-    it "is recognised as travel advice" do
-      expect(subject.is_travel_advice?).to be true
-    end
-  end
-
-  context "with a medical safety alert subscriber list" do
-    subject { build(:subscriber_list, :medical_safety_alert) }
-
-    it "is recognised as a medical safety alert" do
-      expect(subject.is_medical_safety_alert?).to be true
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/PaZNXoMS/320-dev-pain-we-have-special-email-signup-pages-for-foreign-travel-advice

These are only used for testing generic functionality of the system,
and do not need to exist.

Original commit: b8e133f13ce530435dcd643df7383561f0757789