### PR TITLE
Remove group_id field for subscriber lists

### DIFF
--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -1,6 +1,4 @@
 class SubscriberList < ApplicationRecord
-  self.ignored_columns = %w[group_id]
-
   include SymbolizeJSON
   include ActiveModel::Validations
 

--- a/db/migrate/20201217084600_remove_group_id.rb
+++ b/db/migrate/20201217084600_remove_group_id.rb
@@ -1,0 +1,5 @@
+class RemoveGroupId < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :subscriber_lists, :group_id, type: :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_145943) do
+ActiveRecord::Schema.define(version: 2020_12_17_084600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,7 +129,6 @@ ActiveRecord::Schema.define(version: 2020_11_30_145943) do
     t.string "description", default: "", null: false
     t.string "tags_digest"
     t.string "links_digest"
-    t.string "group_id"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

This is unused since [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1519