### PR TITLE
Prepare to auto-update list titles / URLs

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -25,7 +25,7 @@ class SubscriberListsController < ApplicationController
 
   def create
     subscriber_list = CreateSubscriberListService.call(params: params, user: current_user)
-    render json: subscriber_list.to_json, status: :created
+    render json: subscriber_list.to_json
   end
 
 private

--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -24,22 +24,11 @@ class SubscriberListsController < ApplicationController
   end
 
   def create
-    subscriber_list = SubscriberList.create!(subscriber_list_params)
+    subscriber_list = CreateSubscriberListService.call(params: params, user: current_user)
     render json: subscriber_list.to_json, status: :created
   end
 
 private
-
-  def subscriber_list_params
-    title = params.fetch(:title)
-
-    find_exact_query_params.merge(
-      title: title,
-      slug: slugify(title),
-      url: params[:url],
-      signon_user_uid: current_user.uid,
-    )
-  end
 
   def convert_legacy_params(link_or_tags)
     link_or_tags.transform_values do |link_or_tag|
@@ -55,16 +44,5 @@ private
       email_document_supertype: params.fetch(:email_document_supertype, ""),
       government_document_supertype: params.fetch(:government_document_supertype, ""),
     }
-  end
-
-  def slugify(title)
-    slug = title.parameterize.truncate(255, omission: "", separator: "-")
-
-    while SubscriberList.where(slug: slug).exists?
-      slug = title.parameterize.truncate(244, omission: "", separator: "-")
-      slug += "-#{SecureRandom.hex(5)}"
-    end
-
-    slug
   end
 end

--- a/app/services/create_subscriber_list_service.rb
+++ b/app/services/create_subscriber_list_service.rb
@@ -5,7 +5,9 @@ class CreateSubscriberListService < ApplicationService
   end
 
   def call
-    SubscriberList.create!(subscriber_list_params)
+    subscriber_list = FindExactQuery.new(**find_exact_query_params).exact_match
+    return SubscriberList.create!(subscriber_list_params) unless subscriber_list
+    subscriber_list
   end
 
 private

--- a/app/services/create_subscriber_list_service.rb
+++ b/app/services/create_subscriber_list_service.rb
@@ -1,0 +1,52 @@
+class CreateSubscriberListService < ApplicationService
+  def initialize(params:, user:)
+    @params = params
+    @user = user
+  end
+
+  def call
+    SubscriberList.create!(subscriber_list_params)
+  end
+
+private
+
+  attr_reader :params, :user
+
+  def subscriber_list_params
+    title = params.fetch(:title)
+
+    find_exact_query_params.merge(
+      title: title,
+      slug: slugify(title),
+      url: params[:url],
+      signon_user_uid: user.uid,
+    )
+  end
+
+  def convert_legacy_params(link_or_tags)
+    link_or_tags.transform_values do |link_or_tag|
+      link_or_tag.is_a?(Hash) ? link_or_tag : { any: link_or_tag }
+    end
+  end
+
+  def find_exact_query_params
+    {
+      tags: convert_legacy_params(params.permit(tags: {}).to_h.fetch(:tags, {})),
+      links: convert_legacy_params(params.permit(links: {}).to_h.fetch(:links, {})),
+      document_type: params.fetch(:document_type, ""),
+      email_document_supertype: params.fetch(:email_document_supertype, ""),
+      government_document_supertype: params.fetch(:government_document_supertype, ""),
+    }
+  end
+
+  def slugify(title)
+    slug = title.parameterize.truncate(255, omission: "", separator: "-")
+
+    while SubscriberList.where(slug: slug).exists?
+      slug = title.parameterize.truncate(244, omission: "", separator: "-")
+      slug += "-#{SecureRandom.hex(5)}"
+    end
+
+    slug
+  end
+end

--- a/app/services/create_subscriber_list_service.rb
+++ b/app/services/create_subscriber_list_service.rb
@@ -17,11 +17,9 @@ private
   attr_reader :params, :user
 
   def subscriber_list_params
-    title = params.fetch(:title)
-
     find_exact_query_params.merge(
-      title: title,
-      slug: slugify(title),
+      title: params[:title],
+      slug: slug,
       url: params[:url],
       signon_user_uid: user.uid,
     )
@@ -43,14 +41,16 @@ private
     }
   end
 
-  def slugify(title)
-    slug = title.parameterize.truncate(255, omission: "", separator: "-")
+  def slug
+    @slug ||= begin
+      result = params[:title].parameterize.truncate(255, omission: "", separator: "-")
 
-    while SubscriberList.where(slug: slug).exists?
-      slug = title.parameterize.truncate(244, omission: "", separator: "-")
-      slug += "-#{SecureRandom.hex(5)}"
+      while SubscriberList.where(slug: result).exists?
+        result = params[:title].parameterize.truncate(244, omission: "", separator: "-")
+        result += "-#{SecureRandom.hex(5)}"
+      end
+
+      result
     end
-
-    slug
   end
 end

--- a/app/services/create_subscriber_list_service.rb
+++ b/app/services/create_subscriber_list_service.rb
@@ -7,6 +7,8 @@ class CreateSubscriberListService < ApplicationService
   def call
     subscriber_list = FindExactQuery.new(**find_exact_query_params).exact_match
     return SubscriberList.create!(subscriber_list_params) unless subscriber_list
+
+    subscriber_list.update!(subscriber_list_params.slice(:title, :url).compact)
     subscriber_list
   end
 

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(subscriber_list["tags_digest"]).to eq(digested(subscriber_list["tags"]))
     end
 
+    context "an existing subscriber list" do
+      it "returns the existing list" do
+        2.times.each do
+          create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
+                                         location: { all: %w[france germany] } })
+        end
+
+        expect(SubscriberList.count).to eq(1)
+        expect(response.status).to eq(201)
+        expect(response.body).to include("subscriber_list")
+      end
+    end
+
     context "an invalid subscriber list" do
       it "returns 422" do
         post "/subscriber-lists", params: { title: "" }

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -68,23 +68,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(subscriber_list["tags_digest"]).to eq(digested(subscriber_list["tags"]))
     end
 
-    context "with an existing subscriber list with the same slug" do
-      before do
-        create(:subscriber_list, slug: "oil-and-gas")
-      end
-
-      it "creates another subscriber list with a different slug" do
-        allow(SecureRandom).to receive(:hex).and_return("a1a1a1a1a1")
-        create_subscriber_list(title: "oil and gas", tags: { topics: { any: ["oil-and-gas/licensing"] } })
-
-        expect(response.status).to eq(201)
-
-        response_hash = JSON.parse(response.body)
-        subscriber_list = response_hash["subscriber_list"]
-        expect(subscriber_list["slug"]).to eq("oil-and-gas-a1a1a1a1a1")
-      end
-    end
-
     context "when a subscriber list has a long title" do
       it "truncates the slug to be less than 255 characters" do
         long_title = "Find Brexit guidance for your business with Sector / "\

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(SubscriberList.count).to eq(1)
     end
 
-    it "returns a 201" do
+    it "returns a 200" do
       create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] },
                                      location: { all: %w[france germany] } })
 
-      expect(response.status).to eq(201)
+      expect(response.status).to eq(200)
     end
 
     it "returns the created subscriber list" do
@@ -76,7 +76,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
         end
 
         expect(SubscriberList.count).to eq(1)
-        expect(response.status).to eq(201)
+        expect(response.status).to eq(200)
         expect(response.body).to include("subscriber_list")
       end
     end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -68,25 +68,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(subscriber_list["tags_digest"]).to eq(digested(subscriber_list["tags"]))
     end
 
-    describe "using legacy parameters" do
-      it "creates a new subscriber list" do
-        expect {
-          create_subscriber_list(
-            title: "oil and gas licensing",
-            links: { topics: %w[uuid-888] },
-          )
-        }.to change { SubscriberList.count }.by(1)
-      end
-
-      it "returns an error if link isn't an array" do
-        create_subscriber_list(
-          links: { topics: "uuid-888" },
-        )
-
-        expect(response.status).to eq(422)
-      end
-    end
-
     context "an invalid subscriber list" do
       it "returns 422" do
         post "/subscriber-lists", params: { title: "" }

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -68,57 +68,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(subscriber_list["tags_digest"]).to eq(digested(subscriber_list["tags"]))
     end
 
-    context "when a subscriber list has a long title" do
-      it "truncates the slug to be less than 255 characters" do
-        long_title = "Find Brexit guidance for your business with Sector / "\
-                     "Business Area of Accommodation, restaurants and "\
-                     "catering services, Aerospace, Agriculture, Air "\
-                     "transport (aviation), Ancillary services, Animal "\
-                     "health, Automotive, Banking, markets and infrastructure, "\
-                     "Broadcasting, Chemicals, Computer services, "\
-                     "Construction and contracting, Education, Electricity, "\
-                     "Electronics, Environmental services, Fisheries, Food "\
-                     "and drink, Furniture and other manufacturing, Gas "\
-                     "markets, Imports, Imputed rent, Insurance, Land "\
-                     "transport (excluding rail), Medical services, Motor "\
-                     "trades, Oil and gas production, Other personal services, "\
-                     "Parts and machinery, Pharmaceuticals, Post, Professional "\
-                     "and business services, Public administration and "\
-                     "defence, Rail, Real estate (excluding imputed rent), "\
-                     "Retail, Social work, Steel and other metals or "\
-                     "commodities, Telecoms, Textiles and clothing, "\
-                     "Warehousing and support for transportation, "\
-                     "Water transport including maritime and ports, "\
-                     "and Wholesale (excluding motor vehicles), Business "\
-                     "activity of Buy products or goods from abroad, Sell "\
-                     "products or goods abroad, and Transport goods abroad, "\
-                     "Who you employ of EU citizens and No EU citizens, "\
-                     "Personal data of Processing personal data from Europe, "\
-                     "Using websites or services hosted in Europe, and "\
-                     "Providing digital services available to Europe, "\
-                     "Intellectual property of Copyright, Trade marks, "\
-                     "Designs, Patents, and Exhaustion of rights, EU or UK "\
-                     "government funding of EU funding and UK government "\
-                     "funding, and Public sector procurement of Civil "\
-                     "government contracts and Defence contracts"
-        create_subscriber_list(
-          title: long_title,
-          tags: { topics: { any: ["oil-and-gas/licensing"] } },
-        )
-
-        expect(response.status).to eq(201)
-
-        response_hash = JSON.parse(response.body)
-        subscriber_list = response_hash["subscriber_list"]
-        slug = "find-brexit-guidance-for-your-business-with-sector-business-"\
-               "area-of-accommodation-restaurants-and-catering-services-"\
-               "aerospace-agriculture-air-transport-aviation-ancillary-"\
-               "services-animal-health-automotive-banking-markets-and-"\
-               "infrastructure-broadcasting"
-        expect(subscriber_list["slug"]).to eq(slug)
-      end
-    end
-
     describe "using legacy parameters" do
       it "creates a new subscriber list" do
         expect {

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -68,17 +68,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
       expect(subscriber_list["tags_digest"]).to eq(digested(subscriber_list["tags"]))
     end
 
-    it "can create a subscriber_list with a url" do
-      create_subscriber_list(
-        tags: { topics: { any: ["oil-and-gas/licensing"] },
-                location: { all: %w[france germany] } },
-        url: "/oil-and-gas",
-      )
-
-      expect(SubscriberList.count).to eq(1)
-      expect(SubscriberList.first.url).to eq("/oil-and-gas")
-    end
-
     context "with an existing subscriber list with the same slug" do
       before do
         create(:subscriber_list, slug: "oil-and-gas")
@@ -147,21 +136,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
-    it "creates a subscriber_list with a digest of the JSON content" do
-      create_subscriber_list(
-        tags: { topics: { any: ["oil-and-gas/licensing"] },
-                location: { all: %w[france germany] } },
-        links: { topics: { any: %w[oil-and-gas-licensing] },
-                 location: { all: %w[france germany] } },
-      )
-      expect(SubscriberList.last.tags_digest).to eq(digested(SubscriberList.last.tags))
-      expect(SubscriberList.last.links_digest).to eq(digested(SubscriberList.last.links))
-
-      create_subscriber_list(tags: { topics: { any: ["oil-and-gas/licensing"] } })
-      expect(SubscriberList.last.tags_digest).to eq(digested(SubscriberList.last.tags))
-      expect(SubscriberList.last.links_digest).to be_nil
-    end
-
     describe "using legacy parameters" do
       it "creates a new subscriber list" do
         expect {
@@ -178,50 +152,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
         )
 
         expect(response.status).to eq(422)
-      end
-    end
-
-    context "when creating a subscriber list with a document_type" do
-      it "returns a 201" do
-        create_subscriber_list(document_type: "travel_advice")
-
-        expect(response.status).to eq(201)
-      end
-
-      it "sets the document_type on the subscriber list" do
-        create_subscriber_list(
-          tags: { location: { any: %w[andorra] } },
-          document_type: "travel_advice",
-        )
-
-        subscriber_list = SubscriberList.last
-        expect(subscriber_list.document_type).to eq("travel_advice")
-      end
-    end
-
-    context "when creating a subscriber list with no tags or links" do
-      context "and a document_type is provided" do
-        it "returns a 201" do
-          create_subscriber_list(document_type: "travel_advice")
-
-          expect(response.status).to eq(201)
-        end
-      end
-    end
-
-    context "when creating a subscriber list with 'email' and 'government' document supertypes" do
-      it "returns a 201" do
-        create_subscriber_list(
-          email_document_supertype: "publications",
-          government_document_supertype: "news_stories",
-        )
-
-        expect(response.status).to eq(201)
-
-        expect(SubscriberList.last).to have_attributes(
-          email_document_supertype: "publications",
-          government_document_supertype: "news_stories",
-        )
       end
     end
 

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -199,26 +199,6 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
-    context "when creating a subscriber list with content_purpose_subgroup" do
-      it "returns a 201" do
-        create_subscriber_list(tags: { content_purpose_subgroup: { any: %w[news] } })
-
-        expect(response.status).to eq(201)
-      end
-
-      it "sets content_purpose_subgroup on the subscriber list" do
-        create_subscriber_list(
-          tags: {
-            location: { any: %w[andorra] },
-            content_purpose_subgroup: { any: %w[news] },
-          },
-        )
-
-        subscriber_list = SubscriberList.last
-        expect(subscriber_list.tags[:content_purpose_subgroup]).to eq(any: %w[news])
-      end
-    end
-
     context "when creating a subscriber list with no tags or links" do
       context "and a document_type is provided" do
         it "returns a 201" do

--- a/spec/services/create_subscriber_list_service_spec.rb
+++ b/spec/services/create_subscriber_list_service_spec.rb
@@ -58,5 +58,15 @@ RSpec.describe CreateSubscriberListService do
         expect(list.links_digest).to be_nil
       end
     end
+
+    context "when a slug is already in use" do
+      before do
+        create(:subscriber_list, slug: "this-is-a-sample-title")
+      end
+
+      it "makes sure the slug is unique" do
+        expect(list.slug).to match(/this-is-a-sample-title-[a-z0-9]+/)
+      end
+    end
   end
 end

--- a/spec/services/create_subscriber_list_service_spec.rb
+++ b/spec/services/create_subscriber_list_service_spec.rb
@@ -76,5 +76,15 @@ RSpec.describe CreateSubscriberListService do
         expect(list.slug.length).to eq(254)
       end
     end
+
+    context "when links / tags aren't in a hash" do
+      it "nests the legacy params in 'any'" do
+        params.merge!(tags: { topics: %w[blah] })
+        params.merge!(links: { taxon_tree: %w[uuid] })
+
+        expect(list.tags).to eq(topics: { any: %w[blah] })
+        expect(list.links).to eq(taxon_tree: { any: %w[uuid] })
+      end
+    end
   end
 end

--- a/spec/services/create_subscriber_list_service_spec.rb
+++ b/spec/services/create_subscriber_list_service_spec.rb
@@ -68,5 +68,13 @@ RSpec.describe CreateSubscriberListService do
         expect(list.slug).to match(/this-is-a-sample-title-[a-z0-9]+/)
       end
     end
+
+    context "when the list title is very long" do
+      it "truncates the slug to < 255 chars" do
+        params.merge!(title: "long " * 1000)
+        expect(list.slug).to match(/^long-long-long-/)
+        expect(list.slug.length).to eq(254)
+      end
+    end
   end
 end

--- a/spec/services/create_subscriber_list_service_spec.rb
+++ b/spec/services/create_subscriber_list_service_spec.rb
@@ -33,13 +33,30 @@ RSpec.describe CreateSubscriberListService do
     end
 
     context "when a matching list exists" do
-      it "returns early with that list" do
-        existing_list = create(:subscriber_list)
+      let(:existing_list) do
+        create(:subscriber_list,
+               title: "other",
+               url: "/other",
+               updated_at: 2.days.ago.midnight)
+      end
 
+      before do
         allow(existing_list_query).to receive(:exact_match)
           .and_return(existing_list)
+      end
 
+      it "returns early with that list" do
         expect(list).to eq(existing_list)
+      end
+
+      it "updates the title and url" do
+        expect(list.title).to eq("This is a sample title")
+        expect(list.url).to eq("/oil-and-gas")
+      end
+
+      it "only updates if there is a change" do
+        params.merge!(title: "other", url: "/other")
+        expect(list.updated_at).to eq(2.days.ago.midnight)
       end
     end
 

--- a/spec/services/create_subscriber_list_service_spec.rb
+++ b/spec/services/create_subscriber_list_service_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe CreateSubscriberListService do
+  describe ".call" do
+    let(:user) { create :user }
+
+    let(:params) do
+      ActionController::Parameters.new(
+        title: "This is a sample title",
+        tags: { topics: { any: %w[oil-and-gas/licensing] } },
+        links: { taxon_tree: { any: %w[uuid] } },
+        url: "/oil-and-gas",
+        document_type: "travel_advice",
+        email_document_supertype: "publications",
+        government_document_supertype: "news_stories",
+      )
+    end
+
+    let(:list) do
+      described_class.call(params: params, user: user)
+    end
+
+    context "with all of the possible params" do
+      it "creates a list with the given params" do
+        expect(list.title).to eq("This is a sample title")
+        expect(list.url).to eq("/oil-and-gas")
+        expect(list.document_type).to eq("travel_advice")
+        expect(list.email_document_supertype).to eq("publications")
+        expect(list.government_document_supertype).to eq("news_stories")
+        expect(list.tags).to eq(topics: { any: ["oil-and-gas/licensing"] })
+        expect(list.links).to match(taxon_tree: { any: %w[uuid] })
+      end
+
+      it "slugifies the list title" do
+        expect(list.slug).to eq("this-is-a-sample-title")
+      end
+
+      it "digests the links and tags" do
+        expect(list.tags_digest).to eq(HashDigest.new(list.tags).generate)
+        expect(list.links_digest).to eq(HashDigest.new(list.links).generate)
+      end
+    end
+
+    context "with minimal possible params" do
+      let(:params) do
+        ActionController::Parameters.new(title: "This is a sample title")
+      end
+
+      it "creates a list with the given params" do
+        expect(list.tags).to eq({})
+        expect(list.links).to eq({})
+        expect(list.url).to be_nil
+        expect(list.document_type).to eq("")
+        expect(list.email_document_supertype).to eq("")
+        expect(list.government_document_supertype).to eq("")
+      end
+
+      it "does not populate the digest for links / tags" do
+        expect(list.tags_digest).to be_nil
+        expect(list.links_digest).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -2,7 +2,7 @@ module RequestHelpers
   def create_subscriber_list(overrides = {})
     params = { title: "Example", tags: {}, links: {} }.merge(overrides)
     post "/subscriber-lists", params: params.to_json, headers: json_headers
-    expect(response.status).to eq(201)
+    expect(response.status).to eq(200)
     data.dig(:subscriber_list, :id)
   end
 


### PR DESCRIPTION
https://trello.com/c/dgdLhy2H/777-update-transition-to-brexit-in-email-notifications-for-transition-taxon

Currently we have a "find_or_create" API adapter that requires two
complementary actions to find ("index") or "create" a list [1]. For
the purpose of keeping existing list titles and URLs up-to-date with
GOV.UK, this copies the "index" functionality to the "create" action.
The next step will be to change the API adapter to call "create", and
then delete the (now) unused "index" action.

Currently we have to manually update list titles [2][3], and many lists
don't have a URL populated, since we only started sending this kind of
data recently, when creating Brexit Checker lists.

A potential smell here is the naming of the "create" action, which is
really doing a find/create/update. We do have a small precedent with
the "update" endpoint for subscriptions. One possible remedy would be
to rename the endpoint to "find_or_create", which is mostly accurate,
but would be easier to do in a follow-up PR.

[1]: https://github.com/alphagov/gds-api-adapters/blob/3d96f0fe726d5f42d628950ce69016b5cc3b5b1f/lib/gds_api/email_alert_api.rb#L12
[2]: https://github.com/alphagov/govuk-developer-docs/blob/1dfd9ce9a863c649145fc4cd7c359c5a75933402/source/manual/rename-a-country.html.md#5-update-email-alert-api
[3]: https://github.com/alphagov/email-alert-api/pull/1566