### PR TITLE
DRY-up footer across email builders

### DIFF
--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -47,11 +47,7 @@ private
 
   def email_body(subscriber, subscription)
     list = subscription.subscriber_list
-
-    unsubscribe_url = PublicUrls.unsubscribe(
-      subscription_id: subscription.id,
-      subscriber_id: subscriber.id,
-    )
+    unsubscribe_url = PublicUrls.unsubscribe(subscription)
 
     manage_url = PublicUrls.authenticate_url(
       address: subscriber.address,

--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -46,27 +46,12 @@ private
   end
 
   def email_body(subscriber, subscription)
-    list = subscription.subscriber_list
-    unsubscribe_url = PublicUrls.unsubscribe(subscription)
-
-    manage_url = PublicUrls.authenticate_url(
-      address: subscriber.address,
-    )
-
     <<~BODY
-      #{BulkEmailBodyPresenter.call(body, list)}
+      #{BulkEmailBodyPresenter.call(body, subscription.subscriber_list)}
 
       ---
 
-      # Why am I getting this email?
-
-      You asked GOV.UK to send you an email each time we add or update a page about:
-
-      #{list.title}
-
-      [Unsubscribe](#{unsubscribe_url})
-
-      [Manage your email preferences](#{manage_url})
+      #{FooterPresenter.call(subscriber, subscription)}
     BODY
   end
 

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -44,7 +44,7 @@ private
       presenter.call(item, frequency: subscription.frequency)
     end
 
-    changes.join("\n---\n\n").strip
+    changes.join("\n\n---\n\n").strip
   end
 
   def title_and_optional_url

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -34,15 +34,7 @@ private
 
       ---
 
-      # Why am I getting this email?
-
-      #{I18n.t("emails.digests.#{subscription.frequency}.footer_explanation")}
-
-      #{subscriber_list.title}
-
-      [Unsubscribe](#{unsubscribe_url})
-
-      [#{I18n.t!('emails.digests.footer_manage')}](#{PublicUrls.authenticate_url(address: subscriber.address)})
+      #{FooterPresenter.call(subscriber, subscription)}
     BODY
   end
 
@@ -66,9 +58,5 @@ private
 
     result += "\n\n" + source_url if source_url
     result
-  end
-
-  def unsubscribe_url
-    PublicUrls.unsubscribe(subscription)
   end
 end

--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -69,9 +69,6 @@ private
   end
 
   def unsubscribe_url
-    PublicUrls.unsubscribe(
-      subscription_id: subscription.id,
-      subscriber_id: subscriber.id,
-    )
+    PublicUrls.unsubscribe(subscription)
   end
 end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -77,9 +77,6 @@ private
   end
 
   def unsubscribe_url(subscription)
-    PublicUrls.unsubscribe(
-      subscription_id: subscription.id,
-      subscriber_id: subscription.subscriber_id,
-    )
+    PublicUrls.unsubscribe(subscription)
   end
 end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -16,15 +16,15 @@ private
     @records ||= begin
       now = Time.zone.now
       recipients_and_content.map do |recipient_and_content|
-        address = recipient_and_content.fetch(:address)
+        subscriber = recipient_and_content.fetch(:subscriber)
         content = recipient_and_content.fetch(:content)
         subscriptions = recipient_and_content.fetch(:subscriptions)
 
         {
-          address: address,
+          address: subscriber.address,
           subject: subject(content),
-          body: body(content, subscriptions.first, address),
-          subscriber_id: recipient_and_content.fetch(:subscriber_id),
+          body: body(content, subscriptions.first, subscriber),
+          subscriber_id: subscriber.id,
           created_at: now,
           updated_at: now,
         }
@@ -36,7 +36,7 @@ private
     "Update from GOV.UK for: #{content.title}"
   end
 
-  def body(content, subscription, address)
+  def body(content, subscription, subscriber)
     list = subscription.subscriber_list
 
     <<~BODY
@@ -58,7 +58,7 @@ private
 
       [Unsubscribe](#{unsubscribe_url(subscription)})
 
-      [Manage your email preferences](#{PublicUrls.authenticate_url(address: address)})
+      [Manage your email preferences](#{PublicUrls.authenticate_url(address: subscriber.address)})
     BODY
   end
 

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -56,7 +56,7 @@ private
 
   def middle_section(list, content)
     presenter = "#{content.class.name}Presenter".constantize
-    section = presenter.call(content).strip
+    section = presenter.call(content)
 
     source_url = SourceUrlPresenter.call(
       list.url,

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -50,15 +50,7 @@ private
 
       ---
 
-      # Why am I getting this email?
-
-      You asked GOV.UK to send you an email each time we add or update a page about:
-
-      #{list.title}
-
-      [Unsubscribe](#{unsubscribe_url(subscription)})
-
-      [Manage your email preferences](#{PublicUrls.authenticate_url(address: subscriber.address)})
+      #{FooterPresenter.call(subscriber, subscription)}
     BODY
   end
 
@@ -74,9 +66,5 @@ private
 
     section += "\n\n" + source_url if source_url
     section
-  end
-
-  def unsubscribe_url(subscription)
-    PublicUrls.unsubscribe(subscription)
   end
 end

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -14,7 +14,7 @@ class ContentChangePresenter < ApplicationPresenter
       description_markdown,
       change_note_markdown.rstrip,
       footnote_markdown,
-    ].compact.join("\n\n") + "\n"
+    ].compact.join("\n\n")
   end
 
 private

--- a/app/presenters/footer_presenter.rb
+++ b/app/presenters/footer_presenter.rb
@@ -1,0 +1,34 @@
+class FooterPresenter < ApplicationPresenter
+  def initialize(subscriber, subscription)
+    @subscription = subscription
+    @subscriber = subscriber
+  end
+
+  def call
+    result = <<~FOOTER
+      # Why am I getting this email?
+
+      #{I18n.t("emails.footer.#{subscription.frequency}")}
+
+      #{subscription.subscriber_list.title}
+
+      [Unsubscribe](#{unsubscribe_url})
+
+      [Manage your email preferences](#{manage_url})
+    FOOTER
+
+    result.strip
+  end
+
+private
+
+  attr_reader :subscription, :subscriber
+
+  def unsubscribe_url
+    PublicUrls.unsubscribe(subscription)
+  end
+
+  def manage_url
+    PublicUrls.authenticate_url(address: subscriber.address)
+  end
+end

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -5,7 +5,7 @@ class MessagePresenter < ApplicationPresenter
   end
 
   def call
-    message.body + "\n"
+    message.body
   end
 
 private

--- a/app/queries/digest_items_query.rb
+++ b/app/queries/digest_items_query.rb
@@ -35,7 +35,6 @@ private
       .where(subscriptions: { id: subscriptions })
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
-      .order("subscriber_lists.title ASC", "content_changes.created_at ASC")
       .uniq(&:content_id)
       .group_by(&:subscription_id)
   end
@@ -47,7 +46,6 @@ private
       .where(subscriptions: { id: subscriptions })
       .where("messages.created_at >= ?", digest_run.starts_at)
       .where("messages.created_at < ?", digest_run.ends_at)
-      .order("subscriber_lists.title ASC", "messages.created_at ASC")
       .uniq(&:id)
       .group_by(&:subscription_id)
   end

--- a/app/queries/digest_items_query.rb
+++ b/app/queries/digest_items_query.rb
@@ -1,5 +1,5 @@
 class DigestItemsQuery
-  Result = Struct.new(:subscription_id, :subscriber_list_title, :subscriber_list_url, :subscriber_list_slug, :content)
+  Result = Struct.new(:subscription, :content)
 
   def initialize(subscriber, digest_run)
     @subscriber = subscriber
@@ -11,7 +11,15 @@ class DigestItemsQuery
   end
 
   def call
-    build_results(fetch_content_changes, fetch_messages)
+    subscriptions.filter_map do |subscription|
+      content = content_changes[subscription.id].to_a
+      content += messages[subscription.id].to_a
+
+      next unless content.any?
+
+      content = content.sort_by(&:created_at)
+      Result.new(subscription, content)
+    end
   end
 
   private_class_method :new
@@ -20,56 +28,35 @@ private
 
   attr_reader :subscriber, :digest_run
 
-  def build_results(content_changes, messages)
-    result_data = content_changes.each_with_object({}) do |record, memo|
-      id = record[:subscription_id]
-      memo[id] ||= {
-        subscriber_list_title: record[:subscriber_list_title],
-        subscriber_list_url: record[:subscriber_list_url],
-        subscriber_list_slug: record[:subscriber_list_slug],
-      }
-      memo[id][:content_changes] = Array(memo[id][:content_changes]) << record
-    end
-
-    result_data = messages.each_with_object(result_data) do |record, memo|
-      id = record[:subscription_id]
-      memo[id] ||= {
-        subscriber_list_title: record[:subscriber_list_title],
-        subscriber_list_url: record[:subscriber_list_url],
-        subscriber_list_slug: record[:subscriber_list_slug],
-      }
-      memo[id][:messages] = Array(memo[id][:messages]) << record
-    end
-
-    result_data.map do |key, value|
-      content = value.fetch(:content_changes, []) + value.fetch(:messages, [])
-      Result.new(key, value[:subscriber_list_title], value[:subscriber_list_url], value[:subscriber_list_slug], content.sort_by(&:created_at))
-    end
-  end
-
-  def fetch_content_changes
-    ContentChange
-      .select("content_changes.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url", "subscriber_lists.slug AS subscriber_list_slug")
-      .joins(matched_content_changes: { subscriber_list: { subscriptions: :subscriber } })
-      .where(subscribers: { id: subscriber.id })
-      .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
+  def content_changes
+    @content_changes ||= ContentChange
+      .select("content_changes.*, subscriptions.id AS subscription_id")
+      .joins(matched_content_changes: { subscriber_list: :subscriptions })
+      .where(subscriptions: { id: subscriptions })
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
-      .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "content_changes.created_at ASC")
+      .order("subscriber_lists.title ASC", "content_changes.created_at ASC")
       .uniq(&:content_id)
+      .group_by(&:subscription_id)
   end
 
-  def fetch_messages
-    Message
-      .select("messages.*", "subscriptions.id AS subscription_id", "subscriber_lists.title AS subscriber_list_title", "subscriber_lists.url AS subscriber_list_url", "subscriber_lists.slug AS subscriber_list_slug")
-      .joins(matched_messages: { subscriber_list: { subscriptions: :subscriber } })
-      .where(subscribers: { id: subscriber.id })
-      .where(subscriptions: { frequency: Subscription.frequencies[digest_run.range] })
+  def messages
+    @messages ||= Message
+      .select("messages.*, subscriptions.id AS subscription_id")
+      .joins(matched_messages: { subscriber_list: :subscriptions })
+      .where(subscriptions: { id: subscriptions })
       .where("messages.created_at >= ?", digest_run.starts_at)
       .where("messages.created_at < ?", digest_run.ends_at)
-      .merge(Subscription.active)
-      .order("subscriber_list_title ASC", "subscriber_list_url ASC", "messages.created_at ASC")
+      .order("subscriber_lists.title ASC", "messages.created_at ASC")
       .uniq(&:id)
+      .group_by(&:subscription_id)
+  end
+
+  def subscriptions
+    @subscriptions ||= subscriber
+      .subscriptions
+      .active
+      .includes(:subscriber_list)
+      .where(frequency: Subscription.frequencies[digest_run.range])
   end
 end

--- a/app/services/immediate_email_generation_service/batch.rb
+++ b/app/services/immediate_email_generation_service/batch.rb
@@ -27,10 +27,9 @@ class ImmediateEmailGenerationService
       @email_parameters ||= begin
         subscriptions_to_fulfill_by_subscriber.map do |(subscriber, subscriptions)|
           {
-            address: subscriber.address,
+            subscriber: subscriber,
             content: content_change || message,
             subscriptions: subscriptions,
-            subscriber_id: subscriber.id,
           }.compact
         end
       end

--- a/app/workers/digest_email_generation_worker.rb
+++ b/app/workers/digest_email_generation_worker.rb
@@ -32,10 +32,8 @@ private
   def create_email(digest_run_subscriber, digest_item)
     Metrics.digest_email_generation(digest_run_subscriber.digest_run.range) do
       email = DigestEmailBuilder.call(
-        address: digest_run_subscriber.subscriber.address,
-        digest_item: digest_item,
-        digest_run: digest_run_subscriber.digest_run,
-        subscriber_id: digest_run_subscriber.subscriber_id,
+        content: digest_item.content,
+        subscription: digest_item.subscription,
       )
 
       email.id
@@ -48,7 +46,7 @@ private
     records = digest_item.content.map do |content|
       {
         email_id: email_id,
-        subscription_id: digest_item.subscription_id,
+        subscription_id: digest_item.subscription.id,
         content_change_id: content.is_a?(ContentChange) ? content.id : nil,
         message_id: content.is_a?(Message) ? content.id : nil,
         digest_run_subscriber_id: digest_run_subscriber.id,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,12 +9,13 @@ en:
       daily:
         subject: "Daily update from GOV.UK for: %{title}"
         opening_line: "Daily update from GOV.UK for:"
-        footer_explanation: "You asked GOV.UK to send you one email a day about:"
       weekly:
         subject: "Weekly update from GOV.UK for: %{title}"
         opening_line: "Weekly update from GOV.UK for:"
-        footer_explanation: "You asked GOV.UK to send you one email a week about:"
-      footer_manage: "Manage your email preferences"
+    footer:
+      immediately: "You asked GOV.UK to send you an email each time we add or update a page about:"
+      daily: "You asked GOV.UK to send you one email a day about:"
+      weekly: "You asked GOV.UK to send you one email a week about:"
     description_header: "Page summary:"
     change_note_header: "Change made:"
     public_updated_at_header: "Time updated:"

--- a/lib/public_urls.rb
+++ b/lib/public_urls.rb
@@ -15,9 +15,10 @@ module PublicUrls
       url_for(base_path: "/email/manage/authenticate", address: address)
     end
 
-    def unsubscribe(subscription_id:, subscriber_id:)
+    def unsubscribe(subscription)
+      subscriber_id = subscription.subscriber_id
       token = AuthTokenGeneratorService.call(subscriber_id: subscriber_id)
-      url_for(base_path: "/email/unsubscribe/#{subscription_id}", token: token)
+      url_for(base_path: "/email/unsubscribe/#{subscription.id}", token: token)
     end
 
   private

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BulkSubscriberListEmailBuilder do
         .and_return("presented body")
 
       allow(PublicUrls).to receive(:unsubscribe)
-        .with(subscription_id: subscription.id, subscriber_id: subscriber.id)
+        .with(subscription)
         .and_return("unsubscribe_url")
 
       allow(PublicUrls).to receive(:authenticate_url)

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -21,13 +21,9 @@ RSpec.describe BulkSubscriberListEmailBuilder do
         .with("email body", subscriber_lists.first)
         .and_return("presented body")
 
-      allow(PublicUrls).to receive(:unsubscribe)
-        .with(subscription)
-        .and_return("unsubscribe_url")
-
-      allow(PublicUrls).to receive(:authenticate_url)
-        .with(address: subscriber.address)
-        .and_return("manage_url")
+      allow(FooterPresenter).to receive(:call)
+        .with(subscriber, subscription)
+        .and_return("presented_footer")
     end
 
     context "with one subscription" do
@@ -43,15 +39,7 @@ RSpec.describe BulkSubscriberListEmailBuilder do
 
           ---
 
-          # Why am I getting this email?
-
-          You asked GOV.UK to send you an email each time we add or update a page about:
-
-          My List
-
-          [Unsubscribe](unsubscribe_url)
-
-          [Manage your email preferences](manage_url)
+          presented_footer
         BODY
       end
     end

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -1,35 +1,28 @@
 RSpec.describe DigestEmailBuilder do
-  let(:digest_run) { double(range: "daily") }
-  let(:subscriber) { build(:subscriber) }
-  let(:address) { subscriber.address }
-  let(:subscriber_id) { subscriber.id }
+  let(:subscriber_list) { create(:subscriber_list, title: "Test title 1") }
+  let(:subscriber) { create(:subscriber) }
+  let(:frequency) { "daily" }
+  let(:content) { [build(:content_change), build(:message)] }
 
-  let(:digest_item) do
-    double(
-      subscription_id: "ABC1",
-      subscriber_list_title: "Test title 1",
-      subscriber_list_url: nil,
-      subscriber_list_slug: nil,
-      subscriber_list_description: "",
-      content: [
-        build(:content_change),
-        build(:message),
-      ],
+  let(:subscription) do
+    build(
+      :subscription,
+      frequency: frequency,
+      subscriber_list: subscriber_list,
+      subscriber: subscriber,
     )
   end
 
   let(:email) do
     described_class.call(
-      address: address,
-      digest_item: digest_item,
-      digest_run: digest_run,
-      subscriber_id: subscriber_id,
+      content: content,
+      subscription: subscription,
     )
   end
 
   before do
     allow(PublicUrls).to receive(:unsubscribe)
-      .with(subscription_id: digest_item.subscription_id, subscriber_id: subscriber_id)
+      .with(subscription_id: subscription.id, subscriber_id: subscriber.id)
       .and_return("unsubscribe_url")
 
     allow(PublicUrls).to receive(:authenticate_url)
@@ -49,7 +42,7 @@ RSpec.describe DigestEmailBuilder do
   describe ".call" do
     context "for a daily update" do
       it "creates an Email" do
-        expect(email.subscriber_id).to eq(subscriber_id)
+        expect(email.subscriber_id).to eq(subscriber.id)
         expect(email.subject).to eq "Daily update from GOV.UK for: Test title 1"
 
         expect(email.body).to eq(
@@ -83,10 +76,10 @@ RSpec.describe DigestEmailBuilder do
     end
 
     context "for a weekly update" do
-      let(:digest_run) { double(range: "weekly") }
+      let(:frequency) { "weekly" }
 
       it "creates an Email" do
-        expect(email.subscriber_id).to eq(subscriber_id)
+        expect(email.subscriber_id).to eq(subscriber.id)
         expect(email.subject).to eq "Weekly update from GOV.UK for: Test title 1"
 
         expect(email.body).to include(

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe DigestEmailBuilder do
       .and_return(nil)
 
     expect(ContentChangePresenter).to receive(:call)
-      .and_return("presented_content_change\n")
+      .and_return("presented_content_change")
 
     expect(MessagePresenter).to receive(:call)
-      .and_return("presented_message\n")
+      .and_return("presented_message")
   end
 
   describe ".call" do

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DigestEmailBuilder do
 
   before do
     allow(PublicUrls).to receive(:unsubscribe)
-      .with(subscription_id: subscription.id, subscriber_id: subscriber.id)
+      .with(subscription)
       .and_return("unsubscribe_url")
 
     allow(PublicUrls).to receive(:authenticate_url)

--- a/spec/builders/digest_email_builder_spec.rb
+++ b/spec/builders/digest_email_builder_spec.rb
@@ -21,13 +21,9 @@ RSpec.describe DigestEmailBuilder do
   end
 
   before do
-    allow(PublicUrls).to receive(:unsubscribe)
-      .with(subscription)
-      .and_return("unsubscribe_url")
-
-    allow(PublicUrls).to receive(:authenticate_url)
-      .with(address: subscriber.address)
-      .and_return("manage_url")
+    allow(FooterPresenter).to receive(:call)
+      .with(subscriber, subscription)
+      .and_return("presented_footer")
 
     allow(SourceUrlPresenter).to receive(:call)
       .and_return(nil)
@@ -61,15 +57,7 @@ RSpec.describe DigestEmailBuilder do
 
             ---
 
-            # Why am I getting this email?
-
-            You asked GOV.UK to send you one email a day about:
-
-            Test title 1
-
-            [Unsubscribe](unsubscribe_url)
-
-            [Manage your email preferences](manage_url)
+            presented_footer
           BODY
         )
       end
@@ -89,16 +77,6 @@ RSpec.describe DigestEmailBuilder do
             # Test title 1
 
             ---
-          BODY
-        )
-
-        expect(email.body).to include(
-          <<~BODY,
-            # Why am I getting this email?
-
-            You asked GOV.UK to send you one email a week about:
-
-            Test title 1
           BODY
         )
       end

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ImmediateEmailBuilder do
 
     before do
       allow(PublicUrls).to receive(:unsubscribe)
-        .with(subscription_id: subscription.id, subscriber_id: subscriber.id)
+        .with(subscription)
         .and_return("unsubscribe_url")
 
       allow(PublicUrls).to receive(:authenticate_url)

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ImmediateEmailBuilder do
       before do
         allow(ContentChangePresenter).to receive(:call)
           .with(content_change)
-          .and_return("presented_content_change\n")
+          .and_return("presented_content_change")
       end
 
       it "creates an email" do
@@ -70,7 +70,7 @@ RSpec.describe ImmediateEmailBuilder do
       before do
         allow(MessagePresenter).to receive(:call)
           .with(message)
-          .and_return("presented_message\n")
+          .and_return("presented_message")
       end
 
       it "creates an email" do
@@ -107,7 +107,7 @@ RSpec.describe ImmediateEmailBuilder do
       before do
         allow(ContentChangePresenter).to receive(:call)
           .with(content_change)
-          .and_return("presented_content_change\n")
+          .and_return("presented_content_change")
 
         allow(SourceUrlPresenter).to receive(:call).and_return("Presented URL")
       end

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe ImmediateEmailBuilder do
 
     let(:params) do
       {
-        address: subscriber.address,
         subscriptions: [subscription, "other_subscription"],
-        subscriber_id: subscriber.id,
+        subscriber: subscriber,
       }
     end
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -12,13 +12,9 @@ RSpec.describe ImmediateEmailBuilder do
     end
 
     before do
-      allow(PublicUrls).to receive(:unsubscribe)
-        .with(subscription)
-        .and_return("unsubscribe_url")
-
-      allow(PublicUrls).to receive(:authenticate_url)
-        .with(address: subscriber.address)
-        .and_return("manage_url")
+      allow(FooterPresenter).to receive(:call)
+        .with(subscriber, subscription)
+        .and_return("presented_footer")
     end
 
     it "raises an ArgumentError when given an empty collection of parameters" do
@@ -56,15 +52,7 @@ RSpec.describe ImmediateEmailBuilder do
 
             ---
 
-            # Why am I getting this email?
-
-            You asked GOV.UK to send you an email each time we add or update a page about:
-
-            My List
-
-            [Unsubscribe](unsubscribe_url)
-
-            [Manage your email preferences](manage_url)
+            presented_footer
           BODY
         )
       end
@@ -101,15 +89,7 @@ RSpec.describe ImmediateEmailBuilder do
 
             ---
 
-            # Why am I getting this email?
-
-            You asked GOV.UK to send you an email each time we add or update a page about:
-
-            My List
-
-            [Unsubscribe](unsubscribe_url)
-
-            [Manage your email preferences](manage_url)
+            presented_footer
           BODY
         )
       end

--- a/spec/lib/public_urls_spec.rb
+++ b/spec/lib/public_urls_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe PublicUrls do
         .with(subscriber_id: subscription.subscriber_id)
         .and_return("token")
 
-      url = subject.unsubscribe(subscription_id: subscription.id, subscriber_id: subscription.subscriber_id)
+      url = subject.unsubscribe(subscription)
       expect(url).to eq("http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?token=token")
     end
   end

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ContentChangePresenter do
         11:00am, 28 March 2018
       CONTENT_CHANGE
 
-      expect(described_class.call(content_change)).to eq(expected)
+      expect(described_class.call(content_change)).to eq(expected.strip)
     end
 
     context "when content change contains markdown" do
@@ -64,7 +64,7 @@ RSpec.describe ContentChangePresenter do
           10:30am, 28 March 2018
         CONTENT_CHANGE
 
-        expect(described_class.call(content_change)).to eq(expected)
+        expect(described_class.call(content_change)).to eq(expected.strip)
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe ContentChangePresenter do
           10:00am, 1 January 2018
         CONTENT_CHANGE
 
-        expect(described_class.call(content_change)).to eq(expected)
+        expect(described_class.call(content_change)).to eq(expected.strip)
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe ContentChangePresenter do
           footnote
         CONTENT_CHANGE
 
-        expect(described_class.call(content_change)).to eq(expected)
+        expect(described_class.call(content_change)).to eq(expected.strip)
       end
     end
   end

--- a/spec/presenters/footer_presenter_spec.rb
+++ b/spec/presenters/footer_presenter_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe FooterPresenter do
+  describe ".call" do
+    let(:subscriber) { create(:subscriber) }
+    let(:subscription) { create(:subscription) }
+
+    let(:footer) do
+      described_class.call(subscriber, subscription)
+    end
+
+    before do
+      allow(PublicUrls).to receive(:unsubscribe)
+        .with(subscription)
+        .and_return("unsubscribe_url")
+
+      allow(PublicUrls).to receive(:authenticate_url)
+        .with(address: subscriber.address)
+        .and_return("manage_url")
+    end
+
+    it "returns a standard footer" do
+      expected = <<~FOOTER
+        # Why am I getting this email?
+
+        #{I18n.t!('emails.footer.immediately')}
+
+        #{subscription.subscriber_list.title}
+
+        [Unsubscribe](unsubscribe_url)
+
+        [Manage your email preferences](manage_url)
+      FOOTER
+
+      expect(footer).to eq(expected.strip)
+    end
+
+    %w[weekly daily].each do |frequency|
+      context "for a #{frequency} subscription" do
+        let(:subscription) { create(:subscription, frequency: frequency) }
+
+        it "uses a different explanation" do
+          expect(footer).to include(I18n.t!("emails.footer.#{frequency}"))
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MessagePresenter do
         for a user
       MESSAGE
 
-      expect(described_class.call(message)).to eq(expected)
+      expect(described_class.call(message)).to eq(expected.strip)
     end
   end
 end

--- a/spec/queries/digest_items_query_spec.rb
+++ b/spec/queries/digest_items_query_spec.rb
@@ -38,10 +38,7 @@ RSpec.describe DigestItemsQuery do
         expect(results.count).to eq(1)
         expect(results.first.to_h)
           .to match(
-            subscription_id: subscription.id,
-            subscriber_list_title: subscriber_list.title,
-            subscriber_list_url: subscriber_list.url,
-            subscriber_list_slug: subscriber_list.slug,
+            subscription: subscription,
             content: [content_change, message],
           )
       end
@@ -136,19 +133,13 @@ RSpec.describe DigestItemsQuery do
         expect(results.count).to eq(2)
         expect(results.first.to_h)
           .to match(
-            subscription_id: subscription1.id,
-            subscriber_list_title: subscriber_list1.title,
-            subscriber_list_url: subscriber_list1.url,
-            subscriber_list_slug: subscriber_list1.slug,
+            subscription: subscription1,
             content: [content_change1],
           )
 
         expect(results.last.to_h)
           .to match(
-            subscription_id: subscription2.id,
-            subscriber_list_title: subscriber_list2.title,
-            subscriber_list_url: subscriber_list2.url,
-            subscriber_list_slug: subscriber_list2.slug,
+            subscription: subscription2,
             content: [content_change2],
           )
       end
@@ -161,10 +152,7 @@ RSpec.describe DigestItemsQuery do
         expect(results.count).to eq(1)
         expect(results.first.to_h)
           .to match(
-            subscription_id: subscription1.id,
-            subscriber_list_title: subscriber_list1.title,
-            subscriber_list_url: subscriber_list1.url,
-            subscriber_list_slug: subscriber_list1.slug,
+            subscription: subscription1,
             content: [message],
           )
       end

--- a/spec/queries/digest_items_query_spec.rb
+++ b/spec/queries/digest_items_query_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DigestItemsQuery do
 
       it "returns only one content change if there are multiple with same content_id" do
         content_id = SecureRandom.uuid
-        content_change1 = create(
+        create(
           :content_change,
           :matched,
           content_id: content_id,
@@ -89,7 +89,7 @@ RSpec.describe DigestItemsQuery do
           created_at: digest_run.starts_at + 20.minutes,
         )
 
-        expect(results.first.content).to match([content_change1])
+        expect(results.first.content.count).to eq(1)
       end
     end
 

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -21,10 +21,9 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
 
   def email_parameters(content, subscriber, subscriptions)
     {
-      address: subscriber.address,
       content: content,
       subscriptions: subscriptions,
-      subscriber_id: subscriber.id,
+      subscriber: subscriber,
     }.compact
   end
 

--- a/spec/workers/digest_email_generation_worker_spec.rb
+++ b/spec/workers/digest_email_generation_worker_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe DigestEmailGenerationWorker do
     let(:subscriber) { create(:subscriber) }
 
     let(:subscription_one) do
-      create(:subscription, subscriber: subscriber)
+      create(:subscription, subscriber: subscriber, frequency: "daily")
     end
 
     let(:subscription_two) do
-      create(:subscription, subscriber: subscriber)
+      create(:subscription, subscriber: subscriber, frequency: "daily")
     end
 
     let(:digest_run) { create(:digest_run) }
@@ -31,19 +31,11 @@ RSpec.describe DigestEmailGenerationWorker do
     let(:digest_items) do
       [
         double(
-          subscription_id: subscription_one.id,
-          subscriber_list_title: "Test title 1",
-          subscriber_list_url: nil,
-          subscriber_list_slug: nil,
-          subscriber_list_description: nil,
+          subscription: subscription_one,
           content: [create(:content_change)],
         ),
         double(
-          subscription_id: subscription_two.id,
-          subscriber_list_title: "Test title 2",
-          subscriber_list_url: "/test-title-2",
-          subscriber_list_slug: "a-slug",
-          subscriber_list_description: "Test description",
+          subscription: subscription_two,
           content: [create(:message)],
         ),
       ]
@@ -57,10 +49,8 @@ RSpec.describe DigestEmailGenerationWorker do
       digest_items.each do |digest_item|
         expect(DigestEmailBuilder)
           .to receive(:call)
-          .with(address: subscriber.address,
-                digest_item: digest_item,
-                digest_run: digest_run,
-                subscriber_id: subscriber.id)
+          .with(content: digest_item.content,
+                subscription: digest_item.subscription)
           .and_call_original
       end
 


### PR DESCRIPTION
https://trello.com/c/wp7WjPN6/693-draft-email-to-send-out-to-checker-subscribers-following-an-announcement

This makes a few prepatory changes in order to DRY-up
the presentation of the footer into a single presenter.
Making this change will also make it easier to track the
footer links, which may come in a future PR.

Please see the commits for more details.