### PR TITLE
Fix tests for opt-in / manage auth tokens

### DIFF
--- a/app/builders/subscriber_auth_email_builder.rb
+++ b/app/builders/subscriber_auth_email_builder.rb
@@ -41,15 +41,6 @@ private
   end
 
   def link
-    Plek.new.website_uri.tap do |uri|
-      destination_uri = URI.parse(destination)
-      uri.path = destination_uri.path
-      uri.query = if destination_uri.query.present?
-                    "#{destination_uri.query}&token=#{token}"
-                  else
-                    "token=#{token}"
-                  end
-      uri.fragment = destination_uri.fragment
-    end
+    PublicUrls.url_for(base_path: destination, token: token)
   end
 end

--- a/spec/builders/subscriber_auth_email_builder_spec.rb
+++ b/spec/builders/subscriber_auth_email_builder_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe SubscriberAuthEmailBuilder do
       )
     end
 
+    before do
+      allow(PublicUrls).to receive(:url_for)
+        .with(base_path: destination, token: token)
+        .and_return("auth_url")
+    end
+
     it { is_expected.to be_instance_of(Email) }
 
     it "creates an email" do
@@ -25,19 +31,8 @@ RSpec.describe SubscriberAuthEmailBuilder do
     end
 
     it "has body content has a link allowing users to authenticate and manage their subscriptions" do
-      link = "http://www.dev.gov.uk/destination?token=secret"
       email = call
-      expect(email.body).to include(link)
-    end
-
-    context "when destination has a query string and fragment" do
-      let(:destination) { "/destination?query#fragment" }
-
-      it "merges the token" do
-        link = "http://www.dev.gov.uk/destination?query&token=secret#fragment"
-        email = call
-        expect(email.body).to include(link)
-      end
+      expect(email.body).to include("auth_url")
     end
   end
 end

--- a/spec/builders/subscription_auth_email_builder_spec.rb
+++ b/spec/builders/subscription_auth_email_builder_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe SubscriptionAuthEmailBuilder do
       )
     end
 
+    before do
+      allow(PublicUrls).to receive(:url_for)
+        .with(base_path: "/email/subscriptions/authenticate",
+              frequency: frequency,
+              token: "secret",
+              topic_id: subscriber_list.slug)
+        .and_return("auth_url")
+    end
+
     it { is_expected.to be_instance_of(Email) }
 
     it "creates an email" do
@@ -44,9 +53,8 @@ RSpec.describe SubscriptionAuthEmailBuilder do
     end
 
     it "has a link to authenticate" do
-      link = "http://www.dev.gov.uk/email/subscriptions/authenticate?token=#{token}&topic_id=business-tax-corporation-tax&frequency=weekly"
       email = call
-      expect(email.body).to include(link)
+      expect(email.body).to include("auth_url")
     end
   end
 end

--- a/spec/features/create_an_auth_token_spec.rb
+++ b/spec/features/create_an_auth_token_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe "Create an auth token", type: :request do
 
     body = email_data.dig(:personalisation, :body)
     expect(body).to include("http://www.dev.gov.uk#{destination}?token=")
-    token = body.match(/token=([^&\n]+)$/)[1]
+
+    token = URI.decode_www_form_component(
+      body.match(/token=([^&\n]+)/)[1],
+    )
 
     expect(decrypt_and_verify_token(token)).to eq(
       "subscriber_id" => subscriber.id,

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -33,7 +33,10 @@ RSpec.describe "Subscribers auth token", type: :request do
     it "sends an email with the correct token" do
       post path, params: params
       expect(Email.count).to be 1
-      token = Email.last.body.match(/token=([^&\n]+)/)[1]
+
+      token = URI.decode_www_form_component(
+        Email.last.body.match(/token=([^&\n]+)/)[1],
+      )
 
       expect(decrypt_and_verify_token(token)).to eq(
         "subscriber_id" => subscriber.id,

--- a/spec/integration/subscriptions_auth_token_spec.rb
+++ b/spec/integration/subscriptions_auth_token_spec.rb
@@ -88,10 +88,14 @@ RSpec.describe "Subscriptions auth token", type: :request do
       post path, params: params
     end
 
-    xit "sends an email with the correct token" do
+    it "sends an email with the correct token" do
       post path, params: params
       expect(Email.count).to be 1
-      token = Email.last.body.match(/token=([^&)]+)/)[1]
+
+      token = URI.decode_www_form_component(
+        Email.last.body.match(/token=([^&\n]+)/)[1],
+      )
+
       expect(decrypt_and_verify_token(token)).to eq(
         "address" => address,
         "topic_id" => topic_id,


### PR DESCRIPTION
Previously we ignored these in order to quickly fix a bug.
The original fault was due to the removal of URL unescaping
for all tests [1], which allowed the feature and integration
tests to continue passing in spite of the URLs being invalid.

[1]: https://github.com/alphagov/email-alert-api/pull/1548/commits/57f2fca2d83391b88c75aaa3b9862b470715df00#diff-48cb7b27ea61deeffa1a37e42451aaeb4c9fa56ea4b07076c4733cdd858a0a93L11