### PR TITLE
[WIP] Investigate creating two Sidekiq parent workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3088}
 worker: bundle exec sidekiq -C ./config/sidekiq.yml
+send_email_worker: bundle exec sidekiq -C ./config/sidekiq_send_email.yml

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,12 +7,8 @@
 :queues:
   # See here to understand priorities: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
   # Use powers of 2: higher priority groups are checked twice as often.
-  - [send_email_transactional, 8] # To send one-off emails, such as subscription confirmation.
-  - [send_email_immediate_high, 8] # To send high priority emails to users with immediate subscriptions e.g. travel advice.
   - [process_and_generate_emails, 4] # To generate emails to users with immediate subscriptions for content changes and messages.
   - [email_generation_digest, 4] # To generate emails to users with daily or weekly subscriptions for content changes and messages.
-  - [send_email_immediate, 2] # To send emails to users with immediate subscriptions.
-  - [send_email_digest, 2] # To send digest emails to users with either daily or weekly subscriptions.
   - [default, 1] # Miscellaneous operations e.g. initiating digest runs, monitoring, DB cleanup and recovering lost Sidekiq jobs.
 :schedule:
   daily_digest_initiator:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 32
+:concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :timeout: 4
 :max_retries: 9

--- a/config/sidekiq_send_email.yml
+++ b/config/sidekiq_send_email.yml
@@ -1,0 +1,10 @@
+---
+:verbose: false
+:concurrency: 32
+:logfile: ./log/sidekiq_send_email.json.log
+:timeout: 4
+:max_retries: 9
+:queues:
+  # See here to understand priorities: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
+  # Use powers of 2: higher priority groups are checked twice as often.
+  # @TODO

--- a/config/sidekiq_send_email.yml
+++ b/config/sidekiq_send_email.yml
@@ -7,7 +7,7 @@
 :queues:
   # See here to understand priorities: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
   # Use powers of 2: higher priority groups are checked twice as often.
-  - [send_email_transactional, 8] # To send one-off emails, such as subscription confirmation.
-  - [send_email_immediate_high, 8] # To send high priority emails to users with immediate subscriptions e.g. travel advice.
-  - [send_email_immediate, 2] # To send emails to users with immediate subscriptions.
-  - [send_email_digest, 2] # To send digest emails to users with either daily or weekly subscriptions.
+  - [send_email_transactional, 4] # To send one-off emails, such as subscription confirmation.
+  - [send_email_immediate_high, 4] # To send high priority emails to users with immediate subscriptions e.g. travel advice.
+  - [send_email_immediate, 1] # To send emails to users with immediate subscriptions.
+  - [send_email_digest, 1] # To send digest emails to users with either daily or weekly subscriptions.

--- a/config/sidekiq_send_email.yml
+++ b/config/sidekiq_send_email.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 32
+:concurrency: 22
 :logfile: ./log/sidekiq_send_email.json.log
 :timeout: 4
 :max_retries: 9

--- a/config/sidekiq_send_email.yml
+++ b/config/sidekiq_send_email.yml
@@ -7,4 +7,7 @@
 :queues:
   # See here to understand priorities: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues
   # Use powers of 2: higher priority groups are checked twice as often.
-  # @TODO
+  - [send_email_transactional, 8] # To send one-off emails, such as subscription confirmation.
+  - [send_email_immediate_high, 8] # To send high priority emails to users with immediate subscriptions e.g. travel advice.
+  - [send_email_immediate, 2] # To send emails to users with immediate subscriptions.
+  - [send_email_digest, 2] # To send digest emails to users with either daily or weekly subscriptions.


### PR DESCRIPTION
Trello: https://trello.com/c/52YiPQ3y/2273-investigate-splitting-queues-to-send-email-onto-a-different-set-of-workers

## What

This is an investigation into using a dedicated worker for sending emails, leaving the current worker to handle the generation of emails and other miscellaneous jobs such as monitoring and DB cleanup.

## Why

Doing so would unblock sending transactional email (for users trying to subscribe / manage their subscriptions), and we would be able to start sending millions of emails as soon as they’re ready (i.e. the short term throughput would be higher).

## Dependencies

For local development, we'd need to set an additional worker in govuk-docker:
https://github.com/alphagov/govuk-docker/blob/da856818fb571c3c1a2e392603f5e24d143a12ed/projects%2Femail-alert-api%2Fdocker-compose.yml#L45-L53

For this to work on production, we'd also need to define the worker in govuk-puppet. There is a PR for that here: https://github.com/alphagov/govuk-puppet/pull/10901