### PR TITLE
Only send pending emails and do so in a lock

### DIFF
--- a/app/workers/send_email_worker.rb
+++ b/app/workers/send_email_worker.rb
@@ -7,7 +7,8 @@ class SendEmailWorker < ApplicationWorker
   sidekiq_options retry: 9
 
   sidekiq_retries_exhausted do |msg|
-    Email.find(msg["args"].first).update!(status: :failed)
+    Email.find_by(id: msg["args"].first, status: :pending)
+         &.update!(status: :failed)
   end
 
   def perform(email_id, metrics, queue)

--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -113,8 +113,9 @@ namespace :support do
   namespace :resend_failed_emails do
     desc "Re-send failed emails by email ids"
     task by_id: [:environment] do |_, args|
-      scope = Email.where(id: args.to_a)
-      ids = scope.where(status: :failed).pluck(:id)
+      ids = Email.where(id: args.to_a, status: :failed).pluck(:id)
+      Email.where(id: ids).update_all(status: :pending, updated_at: Time.zone.now)
+
       puts "Resending #{ids.length} emails"
 
       ids.each do |id|
@@ -126,8 +127,9 @@ namespace :support do
     task :by_date, %i[from to] => [:environment] do |_, args|
       from = Time.iso8601(args.fetch(:from))
       to = Time.iso8601(args.fetch(:to))
-      scope = Email.where(created_at: from..to)
-      ids = scope.where(status: :failed).pluck(:id)
+      ids = Email.where(created_at: from..to, status: :failed).pluck(:id)
+      Email.where(id: ids).update_all(status: :pending, updated_at: Time.zone.now)
+
       puts "Resending #{ids.length} emails"
 
       ids.each do |id|

--- a/spec/workers/send_email_worker_spec.rb
+++ b/spec/workers/send_email_worker_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe SendEmailWorker do
       described_class.new.perform(email.id, {}, queue)
     end
 
+    it "exits early when there isn't a pending email for the id" do
+      non_pending_email = create(:email, status: :failed)
+      expect(SendEmailService).not_to receive(:call)
+      described_class.new.perform(non_pending_email.id, {}, queue)
+    end
+
     context "when rate limit is exceeded" do
       around { |example| Sidekiq::Testing.fake! { example.run } }
       before { allow(rate_limiter).to receive(:exceeded?).and_return(true) }

--- a/spec/workers/send_email_worker_spec.rb
+++ b/spec/workers/send_email_worker_spec.rb
@@ -75,13 +75,6 @@ RSpec.describe SendEmailWorker do
       expect { described_class.sidekiq_retries_exhausted_block.call(sidekiq_message) }
         .to change { email.reload.status }.to("failed")
     end
-
-    context "when there isn't a delivery attempt" do
-      it "marks the email as failed" do
-        described_class.sidekiq_retries_exhausted_block.call(sidekiq_message)
-        expect(email.reload.status).to eq("failed")
-      end
-    end
   end
 
   describe ".perform_async_in_queue" do


### PR DESCRIPTION
Trello: https://trello.com/c/x0vYijvw/459-make-sending-an-email-idempotent

This changes how the SendEmailWorker runs so that it only attempts to send emails that are in a pending state (to avoid risks of resending the same email) and uses a DB lock to isolate the running (to ensure two workers can't be trying to send the same email at the same time).

This then updates the methods to send failed emails to work with the pending constraint.

More info in the commits.