### PR TITLE
Fix scope bug when creating a new subscription

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -28,8 +28,9 @@ class SubscriptionsController < ApplicationController
         )
       end
 
+      subscription = new_subscription || existing_subscription
+
       unless params[:skip_confirmation_email]
-        subscription = new_subscription || existing_subscription
         email = SubscriptionConfirmationEmailBuilder.call(subscription: subscription)
       end
 

--- a/spec/integration/subscriptions_spec.rb
+++ b/spec/integration/subscriptions_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe "Subscriptions", type: :request do
           create_subscription(extra_params: { skip_confirmation_email: true })
           expect(a_request(:post, /notifications/)).to_not have_been_made
         end
+
+        it "returns status code 200" do
+          create_subscription(extra_params: { skip_confirmation_email: true })
+          expect(response.status).to eq(200)
+        end
       end
 
       context "with an existing subscription with identical frequency" do


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

Previously this was missed due to not testing the response code
when the request specifies to skip a confirmation email.