### PR TITLE
Remove temporary Brexit checker migration task

### DIFF
--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -56,11 +56,4 @@ namespace :data_migration do
       puts "Updated #{args[:key]} in #{list.title} to #{new_criteria}"
     end
   end
-
-  desc "Temporary task to update all existing Brexit checker list titles"
-  task temp_update_all_brexit_list_titles: :environment do
-    SubscriberList
-      .where("tags->'brexit_checklist_criteria' IS NOT NULL")
-      .update_all(title: "Brexit checker results")
-  end
 end


### PR DESCRIPTION
https://trello.com/c/RHB4pu1A/748-change-get-ready-for-2021-to-brexit-checker-results

This has now been run.