### PR TITLE
Remove unused ID in subscription API response

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -17,7 +17,7 @@ class SubscriptionsController < ApplicationController
       SendEmailWorker.perform_async_in_queue(email.id, queue: :send_email_transactional)
     end
 
-    render json: { id: subscription.id, subscription: subscription }
+    render json: { subscription: subscription }
   end
 
   def show

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Creating a subscription", type: :request do
 
       it "returns the existing subscription" do
         create_subscription
-        expect(data[:id]).to eq(subscription.id)
+        expect(data[:subscription][:id]).to eq(subscription.id)
         expect(data[:subscription][:frequency]).to eq frequency
       end
 
@@ -137,7 +137,7 @@ RSpec.describe "Creating a subscription", type: :request do
 
       it "returns the new subscription" do
         create_subscription
-        expect(data[:id]).to_not be_nil
+        expect(data[:subscription][:id]).to_not be_nil
         expect(data[:subscription][:frequency]).to eq frequency
       end
 


### PR DESCRIPTION
https://trello.com/c/hdOrNhuC/669-sign-in-after-subscribing

This is no longer used [1].

[1]: https://github.com/alphagov/govuk-account-manager-prototype/pull/518