### PR TITLE
Replace courtesy copies with a real subscription

### DIFF
--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -27,7 +27,7 @@ private
         {
           address: address,
           subject: subject(recipient_and_content.fetch(:content_change)),
-          body: body(recipient_and_content.fetch(:content_change), recipient_and_content.fetch(:subscriptions), address),
+          body: body(recipient_and_content.fetch(:content_change), recipient_and_content.fetch(:subscriptions).first, address),
           subscriber_id: recipient_and_content.fetch(:subscriber_id),
           created_at: now,
           updated_at: now,
@@ -40,21 +40,21 @@ private
     I18n.t!("emails.content_change.subject", title: content_change.title)
   end
 
-  def body(content_change, subscriptions, address)
+  def body(content_change, subscription, address)
     <<~BODY
       #{I18n.t!('emails.content_change.opening_line')}
 
       ---
-      #{presented_content_change(content_change, subscriptions)}
+      #{presented_content_change(content_change, subscription)}
       ---
-      #{footer(subscriptions, address).strip}
+      #{footer(subscription, address).strip}
     BODY
   end
 
-  def presented_content_change(content_change, subscriptions)
+  def presented_content_change(content_change, subscription)
     copy = ContentChangePresenter.call(content_change)
 
-    subscriber_list = subscriptions.first.subscriber_list
+    subscriber_list = subscription.subscriber_list
     if subscriber_list.description.present?
       copy += "\n#{subscriber_list.description}\n"
     end
@@ -62,9 +62,9 @@ private
     copy
   end
 
-  def footer(subscriptions, address)
+  def footer(subscription, address)
     <<~BODY
-      #{permission_reminder(subscriptions.first.subscriber_list)}
+      #{permission_reminder(subscription.subscriber_list)}
 
       #{ManageSubscriptionsLinkPresenter.call(address)}
     BODY

--- a/app/builders/content_change_email_builder.rb
+++ b/app/builders/content_change_email_builder.rb
@@ -53,7 +53,6 @@ private
 
   def presented_content_change(content_change, subscriptions)
     copy = ContentChangePresenter.call(content_change)
-    return copy if subscriptions.empty?
 
     subscriber_list = subscriptions.first.subscriber_list
     if subscriber_list.description.present?
@@ -64,8 +63,6 @@ private
   end
 
   def footer(subscriptions, address)
-    return "" if subscriptions.empty?
-
     <<~BODY
       #{permission_reminder(subscriptions.first.subscriber_list)}
 

--- a/app/builders/message_email_builder.rb
+++ b/app/builders/message_email_builder.rb
@@ -26,7 +26,7 @@ private
         {
           address: x[:address],
           subject: subject(x[:message]),
-          body: body(x[:message], x[:subscriptions], x[:address]),
+          body: body(x[:message], x[:subscriptions].first, x[:address]),
           subscriber_id: x[:subscriber_id],
           created_at: now,
           updated_at: now,
@@ -39,7 +39,7 @@ private
     I18n.t!("emails.message.subject", title: message.title)
   end
 
-  def body(message, subscriptions, address)
+  def body(message, subscription, address)
     copy = <<~BODY
       #{I18n.t!('emails.message.opening_line')}
 
@@ -47,7 +47,7 @@ private
       #{MessagePresenter.call(message)}
     BODY
 
-    subscriber_list = subscriptions.first.subscriber_list
+    subscriber_list = subscription.subscriber_list
 
     if subscriber_list.description.present?
       copy += "#{subscriber_list.description}\n"

--- a/app/builders/message_email_builder.rb
+++ b/app/builders/message_email_builder.rb
@@ -47,20 +47,18 @@ private
       #{MessagePresenter.call(message)}
     BODY
 
-    if subscriptions.any?
-      subscriber_list = subscriptions.first.subscriber_list
+    subscriber_list = subscriptions.first.subscriber_list
 
-      if subscriber_list.description.present?
-        copy += "#{subscriber_list.description}\n"
-      end
-
-      copy += <<~BODY
-        ---
-        #{permission_reminder(subscriber_list)}
-
-        #{ManageSubscriptionsLinkPresenter.call(address)}
-      BODY
+    if subscriber_list.description.present?
+      copy += "#{subscriber_list.description}\n"
     end
+
+    copy += <<~BODY
+      ---
+      #{permission_reminder(subscriber_list)}
+
+      #{ManageSubscriptionsLinkPresenter.call(address)}
+    BODY
 
     copy
   end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,8 +1,6 @@
 # Any validations added this to this model won't be applied on record
 # creation as this table is populated by the #insert_all bulk method
 class Email < ApplicationRecord
-  COURTESY_EMAIL = "govuk-email-courtesy-copies@digital.cabinet-office.gov.uk".freeze
-
   enum status: { pending: 0, sent: 1, failed: 2 }
 
   def self.timed_bulk_insert(records, batch_size)

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -9,26 +9,7 @@ class ProcessContentChangeWorker < ApplicationWorker
       MatchedContentChangeGenerationService.call(content_change)
       ImmediateEmailGenerationService.call(content_change)
 
-      queue_courtesy_email(content_change)
       content_change.update!(processed_at: Time.zone.now)
     end
-  end
-
-private
-
-  def queue_courtesy_email(content_change)
-    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
-    return unless subscriber
-
-    id = ContentChangeEmailBuilder.call([
-      {
-        address: subscriber.address,
-        subscriptions: [],
-        content_change: content_change,
-        subscriber_id: subscriber.id,
-      },
-    ]).first
-
-    SendEmailWorker.perform_async_in_queue(id, queue: content_change.queue)
   end
 end

--- a/app/workers/process_message_worker.rb
+++ b/app/workers/process_message_worker.rb
@@ -9,26 +9,7 @@ class ProcessMessageWorker < ApplicationWorker
       MatchedMessageGenerationService.call(message)
       ImmediateEmailGenerationService.call(message)
 
-      queue_courtesy_email(message)
       message.update!(processed_at: Time.zone.now)
     end
-  end
-
-private
-
-  def queue_courtesy_email(message)
-    subscriber = Subscriber.find_by(address: Email::COURTESY_EMAIL)
-    return unless subscriber
-
-    id = MessageEmailBuilder.call([
-      {
-        address: subscriber.address,
-        subscriptions: [],
-        message: message,
-        subscriber_id: subscriber.id,
-      },
-    ]).first
-
-    SendEmailWorker.perform_async_in_queue(id, queue: message.queue)
   end
 end

--- a/spec/builders/content_change_email_builder_spec.rb
+++ b/spec/builders/content_change_email_builder_spec.rb
@@ -1,27 +1,13 @@
 RSpec.describe ContentChangeEmailBuilder do
   let(:subscriber) { build(:subscriber, address: "test@example.com") }
 
-  let(:subscription_one) do
+  let(:subscription) do
     build(
       :subscription,
       id: "bef9b608-05ba-46ce-abb7-8567f4180a25",
       subscriber: subscriber,
       subscriber_list: build(:subscriber_list, title: "First Subscription"),
     )
-  end
-  let(:subscription_two) do
-    build(
-      :subscription,
-      id: "69ca6fce-34f5-4ebd-943c-83bd1b2e70fb",
-      subscriber: subscriber,
-      subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription", description: "subscriber_list_description"),
-    )
-  end
-  let(:subscriptions) do
-    [
-      subscription_one,
-      subscription_two,
-    ]
   end
 
   let(:content_change) do
@@ -36,16 +22,12 @@ RSpec.describe ContentChangeEmailBuilder do
   end
 
   describe ".call" do
-    let(:subscription_content) do
-      double(subscription: subscription_one, content_change: content_change)
-    end
-
     let(:params) do
       [
         {
           address: subscriber.address,
           content_change: content_change,
-          subscriptions: [],
+          subscriptions: [subscription, "other_subscription"],
           subscriber_id: subscriber.id,
         },
       ]
@@ -63,9 +45,11 @@ RSpec.describe ContentChangeEmailBuilder do
       expect(email.subject).to eq("Update from GOV.UK – Title")
     end
 
-    it "sets the body and unsubscribe links" do
+    it "sets the body" do
       expect(ContentChangePresenter).to receive(:call)
         .and_return("presented_content_change\n")
+
+      expect(email.status).to eq "pending"
 
       expect(email.body).to eq(
         <<~BODY,
@@ -75,7 +59,9 @@ RSpec.describe ContentChangeEmailBuilder do
           presented_content_change
 
           ---
+          ^You’re getting this email because you subscribed to immediate updates to ‘#{subscription.subscriber_list.title}’ on GOV.UK.
 
+          [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
         BODY
       )
     end
@@ -88,76 +74,37 @@ RSpec.describe ContentChangeEmailBuilder do
       expect { described_class.call([]) }.to raise_error(ArgumentError)
     end
 
-    context "with a subscription" do
-      let(:params) do
-        [
-          {
-            address: subscriber.address,
-            content_change: content_change,
-            subscriptions: [subscription_content.subscription],
-            subscriber_id: subscriber.id,
-          },
-        ]
+    context "with a URL and a description" do
+      let(:subscription) do
+        build(
+          :subscription,
+          id: "69ca6fce-34f5-4ebd-943c-83bd1b2e70fb",
+          subscriber: subscriber,
+          subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription", description: "subscriber_list_description"),
+        )
       end
 
-      subject(:email_import) { described_class.call(params) }
+      it "sets the body" do
+        expect(ContentChangePresenter).to receive(:call)
+          .and_return("presented_content_change\n")
 
-      let(:email) { Email.find(email_import.first) }
+        expect(email.status).to eq "pending"
 
-      context "without a URL" do
-        let(:subscription_content) do
-          double(subscription: subscription_one, content_change: content_change)
-        end
+        expect(email.body).to eq(
+          <<~BODY,
+            Update on GOV.UK.
 
-        it "sets the body" do
-          expect(ContentChangePresenter).to receive(:call)
-            .and_return("presented_content_change\n")
+            ---
+            presented_content_change
 
-          expect(email.status).to eq "pending"
+            subscriber_list_description
 
-          expect(email.body).to eq(
-            <<~BODY,
-              Update on GOV.UK.
+            ---
+            ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscription.subscriber_list.title}](#{Plek.new.website_root}#{subscription.subscriber_list.url})’ on GOV.UK.
 
-              ---
-              presented_content_change
-
-              ---
-              ^You’re getting this email because you subscribed to immediate updates to ‘#{subscriptions.first.subscriber_list.title}’ on GOV.UK.
-
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
-            BODY
-          )
-        end
-      end
-
-      context "with a URL and a description" do
-        let(:subscription_content) do
-          double(subscription: subscription_two, content_change: content_change)
-        end
-
-        it "sets the body" do
-          expect(ContentChangePresenter).to receive(:call)
-            .and_return("presented_content_change\n")
-
-          expect(email.status).to eq "pending"
-
-          expect(email.body).to eq(
-            <<~BODY,
-              Update on GOV.UK.
-
-              ---
-              presented_content_change
-
-              subscriber_list_description
-
-              ---
-              ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscriptions.second.subscriber_list.title}](#{Plek.new.website_root}#{subscriptions.second.subscriber_list.url})’ on GOV.UK.
-
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
-            BODY
-          )
-        end
+            [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
+          BODY
+        )
       end
     end
   end

--- a/spec/builders/message_email_builder_spec.rb
+++ b/spec/builders/message_email_builder_spec.rb
@@ -1,27 +1,12 @@
 RSpec.describe MessageEmailBuilder do
   let(:subscriber) { create(:subscriber, address: "test@example.com") }
 
-  let(:subscription_one) do
+  let(:subscription) do
     create(
       :subscription,
       subscriber: subscriber,
       subscriber_list: build(:subscriber_list, title: "First Subscription"),
     )
-  end
-
-  let(:subscription_two) do
-    create(
-      :subscription,
-      subscriber: subscriber,
-      subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription", description: "subscriber_list_description"),
-    )
-  end
-
-  let(:subscriptions) do
-    [
-      subscription_one,
-      subscription_two,
-    ]
   end
 
   let(:message) { create(:message, title: "Title", body: "Some content") }
@@ -32,7 +17,7 @@ RSpec.describe MessageEmailBuilder do
         {
           address: subscriber.address,
           message: message,
-          subscriptions: [],
+          subscriptions: [subscription, "other_subscription"],
           subscriber_id: subscriber.id,
         },
       ]
@@ -51,6 +36,8 @@ RSpec.describe MessageEmailBuilder do
     end
 
     it "sets the body" do
+      email = Email.find(email_import.first)
+
       expect(email.body).to eq(
         <<~BODY,
           Update on GOV.UK.
@@ -60,6 +47,10 @@ RSpec.describe MessageEmailBuilder do
 
           Some content
 
+          ---
+          ^You’re getting this email because you subscribed to immediate updates to ‘#{subscription.subscriber_list.title}’ on GOV.UK.
+
+          [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
         BODY
       )
     end
@@ -72,71 +63,34 @@ RSpec.describe MessageEmailBuilder do
       expect { described_class.call([]) }.to raise_error(ArgumentError)
     end
 
-    context "with a subscription" do
-      let(:subscription) { nil }
-
-      let(:params) do
-        [
-          {
-            address: subscriber.address,
-            message: message,
-            subscriptions: [subscription],
-            subscriber_id: subscriber.id,
-          },
-        ]
+    context "with a URL and a description" do
+      let(:subscription) do
+        create(
+          :subscription,
+          subscriber: subscriber,
+          subscriber_list: build(:subscriber_list, title: "Second Subscription", url: "/subscription", description: "subscriber_list_description"),
+        )
       end
 
-      subject(:email_import) { described_class.call(params) }
+      it "sets the body" do
+        email = Email.find(email_import.first)
 
-      let(:email) { Email.find(email_import.first) }
+        expect(email.body).to eq(
+          <<~BODY,
+            Update on GOV.UK.
 
-      context "without a URL" do
-        let(:subscription) { subscription_one }
+            ---
+            Title
 
-        it "sets the body" do
-          email = Email.find(email_import.first)
+            Some content
 
-          expect(email.body).to eq(
-            <<~BODY,
-              Update on GOV.UK.
+            subscriber_list_description
+            ---
+            ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscription.subscriber_list.title}](#{Plek.new.website_root}#{subscription.subscriber_list.url})’ on GOV.UK.
 
-              ---
-              Title
-
-              Some content
-
-              ---
-              ^You’re getting this email because you subscribed to immediate updates to ‘#{subscriptions.first.subscriber_list.title}’ on GOV.UK.
-
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
-            BODY
-          )
-        end
-      end
-
-      context "with a URL and a description" do
-        let(:subscription) { subscription_two }
-
-        it "sets the body" do
-          email = Email.find(email_import.first)
-
-          expect(email.body).to eq(
-            <<~BODY,
-              Update on GOV.UK.
-
-              ---
-              Title
-
-              Some content
-
-              subscriber_list_description
-              ---
-              ^You’re getting this email because you subscribed to immediate updates to ‘[#{subscription.subscriber_list.title}](#{Plek.new.website_root}#{subscription.subscriber_list.url})’ on GOV.UK.
-
-              [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
-            BODY
-          )
-        end
+            [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test%40example.com)
+          BODY
+        )
       end
     end
   end

--- a/spec/integration/unpublish_message_spec.rb
+++ b/spec/integration/unpublish_message_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe "Sending an unpublish message", type: :request do
         address: "test@example.com",
       )
 
-      create(
-        :subscriber,
-        address: Email::COURTESY_EMAIL,
-      )
-
       subscriber_list = create(
         :subscriber_list,
         links: { taxon_tree: { any: [content_id] } },
@@ -49,10 +44,6 @@ RSpec.describe "Sending an unpublish message", type: :request do
 
     it "returns status 202" do
       expect(response.status).to eq(202)
-    end
-
-    it "creates an Email and a courtesy email" do
-      expect(Email.count).to eq(2)
     end
 
     it "sends an email" do

--- a/spec/workers/process_content_change_worker_spec.rb
+++ b/spec/workers/process_content_change_worker_spec.rb
@@ -25,22 +25,6 @@ RSpec.describe ProcessContentChangeWorker do
       described_class.new.perform(content_change.id)
     end
 
-    it "can send a courtesy copy email" do
-      create(:subscriber, address: Email::COURTESY_EMAIL)
-      email = create(:email)
-
-      expect(ContentChangeEmailBuilder)
-        .to receive(:call)
-        .with([hash_including(address: Email::COURTESY_EMAIL)])
-        .and_return([email.id])
-
-      expect(SendEmailWorker)
-        .to receive(:perform_async_in_queue)
-        .with(email.id, queue: :send_email_immediate)
-
-      described_class.new.perform(content_change.id)
-    end
-
     it "marks a content change as processed" do
       freeze_time do
         expect { described_class.new.perform(content_change.id) }

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -26,22 +26,6 @@ RSpec.describe ProcessMessageWorker do
       described_class.new.perform(message.id)
     end
 
-    it "can send a courtesy copy email" do
-      create(:subscriber, address: Email::COURTESY_EMAIL)
-      email = create(:email)
-
-      expect(MessageEmailBuilder)
-        .to receive(:call)
-        .with([hash_including(address: Email::COURTESY_EMAIL)])
-        .and_return([email.id])
-
-      expect(SendEmailWorker)
-        .to receive(:perform_async_in_queue)
-        .with(email.id, queue: :send_email_immediate)
-
-      described_class.new.perform(message.id)
-    end
-
     it "marks a message as processed" do
       freeze_time do
         expect { described_class.new.perform(message.id) }


### PR DESCRIPTION
https://trello.com/c/pZqhXafv/671-update-template-for-individual-type-emails-inc-one-click-unsubscribe

This functionality is redundant, as we can achieve a more
realistic outcome by subscribing the current Google Group to
the "all-government-publishing-updates" list.

Please see the commits for more details.

Other things to do:

- Actually subscribe the group to the list.
- Update documentation about the group.
- Consider renaming the group to match Integration / Staging.