### PR TITLE
Remove bulk task for Brexit emails

### DIFF
--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -10,10 +10,4 @@ namespace :bulk_email do
       SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate)
     end
   end
-
-  desc "Email all subscribers of the Brexit checker"
-  task brexit_subscribers: :environment do
-    brexit_lists = SubscriberList.where("subscriber_lists.tags->>'brexit_checklist_criteria' IS NOT NULL")
-    Rake::Task["bulk_email:for_lists"].invoke(*brexit_lists)
-  end
 end

--- a/spec/lib/tasks/bulk_email_spec.rb
+++ b/spec/lib/tasks/bulk_email_spec.rb
@@ -1,45 +1,4 @@
 RSpec.describe "bulk_email" do
-  describe "brexit_subscribers" do
-    let(:tags) { { brexit_checklist_criteria: { any: %w[visiting-eu] } } }
-    let!(:list) { create(:subscriber_list, tags: tags) }
-    before do
-      Rake::Task["bulk_email:brexit_subscribers"].reenable
-      Rake::Task["bulk_email:for_lists"].reenable
-    end
-
-    around(:each) do |example|
-      ClimateControl.modify(SUBJECT: "subject", BODY: "body") do
-        example.run
-      end
-    end
-
-    it "builds emails for a subscriber list" do
-      expect(BulkSubscriberListEmailBuilder)
-        .to receive(:call)
-        .with(subject: "subject",
-              body: "body",
-              subscriber_lists: [list])
-        .and_call_original
-
-      Rake::Task["bulk_email:brexit_subscribers"].invoke
-    end
-
-    it "enqueues the emails for delivery" do
-      allow(BulkSubscriberListEmailBuilder).to receive(:call)
-        .and_return([1, 2])
-
-      expect(SendEmailWorker)
-        .to receive(:perform_async_in_queue)
-        .with(1, queue: :send_email_immediate)
-
-      expect(SendEmailWorker)
-        .to receive(:perform_async_in_queue)
-        .with(2, queue: :send_email_immediate)
-
-      Rake::Task["bulk_email:brexit_subscribers"].invoke
-    end
-  end
-
   describe "for_lists" do
     before do
       Rake::Task["bulk_email:for_lists"].reenable


### PR DESCRIPTION
https://trello.com/c/wp7WjPN6/693-draft-email-to-send-out-to-checker-subscribers-following-an-announcement

We have no plan to run this again, and can easily re-add it if we
do. The task itself is problematic, as it can't be used with the
standard "Run rake task" Jenkins job, which only supports a single
line input i.e. we can't specify multiline body content.