### PR TITLE
Remove unused endpoints in config/routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,8 @@ Rails.application.routes.draw do
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
     get "/subscriber-lists", to: "subscriber_lists#index"
     get "/subscriber-lists/:slug", to: "subscriber_lists#show"
-    get "/subscribables/:slug", to: "subscriber_lists#show" # for backwards compatiblity
 
     post "/unpublish-messages", to: "unpublish_messages#create"
-
-    post "/notifications", to: "content_changes#create" # for backwards compaibility
 
     resources :content_changes, only: %i[create], path: "content-changes"
     resources :messages, only: %i[create]

--- a/spec/integration/send_content_change_spec.rb
+++ b/spec/integration/send_content_change_spec.rb
@@ -85,13 +85,4 @@ RSpec.describe "Sending a content change", type: :request do
       expect(response.status).to eq(403)
     end
   end
-
-  context "with legacy endpoint" do
-    it "creates a ContentChange" do
-      login_with_internal_app
-      expect { post "/notifications", params: valid_request_params.to_json, headers: json_headers }
-        .to change { ContentChange.count }
-        .by(1)
-    end
-  end
 end


### PR DESCRIPTION
These are no longer used since [1] and [2].

[1]: https://github.com/alphagov/gds-api-adapters/pull/907
[2]: https://github.com/alphagov/gds-api-adapters/commit/f01f5f6db63838f677b16b8dd53cc20839806877