### PR TITLE
Switch to one email per digest subscription

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -1,7 +1,7 @@
 class DigestEmailBuilder < ApplicationBuilder
-  def initialize(address:, digest_items:, digest_run:, subscriber_id:)
+  def initialize(address:, digest_item:, digest_run:, subscriber_id:)
     @address = address
-    @digest_items = digest_items
+    @digest_item = digest_item
     @digest_run = digest_run
     @subscriber_id = subscriber_id
   end
@@ -17,7 +17,7 @@ class DigestEmailBuilder < ApplicationBuilder
 
 private
 
-  attr_reader :address, :digest_items, :digest_run, :subscriber_id
+  attr_reader :address, :digest_item, :digest_run, :subscriber_id
 
   def body
     <<~BODY
@@ -31,8 +31,7 @@ private
   end
 
   def presented_results
-    digest_items.map { |result| presented_segment(result) }
-                .join("\n&nbsp;\n\n")
+    presented_segment(digest_item)
   end
 
   def presented_segment(segment)

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -56,7 +56,7 @@ private
 
       #{list.title}
 
-      [Unsubscribe](#{PublicUrls.unsubscribe(subscription)})
+      [Unsubscribe](#{unsubscribe_url(subscription)})
 
       [#{I18n.t!('emails.immediate.footer_manage')}](#{PublicUrls.authenticate_url(address: address)})
     BODY
@@ -68,5 +68,12 @@ private
 
     section += "\n\n" + list.description if list.description.present?
     section
+  end
+
+  def unsubscribe_url(subscription)
+    PublicUrls.unsubscribe(
+      subscription_id: subscription.id,
+      subscriber_id: subscription.subscriber_id,
+    )
   end
 end

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -2,10 +2,10 @@ class DigestEmailGenerationWorker < ApplicationWorker
   sidekiq_options queue: :email_generation_digest
 
   def perform(digest_run_subscriber_id)
-    email = nil
+    email_ids = []
+
     DigestRun.transaction do
       digest_run_subscriber = DigestRunSubscriber.lock.find(digest_run_subscriber_id)
-
       return if digest_run_subscriber.processed_at
 
       digest_items = DigestItemsQuery.call(
@@ -13,40 +13,47 @@ class DigestEmailGenerationWorker < ApplicationWorker
         digest_run_subscriber.digest_run,
       )
 
-      email = create_email(digest_run_subscriber, digest_items)
+      email_ids = digest_items.map do |digest_item|
+        create_email(digest_run_subscriber, digest_item)
+      end
+
+      fill_subscription_content(
+        email_ids,
+        digest_items,
+        digest_run_subscriber,
+      )
+
       digest_run_subscriber.update!(processed_at: Time.zone.now)
     end
 
-    if email
-      SendEmailWorker.perform_async_in_queue(email.id, queue: :send_email_digest)
+    email_ids.each do |email_id|
+      SendEmailWorker.perform_async_in_queue(email_id, queue: :send_email_digest)
     end
   end
 
 private
 
-  def create_email(digest_run_subscriber, digest_items)
-    return if digest_items.empty?
-
+  def create_email(digest_run_subscriber, digest_item)
     Metrics.digest_email_generation(digest_run_subscriber.digest_run.range) do
       email = DigestEmailBuilder.call(
         address: digest_run_subscriber.subscriber.address,
-        digest_items: digest_items,
+        digest_item: digest_item,
         digest_run: digest_run_subscriber.digest_run,
         subscriber_id: digest_run_subscriber.subscriber_id,
       )
-      fill_subscription_content(email, digest_items, digest_run_subscriber)
 
-      email
+      email.id
     end
   end
 
-  def fill_subscription_content(email, digest_items, digest_run_subscriber)
+  def fill_subscription_content(email_ids, digest_items, digest_run_subscriber)
     now = Time.zone.now
-    records = digest_items.flat_map do |result|
-      result.content.map do |content|
+
+    records = digest_items.zip(email_ids).flat_map do |digest_item, email_id|
+      digest_item.content.map do |content|
         {
-          email_id: email.id,
-          subscription_id: result.subscription_id,
+          email_id: email_id,
+          subscription_id: digest_item.subscription_id,
           content_change_id: content.is_a?(ContentChange) ? content.id : nil,
           message_id: content.is_a?(Message) ? content.id : nil,
           digest_run_subscriber_id: digest_run_subscriber.id,
@@ -56,6 +63,6 @@ private
       end
     end
 
-    SubscriptionContent.insert_all!(records)
+    SubscriptionContent.insert_all!(records) if records.any?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,13 +13,14 @@ en:
       footer_manage: "Manage your email preferences"
     digests:
       daily:
-        subject: "Daily update from GOV.UK"
-        opening_line: Daily update from GOV.UK.
-        permission_reminder: "^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK."
+        subject: "Daily update from GOV.UK for: %{title}"
+        opening_line: "Daily update from GOV.UK for:"
+        footer_explanation: "You asked GOV.UK to send you one email a day about:"
       weekly:
-        subject: "Weekly update from GOV.UK"
-        opening_line: Updates on GOV.UK this week.
-        permission_reminder: "^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK."
+        subject: "Weekly update from GOV.UK for: %{title}"
+        opening_line: "Weekly update from GOV.UK for:"
+        footer_explanation: "You asked GOV.UK to send you one email a week about:"
+      footer_manage: "Manage your email preferences"
     description_header: "Page summary:"
     change_note_header: "Change made:"
     public_updated_at_header: "Time updated:"

--- a/lib/public_urls.rb
+++ b/lib/public_urls.rb
@@ -21,9 +21,9 @@ module PublicUrls
       File.join(website_root, path)
     end
 
-    def unsubscribe(subscription)
-      token = AuthTokenGeneratorService.call(subscriber_id: subscription.subscriber_id)
-      "#{website_root}/email/unsubscribe/#{subscription.id}?token=#{token}"
+    def unsubscribe(subscription_id:, subscriber_id:)
+      token = AuthTokenGeneratorService.call(subscriber_id: subscriber_id)
+      "#{website_root}/email/unsubscribe/#{subscription_id}?token=#{token}"
     end
 
   private

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -26,63 +26,106 @@ RSpec.describe DigestEmailBuilder do
     )
   end
 
-  it "returns an Email" do
-    expect(email).to be_a(Email)
-  end
+  before do
+    allow(PublicUrls).to receive(:unsubscribe)
+      .with(subscription_id: digest_item.subscription_id, subscriber_id: subscriber_id)
+      .and_return("unsubscribe_url")
 
-  it "sets the subscriber id on the email" do
-    expect(email.subscriber_id).to eq(subscriber_id)
-  end
-
-  it "adds an entry to body for each content change" do
-    expect(UnsubscribeLinkPresenter)
-      .to receive(:call).with("ABC1", "Test title 1")
-      .and_return("unsubscribe_link_1")
+    allow(PublicUrls).to receive(:authenticate_url)
+      .with(address: subscriber.address)
+      .and_return("manage_url")
 
     expect(ContentChangePresenter).to receive(:call)
       .and_return("presented_content_change\n")
 
     expect(MessagePresenter).to receive(:call)
       .and_return("presented_message\n")
-
-    expect(email.body).to eq(
-      <<~BODY,
-        Daily update from GOV.UK.
-
-        # Test title 1 &nbsp;
-
-        presented_content_change
-
-        ---
-
-        presented_message
-
-        ---
-
-        unsubscribe_link_1
-
-        ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
-
-        [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
-      BODY
-    )
   end
 
-  it "saves the email" do
-    expect(email.id).to_not be_nil
-    expect(Email.count).to eq(1)
-  end
+  describe ".call" do
+    context "for a daily update" do
+      it "creates an Email" do
+        expect(email.subscriber_id).to eq(subscriber_id)
+        expect(email.subject).to eq "Daily update from GOV.UK for: Test title 1"
 
-  context "daily" do
-    it "sets the subject" do
-      expect(email.subject).to eq("Daily update from GOV.UK")
+        expect(email.body).to eq(
+          <<~BODY,
+            Daily update from GOV.UK for:
+
+            # Test title 1
+
+            ---
+
+            presented_content_change
+
+            ---
+
+            presented_message
+
+            ---
+
+            # Why am I getting this email?
+
+            You asked GOV.UK to send you one email a day about:
+
+            Test title 1
+
+            [Unsubscribe](unsubscribe_url)
+
+            [Manage your email preferences](manage_url)
+          BODY
+        )
+      end
     end
-  end
 
-  context "weekly" do
-    let(:digest_run) { double(range: "weekly") }
-    it "sets the subject" do
-      expect(email.subject).to eq("Weekly update from GOV.UK")
+    context "for a weekly update" do
+      let(:digest_run) { double(range: "weekly") }
+
+      it "creates an Email" do
+        expect(email.subscriber_id).to eq(subscriber_id)
+        expect(email.subject).to eq "Weekly update from GOV.UK for: Test title 1"
+
+        expect(email.body).to include(
+          <<~BODY,
+            Weekly update from GOV.UK for:
+
+            # Test title 1
+
+            ---
+          BODY
+        )
+
+        expect(email.body).to include(
+          <<~BODY,
+            # Why am I getting this email?
+
+            You asked GOV.UK to send you one email a week about:
+
+            Test title 1
+          BODY
+        )
+      end
+    end
+
+    context "when the list has a description" do
+      before do
+        allow(digest_item).to receive(:subscriber_list_description)
+          .and_return("A description")
+      end
+
+      it "includes it in the body" do
+        expect(email.body).to include(
+          <<~BODY,
+            Daily update from GOV.UK for:
+
+            # Test title 1
+
+            A description
+
+            ---
+          BODY
+        )
+      end
     end
   end
 end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -3,35 +3,24 @@ RSpec.describe DigestEmailBuilder do
   let(:subscriber) { build(:subscriber) }
   let(:address) { subscriber.address }
   let(:subscriber_id) { subscriber.id }
-  let(:digest_items) do
-    [
-      double(
-        subscription_id: "ABC1",
-        subscriber_list_title: "Test title 1",
-        subscriber_list_url: nil,
-        subscriber_list_description: "",
-        content: [
-          build(:content_change),
-          build(:message),
-        ],
-      ),
-      double(
-        subscription_id: "ABC2",
-        subscriber_list_title: "Test title 2",
-        subscriber_list_url: "/test-title-2",
-        subscriber_list_description: "Test description",
-        content: [
-          build(:message),
-          build(:content_change),
-        ],
-      ),
-    ]
+
+  let(:digest_item) do
+    double(
+      subscription_id: "ABC1",
+      subscriber_list_title: "Test title 1",
+      subscriber_list_url: nil,
+      subscriber_list_description: "",
+      content: [
+        build(:content_change),
+        build(:message),
+      ],
+    )
   end
 
   let(:email) do
     described_class.call(
       address: address,
-      digest_items: digest_items,
+      digest_item: digest_item,
       digest_run: digest_run,
       subscriber_id: subscriber_id,
     )
@@ -50,14 +39,10 @@ RSpec.describe DigestEmailBuilder do
       .to receive(:call).with("ABC1", "Test title 1")
       .and_return("unsubscribe_link_1")
 
-    expect(UnsubscribeLinkPresenter)
-      .to receive(:call).with("ABC2", "Test title 2")
-      .and_return("unsubscribe_link_2")
-
-    expect(ContentChangePresenter).to receive(:call).exactly(2).times
+    expect(ContentChangePresenter).to receive(:call)
       .and_return("presented_content_change\n")
 
-    expect(MessagePresenter).to receive(:call).exactly(2).times
+    expect(MessagePresenter).to receive(:call)
       .and_return("presented_message\n")
 
     expect(email.body).to eq(
@@ -75,22 +60,6 @@ RSpec.describe DigestEmailBuilder do
         ---
 
         unsubscribe_link_1
-
-        &nbsp;
-
-        # [Test title 2](http://www.dev.gov.uk/test-title-2) &nbsp;
-
-        Test description
-
-        presented_message
-
-        ---
-
-        presented_content_change
-
-        ---
-
-        unsubscribe_link_2
 
         ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ImmediateEmailBuilder do
 
     before do
       allow(PublicUrls).to receive(:unsubscribe)
-        .with(subscription)
+        .with(subscription_id: subscription.id, subscriber_id: subscriber.id)
         .and_return("unsubscribe_url")
 
       allow(PublicUrls).to receive(:authenticate_url)

--- a/spec/features/create_and_deliver_a_daily_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_daily_digest_spec.rb
@@ -106,17 +106,24 @@ RSpec.describe "create and deliver a daily digest", type: :request do
       subscriber_one_address,
       first_expected_email_body(
         subscriptions[0],
-        subscriptions[1],
         content_changes[0],
+        subscribers[0],
+      ),
+    )
+
+    second_digest_stub = stub_notify_request(
+      subscriber_one_address,
+      second_expected_email_body(
+        subscriptions[1],
         content_changes[1],
         content_changes[2],
         subscribers[0],
       ),
     )
 
-    second_digest_stub = stub_notify_request(
+    third_digest_stub = stub_notify_request(
       subscriber_two_address,
-      second_expected_email_body(
+      third_expected_email_body(
         subscriptions[2],
         content_changes[0],
         subscribers[1],
@@ -130,6 +137,7 @@ RSpec.describe "create and deliver a daily digest", type: :request do
 
     expect(first_digest_stub).to have_been_requested
     expect(second_digest_stub).to have_been_requested
+    expect(third_digest_stub).to have_been_requested
   end
 
   def url
@@ -150,12 +158,7 @@ RSpec.describe "create and deliver a daily digest", type: :request do
       .to_return(body: {}.to_json)
   end
 
-  def first_expected_email_body(subscription_one,
-                                subscription_two,
-                                content_change_one,
-                                content_change_two,
-                                content_change_three,
-                                subscriber)
+  def first_expected_email_body(subscription_one, content_change_one, subscriber)
     <<~BODY
       Daily update from GOV.UK.
 
@@ -182,7 +185,15 @@ RSpec.describe "create and deliver a daily digest", type: :request do
 
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
 
-      &nbsp;
+      ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
+
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+    BODY
+  end
+
+  def second_expected_email_body(subscription_two, content_change_two, content_change_three, subscriber)
+    <<~BODY
+      Daily update from GOV.UK.
 
       # Subscriber list two &nbsp;
 
@@ -220,7 +231,7 @@ RSpec.describe "create and deliver a daily digest", type: :request do
     BODY
   end
 
-  def second_expected_email_body(subscription, content_change_one, subscriber)
+  def third_expected_email_body(subscription, content_change_one, subscriber)
     <<~BODY
       Daily update from GOV.UK.
 

--- a/spec/features/create_and_deliver_a_daily_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_daily_digest_spec.rb
@@ -98,36 +98,31 @@ RSpec.describe "create and deliver a daily digest", type: :request do
       )
     end
 
-    subscriptions = Subscription.all
     content_changes = ContentChange.order(:created_at)
-    subscribers = Subscriber.all
 
     first_digest_stub = stub_notify_request(
       subscriber_one_address,
       first_expected_email_body(
-        subscriptions[0],
         content_changes[0],
-        subscribers[0],
       ),
+      "Subscriber list one",
     )
 
     second_digest_stub = stub_notify_request(
       subscriber_one_address,
       second_expected_email_body(
-        subscriptions[1],
         content_changes[1],
         content_changes[2],
-        subscribers[0],
       ),
+      "Subscriber list two",
     )
 
     third_digest_stub = stub_notify_request(
       subscriber_two_address,
       third_expected_email_body(
-        subscriptions[2],
         content_changes[0],
-        subscribers[1],
       ),
+      "Subscriber list one",
     )
 
     travel_to(Time.zone.parse("2017-01-02 10:00")) do
@@ -144,12 +139,12 @@ RSpec.describe "create and deliver a daily digest", type: :request do
     "http://www.dev.gov.uk/base-path?"
   end
 
-  def stub_notify_request(email_address, email_body)
+  def stub_notify_request(email_address, email_body, title)
     body = hash_including(
       email_address: email_address,
       personalisation: hash_including(
-        "subject" => "Daily update from GOV.UK",
-        "body" => email_body,
+        "subject" => "Daily update from GOV.UK for: #{title}",
+        "body" => include(email_body),
       ),
     )
 
@@ -158,11 +153,13 @@ RSpec.describe "create and deliver a daily digest", type: :request do
       .to_return(body: {}.to_json)
   end
 
-  def first_expected_email_body(subscription_one, content_change_one, subscriber)
+  def first_expected_email_body(content_change_one)
     <<~BODY
-      Daily update from GOV.UK.
+      Daily update from GOV.UK for:
 
-      # Subscriber list one &nbsp;
+      # Subscriber list one
+
+      ---
 
       # [Title one](#{url}#{utm_params(content_change_one.id, 'daily')})
 
@@ -183,19 +180,21 @@ RSpec.describe "create and deliver a daily digest", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
+      # Why am I getting this email?
 
-      ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
+      You asked GOV.UK to send you one email a day about:
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      Subscriber list one
     BODY
   end
 
-  def second_expected_email_body(subscription_two, content_change_two, content_change_three, subscriber)
+  def second_expected_email_body(content_change_two, content_change_three)
     <<~BODY
-      Daily update from GOV.UK.
+      Daily update from GOV.UK for:
 
-      # Subscriber list two &nbsp;
+      # Subscriber list two
+
+      ---
 
       # [Title three](#{url}#{utm_params(content_change_two.id, 'daily')})
 
@@ -223,19 +222,21 @@ RSpec.describe "create and deliver a daily digest", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id})
+      # Why am I getting this email?
 
-      ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
+      You asked GOV.UK to send you one email a day about:
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      Subscriber list two
     BODY
   end
 
-  def third_expected_email_body(subscription, content_change_one, subscriber)
+  def third_expected_email_body(content_change_one)
     <<~BODY
-      Daily update from GOV.UK.
+      Daily update from GOV.UK for:
 
-      # Subscriber list one &nbsp;
+      # Subscriber list one
+
+      ---
 
       # [Title one](#{url}#{utm_params(content_change_one.id, 'daily')})
 
@@ -256,11 +257,11 @@ RSpec.describe "create and deliver a daily digest", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id})
+      # Why am I getting this email?
 
-      ^You’re getting this email because you subscribed to daily updates on these topics on GOV.UK.
+      You asked GOV.UK to send you one email a day about:
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      Subscriber list one
     BODY
   end
 end

--- a/spec/features/create_and_deliver_a_weekly_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_weekly_digest_spec.rb
@@ -105,39 +105,34 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       )
     end
 
-    subscriptions = Subscription.all
     content_changes = ContentChange.order(:created_at)
     messages = Message.order(:created_at)
-    subscribers = Subscriber.all
 
     first_digest_stub = stub_notify_request(
       subscriber_one_address,
       first_expected_email_body(
-        subscriptions[0],
         content_changes[0],
         messages[0],
-        subscribers[0],
       ),
+      "Subscriber list one",
     )
 
     second_digest_stub = stub_notify_request(
       subscriber_one_address,
       second_expected_email_body(
-        subscriptions[1],
         content_changes[1],
         content_changes[2],
-        subscribers[0],
       ),
+      "Subscriber list two",
     )
 
     third_digest_stub = stub_notify_request(
       subscriber_two_address,
       third_expected_email_body(
-        subscriptions[2],
         content_changes[0],
         messages[0],
-        subscribers[1],
       ),
+      "Subscriber list one",
     )
 
     travel_to(Time.zone.parse("2017-01-07 10:00")) do
@@ -154,12 +149,12 @@ RSpec.describe "create and delive a weekly digest", type: :request do
     "http://www.dev.gov.uk/base-path?"
   end
 
-  def stub_notify_request(email_address, email_body)
+  def stub_notify_request(email_address, email_body, title)
     body = hash_including(
       email_address: email_address,
       personalisation: hash_including(
-        "subject" => "Weekly update from GOV.UK",
-        "body" => email_body,
+        "subject" => "Weekly update from GOV.UK for: #{title}",
+        "body" => include(email_body),
       ),
     )
 
@@ -168,11 +163,13 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       .to_return(body: {}.to_json)
   end
 
-  def first_expected_email_body(subscription_one, content_change_one, message_one, subscriber)
+  def first_expected_email_body(content_change_one, message_one)
     <<~BODY
-      Updates on GOV.UK this week.
+      Weekly update from GOV.UK for:
 
-      # Subscriber list one &nbsp;
+      # Subscriber list one
+
+      ---
 
       # [Title one](#{url}#{utm_params(content_change_one.id, 'weekly')})
 
@@ -193,19 +190,21 @@ RSpec.describe "create and delive a weekly digest", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
+      # Why am I getting this email?
 
-      ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
+      You asked GOV.UK to send you one email a week about:
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      Subscriber list one
     BODY
   end
 
-  def second_expected_email_body(subscription_two, content_change_two, content_change_three, subscriber)
+  def second_expected_email_body(content_change_two, content_change_three)
     <<~BODY
-      Updates on GOV.UK this week.
+      Weekly update from GOV.UK for:
 
-      # Subscriber list two &nbsp;
+      # Subscriber list two
+
+      ---
 
       # [Title three](#{url}#{utm_params(content_change_two.id, 'weekly')})
 
@@ -233,22 +232,21 @@ RSpec.describe "create and delive a weekly digest", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list two’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_two.id})
+      # Why am I getting this email?
 
-      ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
+      You asked GOV.UK to send you one email a week about:
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      Subscriber list two
     BODY
   end
 
-  def third_expected_email_body(subscription,
-                                content_change_one,
-                                message_one,
-                                subscriber)
+  def third_expected_email_body(content_change_one, message_one)
     <<~BODY
-      Updates on GOV.UK this week.
+      Weekly update from GOV.UK for:
 
-      # Subscriber list one &nbsp;
+      # Subscriber list one
+
+      ---
 
       # [Title one](#{url}#{utm_params(content_change_one.id, 'weekly')})
 
@@ -269,11 +267,11 @@ RSpec.describe "create and delive a weekly digest", type: :request do
 
       ---
 
-      [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription.id})
+      # Why am I getting this email?
 
-      ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
+      You asked GOV.UK to send you one email a week about:
 
-      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+      Subscriber list one
     BODY
   end
 end

--- a/spec/features/create_and_deliver_a_weekly_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_weekly_digest_spec.rb
@@ -114,18 +114,25 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       subscriber_one_address,
       first_expected_email_body(
         subscriptions[0],
-        subscriptions[1],
         content_changes[0],
         messages[0],
+        subscribers[0],
+      ),
+    )
+
+    second_digest_stub = stub_notify_request(
+      subscriber_one_address,
+      second_expected_email_body(
+        subscriptions[1],
         content_changes[1],
         content_changes[2],
         subscribers[0],
       ),
     )
 
-    second_digest_stub = stub_notify_request(
+    third_digest_stub = stub_notify_request(
       subscriber_two_address,
-      second_expected_email_body(
+      third_expected_email_body(
         subscriptions[2],
         content_changes[0],
         messages[0],
@@ -140,6 +147,7 @@ RSpec.describe "create and delive a weekly digest", type: :request do
 
     expect(first_digest_stub).to have_been_requested
     expect(second_digest_stub).to have_been_requested
+    expect(third_digest_stub).to have_been_requested
   end
 
   def url
@@ -160,13 +168,7 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       .to_return(body: {}.to_json)
   end
 
-  def first_expected_email_body(subscription_one,
-                                subscription_two,
-                                content_change_one,
-                                message_one,
-                                content_change_two,
-                                content_change_three,
-                                subscriber)
+  def first_expected_email_body(subscription_one, content_change_one, message_one, subscriber)
     <<~BODY
       Updates on GOV.UK this week.
 
@@ -193,7 +195,15 @@ RSpec.describe "create and delive a weekly digest", type: :request do
 
       [Unsubscribe from ‘Subscriber list one’](http://www.dev.gov.uk/email/unsubscribe/#{subscription_one.id})
 
-      &nbsp;
+      ^You’re getting this email because you subscribed to weekly updates on these topics on GOV.UK.
+
+      [View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=#{ERB::Util.url_encode(subscriber.address)})
+    BODY
+  end
+
+  def second_expected_email_body(subscription_two, content_change_two, content_change_three, subscriber)
+    <<~BODY
+      Updates on GOV.UK this week.
 
       # Subscriber list two &nbsp;
 
@@ -231,10 +241,10 @@ RSpec.describe "create and delive a weekly digest", type: :request do
     BODY
   end
 
-  def second_expected_email_body(subscription,
-                                 content_change_one,
-                                 message_one,
-                                 subscriber)
+  def third_expected_email_body(subscription,
+                                content_change_one,
+                                message_one,
+                                subscriber)
     <<~BODY
       Updates on GOV.UK this week.
 

--- a/spec/lib/public_urls_spec.rb
+++ b/spec/lib/public_urls_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe PublicUrls do
         .with(subscriber_id: subscription.subscriber_id)
         .and_return("token")
 
-      expected = "http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?token=token"
-      expect(subject.unsubscribe(subscription)).to eq(expected)
+      url = subject.unsubscribe(subscription_id: subscription.id, subscriber_id: subscription.subscriber_id)
+      expect(url).to eq("http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?token=token")
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/KEcIcyix/673-update-template-for-digest-emails-to-match-design

This PR makes a couple of changes:

- Switches the digest functionality so that we send one
email per digest subscription, instead of an aggregation
of aggregations.

- Updates the digest email template to match the final
design, now that the emails are split.

Please see the commits for more details.

## Before

### Single Subscription

<img width="298" alt="Screenshot 2020-12-17 at 13 17 07" src="https://user-images.githubusercontent.com/9029009/102492951-54e5f600-406a-11eb-95ed-a9a5ae1f081c.png">

### Multiple Subscriptions (top part)

<img width="298" alt="Screenshot 2020-12-17 at 13 17 36" src="https://user-images.githubusercontent.com/9029009/102492952-557e8c80-406a-11eb-927e-300aa6499c9b.png">

### Multiple Subscriptions (bottom part)

(many more news content items above here!)

<img width="302" alt="Screenshot 2020-12-17 at 13 17 57" src="https://user-images.githubusercontent.com/9029009/102492954-56172300-406a-11eb-883c-53495814edd6.png">

## After (similarly for weekly digests)

### First subscription

<img width="200" alt="Screenshot 2020-12-17 at 13 43 16" src="https://user-images.githubusercontent.com/9029009/102495373-e9058c80-406d-11eb-937a-1e8c47cbaf47.png">

### Second subscription

<img width="200" alt="Screenshot 2020-12-17 at 13 43 31" src="https://user-images.githubusercontent.com/9029009/102495374-e9058c80-406d-11eb-9d18-71f49ce97bac.png">