### PR TITLE
Enhance bulk email functionality

### DIFF
--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -58,7 +58,7 @@ private
     )
 
     <<~BODY
-      #{body.gsub('%LISTURL%', list.url.to_s)}
+      #{body.gsub('%LISTURL%', PublicUrls.url_for(base_path: list.url.to_s))}
 
       ---
 

--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -10,7 +10,7 @@ class BulkSubscriberListEmailBuilder < ApplicationBuilder
 
   def call
     batches.flat_map do |batch|
-      records = records_for_batch(batch)
+      records = records_for_batch(batch.to_h)
       Email.insert_all!(records).pluck("id")
     end
   end
@@ -19,18 +19,23 @@ private
 
   attr_reader :subject, :body, :subscriber_lists, :now
 
-  def records_for_batch(subscriber_ids)
-    subscribers = Subscriber
-      .find(subscriber_ids)
-      .index_by(&:id)
+  def records_for_batch(batch)
+    subscriber_ids = batch.keys
+    subscribers = Subscriber.find(subscriber_ids).index_by(&:id)
 
-    subscriber_ids.map do |subscriber_id|
+    subscription_ids = batch.values
+    subscriptions = Subscription.find(subscription_ids).index_by(&:id)
+
+    batch.map do |subscriber_id, subscriber_subscription_ids|
       subscriber = subscribers[subscriber_id]
+
+      subscription = subscriptions.slice(*subscriber_subscription_ids)
+        .values.max_by(&:created_at)
 
       {
         address: subscriber.address,
         subject: subject,
-        body: body,
+        body: body + footer(subscriber, subscription),
         subscriber_id: subscriber_id,
         created_at: now,
         updated_at: now,
@@ -38,12 +43,38 @@ private
     end
   end
 
+  def footer(subscriber, subscription)
+    list = subscription.subscriber_list
+
+    unsubscribe_url = PublicUrls.unsubscribe(
+      subscription_id: subscription.id,
+      subscriber_id: subscriber.id,
+    )
+
+    manage_url = PublicUrls.authenticate_url(
+      address: subscriber.address,
+    )
+
+    "\n\n" + <<~FOOTER
+      ---
+
+      # Why am I getting this email?
+
+      You asked GOV.UK to send you an email each time we add or update a page about:
+
+      #{list.title}
+
+      [Unsubscribe](#{unsubscribe_url})
+
+      [Manage your email preferences](#{manage_url})
+    FOOTER
+  end
+
   def batches
     Subscription
       .active
       .where(subscriber_list: subscriber_lists)
-      .distinct
-      .pluck(:subscriber_id)
+      .subscription_ids_by_subscriber
       .each_slice(BATCH_SIZE)
   end
 end

--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -9,9 +9,11 @@ class BulkSubscriberListEmailBuilder < ApplicationBuilder
   end
 
   def call
-    batches.flat_map do |batch|
-      records = records_for_batch(batch.to_h)
-      Email.insert_all!(records).pluck("id")
+    ActiveRecord::Base.transaction do
+      batches.flat_map do |batch|
+        records = records_for_batch(batch.to_h)
+        Email.insert_all!(records).pluck("id")
+      end
     end
   end
 

--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -35,7 +35,7 @@ private
       {
         address: subscriber.address,
         subject: subject,
-        body: body + footer(subscriber, subscription),
+        body: email_body(subscriber, subscription),
         subscriber_id: subscriber_id,
         created_at: now,
         updated_at: now,
@@ -43,7 +43,7 @@ private
     end
   end
 
-  def footer(subscriber, subscription)
+  def email_body(subscriber, subscription)
     list = subscription.subscriber_list
 
     unsubscribe_url = PublicUrls.unsubscribe(
@@ -55,7 +55,9 @@ private
       address: subscriber.address,
     )
 
-    "\n\n" + <<~FOOTER
+    <<~BODY
+      #{body.gsub('%LISTURL%', list.url.to_s)}
+
       ---
 
       # Why am I getting this email?
@@ -67,7 +69,7 @@ private
       [Unsubscribe](#{unsubscribe_url})
 
       [Manage your email preferences](#{manage_url})
-    FOOTER
+    BODY
   end
 
   def batches

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -1,50 +1,48 @@
 RSpec.describe BulkSubscriberListEmailBuilder do
-  let(:email_subject) { "email subject" }
-  let(:body) { "email body" }
-
   describe ".call" do
-    subject(:email_import) do
-      described_class.call(subject: email_subject, body: body, subscriber_lists: subscriber_lists)
+    let(:subscriber) { create(:subscriber) }
+    let(:subscriber_lists) { create_list(:subscriber_list, 2) }
+
+    let(:email) do
+      email_ids = described_class.call(
+        subject: "email subject",
+        body: "email body",
+        subscriber_lists: subscriber_lists,
+      )
+
+      Email.find(email_ids).first
     end
 
-    context "with one subscriber" do
-      let(:subscriber_lists) { [create(:subscription).subscriber_list] }
-
-      it "returns an email import" do
-        expect(email_import.count).to eq(1)
+    context "with one subscription" do
+      before do
+        create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.first)
       end
 
-      let(:email) { Email.find(email_import.first) }
-
-      it "sets the subject" do
+      it "creates an email" do
         expect(email.subject).to eq("email subject")
-      end
-
-      it "sets the body" do
         expect(email.body).to eq("email body")
       end
     end
 
     context "with an ended subscription" do
-      let(:subscriber_lists) { [create(:subscription, :ended).subscriber_list] }
+      before do
+        create(:subscription, :ended, subscriber_list: subscriber_lists.first)
+      end
 
-      it "imports no emails" do
-        expect(email_import.count).to eq(0)
+      it "creates no emails" do
+        expect(email).to be_nil
       end
     end
 
     context "with many subscriptions" do
-      let(:subscriber_1) { create(:subscriber) }
-
-      let(:subscriber_lists) do
-        [
-          create(:subscription, subscriber: subscriber_1).subscriber_list,
-          create(:subscription, subscriber: subscriber_1).subscriber_list,
-        ]
+      before do
+        create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.first)
+        create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.second)
       end
 
       it "should only create one email per subscriber" do
-        expect(email_import.count).to eq(1)
+        expect(email).to be_present
+        expect(Email.count).to eq(1)
       end
     end
   end

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BulkSubscriberListEmailBuilder do
       end
     end
 
-    context "with an ended subscriptions" do
+    context "with an ended subscription" do
       let(:subscriber_lists) { [create(:subscription, :ended).subscriber_list] }
 
       it "imports no emails" do
@@ -33,23 +33,18 @@ RSpec.describe BulkSubscriberListEmailBuilder do
       end
     end
 
-    context "with many subscribers" do
+    context "with many subscriptions" do
       let(:subscriber_1) { create(:subscriber) }
-      let(:subscriber_2) { create(:subscriber) }
-      let(:subscriber_3) { create(:subscriber) }
 
       let(:subscriber_lists) do
         [
           create(:subscription, subscriber: subscriber_1).subscriber_list,
-          create(:subscription, subscriber: subscriber_2).subscriber_list,
-          create(:subscription, subscriber: subscriber_3).subscriber_list,
           create(:subscription, subscriber: subscriber_1).subscriber_list,
-          create(:subscription, subscriber: subscriber_2).subscriber_list,
         ]
       end
 
       it "should only create one email per subscriber" do
-        expect(email_import.count).to eq(3)
+        expect(email_import.count).to eq(1)
       end
     end
   end

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe BulkSubscriberListEmailBuilder do
     end
 
     before do
+      allow(PublicUrls).to receive(:url_for)
+        .and_return("/url")
+
       allow(PublicUrls).to receive(:unsubscribe)
         .with(subscription_id: subscription.id, subscriber_id: subscriber.id)
         .and_return("unsubscribe_url")
@@ -58,14 +61,6 @@ RSpec.describe BulkSubscriberListEmailBuilder do
 
         it "is substituted in the body" do
           expect(email.body).to include("something [link](/url).")
-        end
-      end
-
-      context "when the body requires a URL" do
-        let(:body) { "something [link](%LISTURL%)." }
-
-        it "is empty if the list has none" do
-          expect(email.body).to include("something [link]().")
         end
       end
     end

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe BulkSubscriberListEmailBuilder do
   describe ".call" do
     let(:subscriber) { create(:subscriber) }
+    let(:body) { "email body" }
 
     let(:subscriber_lists) do
       [create(:subscriber_list, title: "My List"), create(:subscriber_list)]
@@ -9,7 +10,7 @@ RSpec.describe BulkSubscriberListEmailBuilder do
     let(:email) do
       email_ids = described_class.call(
         subject: "email subject",
-        body: "email body",
+        body: body,
         subscriber_lists: subscriber_lists,
       )
 
@@ -49,6 +50,23 @@ RSpec.describe BulkSubscriberListEmailBuilder do
 
           [Manage your email preferences](manage_url)
         BODY
+      end
+
+      context "when the list has a URL" do
+        let(:subscriber_lists) { [create(:subscriber_list, url: "/url")] }
+        let(:body) { "something [link](%LISTURL%)." }
+
+        it "is substituted in the body" do
+          expect(email.body).to include("something [link](/url).")
+        end
+      end
+
+      context "when the body requires a URL" do
+        let(:body) { "something [link](%LISTURL%)." }
+
+        it "is empty if the list has none" do
+          expect(email.body).to include("something [link]().")
+        end
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/wp7WjPN6/693-draft-email-to-send-out-to-checker-subscribers-following-an-announcement

This makes a few changes to the existing bulk email builder:

- It is now batches generation of large quantities of email.
- The email now ends with a standard unsubscribe / manage footer.
- A list URL can be substituted for a "%LISTURL%" placeholder.

Arguably the builder is now doing too much: it should not be
deciding which emails to generate, but simply generating them.
This has lead to the test setup becoming a bit convoluted. In
future work, we should refactor the builder to separate out the
selection of email, like we do for immediate emails [1].

## Before (Link goes to "%LISTURL%" i.e. doesn't work)

<img width="533" alt="Screenshot 2021-01-04 at 14 54 06" src="https://user-images.githubusercontent.com/9029009/103547825-d0360d00-4e9c-11eb-875a-dc239cd3752a.png">

## After (link goes to checker results page for subscriber)

<img width="529" alt="Screenshot 2021-01-04 at 14 44 07" src="https://user-images.githubusercontent.com/9029009/103547920-ea6feb00-4e9c-11eb-8aa9-4f8684123b7d.png">


[1]: https://github.com/alphagov/email-alert-api/blob/d248a8d63324cb2255f6db36104cce9f3ed0bf2f/app/services/immediate_email_generation_service.rb