### PR TITLE
Cache encryption object for auth tokens

### DIFF
--- a/app/services/auth_token_generator_service.rb
+++ b/app/services/auth_token_generator_service.rb
@@ -14,16 +14,16 @@ class AuthTokenGeneratorService < ApplicationService
   end
 
   def call
-    len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
-    key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
-    crypt = ActiveSupport::MessageEncryptor.new(key, **OPTIONS)
-    token = crypt.encrypt_and_sign(data, expires_in: expiry)
+    token = self.class.crypt.encrypt_and_sign(data, expires_in: expiry)
     CGI.escape(token)
   end
 
-private
-
-  def secret
-    Rails.application.secrets.email_alert_auth_token
+  def self.crypt
+    @crypt ||= begin
+                 secret = Rails.application.secrets.email_alert_auth_token
+                 len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
+                 key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
+                 ActiveSupport::MessageEncryptor.new(key, **OPTIONS)
+               end
   end
 end

--- a/spec/services/auth_token_generator_service_spec.rb
+++ b/spec/services/auth_token_generator_service_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe AuthTokenGeneratorService do
       end
     end
   end
+
+  describe ".crypt" do
+    it "caches the encryptor for performance" do
+      expect(described_class.crypt).to be_a ActiveSupport::MessageEncryptor
+      expect(described_class.crypt).to equal(described_class.crypt)
+    end
+  end
 end


### PR DESCRIPTION
Previously we generated a fresh key to encrypt each auth token, but
the original commit does not explain why [1]. Since the generation
of derivative keys is intentionally slow [2], yet still secure, we
should cache the derivative keys to avoid a bottleneck when building
individual emails, each of which requires an auth token.

Benchmarks:

irb(main):014:0> Benchmark.measure { 1000.times.map { Thread.new { ActiveSupport::KeyGenerator.new(secret).generate_key("", len) } }.each(&:j
oin) }
=> #<Benchmark::Tms:0x0000558d4c4e5a28 @label="", @real=72.12279930000659, @cstime=0.0, @cutime=0.0, @stime=1.7194850000000002, @utime=64.97203000000002, @total=66.69151500000002>

irb(main):015:0> Benchmark.measure { 1000.times.map { Thread.new { ActiveSupport::KeyGenerator.new(secret).generate_key("", len) } }.each(&:j
oin) }
=> #<Benchmark::Tms:0x0000558d4a595c68 @label="", @real=60.88592939999944, @cstime=0.0, @cutime=0.0, @stime=1.005351, @utime=57.850420000000014, @total=58.85577100000001>

Benchmark.measure { 10000.times.map { Thread.new { ActiveSupport::KeyGenerator.new(secret).generate_key("", len) } }.each(&:
join) }
=> #<Benchmark::Tms:0x0000558d4c777bd8 @label="", @real=568.584185700005, @cstime=0.0, @cutime=0.0, @stime=4.386428, @utime=562.60465, @total=566.991078>

Indeed, a load test on Staging showed the system appeared to be stuck
trying to compute the keys. (The following is from log/sidekiq.log.)

{"@timestamp":"2020-12-16T20:51:31Z","@fields":{"pid":31835,"tid":"TID-18d8","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@Severity":"WARN","@run_time":null,"@message":"/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/openssl/pkcs5.rb:14:in `pbkdf2_hmac'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/openssl/pkcs5.rb:14:in `pbkdf2_hmac'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/openssl/pkcs5.rb:19:in `pbkdf2_hmac_sha1'

[1]: https://github.com/alphagov/email-alert-api/commit/ceb38317ae2d29f5571dbe54eaf0ee1872152d29#diff-8c42a5fcffdef2c573e42bded73714a50ccc341c31701c6d68a2272029a4279d
[2]: https://docs.python.org/3/library/hashlib.html#key-derivation