### PR TITLE
Revert "Remove archived_at column"

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,6 +1,8 @@
 # Any validations added this to this model won't be applied on record
 # creation as this table is populated by the #insert_all bulk method
 class Email < ApplicationRecord
+  self.ignored_columns = %w[archived_at]
+
   COURTESY_EMAIL = "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk".freeze
 
   enum status: { pending: 0, sent: 1, failed: 2 }

--- a/db/migrate/20201130145943_remove_email_archived_at.rb
+++ b/db/migrate/20201130145943_remove_email_archived_at.rb
@@ -1,5 +1,0 @@
-class RemoveEmailArchivedAt < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :emails, :archived_at, :datetime
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_145943) do
+ActiveRecord::Schema.define(version: 2020_11_10_163036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,10 +71,12 @@ ActiveRecord::Schema.define(version: 2020_11_30_145943) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address", null: false
+    t.datetime "archived_at"
     t.bigint "subscriber_id"
     t.integer "status", default: 0, null: false
     t.datetime "sent_at"
     t.index ["address"], name: "index_emails_on_address"
+    t.index ["archived_at"], name: "index_emails_on_archived_at"
     t.index ["created_at"], name: "index_emails_on_created_at"
     t.index ["subscriber_id"], name: "index_emails_on_subscriber_id"
   end


### PR DESCRIPTION
https://trello.com/c/UMGXUk5R/654-retire-archiving-emails

This reverts commit caec57b6b47fcd4ac8d76c2c0d292ffba3c2d845.

Applying this on Integration has lead to a table lock that's lasted
for over 30 minutes. We should investigate how we can make this change
without causing any downtime.