### PR TITLE
Stop printing Message title in email body

### DIFF
--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -5,53 +5,10 @@ class MessagePresenter < ApplicationPresenter
   end
 
   def call
-    [
-      title_markdown,
-      body,
-    ].compact.join("\n\n") + "\n"
+    message.body + "\n"
   end
 
 private
 
-  attr_reader :message, :frequency
-
-  delegate :title, :body, :url, to: :message
-
-  def absolute_url
-    return unless url
-
-    parsed = URI.join(Plek.new.website_root, url)
-    add_ga_query_params(parsed)
-
-    parsed.to_s
-  rescue URI::InvalidURIError
-    nil
-  end
-
-  def add_ga_query_params(uri)
-    return unless uri.to_s.start_with?(Plek.new.website_root)
-
-    query_params = Rack::Utils.parse_nested_query(uri.query)
-
-    return if query_params.keys.any? { |k| k.match(/\Autm/) }
-
-    query = {
-      utm_source: message.id,
-      utm_medium: "email",
-      utm_campaign: "govuk-notifications-message",
-      utm_content: frequency,
-    }.to_query
-
-    if uri.query
-      uri.query += "&#{query}"
-    else
-      uri.query = query
-    end
-  end
-
-  def title_markdown
-    return title unless (destination = absolute_url)
-
-    "[#{title}](#{destination})"
-  end
+  attr_reader :message
 end

--- a/spec/features/create_and_deliver_a_daily_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_daily_digest_spec.rb
@@ -174,8 +174,6 @@ RSpec.describe "create and deliver a daily digest", type: :request do
 
       ---
 
-      Title two
-
       Body
 
       ---
@@ -250,8 +248,6 @@ RSpec.describe "create and deliver a daily digest", type: :request do
       10:00am, 1 January 2017
 
       ---
-
-      Title two
 
       Body
 

--- a/spec/features/create_and_deliver_a_weekly_digest_spec.rb
+++ b/spec/features/create_and_deliver_a_weekly_digest_spec.rb
@@ -106,13 +106,11 @@ RSpec.describe "create and delive a weekly digest", type: :request do
     end
 
     content_changes = ContentChange.order(:created_at)
-    messages = Message.order(:created_at)
 
     first_digest_stub = stub_notify_request(
       subscriber_one_address,
       first_expected_email_body(
         content_changes[0],
-        messages[0],
       ),
       "Subscriber list one",
     )
@@ -130,7 +128,6 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       subscriber_two_address,
       third_expected_email_body(
         content_changes[0],
-        messages[0],
       ),
       "Subscriber list one",
     )
@@ -163,7 +160,7 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       .to_return(body: {}.to_json)
   end
 
-  def first_expected_email_body(content_change_one, message_one)
+  def first_expected_email_body(content_change_one)
     <<~BODY
       Weekly update from GOV.UK for:
 
@@ -183,8 +180,6 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       10:00am, 1 January 2017
 
       ---
-
-      [Title two](#{url}#{message_utm_params(message_one.id, 'weekly')})
 
       Body
 
@@ -240,7 +235,7 @@ RSpec.describe "create and delive a weekly digest", type: :request do
     BODY
   end
 
-  def third_expected_email_body(content_change_one, message_one)
+  def third_expected_email_body(content_change_one)
     <<~BODY
       Weekly update from GOV.UK for:
 
@@ -260,8 +255,6 @@ RSpec.describe "create and delive a weekly digest", type: :request do
       10:00am, 1 January 2017
 
       ---
-
-      [Title two](#{url}#{message_utm_params(message_one.id, 'weekly')})
 
       Body
 

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -9,103 +9,10 @@ RSpec.describe MessagePresenter do
     it "returns a presenter message" do
       message = create(
         :message,
-        title: "My title",
         body: "Some information\nfor a user",
       )
 
       expected = <<~MESSAGE
-        My title
-
-        Some information
-        for a user
-      MESSAGE
-
-      expect(described_class.call(message)).to eq(expected)
-    end
-
-    it "can link to the title" do
-      message = create(
-        :message,
-        title: "My title",
-        url: "/my-page",
-        body: "Some information\nfor a user",
-      )
-
-      expected = <<~MESSAGE
-        [My title](https://www.gov.uk/my-page?#{message_utm_params(message.id, 'immediate')})
-
-        Some information
-        for a user
-      MESSAGE
-
-      expect(described_class.call(message)).to eq(expected)
-    end
-
-    it "copes with a path with a query string" do
-      message = create(
-        :message,
-        title: "My title",
-        url: "/my-page?my-query=this",
-        body: "Some information\nfor a user",
-      )
-
-      expected = <<~MESSAGE
-        [My title](https://www.gov.uk/my-page?my-query=this&#{message_utm_params(message.id, 'immediate')})
-
-        Some information
-        for a user
-      MESSAGE
-
-      expect(described_class.call(message)).to eq(expected)
-    end
-
-    it "doesn't replace the host of an absolute URL" do
-      message = create(
-        :message,
-        title: "My title",
-        url: "https://other-government-service/test",
-        body: "Some information\nfor a user",
-      )
-
-      expected = <<~MESSAGE
-        [My title](https://other-government-service/test)
-
-        Some information
-        for a user
-      MESSAGE
-
-      expect(described_class.call(message)).to eq(expected)
-    end
-
-    it "doesn't add Google Analytics params to a URL which already has this" do
-      message = create(
-        :message,
-        title: "My title",
-        url: "/test?utm_source=custom-source",
-        body: "Some information\nfor a user",
-      )
-
-      expected = <<~MESSAGE
-        [My title](https://www.gov.uk/test?utm_source=custom-source)
-
-        Some information
-        for a user
-      MESSAGE
-
-      expect(described_class.call(message)).to eq(expected)
-    end
-
-    it "adds Google Analytics params to an absolute GOV.UK URL" do
-      message = create(
-        :message,
-        title: "My title",
-        url: "https://www.gov.uk/test",
-        body: "Some information\nfor a user",
-      )
-
-      expected = <<~MESSAGE
-        [My title](https://www.gov.uk/test?#{message_utm_params(message.id, 'immediate')})
-
         Some information
         for a user
       MESSAGE

--- a/spec/support/utm_helpers.rb
+++ b/spec/support/utm_helpers.rb
@@ -2,8 +2,4 @@ module UTMHelpers
   def utm_params(content_change_id, frequency)
     "utm_source=#{content_change_id}&utm_medium=email&utm_campaign=govuk-notifications&utm_content=#{frequency}"
   end
-
-  def message_utm_params(message_id, frequency)
-    "utm_campaign=govuk-notifications-message&utm_content=#{frequency}&utm_medium=email&utm_source=#{message_id}"
-  end
 end


### PR DESCRIPTION
https://trello.com/c/N98texVc/735-update-static-parts-of-email-templates-so-theyre-consistent-with-other-navigation-options-2b

Previously this was used in both the email body and in the subject of
individual-type emails. While this coupling works for content changes,
it doesn't for messages, since they are by definition ad-hoc [1], and
we should avoid making any assumptions about the structure of the body
content for the email. This does the simplest thing to decouple the
subject line from the email body content - the Brexit Checker is still
the only consumer of the /messages API, and we will update it to render
a suitable replacement to the current title.

Arguably the subject should also be completely flexible, and not start
with "Update from GOV.UK for", but that would be a wider change.

Note that the tracking for the title is necessarily removed, and is now
entirely the concern of the API consumer to add tracking on any links,
which the Brexit Checker is already doing [2]. (It is actually quite
confusing that we showed two different pieces of text that link to the
same URL, but with different tracking attributes!)

[1]: https://github.com/alphagov/email-alert-api/blob/master/docs/adr/adr-004-message-concept.md#introduction
[2]: https://github.com/alphagov/finder-frontend/blob/f55dfc4bcb5e29926629e503ebd4c42b720f937e/app/helpers/brexit_checker_helper.rb#L38-L49