### PR TITLE
Update confirm email and remove description field

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -48,11 +48,9 @@ private
 
   def presented_header(segment)
     copy = "# #{presented_title(segment)} &nbsp;"
+    source_url = SourceUrlPresenter.call(segment.subscriber_list_url)
 
-    if segment.subscriber_list_description.present?
-      copy += "\n\n#{segment.subscriber_list_description}"
-    end
-
+    copy += "\n\n" + source_url if source_url
     copy
   end
 

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -66,7 +66,8 @@ private
     presenter = "#{content.class.name}Presenter".constantize
     section = presenter.call(content).strip
 
-    section += "\n\n" + list.description if list.description.present?
+    source_url = SourceUrlPresenter.call(list.url)
+    section += "\n\n" + source_url if source_url
     section
   end
 end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -58,7 +58,7 @@ private
 
       [Unsubscribe](#{PublicUrls.unsubscribe(subscription)})
 
-      [Manage your email preferences](#{PublicUrls.authenticate_url(address: address)})
+      [#{I18n.t!('emails.footer_manage')}](#{PublicUrls.authenticate_url(address: address)})
     BODY
   end
 

--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -26,7 +26,7 @@ private
 
       #{I18n.t("emails.subscription_confirmation.frequency.#{subscription.frequency}")}
 
-      #{title_and_description}
+      #{title_and_source_url}
 
       Thanks
       GOV.UK emails
@@ -38,11 +38,12 @@ private
     BODY
   end
 
-  def title_and_description
-    title = subscriber_list.title
-    return title if subscriber_list.description.blank?
+  def title_and_source_url
+    source_url = SourceUrlPresenter.call(subscriber_list.url)
+    result = subscriber_list.title
 
-    title + "\n\n" + subscriber_list.description
+    result += "\n\n" + source_url if source_url
+    result
   end
 
   def subscriber

--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -16,46 +16,40 @@ private
 
   attr_reader :subscription
 
+  def subject
+    "You’ve subscribed to: #{subscriber_list.title}"
+  end
+
+  def body
+    <<~BODY
+      # You’ve subscribed to GOV.UK emails
+
+      #{I18n.t("emails.subscription_confirmation.frequency.#{subscription.frequency}")}
+
+      #{title_and_description}
+
+      Thanks
+      GOV.UK emails
+      https://www.gov.uk/help/update-email-notifications
+
+      [Unsubscribe](#{PublicUrls.unsubscribe(subscription)})
+
+      [#{I18n.t!('emails.footer_manage')}](#{PublicUrls.authenticate_url(address: subscriber.address)})
+    BODY
+  end
+
+  def title_and_description
+    title = subscriber_list.title
+    return title if subscriber_list.description.blank?
+
+    title + "\n\n" + subscriber_list.description
+  end
+
   def subscriber
     @subscriber ||= subscription.subscriber
   end
 
   def subscriber_list
     @subscriber_list ||= subscription.subscriber_list
-  end
-
-  def subject
-    "You've subscribed to #{subscriber_list.title}"
-  end
-
-  def body
-    <<~BODY
-      You’ll get an email each time there are changes to #{title}.
-
-      #{subscriber_list.description}
-
-      ---
-
-      #{ManageSubscriptionsLinkPresenter.call(subscriber.address)}
-    BODY
-  end
-
-  def title
-    return subscriber_list.title unless subscriber_list.url
-
-    "[#{subscriber_list.title}](#{title_url})"
-  end
-
-  def title_url
-    query = {
-      utm_source: subscriber_list.slug,
-      utm_medium: "email",
-      utm_campaign: "govuk-notifications-subscription-confirmation",
-    }.to_query
-
-    url = subscriber_list.url
-    tracked_url = url + (url.include?("?") ? "&" : "?") + query
-
-    PublicUrls.url_for(base_path: tracked_url)
   end
 end

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -37,7 +37,6 @@ private
       title: title,
       slug: slugify(title),
       url: params[:url],
-      description: (params[:description] || ""),
       signon_user_uid: current_user.uid,
     )
   end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -1,4 +1,6 @@
 class SubscriberList < ApplicationRecord
+  self.ignored_columns = %w[description]
+
   include SymbolizeJSON
   include ActiveModel::Validations
 

--- a/app/presenters/source_url_presenter.rb
+++ b/app/presenters/source_url_presenter.rb
@@ -1,0 +1,16 @@
+class SourceUrlPresenter < ApplicationPresenter
+  def initialize(url)
+    @url = url
+  end
+
+  def call
+    return unless url =~ %r{transition-check/results}
+
+    absolute_url = PublicUrls.url_for(base_path: url)
+    "[You can view a copy of your results on GOV.UK](#{absolute_url})"
+  end
+
+private
+
+  attr_reader :url
+end

--- a/app/queries/digest_items_query.rb
+++ b/app/queries/digest_items_query.rb
@@ -1,5 +1,5 @@
 class DigestItemsQuery
-  Result = Struct.new(:subscription_id, :subscriber_list_title, :subscriber_list_url, :subscriber_list_description, :content)
+  Result = Struct.new(:subscription_id, :subscriber_list_title, :subscriber_list_url, :content)
 
   def initialize(subscriber, digest_run)
     @subscriber = subscriber
@@ -26,7 +26,6 @@ private
       memo[id] ||= {
         subscriber_list_title: record[:subscriber_list_title],
         subscriber_list_url: record[:subscriber_list_url],
-        subscriber_list_description: record[:subscriber_list_description],
       }
       memo[id][:content_changes] = Array(memo[id][:content_changes]) << record
     end
@@ -36,40 +35,39 @@ private
       memo[id] ||= {
         subscriber_list_title: record[:subscriber_list_title],
         subscriber_list_url: record[:subscriber_list_url],
-        subscriber_list_description: record[:subscriber_list_description],
       }
       memo[id][:messages] = Array(memo[id][:messages]) << record
     end
 
     result_data.map do |key, value|
       content = value.fetch(:content_changes, []) + value.fetch(:messages, [])
-      Result.new(key, value[:subscriber_list_title], value[:subscriber_list_url], value[:subscriber_list_description], content.sort_by(&:created_at))
+      Result.new(key, value[:subscriber_list_title], value[:subscriber_list_url], content.sort_by(&:created_at))
     end
   end
 
   def fetch_content_changes
     ContentChange
-      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url", "subscriber_lists.description AS subscriber_list_description")
+      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url")
       .joins(matched_content_changes: { subscriber_list: { subscriptions: :subscriber } })
       .where(subscribers: { id: subscriber.id })
       .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
       .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "subscriber_list_description ASC", "content_changes.created_at ASC")
+      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "content_changes.created_at ASC")
       .uniq(&:content_id)
   end
 
   def fetch_messages
     Message
-      .select("messages.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url", "subscriber_lists.description AS subscriber_list_description")
+      .select("messages.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url")
       .joins(matched_messages: { subscriber_list: { subscriptions: :subscriber } })
       .where(subscribers: { id: subscriber.id })
       .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
       .where("messages.created_at >= ?", digest_run.starts_at)
       .where("messages.created_at < ?", digest_run.ends_at)
       .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "subscriber_list_description ASC", "messages.created_at ASC")
+      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "messages.created_at ASC")
       .uniq(&:id)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,11 @@
 en:
   emails:
+    subscription_confirmation:
+      subject: "You’ve subscribed to: %{title}"
+      frequency:
+        daily: "You’ll get one email a day from GOV.UK about:"
+        weekly: "You’ll get one email a week from GOV.UK about:"
+        immediately: "You’ll get an email from GOV.UK each time we add or update a page about:"
     subscription_auth:
       frequency:
         daily: You’ll get one email a day
@@ -17,3 +23,4 @@ en:
     description_header: "Page summary:"
     change_note_header: "Change made:"
     public_updated_at_header: "Time updated:"
+    footer_manage: "Manage your email preferences"

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,6 @@ It will respond with the JSON response for the `GET` call above.
 The following fields are accepted:
 
 - title: The title of this particular list, which will be shown to the user;
-- description: Markdown text that will be used as copy in the confirmation
   email sent to a user;
 - url: A url to a page that reflects what the user signed up to and can be
   linked to with their list;

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe DigestEmailBuilder do
     )
   end
 
+  before do
+    allow(SourceUrlPresenter).to receive(:call)
+      .and_return(nil)
+
+    allow(SourceUrlPresenter).to receive(:call)
+      .with("/test-title-2")
+      .and_return("Presented URL")
+  end
+
   it "returns an Email" do
     expect(email).to be_a(Email)
   end
@@ -80,7 +89,7 @@ RSpec.describe DigestEmailBuilder do
 
         # [Test title 2](http://www.dev.gov.uk/test-title-2) &nbsp;
 
-        Test description
+        Presented URL
 
         presented_message
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -116,8 +116,7 @@ RSpec.describe ImmediateEmailBuilder do
       end
     end
 
-    context "when the list has a description" do
-      let(:subscriber_list) { create(:subscriber_list, description: "description") }
+    context "when the list has a source URL" do
       let(:content_change) { build(:content_change, title: "Title") }
 
       subject(:email) do
@@ -130,6 +129,8 @@ RSpec.describe ImmediateEmailBuilder do
         allow(ContentChangePresenter).to receive(:call)
           .with(content_change)
           .and_return("presented_content_change\n")
+
+        allow(SourceUrlPresenter).to receive(:call).and_return("Presented URL")
       end
 
       it "includes it in the body" do
@@ -139,7 +140,7 @@ RSpec.describe ImmediateEmailBuilder do
 
             presented_content_change
 
-            description
+            Presented URL
 
             ---
           BODY

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -63,16 +63,16 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
       end
     end
 
-    context "when the list has a description" do
-      let(:subscriber_list) do
-        create(:subscriber_list, title: "Example", description: "A description")
+    context "when the list has a source URL" do
+      before do
+        allow(SourceUrlPresenter).to receive(:call).and_return("Presented URL")
       end
 
       it "includes the description" do
         expect(email.body).to include <<~BODY
           Example
 
-          A description
+          Presented URL
 
           Thanks
           GOV.UK emails

--- a/spec/features/subscribing_spec.rb
+++ b/spec/features/subscribing_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe "Subscribing to a subscriber_list", type: :request do
   def expect_a_subscription_confirmation_email_was_sent
     email_data = expect_an_email_was_sent
     subject = email_data.fetch(:personalisation).fetch(:subject)
-    expect(subject).to match(/You've subscribed to/)
+    expect(subject).to match(/You’ve subscribed to/)
   end
 end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
           id
           title
           slug
-          description
           document_type
           created_at
           updated_at
@@ -246,29 +245,9 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
-    context "creating subscriber list with a description" do
-      it "returns a 201" do
-        post "/subscriber-lists",
-             params: {
-               title: "General title",
-               description: "Some description",
-             }
-
-        expect(response.status).to eq(201)
-
-        subscriber_list = JSON.parse(response.body)["subscriber_list"]
-        expect(subscriber_list["description"]).to eq("Some description")
-      end
-    end
-
     context "an invalid subscriber list" do
       it "returns 422" do
-        post "/subscriber-lists",
-             params: {
-               title: "",
-               description: "Some description",
-             }
-
+        post "/subscriber-lists", params: { title: "" }
         expect(response.status).to eq(422)
 
         expect(JSON.parse(response.body)).to match(

--- a/spec/presenters/source_url_presenter_spec.rb
+++ b/spec/presenters/source_url_presenter_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe SourceUrlPresenter do
+  describe ".call" do
+    it "returns nil if the list has no URL" do
+      expect(described_class.call(nil)).to be_nil
+    end
+
+    it "returns nil if the URL is not for the Brexit Checker" do
+      expect(described_class.call("/a-url")).to be_nil
+    end
+
+    it "returns a markdown URL to view Brexit Checker results" do
+      url = "/transition-check/results?foo=bar"
+
+      expect(described_class.call(url)).to eq(
+        "[You can view a copy of your results on GOV.UK](http://www.dev.gov.uk#{url})",
+      )
+    end
+  end
+end

--- a/spec/queries/digest_items_query_spec.rb
+++ b/spec/queries/digest_items_query_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe DigestItemsQuery do
             subscription_id: subscription.id,
             subscriber_list_title: subscriber_list.title,
             subscriber_list_url: subscriber_list.url,
-            subscriber_list_description: subscriber_list.description,
             content: [content_change, message],
           )
       end
@@ -98,7 +97,7 @@ RSpec.describe DigestItemsQuery do
 
     context "with multiple subscriber lists" do
       let(:subscriber_list1) { create(:subscriber_list, title: "Subscriber List A") }
-      let(:subscriber_list2) { create(:subscriber_list, title: "Subscriber List B", url: "/example", description: "Description") }
+      let(:subscriber_list2) { create(:subscriber_list, title: "Subscriber List B", url: "/example") }
 
       let!(:subscription1) do
         create(
@@ -139,7 +138,6 @@ RSpec.describe DigestItemsQuery do
             subscription_id: subscription1.id,
             subscriber_list_title: subscriber_list1.title,
             subscriber_list_url: subscriber_list1.url,
-            subscriber_list_description: subscriber_list1.description,
             content: [content_change1],
           )
 
@@ -148,7 +146,6 @@ RSpec.describe DigestItemsQuery do
             subscription_id: subscription2.id,
             subscriber_list_title: subscriber_list2.title,
             subscriber_list_url: subscriber_list2.url,
-            subscriber_list_description: subscriber_list2.description,
             content: [content_change2],
           )
       end
@@ -164,7 +161,6 @@ RSpec.describe DigestItemsQuery do
             subscription_id: subscription1.id,
             subscriber_list_title: subscriber_list1.title,
             subscriber_list_url: subscriber_list1.url,
-            subscriber_list_description: subscriber_list1.description,
             content: [message],
           )
       end


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

This PR does a couple of things:

- Updates the confirmation email to match the new design
- Replaces the description field with hard-coded text

In the next PR, we will look at adding tracking attributes to the former 
description URLs, as well as for the new one-click unsubscribe links. 

Please see the commits for more details.

## Before

<img width="303" alt="Screenshot 2020-12-15 at 17 56 31" src="https://user-images.githubusercontent.com/9029009/102253158-e5072c80-3efe-11eb-80cb-b10f7f5d4a7e.png">

## After

<img width="301" alt="Screenshot 2020-12-15 at 17 55 48" src="https://user-images.githubusercontent.com/9029009/102253178-eafd0d80-3efe-11eb-9074-9b43e7626b12.png">
