### PR TITLE
Update confirmation email and add tracking

### DIFF
--- a/app/builders/digest_email_builder.rb
+++ b/app/builders/digest_email_builder.rb
@@ -41,7 +41,7 @@ private
   def presented_results
     changes = content.map do |item|
       presenter = "#{item.class.name}Presenter".constantize
-      presenter.call(item, frequency: subscription.frequency)
+      presenter.call(item, subscription)
     end
 
     changes.join("\n\n---\n\n").strip

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -46,7 +46,7 @@ private
 
       ---
 
-      #{middle_section(list, content)}
+      #{middle_section(subscription, content)}
 
       ---
 
@@ -54,13 +54,14 @@ private
     BODY
   end
 
-  def middle_section(list, content)
+  def middle_section(subscription, content)
+    subscriber_list = subscription.subscriber_list
     presenter = "#{content.class.name}Presenter".constantize
-    section = presenter.call(content)
+    section = presenter.call(content, subscription)
 
     source_url = SourceUrlPresenter.call(
-      list.url,
-      utm_source: list.slug,
+      subscriber_list.url,
+      utm_source: subscriber_list.slug,
       utm_content: "immediate",
     )
 

--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -53,10 +53,18 @@ private
   end
 
   def unsubscribe_url
-    PublicUrls.unsubscribe(subscription)
+    PublicUrls.unsubscribe(
+      subscription,
+      utm_source: subscriber_list.slug,
+      utm_content: subscription.frequency,
+    )
   end
 
   def manage_url
-    PublicUrls.manage_url(subscriber)
+    PublicUrls.manage_url(
+      subscriber,
+      utm_source: subscriber_list.slug,
+      utm_content: subscription.frequency,
+    )
   end
 end

--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -57,6 +57,6 @@ private
   end
 
   def manage_url
-    PublicUrls.authenticate_url(address: subscriber.address)
+    PublicUrls.manage_url(subscriber)
   end
 end

--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -1,6 +1,8 @@
 class SubscriptionConfirmationEmailBuilder < ApplicationBuilder
   def initialize(subscription:)
     @subscription = subscription
+    @subscriber = subscription.subscriber
+    @subscriber_list = subscription.subscriber_list
   end
 
   def call
@@ -14,32 +16,31 @@ class SubscriptionConfirmationEmailBuilder < ApplicationBuilder
 
 private
 
-  attr_reader :subscription
-
-  def subscriber
-    @subscriber ||= subscription.subscriber
-  end
-
-  def subscriber_list
-    @subscriber_list ||= subscription.subscriber_list
-  end
+  attr_reader :subscription, :subscriber, :subscriber_list
 
   def subject
-    "You’ve subscribed to #{subscriber_list.title}"
+    "You’ve subscribed to: #{subscriber_list.title}"
   end
 
   def body
     <<~BODY
+      # You’ve subscribed to GOV.UK emails
+
+      #{I18n.t!("emails.confirmation.frequency.#{subscription.frequency}")}
+
       #{title_and_optional_url}
 
-      ---
+      Thanks
+      GOV.UK emails
 
-      #{ManageSubscriptionsLinkPresenter.call(subscriber.address)}
+      [Unsubscribe](#{unsubscribe_url})
+
+      [Manage your email preferences](#{manage_url})
     BODY
   end
 
   def title_and_optional_url
-    result = "You’ll get an email each time there are changes to #{subscriber_list.title}"
+    result = subscriber_list.title
 
     source_url = SourceUrlPresenter.call(
       subscriber_list.url,
@@ -49,5 +50,13 @@ private
 
     result += "\n\n" + source_url if source_url
     result
+  end
+
+  def unsubscribe_url
+    PublicUrls.unsubscribe(subscription)
+  end
+
+  def manage_url
+    PublicUrls.authenticate_url(address: subscriber.address)
   end
 end

--- a/app/models/email_parameters.rb
+++ b/app/models/email_parameters.rb
@@ -6,7 +6,7 @@ class EmailParameters
     @subject = subject
     @template_data = template_data.merge(
       subject: subject,
-      address: subscriber.address,
+      subscriber: subscriber,
     )
   end
 end

--- a/app/models/email_template_context.rb
+++ b/app/models/email_template_context.rb
@@ -18,7 +18,7 @@ class EmailTemplateContext
     uri.to_s
   end
 
-  def presented_manage_subscriptions_links(address)
-    ManageSubscriptionsLinkPresenter.call(address)
+  def presented_manage_subscriptions_links(subscriber)
+    ManageSubscriptionsLinkPresenter.call(subscriber)
   end
 end

--- a/app/presenters/content_change_presenter.rb
+++ b/app/presenters/content_change_presenter.rb
@@ -3,9 +3,9 @@ require "redcarpet/render_strip"
 class ContentChangePresenter < ApplicationPresenter
   EMAIL_DATE_FORMAT = "%l:%M%P, %-d %B %Y".freeze
 
-  def initialize(content_change, frequency: "immediate")
+  def initialize(content_change, subscription)
     @content_change = content_change
-    @frequency = frequency
+    @subscription = subscription
   end
 
   def call
@@ -19,7 +19,7 @@ class ContentChangePresenter < ApplicationPresenter
 
 private
 
-  attr_reader :content_change, :frequency
+  attr_reader :content_change, :subscription
 
   delegate :title, :description, :change_note, :footnote, to: :content_change
 
@@ -27,7 +27,7 @@ private
     PublicUrls.url_for(
       base_path: content_change.base_path,
       utm_source: content_change.id,
-      utm_content: frequency,
+      utm_content: subscription.frequency,
     )
   end
 

--- a/app/presenters/footer_presenter.rb
+++ b/app/presenters/footer_presenter.rb
@@ -2,6 +2,7 @@ class FooterPresenter < ApplicationPresenter
   def initialize(subscriber, subscription)
     @subscription = subscription
     @subscriber = subscriber
+    @subscriber_list = subscription.subscriber_list
   end
 
   def call
@@ -10,7 +11,7 @@ class FooterPresenter < ApplicationPresenter
 
       #{I18n.t("emails.footer.#{subscription.frequency}")}
 
-      #{subscription.subscriber_list.title}
+      #{subscriber_list.title}
 
       [Unsubscribe](#{unsubscribe_url})
 
@@ -22,13 +23,21 @@ class FooterPresenter < ApplicationPresenter
 
 private
 
-  attr_reader :subscription, :subscriber
+  attr_reader :subscription, :subscriber, :subscriber_list
 
   def unsubscribe_url
-    PublicUrls.unsubscribe(subscription)
+    PublicUrls.unsubscribe(
+      subscription,
+      utm_source: subscriber_list.slug,
+      utm_content: subscription.frequency,
+    )
   end
 
   def manage_url
-    PublicUrls.manage_url(subscriber)
+    PublicUrls.manage_url(
+      subscriber,
+      utm_source: subscriber_list.slug,
+      utm_content: subscription.frequency,
+    )
   end
 end

--- a/app/presenters/footer_presenter.rb
+++ b/app/presenters/footer_presenter.rb
@@ -29,6 +29,6 @@ private
   end
 
   def manage_url
-    PublicUrls.authenticate_url(address: subscriber.address)
+    PublicUrls.manage_url(subscriber)
   end
 end

--- a/app/presenters/manage_subscriptions_link_presenter.rb
+++ b/app/presenters/manage_subscriptions_link_presenter.rb
@@ -1,6 +1,6 @@
 class ManageSubscriptionsLinkPresenter < ApplicationPresenter
-  def initialize(address)
-    @address = address
+  def initialize(subscriber)
+    @subscriber = subscriber
   end
 
   def call
@@ -9,9 +9,9 @@ class ManageSubscriptionsLinkPresenter < ApplicationPresenter
 
 private
 
-  attr_reader :address
+  attr_reader :subscriber
 
   def url
-    PublicUrls.authenticate_url(address: address)
+    PublicUrls.manage_url(subscriber)
   end
 end

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -1,7 +1,6 @@
 class MessagePresenter < ApplicationPresenter
-  def initialize(message, frequency: "immediate")
+  def initialize(message, _subscription = nil)
     @message = message
-    @frequency = frequency
   end
 
   def call

--- a/app/services/unpublish_handler_service.rb
+++ b/app/services/unpublish_handler_service.rb
@@ -4,7 +4,7 @@ class UnpublishHandlerService < ApplicationService
 
     You might want to subscribe to updates about '<%=redirect.title%>' instead: [<%=redirect.url%>](<%=add_utm(redirect.url, utm_parameters)%>)
 
-    <%=presented_manage_subscriptions_links(address)%>
+    <%=presented_manage_subscriptions_links(subscriber)%>
   BODY
 
   TEMPLATES = {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,11 @@ en:
         daily: You’ll get one email a day
         weekly: You’ll get one email a week
         immediately: You’ll get an email each time we add or update a page
+    confirmation:
+      frequency:
+        daily: "You’ll get one email a day from GOV.UK about:"
+        weekly: "You’ll get one email a week from GOV.UK about:"
+        immediately: "You’ll get an email from GOV.UK each time we add or update a page about:"
     digests:
       daily:
         subject: "Daily update from GOV.UK for: %{title}"

--- a/lib/public_urls.rb
+++ b/lib/public_urls.rb
@@ -11,8 +11,8 @@ module PublicUrls
       uri.to_s
     end
 
-    def authenticate_url(address:)
-      url_for(base_path: "/email/manage/authenticate", address: address)
+    def manage_url(subscriber)
+      url_for(base_path: "/email/manage/authenticate", address: subscriber.address)
     end
 
     def unsubscribe(subscription)

--- a/lib/public_urls.rb
+++ b/lib/public_urls.rb
@@ -11,14 +11,17 @@ module PublicUrls
       uri.to_s
     end
 
-    def manage_url(subscriber)
-      url_for(base_path: "/email/manage/authenticate", address: subscriber.address)
+    def manage_url(subscriber, **utm_params)
+      params = utm_params.merge(address: subscriber.address)
+      url_for(base_path: "/email/manage/authenticate", **params)
     end
 
-    def unsubscribe(subscription)
+    def unsubscribe(subscription, **utm_params)
       subscriber_id = subscription.subscriber_id
       token = AuthTokenGeneratorService.call(subscriber_id: subscriber_id)
-      url_for(base_path: "/email/unsubscribe/#{subscription.id}", token: token)
+
+      params = utm_params.merge(token: token)
+      url_for(base_path: "/email/unsubscribe/#{subscription.id}", **params)
     end
 
   private

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ImmediateEmailBuilder do
 
       before do
         allow(ContentChangePresenter).to receive(:call)
-          .with(content_change)
+          .with(content_change, subscription)
           .and_return("presented_content_change")
       end
 
@@ -69,7 +69,7 @@ RSpec.describe ImmediateEmailBuilder do
 
       before do
         allow(MessagePresenter).to receive(:call)
-          .with(message)
+          .with(message, subscription)
           .and_return("presented_message")
       end
 
@@ -106,7 +106,7 @@ RSpec.describe ImmediateEmailBuilder do
 
       before do
         allow(ContentChangePresenter).to receive(:call)
-          .with(content_change)
+          .with(content_change, subscription)
           .and_return("presented_content_change")
 
         allow(SourceUrlPresenter).to receive(:call).and_return("Presented URL")

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
         .with(subscription)
         .and_return("unsubscribe_url")
 
-      allow(PublicUrls).to receive(:authenticate_url)
-        .with(address: subscriber.address)
+      allow(PublicUrls).to receive(:manage_url)
+        .with(subscriber)
         .and_return("manage_url")
     end
 

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -8,12 +8,17 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
     subject(:email) { described_class.call(subscription: subscription) }
 
     before do
+      utm_params = {
+        utm_source: subscription.subscriber_list.slug,
+        utm_content: frequency,
+      }
+
       allow(PublicUrls).to receive(:unsubscribe)
-        .with(subscription)
+        .with(subscription, **utm_params)
         .and_return("unsubscribe_url")
 
       allow(PublicUrls).to receive(:manage_url)
-        .with(subscriber)
+        .with(subscriber, **utm_params)
         .and_return("manage_url")
     end
 

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -1,35 +1,55 @@
 RSpec.describe SubscriptionConfirmationEmailBuilder do
   describe ".call" do
-    let(:subscriber_list) { create(:subscriber_list, title: "Example") }
-    let(:subscription) { create(:subscription, subscriber_list: subscriber_list) }
+    let(:frequency) { "immediately" }
+    let(:subscriber_list) { build(:subscriber_list, title: "My List") }
+    let(:subscription) { build(:subscription, subscriber_list: subscriber_list, frequency: frequency) }
+    let(:subscriber) { subscription.subscriber }
+
+    subject(:email) { described_class.call(subscription: subscription) }
 
     before do
-      allow(SourceUrlPresenter).to receive(:call)
-        .and_return(nil)
+      allow(PublicUrls).to receive(:unsubscribe)
+        .with(subscription)
+        .and_return("unsubscribe_url")
 
-      allow(ManageSubscriptionsLinkPresenter)
-        .to receive(:call)
-        .with(subscription.subscriber.address)
+      allow(PublicUrls).to receive(:authenticate_url)
+        .with(address: subscriber.address)
         .and_return("manage_url")
     end
 
-    subject(:email) do
-      described_class.call(subscription: subscription)
-    end
-
-    context "for all subscriptions" do
+    context "for an immediate subscription" do
       it "creates an email" do
-        expect(email.subject).to eq("You’ve subscribed to Example")
+        expect(email.subject).to eq("You’ve subscribed to: My List")
+        expect(email.subscriber_id).to eq(subscriber.id)
 
         expect(email.body).to eq(
           <<~BODY,
-            You’ll get an email each time there are changes to Example
+            # You’ve subscribed to GOV.UK emails
 
-            ---
+            #{I18n.t!('emails.confirmation.frequency.immediately')}
 
-            manage_url
+            My List
+
+            Thanks
+            GOV.UK emails
+
+            [Unsubscribe](unsubscribe_url)
+
+            [Manage your email preferences](manage_url)
           BODY
         )
+      end
+    end
+
+    %w[daily weekly].each do |frequency|
+      context "for a #{frequency} subscription" do
+        let(:frequency) { frequency }
+
+        it "creates an email" do
+          expect(email.body).to include(
+            I18n.t!("emails.confirmation.frequency.#{frequency}"),
+          )
+        end
       end
     end
 
@@ -40,15 +60,13 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
       end
 
       it "includes it in the body" do
-        expect(email.body).to eq(
+        expect(email.body).to include(
           <<~BODY,
-            You’ll get an email each time there are changes to Example
+            My List
 
             Presented URL
 
-            ---
-
-            manage_url
+            Thanks
           BODY
         )
       end

--- a/spec/features/daily_digest_spec.rb
+++ b/spec/features/daily_digest_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Daily digests", type: :request do
     expect(body).to include("Body")
     expect(body).to include("10:00am, 1 January 2017")
     expect(body).to include("[Unsubscribe](http://www.dev.gov.uk/email/unsubscribe")
-    expect(body).to include("gov.uk/email/manage/authenticate?address=")
+    expect(body).to include("gov.uk/email/manage/authenticate")
   end
 
   scenario "multiple lists" do

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sending an email", type: :request do
     expect(body).to include("Change note")
     expect(body).to include("12:00am, 1 January 2017")
     expect(body).to include("[Unsubscribe](http://www.dev.gov.uk/email/unsubscribe")
-    expect(body).to include("gov.uk/email/manage/authenticate?address=")
+    expect(body).to include("gov.uk/email/manage/authenticate")
   end
 
   scenario "sending an email for a message" do
@@ -39,6 +39,6 @@ RSpec.describe "Sending an email", type: :request do
     body = email_data.dig(:personalisation, :body)
     expect(body).to include("Body")
     expect(body).to include("[Unsubscribe](http://www.dev.gov.uk/email/unsubscribe")
-    expect(body).to include("gov.uk/email/manage/authenticate?address=")
+    expect(body).to include("gov.uk/email/manage/authenticate")
   end
 end

--- a/spec/features/weekly_digest_spec.rb
+++ b/spec/features/weekly_digest_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Weekly digests", type: :request do
     expect(body).to include("Body")
     expect(body).to include("10:00am, 1 January 2017")
     expect(body).to include("[Unsubscribe](http://www.dev.gov.uk/email/unsubscribe")
-    expect(body).to include("gov.uk/email/manage/authenticate?address=")
+    expect(body).to include("gov.uk/email/manage/authenticate")
   end
 
   scenario "multiple lists" do

--- a/spec/lib/public_urls_spec.rb
+++ b/spec/lib/public_urls_spec.rb
@@ -37,4 +37,12 @@ RSpec.describe PublicUrls do
       expect(url).to eq("http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?token=token")
     end
   end
+
+  describe ".manage_url" do
+    it "returns the GOV.UK url to manage subscriptions" do
+      subscriber = create(:subscriber, address: "foo@bar.com")
+      url = subject.manage_url(subscriber)
+      expect(url).to eq("http://www.dev.gov.uk/email/manage/authenticate?address=foo%40bar.com")
+    end
+  end
 end

--- a/spec/lib/public_urls_spec.rb
+++ b/spec/lib/public_urls_spec.rb
@@ -25,24 +25,37 @@ RSpec.describe PublicUrls do
   end
 
   describe ".unsubscribe" do
-    it "returns the GOV.UK url for a one-click unsubscribe" do
-      subscription = create :subscription
+    let(:subscription) { create :subscription }
 
+    before do
       allow(AuthTokenGeneratorService)
         .to receive(:call)
         .with(subscriber_id: subscription.subscriber_id)
         .and_return("token")
+    end
 
+    it "returns the GOV.UK url for a one-click unsubscribe" do
       url = subject.unsubscribe(subscription)
       expect(url).to eq("http://www.dev.gov.uk/email/unsubscribe/#{subscription.id}?token=token")
+    end
+
+    it "accepts additional UTM params" do
+      url = subject.unsubscribe(subscription, utm_source: "source")
+      expect(url).to include("utm_source=source")
     end
   end
 
   describe ".manage_url" do
+    let(:subscriber) { create(:subscriber, address: "foo@bar.com") }
+
     it "returns the GOV.UK url to manage subscriptions" do
-      subscriber = create(:subscriber, address: "foo@bar.com")
       url = subject.manage_url(subscriber)
       expect(url).to eq("http://www.dev.gov.uk/email/manage/authenticate?address=foo%40bar.com")
+    end
+
+    it "accepts additional UTM params" do
+      url = subject.manage_url(subscriber, utm_source: "source")
+      expect(url).to include("utm_source=source")
     end
   end
 end

--- a/spec/presenters/content_change_presenter_spec.rb
+++ b/spec/presenters/content_change_presenter_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ContentChangePresenter do
+  let(:subscription) { create(:subscription, frequency: "immediately") }
+
   let(:content_change) do
     build(
       :content_change,
@@ -10,12 +12,16 @@ RSpec.describe ContentChangePresenter do
     )
   end
 
+  let(:result) do
+    described_class.call(content_change, subscription)
+  end
+
   before do
     allow(PublicUrls).to receive(:url_for)
       .with(
         base_path: content_change.base_path,
         utm_source: content_change.id,
-        utm_content: "immediate",
+        utm_content: subscription.frequency,
       )
       .and_return("public_url")
   end
@@ -35,7 +41,7 @@ RSpec.describe ContentChangePresenter do
         11:00am, 28 March 2018
       CONTENT_CHANGE
 
-      expect(described_class.call(content_change)).to eq(expected.strip)
+      expect(result).to eq(expected.strip)
     end
 
     context "when content change contains markdown" do
@@ -64,7 +70,7 @@ RSpec.describe ContentChangePresenter do
           10:30am, 28 March 2018
         CONTENT_CHANGE
 
-        expect(described_class.call(content_change)).to eq(expected.strip)
+        expect(result).to eq(expected.strip)
       end
     end
 
@@ -88,7 +94,7 @@ RSpec.describe ContentChangePresenter do
           10:00am, 1 January 2018
         CONTENT_CHANGE
 
-        expect(described_class.call(content_change)).to eq(expected.strip)
+        expect(result).to eq(expected.strip)
       end
     end
 
@@ -117,7 +123,7 @@ RSpec.describe ContentChangePresenter do
           footnote
         CONTENT_CHANGE
 
-        expect(described_class.call(content_change)).to eq(expected.strip)
+        expect(result).to eq(expected.strip)
       end
     end
   end

--- a/spec/presenters/footer_presenter_spec.rb
+++ b/spec/presenters/footer_presenter_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe FooterPresenter do
         .with(subscription)
         .and_return("unsubscribe_url")
 
-      allow(PublicUrls).to receive(:authenticate_url)
-        .with(address: subscriber.address)
+      allow(PublicUrls).to receive(:manage_url)
+        .with(subscriber)
         .and_return("manage_url")
     end
 

--- a/spec/presenters/footer_presenter_spec.rb
+++ b/spec/presenters/footer_presenter_spec.rb
@@ -1,19 +1,25 @@
 RSpec.describe FooterPresenter do
   describe ".call" do
     let(:subscriber) { create(:subscriber) }
-    let(:subscription) { create(:subscription) }
+    let(:frequency) { "immediately" }
+    let(:subscription) { create(:subscription, frequency: frequency) }
 
     let(:footer) do
       described_class.call(subscriber, subscription)
     end
 
     before do
+      utm_params = {
+        utm_source: subscription.subscriber_list.slug,
+        utm_content: frequency,
+      }
+
       allow(PublicUrls).to receive(:unsubscribe)
-        .with(subscription)
+        .with(subscription, **utm_params)
         .and_return("unsubscribe_url")
 
       allow(PublicUrls).to receive(:manage_url)
-        .with(subscriber)
+        .with(subscriber, **utm_params)
         .and_return("manage_url")
     end
 
@@ -35,7 +41,7 @@ RSpec.describe FooterPresenter do
 
     %w[weekly daily].each do |frequency|
       context "for a #{frequency} subscription" do
-        let(:subscription) { create(:subscription, frequency: frequency) }
+        let(:frequency) { frequency }
 
         it "uses a different explanation" do
           expect(footer).to include(I18n.t!("emails.footer.#{frequency}"))

--- a/spec/presenters/manage_subscriptions_link_presenter_spec.rb
+++ b/spec/presenters/manage_subscriptions_link_presenter_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe ManageSubscriptionsLinkPresenter do
   describe ".call" do
     it "returns a manage subscriptions link" do
+      subscriber = create(:subscriber, address: "test-email@test.com")
       expected = "[View, unsubscribe or change the frequency of your subscriptions](http://www.dev.gov.uk/email/manage/authenticate?address=test-email%40test.com)"
-      expect(described_class.call("test-email@test.com")).to eq(expected)
+      expect(described_class.call(subscriber)).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

This updates the template for the confirmation received after
a user has subscribed. In doing so, we also adds tracking to
all "unsubscribe" and "manage" links, in all emails in which
they appear. Please see the commits for more details.

## Before

<img width="588" alt="Screenshot 2021-01-08 at 17 15 48" src="https://user-images.githubusercontent.com/9029009/104044567-6340b100-51d5-11eb-906b-f8afa5f94d78.png">

## After

<img width="603" alt="Screenshot 2021-01-08 at 17 17 14" src="https://user-images.githubusercontent.com/9029009/104044580-68056500-51d5-11eb-8f64-5081193bf10e.png">
