### PR TITLE
Recover sending individual emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "plek"
 gem "ratelimit"
 gem "redcarpet"
 gem "sidekiq-scheduler"
+gem "sidekiq-unique-jobs"
 gem "with_advisory_lock"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,10 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
+    sidekiq-unique-jobs (6.0.25)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      sidekiq (>= 4.0, < 7.0)
+      thor (>= 0.20, < 2.0)
     simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -384,6 +388,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sidekiq-scheduler
+  sidekiq-unique-jobs
   simplecov
   webmock
   with_advisory_lock

--- a/app/workers/recover_lost_jobs_worker.rb
+++ b/app/workers/recover_lost_jobs_worker.rb
@@ -2,5 +2,6 @@ class RecoverLostJobsWorker < ApplicationWorker
   def perform
     RecoverLostJobsWorker::UnprocessedCheck.new.call
     RecoverLostJobsWorker::MissingDigestRunsCheck.new.call
+    RecoverLostJobsWorker::OldPendingEmailsCheck.new.call
   end
 end

--- a/app/workers/recover_lost_jobs_worker/old_pending_emails_check.rb
+++ b/app/workers/recover_lost_jobs_worker/old_pending_emails_check.rb
@@ -1,0 +1,18 @@
+class RecoverLostJobsWorker::OldPendingEmailsCheck
+  def call
+    old_pending_emails = Email.where(status: :pending)
+                              .where("created_at <= ?", 1.hour.ago)
+
+    recover(old_pending_emails)
+  end
+
+private
+
+  def recover(old_pending_emails)
+    old_pending_emails.in_batches do |relation|
+      relation.pluck(:id).each do |id|
+        SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate)
+      end
+    end
+  end
+end

--- a/app/workers/send_email_worker.rb
+++ b/app/workers/send_email_worker.rb
@@ -4,11 +4,6 @@ class SendEmailWorker < ApplicationWorker
   RATE_LIMIT_THRESHOLD = 21_600 # max requests in a minute, equates to 350 a second
   RATE_LIMIT_INTERVAL = 60
 
-  sidekiq_retries_exhausted do |msg|
-    Email.find_by(id: msg["args"].first, status: :pending)
-         &.update!(status: :failed)
-  end
-
   sidekiq_options lock: :until_executing,
                   unique_across_queues: true,
                   unique_args: :uniqueness_with, # in upcoming version 7 of sidekiq-unique-jobs, :unique_args is replaced with :lock_args

--- a/spec/workers/recover_lost_jobs_worker/old_pending_emails_check_spec.rb
+++ b/spec/workers/recover_lost_jobs_worker/old_pending_emails_check_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe RecoverLostJobsWorker::OldPendingEmailsCheck do
+  describe "#call" do
+    it "recovers pending emails over an hour old" do
+      email = create(:email, created_at: 2.hours.ago)
+      expect(SendEmailWorker)
+        .to receive(:perform_async_in_queue)
+        .with(email.id, queue: :send_email_immediate)
+
+      subject.call
+    end
+
+    it "does not recover recent pending emails" do
+      create(:email, created_at: 59.minutes.ago)
+      expect(SendEmailWorker).to_not receive(:perform_async_in_queue)
+      subject.call
+    end
+
+    it "does not recover emails that aren't pending" do
+      create(:email, created_at: 2.hours.ago, status: :sent)
+      expect(ProcessContentChangeWorker).not_to receive(:perform_async_in_queue)
+      subject.call
+    end
+  end
+end

--- a/spec/workers/recover_lost_jobs_worker_spec.rb
+++ b/spec/workers/recover_lost_jobs_worker_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe RecoverLostJobsWorker do
+  describe "#perform" do
+    it "delegates recovery" do
+      expect_any_instance_of(RecoverLostJobsWorker::UnprocessedCheck).to receive(:call)
+      expect_any_instance_of(RecoverLostJobsWorker::MissingDigestRunsCheck).to receive(:call)
+      expect_any_instance_of(RecoverLostJobsWorker::OldPendingEmailsCheck).to receive(:call)
+
+      subject.perform
+    end
+  end
+end

--- a/spec/workers/send_email_worker_spec.rb
+++ b/spec/workers/send_email_worker_spec.rb
@@ -84,15 +84,27 @@ RSpec.describe SendEmailWorker do
   end
 
   describe ".perform_async_in_queue" do
-    let(:email) { double(id: 0) }
+    let(:email) { create(:email) }
+    let(:email_two) { create(:email) }
 
     around do |example|
       Sidekiq::Testing.fake! { example.run }
     end
 
-    it "can add a job to a specific queue" do
+    it "can add jobs to specific queues" do
       described_class.perform_async_in_queue(email.id, queue: "send_email_immediate")
+      described_class.perform_async_in_queue(email_two.id, queue: "send_email_immediate_high")
+
       expect(Sidekiq::Queues["send_email_immediate"].size).to eq(1)
+      expect(Sidekiq::Queues["send_email_immediate_high"].size).to eq(1)
+    end
+
+    it "doesn't add a job to any queue if the email is already queued" do
+      described_class.perform_async_in_queue(email.id, queue: "send_email_immediate")
+      described_class.perform_async_in_queue(email.id, queue: "send_email_immediate_high")
+
+      expect(Sidekiq::Queues["send_email_immediate"].size).to eq(1)
+      expect(Sidekiq::Queues["send_email_immediate_high"].size).to eq(0)
     end
   end
 end

--- a/spec/workers/send_email_worker_spec.rb
+++ b/spec/workers/send_email_worker_spec.rb
@@ -67,22 +67,6 @@ RSpec.describe SendEmailWorker do
     end
   end
 
-  describe ".sidekiq_retries_exhausted_block" do
-    let(:email) { create(:email) }
-    let(:sidekiq_message) do
-      {
-        "args" => [email.id, {}],
-        "queue" => "send_email_immediate_high",
-        "class" => described_class.name,
-      }
-    end
-
-    it "marks the job as failed" do
-      expect { described_class.sidekiq_retries_exhausted_block.call(sidekiq_message) }
-        .to change { email.reload.status }.to("failed")
-    end
-  end
-
   describe ".perform_async_in_queue" do
     let(:email) { create(:email) }
     let(:email_two) { create(:email) }


### PR DESCRIPTION
We now recover and retry all emails that have a `pending` state which are an hour old. Historically we ended up with a cruft of `pending` emails that never got sent or removed from the system. All emails now get removed after 7 days so the cruft is limited but it's still true that some emails never get sent which this PR addresses.

See the commits for more info ->

## Prerequisites

- [x] Test this branch on integration by queuing up a large amount of emails to send and monitor the progress. We should check this change doesn't adversely effect performance / doesn't throw up any surprises.

Trello:
https://trello.com/c/iSL6WUwO/460-recover-sending-individual-emails