### PR TITLE
Update subject for subscription confirmation email

### DIFF
--- a/app/builders/subscription_auth_email_builder.rb
+++ b/app/builders/subscription_auth_email_builder.rb
@@ -25,7 +25,7 @@ private
   attr_reader :address, :token, :frequency, :subscriber_list
 
   def subject
-    "Confirm your subscription"
+    "Confirm that you want to get emails from GOV.UK"
   end
 
   def body


### PR DESCRIPTION
https://trello.com/c/g3cR5QGg/618-update-confirm-subscription-email-content

This was missed in [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1478