### PR TITLE
Reinstate confirmation email for subscriptions

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -1,0 +1,67 @@
+class SubscriptionConfirmationEmailBuilder
+  def initialize(subscription:)
+    @subscription = subscription
+  end
+
+  def self.call(**args)
+    new(**args).call
+  end
+
+  def call
+    Email.create!(
+      subject: subject,
+      body: body,
+      address: subscriber.address,
+      subscriber_id: subscriber.id,
+    )
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :subscription
+
+  def subscriber
+    @subscriber ||= subscription.subscriber
+  end
+
+  def subscriber_list
+    @subscriber_list ||= subscription.subscriber_list
+  end
+
+  def subject
+    "You've subscribed to #{subscriber_list.title}"
+  end
+
+  def body
+    <<~BODY
+      You’ll get an email each time there are changes to #{title}.
+
+      #{subscriber_list.description}
+
+      ---
+
+      #{ManageSubscriptionsLinkPresenter.call(subscriber.address)}
+    BODY
+  end
+
+  def title
+    return subscriber_list.title unless subscriber_list.url
+
+    "[#{subscriber_list.title}](#{title_url})"
+  end
+
+  def title_url
+    query = {
+      utm_source: subscriber_list.slug,
+      utm_medium: "email",
+      utm_campaign: "govuk-notifications-subscription-confirmation",
+    }.to_query
+
+    url = subscriber_list.url
+    tracked_url = url + (url.include?("?") ? "&" : "?") + query
+
+    PublicUrls.url_for(base_path: tracked_url)
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -190,7 +190,7 @@ It will create a new subscription between the email address and the subscriber
 list. It will respond with a `201 Created` if it's a new subscription or a `200
 OK` if the subscription already exists. If a subscription already exists but
 the frequency is different, the current subscription is ended and a new one
-with the updated frequency is created.
+with the updated frequency is created. A confirmation email will be sent.
 
 > Note: using any email address that ends with `@notifications.service.gov.uk`
 will not create a subscriber or a subscription, however will return a `201 Created` response.

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe SubscriptionConfirmationEmailBuilder do
+  describe ".call" do
+    let(:subscriber_list) { create(:subscriber_list, title: "Example") }
+    let(:subscription) { create(:subscription, subscriber_list: subscriber_list) }
+
+    subject(:call) do
+      described_class.call(subscription: subscription)
+    end
+
+    it { is_expected.to be_instance_of(Email) }
+
+    it "creates an email" do
+      expect { call }.to change(Email, :count).by(1)
+    end
+
+    it "includes the title of the subscriber list" do
+      title = "Example"
+      email = call
+      expect(email.subject).to include(title)
+      expect(email.body).to include(title)
+      expect(email.body).to match(/You’ll get an email each time there are changes to/)
+    end
+
+    it "includes a link to manage subscriptions" do
+      text = "View, unsubscribe or change the frequency of your subscriptions"
+      email = call
+      expect(email.body).to include(text)
+    end
+
+    context "when the subscriber list has a URL" do
+      let(:subscriber_list) { create(:subscriber_list, url: "/example") }
+
+      it "includes a link to the subscriber list" do
+        link = "http://www.dev.gov.uk/example?utm_campaign=govuk-notifications-subscription-confirmation&utm_medium=email&utm_source=#{subscriber_list.slug}"
+        email = call
+        expect(email.body).to include(link)
+      end
+    end
+
+    context "when the subscriber list has a description" do
+      let(:subscriber_list) { create(:subscriber_list, description: "Example description") }
+
+      it "includes the description of the subscriber list" do
+        description = "Example description"
+        email = call
+        expect(email.body).to include(description)
+      end
+    end
+  end
+end

--- a/spec/features/subscribing_spec.rb
+++ b/spec/features/subscribing_spec.rb
@@ -5,7 +5,15 @@ RSpec.describe "Subscribing to a subscriber_list", type: :request do
     subscriber_list_id = create_subscriber_list
 
     subscribe_to_subscriber_list(subscriber_list_id, expected_status: 201)
+    expect_a_subscription_confirmation_email_was_sent
+
     subscribe_to_subscriber_list(subscriber_list_id, expected_status: 200)
     subscribe_to_subscriber_list("missing",          expected_status: 404)
+  end
+
+  def expect_a_subscription_confirmation_email_was_sent
+    email_data = expect_an_email_was_sent
+    subject = email_data.fetch(:personalisation).fetch(:subject)
+    expect(subject).to match(/You've subscribed to/)
   end
 end


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

Previously we removed this because it adds no value for a standard
GOV.UK subscription, except in the case where the list description
was present i.e. a link to Brexit Checker results. This reinstates
the confirmation email, but only when it's useful.

Note that this also removes the previous conditional around whether
an existing subscription was overridden, since this has no bearing
on the expectations of the user, and helps simplify the code.