### PR TITLE
Remove description field

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -1,6 +1,4 @@
 class SubscriberList < ApplicationRecord
-  self.ignored_columns = %w[description]
-
   include SymbolizeJSON
   include ActiveModel::Validations
 

--- a/db/migrate/20201218095119_remove_description_field.rb
+++ b/db/migrate/20201218095119_remove_description_field.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionField < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :subscriber_lists, :description, type: :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_17_084600) do
+ActiveRecord::Schema.define(version: 2020_12_18_095119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,7 +126,6 @@ ActiveRecord::Schema.define(version: 2020_12_17_084600) do
     t.string "signon_user_uid"
     t.string "slug", null: false
     t.string "url"
-    t.string "description", default: "", null: false
     t.string "tags_digest"
     t.string "links_digest"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

Depends on: https://github.com/alphagov/email-alert-api/pull/1527

This is no longer used since: https://github.com/alphagov/email-alert-api/pull/1527