### PR TITLE
Remove link to feedback survey in emails

### DIFF
--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -64,14 +64,12 @@ private
   end
 
   def footer(subscriptions, address)
-    return feedback_link if subscriptions.empty?
+    return "" if subscriptions.empty?
 
     <<~BODY
       #{permission_reminder(subscriptions.first.subscriber_list)}
 
       #{ManageSubscriptionsLinkPresenter.call(address)}
-
-      #{feedback_link}
     BODY
   end
 
@@ -83,13 +81,5 @@ private
             end
 
     I18n.t!("emails.content_change.permission_reminder", topic: topic)
-  end
-
-  def feedback_link
-    I18n.t!(
-      "emails.feedback_link",
-      survey_link: I18n.t!("emails.content_change.survey_link"),
-      feedback_link: "#{Plek.new.website_root}/contact",
-    )
   end
 end

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -33,8 +33,6 @@ private
       #{I18n.t!("emails.digests.#{digest_run.range}.permission_reminder")}
 
       #{ManageSubscriptionsLinkPresenter.call(address)}
-
-      #{feedback_link.strip}
     BODY
   end
 
@@ -85,13 +83,5 @@ private
     end
 
     changes.join("\n---\n\n")
-  end
-
-  def feedback_link
-    I18n.t!(
-      "emails.feedback_link",
-      survey_link: I18n.t!("emails.digests.#{digest_run.range}.survey_link"),
-      feedback_link: "#{Plek.new.website_root}/contact",
-    )
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,19 +13,15 @@ en:
       subject: "Update from GOV.UK – %{title}"
       opening_line: Update on GOV.UK.
       permission_reminder: "^You’re getting this email because you subscribed to immediate updates to ‘%{topic}’ on GOV.UK."
-      survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate
     digests:
       daily:
         subject: "Daily update from GOV.UK"
         opening_line: Daily update from GOV.UK.
         permission_reminder: "^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK."
-        survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
       weekly:
         subject: "Weekly update from GOV.UK"
         opening_line: Updates on GOV.UK this week.
         permission_reminder: "^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK."
-        survey_link: https://www.smartsurvey.co.uk/s/govuk-email/?f=digests
     description_header: "Page summary"
     change_note_header: "Change made"
     public_updated_at_header: "Time updated"
-    feedback_link: "Is this email useful? [Answer some questions to tell us more](%{survey_link})."

--- a/spec/builders/content_change_email_builder_spec.rb
+++ b/spec/builders/content_change_email_builder_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ContentChangeEmailBuilder do
           presented_content_change
 
           ---
-          Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
+
         BODY
       )
     end
@@ -126,8 +126,6 @@ RSpec.describe ContentChangeEmailBuilder do
               ^You’re getting this email because you subscribed to immediate updates to ‘#{subscriptions.first.subscriber_list.title}’ on GOV.UK.
 
               [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
-
-              Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
             BODY
           )
         end
@@ -157,8 +155,6 @@ RSpec.describe ContentChangeEmailBuilder do
               ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscriptions.second.subscriber_list.title}](#{Plek.new.website_root}#{subscriptions.second.subscriber_list.url})’ on GOV.UK.
 
               [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
-
-              Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=immediate).
             BODY
           )
         end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -95,8 +95,6 @@ RSpec.describe DigestEmailBuilder do
         ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
         [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
-
-        Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
       BODY
     )
   end

--- a/spec/features/create_and_deliver_a_daily_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_daily_digest_spec.rb
@@ -217,8 +217,6 @@ RSpec.describe "create and deliver a daily digest", type: :request do
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
-
-      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -252,8 +250,6 @@ RSpec.describe "create and deliver a daily digest", type: :request do
       ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
-
-      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 end

--- a/spec/features/create_and_deliver_a_weekly_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_weekly_digest_spec.rb
@@ -228,8 +228,6 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
-
-      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 
@@ -266,8 +264,6 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
 
       [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
-
-      Is this email useful? [Answer some questions to tell us more](https://www.smartsurvey.co.uk/s/govuk-email/?f=digests).
     BODY
   end
 end


### PR DESCRIPTION
https://trello.com/c/7EUikumz/665-close-smart-survey-which-we-link-to-in-emails-we-send

This is being removed since the Notifications team is being paused,
and there is no one to look at the feedback collected. While it may
normally be useful to continuously gather feedback, we also know that
the questions in the current survey are flawed i.e. there's no point
someone filling it in, because the data isn't useful.

Note that, if a user unsubscribes after an individual-type email is
generated, they will see a pointless separator at the bottom of the
email, due to the way the builder for this email is structure. This
doesn't like a big issue, and we're intending to rewrite the template
for them anyway, so I've left it that way for now.