### PR TITLE
Modify rake task support:view_emails to support users who haven't yet subscribed

### DIFF
--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe "support" do
     end
   end
 
+  describe "view_emails" do
+    it "outputs the latest emails sent to an email address" do
+      expect { Rake::Task["support:view_emails"].invoke("foo@example.org") }
+        .to output.to_stdout
+    end
+  end
+
   describe "resend_failed_emails:by_id" do
     before { Rake::Task["support:resend_failed_emails:by_id"].reenable }
 


### PR DESCRIPTION
This task will help when investigating cases where a user reports that they have not received an invite email / any other emails, since they may not be a subscriber when we investigate.