### PR TITLE
Fix bug with not creating new subscriptions

### DIFF
--- a/app/services/create_subscription_service.rb
+++ b/app/services/create_subscription_service.rb
@@ -12,7 +12,7 @@ class CreateSubscriptionService < ApplicationService
     ApplicationRecord.transaction do
       subscriber.lock!
 
-      subscription = Subscription.find_by(
+      subscription = Subscription.active.find_by(
         subscriber_list: subscriber_list,
         subscriber: subscriber,
       )

--- a/spec/services/create_subscription_service_spec.rb
+++ b/spec/services/create_subscription_service_spec.rb
@@ -45,6 +45,21 @@ RSpec.describe CreateSubscriptionService do
       expect(new_subscription).to eq subscription
     end
 
+    it "ignores subscriptions that were previously ended" do
+      create(
+        :subscription,
+        :ended,
+        subscriber_list: subscriber_list,
+        subscriber: subscriber,
+        frequency: frequency,
+      )
+
+      new_subscription = described_class.call(*args)
+      expect(new_subscription).to_not be_ended
+      expect(new_subscription.frequency).to eq frequency
+      expect(new_subscription.source).to eq "user_signed_up"
+    end
+
     it "raises a RecordInvalid error if the frequency is invalid" do
       expect { described_class.call(subscriber_list, subscriber, "foo", user) }
         .to raise_error ActiveRecord::RecordInvalid


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

We can only have at most one (active) subscription per list, but
the code was not filtering for these, which meant that we would
not create a new (active) subscription in the case the user had
previously subscribed:

- Either we would return the ended subscription (if the frequencies)
matched;

- Or we would raise an error trying to end an ended subscription (if
the frequencies did not match).

This fixes the bug.