### PR TITLE
Remove passthrough for "redirect" in auth token

### DIFF
--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -15,10 +15,7 @@ class SubscribersAuthTokenController < ApplicationController
 private
 
   def generate_token(subscriber)
-    AuthTokenGeneratorService.call(
-      "subscriber_id" => subscriber.id,
-      "redirect" => expected_params[:redirect],
-    )
+    AuthTokenGeneratorService.call("subscriber_id" => subscriber.id)
   end
 
   def build_email(subscriber, token)
@@ -30,7 +27,7 @@ private
   end
 
   def expected_params
-    params.permit(:address, :destination, :redirect)
+    params.permit(:address, :destination)
   end
 
   def validate_params
@@ -45,6 +42,5 @@ private
 
     validates :destination, presence: true
     validates :destination, root_relative_url: true, allow_blank: true
-    validates :redirect, root_relative_url: true, allow_blank: true
   end
 end

--- a/spec/features/create_an_auth_token_spec.rb
+++ b/spec/features/create_an_auth_token_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Create an auth token", type: :request do
   let(:address) { "test@example.com" }
   let!(:subscriber) { create(:subscriber, address: address) }
   let(:destination) { "/authenticate" }
-  let(:redirect) { "/logged-in-page" }
 
   scenario "successful auth token" do
     login_with_internal_app
@@ -19,15 +18,14 @@ RSpec.describe "Create an auth token", type: :request do
          params: {
            address: address,
            destination: destination,
-           redirect: redirect,
          }
 
-    notify_email_stub = notify_email(subscriber, destination, redirect)
+    notify_email_stub = notify_email(subscriber, destination)
     expect(response.status).to be 201
     expect(notify_email_stub).to have_been_requested
   end
 
-  def notify_email(subscriber, destination, redirect)
+  def notify_email(subscriber, destination)
     stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email")
       .with(
         "body" => hash_including(
@@ -43,7 +41,6 @@ RSpec.describe "Create an auth token", type: :request do
 
         expect(decrypt_and_verify_token(token)).to eq(
           "subscriber_id" => subscriber.id,
-          "redirect" => redirect,
         )
       end
   end

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe "Subscribers auth token", type: :request do
     let(:path) { "/subscribers/auth-token" }
     let(:address) { "test@example.com" }
     let(:destination) { "/test" }
-    let(:redirect) { nil }
     let(:params) do
       {
         address: address,
         destination: destination,
-        redirect: redirect,
       }
     end
     let!(:subscriber) { create(:subscriber, address: "test@example.com") }
@@ -36,9 +34,9 @@ RSpec.describe "Subscribers auth token", type: :request do
       post path, params: params
       expect(Email.count).to be 1
       token = Email.last.body.match(/token=([^&\n]+)/)[1]
+
       expect(decrypt_and_verify_token(token)).to eq(
         "subscriber_id" => subscriber.id,
-        "redirect" => redirect,
       )
     end
 
@@ -80,24 +78,6 @@ RSpec.describe "Subscribers auth token", type: :request do
 
     context "when we're given a bad destination" do
       let(:destination) { "http://example.com/test" }
-
-      it "returns a 422" do
-        post path, params: params
-        expect(response.status).to eq(422)
-      end
-    end
-
-    context "when we're given a path redirect" do
-      let(:redirect) { "/test" }
-
-      it "returns a 201" do
-        post path, params: params
-        expect(response.status).to eq(201)
-      end
-    end
-
-    context "when we're given a bad redirect" do
-      let(:redirect) { "http://example.com/test" }
 
       it "returns a 422" do
         post path, params: params


### PR DESCRIPTION
https://trello.com/c/sgJIkObA/662-authenticate-before-unsubscribing-from-digest-emails

Previously the subscriber auth API accepted a "redirect" parameter,
which Email Alert Frontend could then use to forward the subscriber
to a particular page, after authenticating at the "destination" [1].
In practice this is not used, and makes it harder to understand the
sign in process (just because it's not used). This removes support
for the parameter, noting it's never been sent by the frontend [2].

[1]: https://github.com/alphagov/email-alert-api/pull/560/commits/b609e2464fe4734675931492a220d202fcc736fd
[2]: https://github.com/alphagov/email-alert-frontend/commit/ceac5ac17412f6afaac41642767d9f898e8d4d74#diff-6966e9ac443db47e60dc97c2beb2864ce79ab9a4ce5e477d5280232620d4baedR19-R22