### PR TITLE
Stop logging every email (fills up the disk!)

### DIFF
--- a/app/services/send_email_service/send_pseudo_email.rb
+++ b/app/services/send_email_service/send_pseudo_email.rb
@@ -11,8 +11,6 @@ class SendEmailService::SendPseudoEmail
     Rails.logger.info <<~INFO
       Logging email (#{email.id}) we'd have attempted to send to #{email.address}
       Subject: #{email.subject}
-      Body:
-      #{email.body}
     INFO
 
     Metrics.sent_to_pseudo_successfully


### PR DESCRIPTION
    Previously we emulated the behaviour of the former PseudoProvider
    by writing pseudo-sent email contents to a log file. However, this
    never used to happen in Integration/Staging, since we actually used
    the NotifyProvider with an allowed list [1]. This removes some of
    the logging, since the sheer volume of logs has actually filled
    one of the disks in Integration.

    [1]: https://github.com/alphagov/email-alert-api/pull/1489