### PR TITLE
Prepare to delete unused group_id field

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -38,7 +38,6 @@ private
       slug: slugify(title),
       url: params[:url],
       description: (params[:description] || ""),
-      group_id: params[:group_id],
       signon_user_uid: current_user.uid,
     )
   end

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -1,4 +1,6 @@
 class SubscriberList < ApplicationRecord
+  self.ignored_columns = %w[group_id]
+
   include SymbolizeJSON
   include ActiveModel::Validations
 
@@ -11,7 +13,6 @@ class SubscriberList < ApplicationRecord
   validates :title, presence: true
   validates :slug, uniqueness: true
   validates :url, root_relative_url: true, allow_nil: true
-  validates :group_id, uuid: true, allow_nil: true
 
   has_many :subscriptions, dependent: :destroy
   has_many :subscribers, through: :subscriptions

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,6 @@ Gets a stored subscriber list that's relevant to just the `cabinet-office` organ
     "title": "Title of topic",
     "subscription_url": "https://public-url/subscribe-here?topic_id=123",
     "gov_delivery_id": "123",
-    "group_id": "f513e107-b2c6-44a6-8d8a-9e6a3ea37b9d",
     "document_type": "",
     "created_at": "20141010T12:00:00",
     "updated_at": "20141010T12:00:00",
@@ -31,7 +30,6 @@ Gets a stored subscriber list that's relevant to just the `cabinet-office` organ
 ```json
 {
   "title": "My title",
-  "group_id": "f513e107-b2c6-44a6-8d8a-9e6a3ea37b9d",
   "tags": {
     "any": {
       "organisations": ["my-org"],
@@ -49,8 +47,6 @@ The following fields are accepted:
   email sent to a user;
 - url: A url to a page that reflects what the user signed up to and can be
   linked to with their list;
-- group_id: A UUID that can be provided by an application to group together
-  lists for the same resource with different criteria;
 - links: An object where keys are a link type and the value is an object
   containing a key of "any" or "all" associated with an array of link values,
   this is used to match content changes and messages to the list;

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
           url
           tags
           links
-          group_id
           email_document_supertype
           government_document_supertype
           active_subscriptions_count
@@ -261,23 +260,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
         subscriber_list = JSON.parse(response.body)["subscriber_list"]
         expect(subscriber_list["description"]).to eq("Some description")
-      end
-    end
-
-    context "creating subscriber list with a group_id" do
-      it "returns a 201" do
-        group_id = SecureRandom.uuid
-        post "/subscriber-lists",
-             params: {
-               title: "General title",
-               description: "Some description",
-               group_id: group_id,
-             }
-
-        expect(response.status).to eq(201)
-
-        subscriber_list = JSON.parse(response.body)["subscriber_list"]
-        expect(subscriber_list["group_id"]).to eq(group_id)
       end
     end
 

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -87,20 +87,6 @@ RSpec.describe SubscriberList, type: :model do
         expect(build(:subscriber_list, url: "https://example.com/test")).to be_invalid
       end
     end
-
-    describe "group_id" do
-      it "is valid when group_id is a valid UUID" do
-        expect(build(:subscriber_list, group_id: SecureRandom.uuid)).to be_valid
-      end
-
-      it "is valid when group_id is nil" do
-        expect(build(:subscriber_list, group_id: nil)).to be_valid
-      end
-
-      it "is invalid when group_id is not a valid UUID" do
-        expect(build(:subscriber_list, group_id: "notavaliduuid")).to be_invalid
-      end
-    end
   end
 
   context "when a subscriber_list is deleted" do


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

This was added in expectation of making it easier to group lists for
analytics [1], but this has not been the case in practice [2]. Since
the field is currently only used for Brexit Checker lists, we could
always reproduce its current content in future, because these lists
all share the same "tags" structure.

[1]: https://github.com/alphagov/email-alert-api/pull/973
[2]: https://github.com/alphagov/email-alert-api/pull/1485/commits/443ac32d52c9ec7a2f8eb54110b9956c180ab429