### PR TITLE
Only use I18n where it adds value

### DIFF
--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -33,14 +33,14 @@ private
   end
 
   def subject(content)
-    I18n.t!("emails.immediate.subject", title: content.title)
+    "Update from GOV.UK for: #{content.title}"
   end
 
   def body(content, subscription, address)
     list = subscription.subscriber_list
 
     <<~BODY
-      #{I18n.t!('emails.immediate.opening_line')}
+      Update from GOV.UK for:
 
       # #{list.title}
 
@@ -50,15 +50,15 @@ private
 
       ---
 
-      # #{I18n.t!('emails.immediate.footer_header')}
+      # Why am I getting this email?
 
-      #{I18n.t!('emails.immediate.footer_explanation')}
+      You asked GOV.UK to send you an email each time we add or update a page about:
 
       #{list.title}
 
       [Unsubscribe](#{PublicUrls.unsubscribe(subscription)})
 
-      [#{I18n.t!('emails.immediate.footer_manage')}](#{PublicUrls.authenticate_url(address: address)})
+      [Manage your email preferences](#{PublicUrls.authenticate_url(address: address)})
     BODY
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,12 +5,6 @@ en:
         daily: You’ll get one email a day
         weekly: You’ll get one email a week
         immediately: You’ll get an email each time we add or update a page
-    immediate:
-      subject: "Update from GOV.UK for: %{title}"
-      opening_line: "Update from GOV.UK for:"
-      footer_header: "Why am I getting this email?"
-      footer_explanation: "You asked GOV.UK to send you an email each time we add or update a page about:"
-      footer_manage: "Manage your email preferences"
     digests:
       daily:
         subject: "Daily update from GOV.UK"


### PR DESCRIPTION
https://trello.com/c/pZqhXafv/671-update-template-for-individual-type-emails-inc-one-click-unsubscribe

Previously we extracted much of the text of individual-type emails
to I18n keys, which is just unnecessary indirection:

- We only support emails in English.
- It makes it harder to grasp the overall content.
- Each line of the content needs its own (arbitrary) key.
- The tests don't make use of I18n at all.

This replaces uses of I18n where the text is only used once, without
any modifiers. We can still benefit from I18n:

- For some text, as a way to keep it consistent across the app.
- For semi-dynamic text like frequencies, as a simple switch mechanism.

Note that I've only applied this approach to the ImmediateEmailBuilder,
to avoid blocking upcoming design changes to digest emails.