### PR TITLE
Revert "Move rate_limiter out of Services module" 

### DIFF
--- a/app/workers/send_email_worker.rb
+++ b/app/workers/send_email_worker.rb
@@ -35,9 +35,9 @@ class SendEmailWorker < ApplicationWorker
 private
 
   def rate_limit_exceeded?
-    rate_limiter.exceeded?("requests",
-                           threshold: RATE_LIMIT_THRESHOLD,
-                           interval: RATE_LIMIT_INTERVAL)
+    Services.rate_limiter.exceeded?("requests",
+                                    threshold: RATE_LIMIT_THRESHOLD,
+                                    interval: RATE_LIMIT_INTERVAL)
   end
 
   # Sidekiq uses JSON for a workers arguments, so richer objects are not
@@ -50,10 +50,6 @@ private
   end
 
   def increment_rate_limiter
-    rate_limiter.add("requests")
-  end
-
-  def rate_limiter
-    Services.rate_limiter
+    Services.rate_limiter.add("requests")
   end
 end

--- a/app/workers/send_email_worker.rb
+++ b/app/workers/send_email_worker.rb
@@ -54,8 +54,6 @@ private
   end
 
   def rate_limiter
-    @rate_limiter ||= Sidekiq.redis do |redis|
-      Ratelimit.new("send_email", redis: redis)
-    end
+    Services.rate_limiter
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,4 +2,8 @@ module Services
   def self.content_store
     @content_store ||= GdsApi::ContentStore.new(Plek.new.find("content-store"))
   end
+
+  def self.rate_limiter
+    @rate_limiter ||= Ratelimit.new("email-alert-api:deliveries")
+  end
 end

--- a/spec/workers/send_email_worker_spec.rb
+++ b/spec/workers/send_email_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SendEmailWorker do
   end
 
   before do
-    allow(Ratelimit).to receive(:new).and_return(rate_limiter)
+    allow(Services).to receive(:rate_limiter).and_return(rate_limiter)
   end
 
   describe "#perform" do


### PR DESCRIPTION
Trello: https://trello.com/c/sa9Qgdz7/661-look-into-sendemailworker-occasionally-taking-ages-to-run

We seem to have picked up an intermittent performance issue due to this
change that we've not been able to diagnose.

We have seen the occasional SendEmailWorker take crazy amounts of time
(around 4 hours). In trying to diagnose this on integration we found it
relatively easy to have a pool of workers take > 10 mins to
SendEmailWorker. We found that this 10 minutes was spent incrementing
the RateLimiter. Reverting this commit resolved this problem.

I'm not sure where the time gets lost in this, certainly not for hours.
I'm assuming there is some sort of deadlock that occurs which is
resolved by a timeout. This look a total pain to debug and we don't
have much time left as a team so I'm taking the rather ignorant route of
reverting without understanding exactly why the problem occurs.