### PR TITLE
Add tracking to bulk email injected URL

### DIFF
--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -58,7 +58,7 @@ private
     )
 
     <<~BODY
-      #{body.gsub('%LISTURL%', PublicUrls.url_for(base_path: list.url.to_s))}
+      #{BulkEmailBodyPresenter.call(body, list)}
 
       ---
 

--- a/app/presenters/bulk_email_body_presenter.rb
+++ b/app/presenters/bulk_email_body_presenter.rb
@@ -1,0 +1,14 @@
+class BulkEmailBodyPresenter < ApplicationPresenter
+  def initialize(body, subscriber_list)
+    @body = body
+    @subscriber_list = subscriber_list
+  end
+
+  def call
+    body.gsub("%LISTURL%", PublicUrls.url_for(base_path: subscriber_list.url.to_s))
+  end
+
+private
+
+  attr_reader :body, :subscriber_list
+end

--- a/app/presenters/bulk_email_body_presenter.rb
+++ b/app/presenters/bulk_email_body_presenter.rb
@@ -5,10 +5,24 @@ class BulkEmailBodyPresenter < ApplicationPresenter
   end
 
   def call
-    body.gsub("%LISTURL%", PublicUrls.url_for(base_path: subscriber_list.url.to_s))
+    body.gsub("%LISTURL%", list_url)
   end
 
 private
 
   attr_reader :body, :subscriber_list
+
+  def list_url
+    tracking_params = [
+      "utm_source=#{subscriber_list.slug}",
+      "utm_medium=email",
+      "utm_campaign=govuk-notifications-bulk",
+    ]
+
+    uri = URI.parse(subscriber_list.url)
+    uri.query = ([uri.query] + tracking_params).compact.join("&")
+    PublicUrls.url_for(base_path: uri.to_s)
+  rescue URI::InvalidURIError
+    ""
+  end
 end

--- a/spec/presenters/bulk_email_body_presenter_spec.rb
+++ b/spec/presenters/bulk_email_body_presenter_spec.rb
@@ -5,18 +5,29 @@ RSpec.describe BulkEmailBodyPresenter do
       body = "something [link](%LISTURL%)."
 
       allow(PublicUrls).to receive(:url_for)
-        .with(base_path: "/url")
+        .with(base_path: %r{^/url\?utm_source=})
         .and_return("domain/url")
 
       result = described_class.call(body, subscriber_list)
       expect(result).to include("something [link](domain/url).")
     end
 
+    it "copes if the URL already has query params" do
+      subscriber_list = build(:subscriber_list, url: "/url?foo=bar")
+
+      expect(PublicUrls).to receive(:url_for)
+        .with(base_path: %r{^/url\?foo=bar&utm_source})
+        .and_call_original
+
+      described_class.call("body", subscriber_list)
+    end
+
     it "copes when the subscriber list has no URL" do
       subscriber_list = build(:subscriber_list)
+      body = "something [link](%LISTURL%)."
 
-      expect { described_class.call("body", subscriber_list) }
-        .to_not raise_error
+      result = described_class.call(body, subscriber_list)
+      expect(result).to include("something [link]().")
     end
   end
 end

--- a/spec/presenters/bulk_email_body_presenter_spec.rb
+++ b/spec/presenters/bulk_email_body_presenter_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe BulkEmailBodyPresenter do
+  describe ".call" do
+    it "substitutes the list URL in the body" do
+      subscriber_list = build(:subscriber_list, url: "/url")
+      body = "something [link](%LISTURL%)."
+
+      allow(PublicUrls).to receive(:url_for)
+        .with(base_path: "/url")
+        .and_return("domain/url")
+
+      result = described_class.call(body, subscriber_list)
+      expect(result).to include("something [link](domain/url).")
+    end
+
+    it "copes when the subscriber list has no URL" do
+      subscriber_list = build(:subscriber_list)
+
+      expect { described_class.call("body", subscriber_list) }
+        .to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/wp7WjPN6/693-draft-email-to-send-out-to-checker-subscribers-following-an-announcement

Please see the commits for more details.