### PR TITLE
Fix not showing link to some checker results

### DIFF
--- a/app/presenters/source_url_presenter.rb
+++ b/app/presenters/source_url_presenter.rb
@@ -4,7 +4,7 @@ class SourceUrlPresenter < ApplicationPresenter
   end
 
   def call
-    url_for_brexit_checker_results if url =~ %r{transition-check/results}
+    url_for_brexit_checker_results if is_a_brexit_checker_list?
   end
 
 private
@@ -14,5 +14,10 @@ private
   def url_for_brexit_checker_results
     absolute_url = PublicUrls.url_for(base_path: url)
     "[You can view a copy of your results on GOV.UK](#{absolute_url})"
+  end
+
+  def is_a_brexit_checker_list?
+    url =~ %r{transition-check/results} ||
+      url =~ %r{get-ready-brexit-check/results}
   end
 end

--- a/spec/presenters/source_url_presenter_spec.rb
+++ b/spec/presenters/source_url_presenter_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe SourceUrlPresenter do
       expect(described_class.call(url)).to eq(
         "[You can view a copy of your results on GOV.UK](#{Plek.new.website_root + url})",
       )
+
+      url = "/get-ready-brexit-check/results?foo=bar"
+
+      expect(described_class.call(url)).to eq(
+        "[You can view a copy of your results on GOV.UK](#{Plek.new.website_root + url})",
+      )
     end
   end
 end


### PR DESCRIPTION
Previously we adopted this hack in favour of manually specifying a
fake "description" for each subscriber list [1]. However, we forgot
that the URL for checker results has changed. This fixes the hack
to cope with both versions of the checker results URL.

[1]: 520be069