### PR TITLE
Simplify code to generate unique emails

### DIFF
--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -23,7 +23,7 @@ private
 
   def records_for_batch(subscription_ids)
     subscriptions = Subscription
-      .includes(:subscriber)
+      .includes(:subscriber, :subscriber_list)
       .find(subscription_ids)
 
     subscriptions.map do |subscription|

--- a/app/builders/bulk_subscriber_list_email_builder.rb
+++ b/app/builders/bulk_subscriber_list_email_builder.rb
@@ -10,8 +10,8 @@ class BulkSubscriberListEmailBuilder < ApplicationBuilder
 
   def call
     ActiveRecord::Base.transaction do
-      batches.flat_map do |batch|
-        records = records_for_batch(batch.to_h)
+      batches.flat_map do |subscription_ids|
+        records = records_for_batch(subscription_ids)
         Email.insert_all!(records).pluck("id")
       end
     end
@@ -21,24 +21,19 @@ private
 
   attr_reader :subject, :body, :subscriber_lists, :now
 
-  def records_for_batch(batch)
-    subscriber_ids = batch.keys
-    subscribers = Subscriber.find(subscriber_ids).index_by(&:id)
+  def records_for_batch(subscription_ids)
+    subscriptions = Subscription
+      .includes(:subscriber)
+      .find(subscription_ids)
 
-    subscription_ids = batch.values
-    subscriptions = Subscription.find(subscription_ids).index_by(&:id)
-
-    batch.map do |subscriber_id, subscriber_subscription_ids|
-      subscriber = subscribers[subscriber_id]
-
-      subscription = subscriptions.slice(*subscriber_subscription_ids)
-        .values.max_by(&:created_at)
+    subscriptions.map do |subscription|
+      subscriber = subscription.subscriber
 
       {
         address: subscriber.address,
         subject: subject,
         body: email_body(subscriber, subscription),
-        subscriber_id: subscriber_id,
+        subscriber_id: subscriber.id,
         created_at: now,
         updated_at: now,
       }
@@ -59,7 +54,7 @@ private
     Subscription
       .active
       .where(subscriber_list: subscriber_lists)
-      .subscription_ids_by_subscriber
+      .dedup_by_subscriber
       .each_slice(BATCH_SIZE)
   end
 end

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -16,14 +16,14 @@ private
     @records ||= begin
       now = Time.zone.now
       recipients_and_content.map do |recipient_and_content|
-        subscriber = recipient_and_content.fetch(:subscriber)
         content = recipient_and_content.fetch(:content)
-        subscriptions = recipient_and_content.fetch(:subscriptions)
+        subscription = recipient_and_content.fetch(:subscription)
+        subscriber = subscription.subscriber
 
         {
           address: subscriber.address,
           subject: subject(content),
-          body: body(content, subscriptions.first, subscriber),
+          body: body(content, subscription, subscriber),
           subscriber_id: subscriber.id,
           created_at: now,
           updated_at: now,

--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -1,6 +1,7 @@
 class ImmediateEmailBuilder < ApplicationBuilder
-  def initialize(recipients_and_content)
-    @recipients_and_content = recipients_and_content
+  def initialize(content, subscriptions)
+    @content = content
+    @subscriptions = subscriptions
   end
 
   def call
@@ -10,20 +11,18 @@ class ImmediateEmailBuilder < ApplicationBuilder
 
 private
 
-  attr_reader :recipients_and_content
+  attr_reader :content, :subscriptions
 
   def records
     @records ||= begin
       now = Time.zone.now
-      recipients_and_content.map do |recipient_and_content|
-        content = recipient_and_content.fetch(:content)
-        subscription = recipient_and_content.fetch(:subscription)
+      subscriptions.map do |subscription|
         subscriber = subscription.subscriber
 
         {
           address: subscriber.address,
-          subject: subject(content),
-          body: body(content, subscription, subscriber),
+          subject: subject,
+          body: body(subscription, subscriber),
           subscriber_id: subscriber.id,
           created_at: now,
           updated_at: now,
@@ -32,11 +31,11 @@ private
     end
   end
 
-  def subject(content)
+  def subject
     "Update from GOV.UK for: #{content.title}"
   end
 
-  def body(content, subscription, subscriber)
+  def body(subscription, subscriber)
     list = subscription.subscriber_list
 
     <<~BODY
@@ -46,7 +45,7 @@ private
 
       ---
 
-      #{middle_section(subscription, content)}
+      #{middle_section(subscription)}
 
       ---
 
@@ -54,7 +53,7 @@ private
     BODY
   end
 
-  def middle_section(subscription, content)
+  def middle_section(subscription)
     subscriber_list = subscription.subscriber_list
     presenter = "#{content.class.name}Presenter".constantize
     section = presenter.call(content, subscription)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -36,6 +36,13 @@ class Subscription < ApplicationRecord
             .to_h
         }
 
+  scope :dedup_by_subscriber,
+        lambda {
+          order("subscriptions.subscriber_id DESC, subscriptions.created_at desc")
+            .pluck(Arel.sql("DISTINCT ON (subscriptions.subscriber_id) subscriber_id, subscriptions.id as id"))
+            .map(&:last)
+        }
+
   def as_json(options = {})
     options[:except] ||= %i[signon_user_uid subscriber_list_id subscriber_id]
     options[:include] ||= %i[subscriber_list subscriber]

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -29,13 +29,6 @@ class Subscription < ApplicationRecord
             .where(matched_messages: { message_id: message.id })
         }
 
-  scope :subscription_ids_by_subscriber,
-        lambda {
-          group(:subscriber_id)
-            .pluck(:subscriber_id, Arel.sql("ARRAY_AGG(subscriptions.id)"))
-            .to_h
-        }
-
   scope :dedup_by_subscriber,
         lambda {
           order("subscriptions.subscriber_id DESC, subscriptions.created_at desc")

--- a/app/services/immediate_email_generation_service.rb
+++ b/app/services/immediate_email_generation_service.rb
@@ -30,10 +30,10 @@ private
       scope
         .active
         .immediately
-        .subscription_ids_by_subscriber
+        .dedup_by_subscriber
         .each_slice(BATCH_SIZE)
-        .map do |batch_of_subscribers|
-          Batch.new(content, batch_of_subscribers.to_h)
+        .map do |subscription_ids|
+          Batch.new(content, subscription_ids)
         end
     end
   end

--- a/app/services/immediate_email_generation_service/batch.rb
+++ b/app/services/immediate_email_generation_service/batch.rb
@@ -27,9 +27,8 @@ class ImmediateEmailGenerationService
       @email_parameters ||= begin
         subscriptions_to_fulfill.map do |subscription|
           {
-            subscriber: subscription.subscriber,
             content: content_change || message,
-            subscriptions: [subscription],
+            subscription: subscription,
           }.compact
         end
       end
@@ -37,9 +36,7 @@ class ImmediateEmailGenerationService
 
     def subscription_content_records(email_ids)
       email_parameters.flat_map.with_index do |params, index|
-        params[:subscriptions].map do |subscription|
-          { subscription_id: subscription.id, email_id: email_ids[index] }
-        end
+        { subscription_id: params[:subscription].id, email_id: email_ids[index] }
       end
     end
 

--- a/app/services/immediate_email_generation_service/batch.rb
+++ b/app/services/immediate_email_generation_service/batch.rb
@@ -1,8 +1,8 @@
 class ImmediateEmailGenerationService
   class Batch
-    def initialize(content, subscription_ids_by_subscriber_id)
+    def initialize(content, subscription_ids)
       @content = content
-      @subscription_ids_by_subscriber_id = subscription_ids_by_subscriber_id
+      @subscription_ids = subscription_ids
     end
 
     def generate_emails
@@ -21,15 +21,15 @@ class ImmediateEmailGenerationService
 
   private
 
-    attr_reader :subscription_ids_by_subscriber_id, :content
+    attr_reader :subscription_ids, :content
 
     def email_parameters
       @email_parameters ||= begin
-        subscriptions_to_fulfill_by_subscriber.map do |(subscriber, subscriptions)|
+        subscriptions_to_fulfill.map do |subscription|
           {
-            subscriber: subscriber,
+            subscriber: subscription.subscriber,
             content: content_change || message,
-            subscriptions: subscriptions,
+            subscriptions: [subscription],
           }.compact
         end
       end
@@ -43,24 +43,7 @@ class ImmediateEmailGenerationService
       end
     end
 
-    def subscriptions_to_fulfill_by_subscriber
-      all_subscribers = Subscriber
-        .where(id: subscription_ids_by_subscriber_id.keys)
-        .index_by(&:id)
-
-      all_subscriptions = unfulfilled_active_subscriptions(
-        subscription_ids_by_subscriber_id.values.flatten,
-      )
-
-      subscription_ids_by_subscriber_id
-        .each_with_object({}) do |(subscriber_id, subscription_ids), memo|
-          subscriber = all_subscribers[subscriber_id]
-          subscriptions = all_subscriptions.values_at(*subscription_ids).compact
-          memo[subscriber] = subscriptions if subscriber && subscriptions.any?
-        end
-    end
-
-    def unfulfilled_active_subscriptions(subscription_ids)
+    def subscriptions_to_fulfill
       criteria = { message: message,
                    content_change: content_change,
                    subscription_id: subscription_ids }.compact
@@ -68,9 +51,8 @@ class ImmediateEmailGenerationService
                                                        .pluck(:subscription_id)
       Subscription.active
                   .immediately
-                  .includes(:subscriber_list)
+                  .includes(:subscriber_list, :subscriber)
                   .where(id: subscription_ids - covered_by_earlier_attempts)
-                  .index_by(&:id)
     end
 
     def content_change

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe ImmediateEmailBuilder do
     let(:subscription) { build(:subscription, subscriber_list: subscriber_list) }
     let(:subscriber) { subscription.subscriber }
 
-    let(:params) do
-      { subscription: subscription }
-    end
-
     before do
       allow(FooterPresenter).to receive(:call)
         .with(subscriber, subscription)
@@ -22,8 +18,7 @@ RSpec.describe ImmediateEmailBuilder do
       let(:content_change) { build(:content_change, title: "Title") }
 
       subject(:email) do
-        params.merge!(content: content_change)
-        import = described_class.call([params])
+        import = described_class.call(content_change, [subscription])
         Email.find(import.first)
       end
 
@@ -59,8 +54,7 @@ RSpec.describe ImmediateEmailBuilder do
       let(:message) { build(:message, title: "Title") }
 
       subject(:email) do
-        params.merge!(content: message)
-        import = described_class.call([params])
+        import = described_class.call(message, [subscription])
         Email.find(import.first)
       end
 
@@ -96,8 +90,7 @@ RSpec.describe ImmediateEmailBuilder do
       let(:content_change) { build(:content_change, title: "Title") }
 
       subject(:email) do
-        params.merge!(content: content_change)
-        import = described_class.call([params])
+        import = described_class.call(content_change, [subscription])
         Email.find(import.first)
       end
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -5,10 +5,7 @@ RSpec.describe ImmediateEmailBuilder do
     let(:subscriber) { subscription.subscriber }
 
     let(:params) do
-      {
-        subscriptions: [subscription, "other_subscription"],
-        subscriber: subscriber,
-      }
+      { subscription: subscription }
     end
 
     before do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -112,17 +112,6 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe ".subscription_ids_by_subscriber" do
-    it "returns a hash of subscriber id to an array of subscriptions" do
-      subscriber = create(:subscriber)
-      subscription1 = create(:subscription, subscriber: subscriber)
-      subscription2 = create(:subscription, subscriber: subscriber)
-
-      expect(Subscription.subscription_ids_by_subscriber)
-        .to match(subscriber.id => match_array([subscription1.id, subscription2.id]))
-    end
-  end
-
   describe ".dedup_by_subscriber" do
     it "returns the latest subscription for a subscriber" do
       subscriber = create(:subscriber)

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -1,39 +1,25 @@
 RSpec.describe ImmediateEmailGenerationService::Batch do
-  let(:content_change) { create(:content_change) }
-  let(:message) { create(:message) }
-  let(:subscriber1) { create(:subscriber) }
-  let(:subscriber2) { create(:subscriber) }
+  let(:content) { create(:content_change) }
+  let(:subscriptions) { [create(:subscription, :immediately)] }
 
-  let(:subscriber1_subscription) do
-    create(:subscription, :immediately, subscriber: subscriber1)
+  let(:instance) do
+    described_class.new(content, subscriptions.map(&:id))
   end
-
-  let(:subscriber2_subscription) do
-    create(:subscription, :immediately, subscriber: subscriber2)
-  end
-
-  let(:subscriptions) do
-    [subscriber1_subscription, subscriber2_subscription]
-  end
-
-  let(:subscription_ids) { subscriptions.map(&:id) }
 
   describe "#generate_emails" do
-    let(:instance) { described_class.new(content_change, subscription_ids) }
-
     it "creates emails" do
       expect { instance.generate_emails }
         .to change { Email.count }
-        .by(2)
+        .by(1)
     end
 
     it "populates subscription_contents" do
-      scope = SubscriptionContent.where(content_change: content_change,
-                                        subscription_id: subscription_ids)
+      scope = SubscriptionContent.where(content_change: content,
+                                        subscription: subscriptions)
 
       expect { instance.generate_emails }
         .to change { scope.count }
-        .by(subscription_ids.count)
+        .by(1)
     end
 
     it "returns ids of emails created" do
@@ -42,11 +28,9 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
     end
 
     context "when content is a content_change" do
-      let(:instance) { described_class.new(content_change, subscription_ids) }
-
       it "uses ImmediateEmailBuilder to build emails" do
         expect(ImmediateEmailBuilder).to receive(:call)
-           .with(content_change, subscriptions)
+           .with(content, subscriptions)
            .and_call_original
 
         instance.generate_emails
@@ -54,17 +38,18 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
 
       it "sends stats about the generated emails" do
         expect(Metrics).to receive(:content_change_emails)
-                              .with(content_change, 2)
+          .with(content, 1)
+
         instance.generate_emails
       end
     end
 
     context "when content is a message" do
-      let(:instance) { described_class.new(message, subscription_ids) }
+      let(:content) { create(:message) }
 
       it "uses ImmediateEmailBuilder to build emails" do
         expect(ImmediateEmailBuilder).to receive(:call)
-           .with(message, subscriptions)
+           .with(content, subscriptions)
            .and_call_original
 
         instance.generate_emails
@@ -72,73 +57,55 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
     end
 
     context "when a subscription was ended after determining which lists to email" do
-      let(:subscriber1_subscription) do
-        create(:subscription, :immediately, :ended, subscriber: subscriber1)
-      end
-
-      let(:subscriber2_subscription) do
-        create(:subscription, :immediately, subscriber: subscriber2)
-      end
+      let(:subscriptions) { [create(:subscription, :immediately, :ended)] }
 
       it "doesn't email a subscriber without active subscriptions" do
         expect { instance.generate_emails }
-          .not_to(change { Email.where(address: subscriber1.address).count })
+          .not_to(change { Email.count })
       end
 
       it "only uses active subscriptions to create the email" do
-        expect(ImmediateEmailBuilder).to receive(:call)
-           .with(content_change, [subscriber2_subscription])
-           .and_call_original
-
+        expect(ImmediateEmailBuilder).to_not receive(:call)
         instance.generate_emails
       end
     end
 
     context "when one of the specified subscriptions is not immediate" do
-      let(:subscriber1_subscription) do
-        create(:subscription, :daily, subscriber: subscriber1)
-      end
-
-      let(:subscriber2_subscription) do
-        create(:subscription, :immediately, subscriber: subscriber2)
-      end
+      let(:subscriptions) { [create(:subscription, :daily)] }
 
       it "doesn't use that subscription to create the email" do
-        expect(ImmediateEmailBuilder).to receive(:call)
-           .with(content_change, [subscriber2_subscription])
-           .and_call_original
-
+        expect(ImmediateEmailBuilder).to_not receive(:call)
         instance.generate_emails
       end
     end
 
-    context "when a previous attempt to generate emails failed and some of the " \
-      "emails were already created" do
+    context "when only some of the emails were generated due to a failure" do
+      let(:subscription) { create(:subscription, :immediately) }
+      let(:other_subscription) { create(:subscription, :immediately) }
+      let(:subscriptions) { [subscription, other_subscription] }
+
       before do
         email = create(:email)
-
         create(:subscription_content,
-               subscription: subscriber1_subscription,
+               subscription: other_subscription,
                email: email,
-               content_change: content_change)
+               content_change: content)
       end
 
       it "only creates emails that haven't been previously created" do
         expect { instance.generate_emails }
-          .to change { Email.where(address: subscriber2.address).count }.by(1)
-          .and change { Email.where(address: subscriber1.address).count }.by(0)
+          .to change { Email.where(subscriber_id: subscription.subscriber_id).count }.by(1)
+          .and change { Email.where(address: other_subscription.subscriber_id).count }.by(0)
       end
     end
 
     context "when a previous attempt created all the emails of this batch" do
       before do
         email = create(:email)
-        [subscriber1_subscription, subscriber2_subscription].each do |subscription|
-          create(:subscription_content,
-                 subscription: subscription,
-                 email: email,
-                 content_change: content_change)
-        end
+        create(:subscription_content,
+               subscription: subscriptions.first,
+               email: email,
+               content_change: content)
       end
 
       it "happily creates no emails" do

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
       end
     end
 
-    context "when a subscriptions frequency was changed after determining which lists to email" do
+    context "when one of the subscription frequencies is not immediate" do
       let(:subscriber1_subscriptions) do
         create_list(:subscription, 2, :daily, :ended, subscriber: subscriber1)
       end

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -16,11 +16,10 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
     [subscriber1_subscription.id, subscriber2_subscription.id]
   end
 
-  def email_parameters(content, subscriber, subscription)
+  def email_parameters(content, subscription)
     {
       content: content,
-      subscriptions: [subscription],
-      subscriber: subscriber,
+      subscription: subscription,
     }.compact
   end
 
@@ -52,8 +51,8 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
 
       it "uses ImmediateEmailBuilder to build emails" do
         emails_params = [
-          email_parameters(content_change, subscriber1, subscriber1_subscription),
-          email_parameters(content_change, subscriber2, subscriber2_subscription),
+          email_parameters(content_change, subscriber1_subscription),
+          email_parameters(content_change, subscriber2_subscription),
         ]
 
         expect(ImmediateEmailBuilder).to receive(:call)
@@ -74,8 +73,8 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
 
       it "uses ImmediateEmailBuilder to build emails" do
         emails_params = [
-          email_parameters(message, subscriber1, subscriber1_subscription),
-          email_parameters(message, subscriber2, subscriber2_subscription),
+          email_parameters(message, subscriber1_subscription),
+          email_parameters(message, subscriber2_subscription),
         ]
 
         expect(ImmediateEmailBuilder).to receive(:call)
@@ -101,7 +100,6 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
 
       it "only uses active subscriptions to create the email" do
         email_params = email_parameters(content_change,
-                                        subscriber2,
                                         subscriber2_subscription)
 
         expect(ImmediateEmailBuilder).to receive(:call)
@@ -122,7 +120,6 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
 
       it "doesn't use that subscription to create the email" do
         email_params = email_parameters(content_change,
-                                        subscriber2,
                                         subscriber2_subscription)
 
         expect(ImmediateEmailBuilder).to receive(:call)

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -12,16 +12,11 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
     create(:subscription, :immediately, subscriber: subscriber2)
   end
 
-  let(:subscription_ids) do
-    [subscriber1_subscription.id, subscriber2_subscription.id]
+  let(:subscriptions) do
+    [subscriber1_subscription, subscriber2_subscription]
   end
 
-  def email_parameters(content, subscription)
-    {
-      content: content,
-      subscription: subscription,
-    }.compact
-  end
+  let(:subscription_ids) { subscriptions.map(&:id) }
 
   describe "#generate_emails" do
     let(:instance) { described_class.new(content_change, subscription_ids) }
@@ -50,14 +45,10 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
       let(:instance) { described_class.new(content_change, subscription_ids) }
 
       it "uses ImmediateEmailBuilder to build emails" do
-        emails_params = [
-          email_parameters(content_change, subscriber1_subscription),
-          email_parameters(content_change, subscriber2_subscription),
-        ]
-
         expect(ImmediateEmailBuilder).to receive(:call)
-                                         .with(emails_params)
-                                         .and_call_original
+           .with(content_change, subscriptions)
+           .and_call_original
+
         instance.generate_emails
       end
 
@@ -72,14 +63,10 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
       let(:instance) { described_class.new(message, subscription_ids) }
 
       it "uses ImmediateEmailBuilder to build emails" do
-        emails_params = [
-          email_parameters(message, subscriber1_subscription),
-          email_parameters(message, subscriber2_subscription),
-        ]
-
         expect(ImmediateEmailBuilder).to receive(:call)
-                                   .with(emails_params)
-                                   .and_call_original
+           .with(message, subscriptions)
+           .and_call_original
+
         instance.generate_emails
       end
     end
@@ -99,12 +86,10 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
       end
 
       it "only uses active subscriptions to create the email" do
-        email_params = email_parameters(content_change,
-                                        subscriber2_subscription)
-
         expect(ImmediateEmailBuilder).to receive(:call)
-                                         .with([email_params])
-                                         .and_call_original
+           .with(content_change, [subscriber2_subscription])
+           .and_call_original
+
         instance.generate_emails
       end
     end
@@ -119,12 +104,10 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
       end
 
       it "doesn't use that subscription to create the email" do
-        email_params = email_parameters(content_change,
-                                        subscriber2_subscription)
-
         expect(ImmediateEmailBuilder).to receive(:call)
-                                         .with([email_params])
-                                         .and_call_original
+           .with(content_change, [subscriber2_subscription])
+           .and_call_original
+
         instance.generate_emails
       end
     end


### PR DESCRIPTION
https://trello.com/c/wp7WjPN6/693-draft-email-to-send-out-to-checker-subscribers-following-an-announcement

This introduces a new "dedup_by_subscriber" scope as an alternative
to the current "subscription_ids_by_subscriber", and switches bulk
and immediate email generation to use it. In doing this, we simplify
the code to focus on single subscription objects.

Please see the commits for more details.