### PR TITLE
Add new report about potentially dead lists

### DIFF
--- a/lib/reports/potentially_dead_lists_report.rb
+++ b/lib/reports/potentially_dead_lists_report.rb
@@ -1,0 +1,21 @@
+class Reports::PotentiallyDeadListsReport
+  def call
+    distinct_list_sql = Arel.sql("distinct subscriber_list_id")
+
+    recent_subscriptions = Subscription
+      .where("created_at > ?", 1.year.ago)
+      .pluck(distinct_list_sql)
+
+    all_changes = MatchedContentChange.pluck(distinct_list_sql) +
+      MatchedMessage.pluck(distinct_list_sql)
+
+    potentially_dead_slugs = SubscriberList
+      .where(id: Subscription.active.pluck(distinct_list_sql))
+      .where.not(id: recent_subscriptions | all_changes)
+      .pluck(:slug)
+
+    Reports::SubscriberListsReport.new(
+      Date.yesterday.to_s, slugs: potentially_dead_slugs.join(",")
+    ).call
+  end
+end

--- a/lib/reports/subscriber_lists_report.rb
+++ b/lib/reports/subscriber_lists_report.rb
@@ -3,6 +3,7 @@ class Reports::SubscriberListsReport
 
   CSV_HEADERS = %i[title
                    slug
+                   url
                    matching_criteria
                    created_at
                    individual_subscribers
@@ -58,6 +59,7 @@ private
 
     [list.title,
      list.slug,
+     list.url,
      criteria(list),
      list.created_at,
      scope.immediately.count,

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -10,4 +10,9 @@ namespace :report do
     options = { slugs: ENV.fetch("SLUGS", ""), tags_pattern: ENV["TAGS_PATTERN"], links_pattern: ENV["LINKS_PATTERN"] }
     puts Reports::SubscriberListsReport.new(args[:date], **options).call
   end
+
+  desc "Outputs a CSV of subscriber lists that appear to be inactive (tech debt)"
+  task potentially_dead_lists: :environment do
+    puts Reports::PotentiallyDeadListsReport.new.call
+  end
 end

--- a/spec/lib/reports/potentially_dead_lists_report_spec.rb
+++ b/spec/lib/reports/potentially_dead_lists_report_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Reports::PotentiallyDeadListsReport do
+  it "delegates to the subscriber list report" do
+    inactive_list = create(:subscriber_list,
+                           created_at: 2.years.ago)
+
+    create(:subscription,
+           subscriber_list: inactive_list,
+           created_at: 13.months.ago)
+
+    # active lists
+    create(:subscription, created_at: 11.months.ago)
+    create(:matched_content_change)
+    create(:matched_message)
+
+    # archivable list
+    create(:subscriber_list)
+
+    expect(Reports::SubscriberListsReport).to receive(:new)
+      .with(Date.yesterday.to_s, slugs: inactive_list.slug)
+      .and_call_original
+
+    described_class.new.call
+  end
+end

--- a/spec/lib/reports/subscriber_lists_report_spec.rb
+++ b/spec/lib/reports/subscriber_lists_report_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Reports::SubscriberListsReport do
   let(:created_at) { Time.zone.parse("2020-06-15").midday }
 
   before do
-    list = create(:subscriber_list, created_at: created_at, title: "list 1", slug: "list-1")
+    list = create(:subscriber_list, created_at: created_at, title: "list 1", slug: "list-1", url: "/url")
 
     create(:subscription, :immediately, subscriber_list: list, created_at: created_at)
     create(:subscription, :daily, subscriber_list: list, created_at: created_at)
@@ -20,7 +20,7 @@ RSpec.describe Reports::SubscriberListsReport do
 
     expected = CSV.generate do |csv|
       csv << Reports::SubscriberListsReport::CSV_HEADERS
-      csv << ["list 1", "list-1", expected_criteria_bits, created_at, 1, 1, 1, 1, 1, 1]
+      csv << ["list 1", "list-1", "/url", expected_criteria_bits, created_at, 1, 1, 1, 1, 1, 1]
     end
 
     expect(described_class.new("2020-06-15").call).to eq expected

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -12,4 +12,11 @@ RSpec.describe "report" do
         .to output.to_stdout
     end
   end
+
+  describe "potentially_dead_lists" do
+    it "outputs a report of data for subscriber lists that appear to be inactive" do
+      expect { Rake::Task["report:potentially_dead_lists"].invoke }
+        .to output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/PjRE1A0G/200-email-alert-api-has-dead-lists-that-will-never-send-any-email

This means we can start to quantify the scale of the tech debt, in
which the email system gets out-of-sync with GOV.UK over time.