### PR TITLE
Annotate reason enums for subscriptions

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,8 +5,24 @@ class Subscription < ApplicationRecord
   has_many :subscription_contents, dependent: :destroy
 
   enum frequency: { immediately: 0, daily: 1, weekly: 2 }
-  enum source: { user_signed_up: 0, frequency_changed: 1, imported: 2, subscriber_list_changed: 3, bulk_immediate_to_digest: 4 }, _prefix: true
-  enum ended_reason: { unsubscribed: 0, non_existent_email: 1, frequency_changed: 2, subscriber_list_changed: 3, marked_as_spam: 4, unpublished: 5, bulk_immediate_to_digest: 6 }, _prefix: :ended
+
+  enum source: {
+    user_signed_up: 0,
+    frequency_changed: 1,
+    imported: 2, # Historical (from govDelivery migration)
+    subscriber_list_changed: 3,
+    bulk_immediate_to_digest: 4, # Historical (for a one-off migration)
+  }, _prefix: true
+
+  enum ended_reason: {
+    unsubscribed: 0,
+    non_existent_email: 1,
+    frequency_changed: 2,
+    subscriber_list_changed: 3,
+    marked_as_spam: 4,
+    unpublished: 5, # Unused since 5eeda132 (can be removed after a year)
+    bulk_immediate_to_digest: 6, # Potentially unused (for a one-off migration)
+  }, _prefix: :ended
 
   scope :active, -> { where(ended_at: nil) }
   scope :ended, -> { where.not(ended_at: nil) }


### PR DESCRIPTION
https://trello.com/c/fbmVmwG3/666-remove-the-undocumented-taxon-unpublish-redirect-feature

This is to help future developers understand the values in the enum,
noting that they are no longer searchable in the codebase.

See here for the use of "imported" [1].

[1]: https://github.com/alphagov/email-alert-api/commit/04065f2e024a8e6e2812d71a04c8eff36f472de1#diff-124fa98d3b37018f019b3bb46f2d279943c479f42f79d7a434ba72dcf0a3ddbcR134