### PR TITLE
Update API documentation for GET /subscriber-lists

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,6 @@ Gets a stored subscriber list that's relevant to just the `cabinet-office` organ
   "subscriber_list": {
     "id": "an id",
     "title": "Title of topic",
-    "subscription_url": "https://public-url/subscribe-here?topic_id=123",
     "gov_delivery_id": "123",
     "document_type": "",
     "created_at": "20141010T12:00:00",


### PR DESCRIPTION
The `subscription_url` value was removed in 75137c2f40b1902a2bf1da481a3a835744dc8e13, so the API no longer returns
this value.

Trello card: https://trello.com/c/qr574f7A