### PR TITLE
Add "Email is too large" catch to Undeliverable Failures

### DIFF
--- a/app/services/send_email_service/send_notify_email.rb
+++ b/app/services/send_email_service/send_notify_email.rb
@@ -42,6 +42,9 @@ private
   def undeliverable_failure?(error)
     return false unless error.is_a?(Notifications::Client::BadRequestError)
 
-    error.message.end_with?("Not a valid email address")
+    return true if error.message.end_with?("Not a valid email address")
+
+    # We have a hard limit in notify that cannot be bypassed here.
+    error.message.start_with?("BadRequestError: Your message is too long")
   end
 end


### PR DESCRIPTION
Notify has a hard limit on the size of an email in bytes that can be
send. This cannot be bypassed at this step so if any emails come through
that are too large, we want to fail them outright rather than attempting
to resend them.