### PR TITLE
Add temporary task to migrate Brexit list titles

### DIFF
--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -81,4 +81,49 @@ namespace :data_migration do
       end
     end
   end
+
+  desc "Update titles for Brexit lists away from Transition terminology"
+  task temp_update_brexit_list_titles: :environment do
+    excluded_ids = [
+      11_133,
+      8951,
+      62_108,
+      62_155,
+      63_105,
+      64_274,
+      65_157,
+      64_346,
+      64_730,
+      64_837,
+      65_521,
+      10_602,
+      13_889,
+      9888,
+      9532,
+      67_143,
+      70_348,
+      74_038,
+      74_369,
+      74_370,
+      74_371,
+      74_372,
+      74_373,
+      74_409,
+      74_410,
+      74_411,
+      74_413,
+      81_021,
+    ]
+
+    lists = SubscriberList.where("title LIKE '%Transition%'")
+      .where.not(id: excluded_ids)
+
+    lists.each do |list|
+      new_title = list.title
+        .gsub("Transition period", "Brexit")
+        .gsub("Transition", "Brexit")
+
+      list.update!(title: new_title)
+    end
+  end
 end

--- a/spec/lib/tasks/data_migration_spec.rb
+++ b/spec/lib/tasks/data_migration_spec.rb
@@ -38,4 +38,36 @@ RSpec.describe "data_migration" do
       expect(Subscription.active.count).to eq(1)
     end
   end
+
+  describe "temp_update_brexit_list_titles" do
+    before do
+      Rake::Task["data_migration:temp_update_brexit_list_titles"].reenable
+    end
+
+    it "updates lists with 'Transition period' in the title" do
+      list = create(:subscriber_list, title: "Transition period")
+      Rake::Task["data_migration:temp_update_brexit_list_titles"].invoke
+      expect(list.reload.title).to eq("Brexit")
+    end
+
+    it "does not update lists with normal uses of 'transition'" do
+      list = create(:subscriber_list, title: "Brexit transition")
+      Rake::Task["data_migration:temp_update_brexit_list_titles"].invoke
+      expect(list.reload.title).to eq("Brexit transition")
+    end
+
+    it "updates lists with 'Transition' in the title" do
+      list1 = create(:subscriber_list, title: "Transition")
+      list2 = create(:subscriber_list, title: "Blah topic of Transition")
+      Rake::Task["data_migration:temp_update_brexit_list_titles"].invoke
+      expect(list1.reload.title).to eq("Brexit")
+      expect(list2.reload.title).to eq("Blah topic of Brexit")
+    end
+
+    it "does not update lists for world location taxons" do
+      list = create(:subscriber_list, id: 11_133, title: "Really should Transition")
+      Rake::Task["data_migration:temp_update_brexit_list_titles"].invoke
+      expect(list.reload.title).to eq("Really should Transition")
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/dgdLhy2H/777-update-transition-to-brexit-in-email-notifications-for-transition-taxon

Note this excludes a number of lists for world location taxons, as
these page titles still read "Transition". Since the system doesn't
have enough data to distinguish these lists from non-world taxons,
this uses the specific list IDs to exclude them.