### PR TITLE
Update login email to match design

### DIFF
--- a/app/builders/subscriber_auth_email_builder.rb
+++ b/app/builders/subscriber_auth_email_builder.rb
@@ -19,24 +19,21 @@ private
   attr_reader :subscriber, :destination, :token
 
   def subject
-    "Manage your GOV.UK email subscriptions"
+    "Change your GOV.UK email preferences"
   end
 
   def body
     <<~BODY
-      # Manage your GOV.UK email subscriptions
+      # Click the link to confirm your email address
 
-      Use this link to unsubscribe or change your email subscriptions:
+      # [Yes, I want to change my GOV.UK email preferences](#{link})
 
-      #{link}
+      This link will stop working after 7 days.
 
-      The link will stop working in 7 days.
+      If you did not request this email, you can ignore it.
 
-      # Didn’t request this email?
-
-      Ignore or delete this email if you didn’t request it. Your subscriptions will not be changed.
-
-      [Contact GOV.UK](https://www.gov.uk/contact/govuk) if you have any problems with your email subscriptions.
+      Thanks
+      GOV.UK emails
     BODY
   end
 

--- a/app/presenters/footer_presenter.rb
+++ b/app/presenters/footer_presenter.rb
@@ -15,7 +15,7 @@ class FooterPresenter < ApplicationPresenter
 
       [Unsubscribe](#{unsubscribe_url})
 
-      [Manage your email preferences](#{manage_url})
+      [Change your email preferences](#{manage_url})
     FOOTER
 
     result.strip

--- a/spec/builders/subscription_auth_email_builder_spec.rb
+++ b/spec/builders/subscription_auth_email_builder_spec.rb
@@ -1,14 +1,15 @@
 RSpec.describe SubscriptionAuthEmailBuilder do
   describe ".call" do
-    let(:address) { "test@gov.uk" }
-    let(:token) { "secret" }
     let(:frequency) { "weekly" }
-    let(:subscriber_list) { create :subscriber_list, slug: "business-tax-corporation-tax" }
 
-    subject(:call) do
+    let(:subscriber_list) do
+      create(:subscriber_list, slug: "business-tax-corporation-tax", title: "My List")
+    end
+
+    subject(:email) do
       described_class.call(
-        address: address,
-        token: token,
+        address: "test@gov.uk",
+        token: "secret",
         subscriber_list: subscriber_list,
         frequency: frequency,
       )
@@ -23,22 +24,32 @@ RSpec.describe SubscriptionAuthEmailBuilder do
         .and_return("auth_url")
     end
 
-    it { is_expected.to be_instance_of(Email) }
-
     it "creates an email" do
-      expect { call }.to change(Email, :count).by(1)
-    end
+      expect(email.subject).to eq("Confirm that you want to get emails from GOV.UK")
 
-    it "has content for weekly subscriptions" do
-      email = call
-      expect(email.body).to include(I18n.t!("emails.subscription_auth.frequency.weekly"))
+      expect(email.body).to eq(
+        <<~BODY,
+          # Click the link to confirm that you want to get emails from GOV.UK
+
+          # [Yes, I want emails about My List](auth_url)
+
+          This link will stop working after 7 days.
+
+          #{I18n.t!('emails.subscription_auth.frequency.weekly')}. You can change this at any time.
+
+          If you did not request this email, you can ignore it.
+
+          Thanks 
+          GOV.UK emails 
+          [https://www.gov.uk/help/update-email-notifications](https://www.gov.uk/help/update-email-notifications)
+        BODY
+      )
     end
 
     context "for daily subscriptions" do
       let(:frequency) { "daily" }
 
       it "has relevant content" do
-        email = call
         expect(email.body).to include(I18n.t!("emails.subscription_auth.frequency.daily"))
       end
     end
@@ -47,14 +58,8 @@ RSpec.describe SubscriptionAuthEmailBuilder do
       let(:frequency) { "immediately" }
 
       it "has relevant content" do
-        email = call
         expect(email.body).to include(I18n.t!("emails.subscription_auth.frequency.immediately"))
       end
-    end
-
-    it "has a link to authenticate" do
-      email = call
-      expect(email.body).to include("auth_url")
     end
   end
 end

--- a/spec/features/create_an_auth_token_spec.rb
+++ b/spec/features/create_an_auth_token_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Create an auth token", type: :request do
 
     email_data = expect_an_email_was_sent(
       address: "test@example.com",
-      subject: "Manage your GOV.UK email subscriptions",
+      subject: "Change your GOV.UK email preferences",
     )
 
     expect(response.status).to be 201
@@ -31,7 +31,7 @@ RSpec.describe "Create an auth token", type: :request do
     expect(body).to include("http://www.dev.gov.uk#{destination}?token=")
 
     token = URI.decode_www_form_component(
-      body.match(/token=([^&\n]+)/)[1],
+      body.match(/token=([^&)]+)/)[1],
     )
 
     expect(decrypt_and_verify_token(token)).to eq(

--- a/spec/features/daily_digest_spec.rb
+++ b/spec/features/daily_digest_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Daily digests", type: :request do
   let(:list_one_topic_id) { "0eb5d0f0-d384-4f27-9da8-3f9e9b22a820" }
   let(:list_two_taxon_id) { "6416e4e0-c0c1-457a-8337-4bf8ed9d5f80" }
 
-  let(:subscriber_list_one_id) do
+  let(:subscriber_list_one) do
     create_subscriber_list(
       title: "Subscriber list one",
       links: {
@@ -11,7 +11,7 @@ RSpec.describe "Daily digests", type: :request do
     )
   end
 
-  let(:subscriber_list_two_id) do
+  let(:subscriber_list_two) do
     create_subscriber_list(
       title: "Subscriber list two",
       links: {
@@ -26,7 +26,7 @@ RSpec.describe "Daily digests", type: :request do
 
   scenario "single list" do
     subscribe_to_subscriber_list(
-      subscriber_list_one_id,
+      subscriber_list_one[:id],
       frequency: Frequency::DAILY,
     )
 
@@ -71,12 +71,12 @@ RSpec.describe "Daily digests", type: :request do
 
   scenario "multiple lists" do
     subscribe_to_subscriber_list(
-      subscriber_list_one_id,
+      subscriber_list_one[:id],
       frequency: Frequency::DAILY,
     )
 
     subscribe_to_subscriber_list(
-      subscriber_list_two_id,
+      subscriber_list_two[:id],
       frequency: Frequency::DAILY,
     )
 

--- a/spec/features/login_verify_email_spec.rb
+++ b/spec/features/login_verify_email_spec.rb
@@ -1,12 +1,6 @@
 RSpec.describe "Login verify email", type: :request do
   include TokenHelpers
 
-  around do |example|
-    Sidekiq::Testing.inline! do
-      freeze_time { example.run }
-    end
-  end
-
   let(:address) { "test@example.com" }
   let!(:subscriber) { create(:subscriber, address: address) }
   let(:destination) { "/authenticate" }

--- a/spec/features/login_verify_email_spec.rb
+++ b/spec/features/login_verify_email_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Create an auth token", type: :request do
+RSpec.describe "Login verify email", type: :request do
   include TokenHelpers
 
   around do |example|

--- a/spec/features/login_verify_email_spec.rb
+++ b/spec/features/login_verify_email_spec.rb
@@ -24,11 +24,7 @@ RSpec.describe "Login verify email", type: :request do
     body = email_data.dig(:personalisation, :body)
     expect(body).to include("http://www.dev.gov.uk#{destination}?token=")
 
-    token = URI.decode_www_form_component(
-      body.match(/token=([^&)]+)/)[1],
-    )
-
-    expect(decrypt_and_verify_token(token)).to eq(
+    expect(decrypt_token_from_link(body)).to eq(
       "subscriber_id" => subscriber.id,
     )
   end

--- a/spec/features/sending_email_spec.rb
+++ b/spec/features/sending_email_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe "Sending an email", type: :request do
   scenario "sending an email for a content change" do
     login_with_internal_app
 
-    subscriber_list_id = create_subscriber_list
-    subscribe_to_subscriber_list(subscriber_list_id)
+    subscriber_list = create_subscriber_list
+    subscribe_to_subscriber_list(subscriber_list[:id])
     create_content_change
 
     email_data = expect_an_email_was_sent(
@@ -23,10 +23,10 @@ RSpec.describe "Sending an email", type: :request do
   scenario "sending an email for a message" do
     login_with_internal_app
 
-    subscriber_list_id = create_subscriber_list(
+    subscriber_list = create_subscriber_list(
       tags: { brexit_checklist_criteria: { any: %w[eu-national] } },
     )
-    subscribe_to_subscriber_list(subscriber_list_id)
+    subscribe_to_subscriber_list(subscriber_list[:id])
     create_message(
       criteria_rules: [{ type: "tag", key: "brexit_checklist_criteria", value: "eu-national" }],
     )

--- a/spec/features/status_update_spec.rb
+++ b/spec/features/status_update_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Status updates", type: :request do
   before do
     login_with(%w[internal_app status_updates])
-    subscriber_list_id = create_subscriber_list
-    subscribe_to_subscriber_list(subscriber_list_id)
+    subscriber_list = create_subscriber_list
+    subscribe_to_subscriber_list(subscriber_list[:id])
     create_content_change
     @email_data = expect_an_email_was_sent
   end

--- a/spec/features/subscribing_spec.rb
+++ b/spec/features/subscribing_spec.rb
@@ -25,11 +25,7 @@ RSpec.describe "Subscribing", type: :request do
     body = email_data.dig(:personalisation, :body)
     expect(body).to include("http://www.dev.gov.uk/email/subscriptions/authenticate?token=")
 
-    token = URI.decode_www_form_component(
-      body.match(/token=([^&)]+)/)[1],
-    )
-
-    expect(decrypt_and_verify_token(token)).to eq(
+    expect(decrypt_token_from_link(body)).to eq(
       "address" => address,
       "frequency" => frequency,
       "topic_id" => subscriber_list[:slug],

--- a/spec/features/subscribing_spec.rb
+++ b/spec/features/subscribing_spec.rb
@@ -3,11 +3,7 @@ RSpec.describe "Subscribing", type: :request do
 
   let(:address) { "test@example.com" }
   let(:frequency) { "immediately" }
-
-  let(:subscriber_list) do
-    subscriber_list_id = create_subscriber_list
-    SubscriberList.find(subscriber_list_id)
-  end
+  let(:subscriber_list) { create_subscriber_list }
 
   before do
     login_with_internal_app
@@ -17,7 +13,7 @@ RSpec.describe "Subscribing", type: :request do
     post "/subscriptions/auth-token",
          params: {
            address: address,
-           topic_id: subscriber_list.slug,
+           topic_id: subscriber_list[:slug],
            frequency: frequency,
          }
 
@@ -36,13 +32,13 @@ RSpec.describe "Subscribing", type: :request do
     expect(decrypt_and_verify_token(token)).to eq(
       "address" => address,
       "frequency" => frequency,
-      "topic_id" => subscriber_list.slug,
+      "topic_id" => subscriber_list[:slug],
     )
 
     # It's expected that the frontend app will interpret the data in
     # the token in order to make this call.
     subscribe_to_subscriber_list(
-      subscriber_list.id,
+      subscriber_list[:id],
       address: address,
       frequency: frequency,
       expected_status: 200,
@@ -55,7 +51,7 @@ RSpec.describe "Subscribing", type: :request do
   end
 
   scenario "repeat subscription" do
-    subscribe_to_subscriber_list(subscriber_list.id, expected_status: 200)
-    subscribe_to_subscriber_list(subscriber_list.id, expected_status: 200)
+    subscribe_to_subscriber_list(subscriber_list[:id], expected_status: 200)
+    subscribe_to_subscriber_list(subscriber_list[:id], expected_status: 200)
   end
 end

--- a/spec/features/subscribing_spec.rb
+++ b/spec/features/subscribing_spec.rb
@@ -1,13 +1,61 @@
-RSpec.describe "Subscribing to a subscriber_list", type: :request do
-  scenario "subscribing to a subscriber_list" do
-    login_with_internal_app
+RSpec.describe "Subscribing", type: :request do
+  include TokenHelpers
 
+  let(:address) { "test@example.com" }
+  let(:frequency) { "immediately" }
+
+  let(:subscriber_list) do
     subscriber_list_id = create_subscriber_list
+    SubscriberList.find(subscriber_list_id)
+  end
 
-    subscribe_to_subscriber_list(subscriber_list_id, expected_status: 200)
-    expect_an_email_was_sent(subject: /You’ve subscribed to/)
+  before do
+    login_with_internal_app
+  end
 
-    subscribe_to_subscriber_list(subscriber_list_id, expected_status: 200)
-    subscribe_to_subscriber_list("missing",          expected_status: 404)
+  scenario "successful subscription" do
+    post "/subscriptions/auth-token",
+         params: {
+           address: address,
+           topic_id: subscriber_list.slug,
+           frequency: frequency,
+         }
+
+    email_data = expect_an_email_was_sent(
+      address: "test@example.com",
+      subject: "Confirm that you want to get emails from GOV.UK",
+    )
+
+    body = email_data.dig(:personalisation, :body)
+    expect(body).to include("http://www.dev.gov.uk/email/subscriptions/authenticate?token=")
+
+    token = URI.decode_www_form_component(
+      body.match(/token=([^&)]+)/)[1],
+    )
+
+    expect(decrypt_and_verify_token(token)).to eq(
+      "address" => address,
+      "frequency" => frequency,
+      "topic_id" => subscriber_list.slug,
+    )
+
+    # It's expected that the frontend app will interpret the data in
+    # the token in order to make this call.
+    subscribe_to_subscriber_list(
+      subscriber_list.id,
+      address: address,
+      frequency: frequency,
+      expected_status: 200,
+    )
+
+    expect_an_email_was_sent(
+      subject: /You’ve subscribed to/,
+      address: address,
+    )
+  end
+
+  scenario "repeat subscription" do
+    subscribe_to_subscriber_list(subscriber_list.id, expected_status: 200)
+    subscribe_to_subscriber_list(subscriber_list.id, expected_status: 200)
   end
 end

--- a/spec/features/unsubscribing_spec.rb
+++ b/spec/features/unsubscribing_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "Unsubscribing from a subscriber_list", type: :request do
   scenario "unsubscribing from an email uuid, then no longer receiving emails" do
     login_with_internal_app
-    subscriber_list_id = create_subscriber_list
-    subscribe_to_subscriber_list(subscriber_list_id, frequency: "daily")
+    subscriber_list = create_subscriber_list
+    subscribe_to_subscriber_list(subscriber_list[:id], frequency: "daily")
 
     travel_to(Time.zone.yesterday.midday) { create_content_change }
 

--- a/spec/features/weekly_digest_spec.rb
+++ b/spec/features/weekly_digest_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Weekly digests", type: :request do
   let(:list_one_topic_id) { "0eb5d0f0-d384-4f27-9da8-3f9e9b22a820" }
   let(:list_two_taxon_id) { "6416e4e0-c0c1-457a-8337-4bf8ed9d5f80" }
 
-  let(:subscriber_list_one_id) do
+  let(:subscriber_list_one) do
     create_subscriber_list(
       title: "Subscriber list one",
       links: {
@@ -11,7 +11,7 @@ RSpec.describe "Weekly digests", type: :request do
     )
   end
 
-  let(:subscriber_list_two_id) do
+  let(:subscriber_list_two) do
     create_subscriber_list(
       title: "Subscriber list two",
       links: {
@@ -26,7 +26,7 @@ RSpec.describe "Weekly digests", type: :request do
 
   scenario "single list" do
     subscribe_to_subscriber_list(
-      subscriber_list_one_id,
+      subscriber_list_one[:id],
       frequency: Frequency::WEEKLY,
     )
 
@@ -75,12 +75,12 @@ RSpec.describe "Weekly digests", type: :request do
 
   scenario "multiple lists" do
     subscribe_to_subscriber_list(
-      subscriber_list_one_id,
+      subscriber_list_one[:id],
       frequency: Frequency::WEEKLY,
     )
 
     subscribe_to_subscriber_list(
-      subscriber_list_two_id,
+      subscriber_list_two[:id],
       frequency: Frequency::WEEKLY,
     )
 

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Subscribers auth token", type: :request do
       expect(Email.count).to be 1
 
       token = URI.decode_www_form_component(
-        Email.last.body.match(/token=([^&\n]+)/)[1],
+        Email.last.body.match(/token=([^&)]+)/)[1],
       )
 
       expect(decrypt_and_verify_token(token)).to eq(

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -34,11 +34,7 @@ RSpec.describe "Subscribers auth token", type: :request do
       post path, params: params
       expect(Email.count).to be 1
 
-      token = URI.decode_www_form_component(
-        Email.last.body.match(/token=([^&)]+)/)[1],
-      )
-
-      expect(decrypt_and_verify_token(token)).to eq(
+      expect(decrypt_token_from_link(Email.last.body)).to eq(
         "subscriber_id" => subscriber.id,
       )
     end

--- a/spec/integration/subscriptions_auth_token_spec.rb
+++ b/spec/integration/subscriptions_auth_token_spec.rb
@@ -92,11 +92,7 @@ RSpec.describe "Subscriptions auth token", type: :request do
       post path, params: params
       expect(Email.count).to be 1
 
-      token = URI.decode_www_form_component(
-        Email.last.body.match(/token=([^&\n]+)/)[1],
-      )
-
-      expect(decrypt_and_verify_token(token)).to eq(
+      expect(decrypt_token_from_link(Email.last.body)).to eq(
         "address" => address,
         "topic_id" => topic_id,
         "frequency" => frequency,

--- a/spec/presenters/footer_presenter_spec.rb
+++ b/spec/presenters/footer_presenter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe FooterPresenter do
 
         [Unsubscribe](unsubscribe_url)
 
-        [Manage your email preferences](manage_url)
+        [Change your email preferences](manage_url)
       FOOTER
 
       expect(footer).to eq(expected.strip)

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -3,7 +3,7 @@ module RequestHelpers
     params = { title: "Example", tags: {}, links: {} }.merge(overrides)
     post "/subscriber-lists", params: params.to_json, headers: json_headers
     expect(response.status).to eq(200)
-    data.dig(:subscriber_list, :id)
+    data[:subscriber_list]
   end
 
   def subscribe_to_subscriber_list(subscriber_list_id, expected_status: 200,

--- a/spec/support/token_helpers.rb
+++ b/spec/support/token_helpers.rb
@@ -1,4 +1,12 @@
 module TokenHelpers
+  def decrypt_token_from_link(body)
+    token = URI.decode_www_form_component(
+      body.match(/token=([^&)]+)/)[1],
+    )
+
+    decrypt_and_verify_token(token)
+  end
+
   def decrypt_and_verify_token(data)
     cipher = AuthTokenGeneratorService::CIPHER
     len = ActiveSupport::MessageEncryptor.key_len(cipher)


### PR DESCRIPTION
https://trello.com/c/l2cC0fY4/678-update-sign-in-journey-email-screens-to-match-design

This makes a couple of user-facing changing:

- Fixes a longterm typo in the common email footer
- Updates the login email design to match other emails

And then there are a few minor refactorings. Please see
the commits for more details.

## Before

<img width="452" alt="Screenshot 2021-01-25 at 11 56 54" src="https://user-images.githubusercontent.com/9029009/105702955-71e0d500-5f04-11eb-92ee-935786a49408.png">

## After

<img width="447" alt="Screenshot 2021-01-25 at 12 03 55" src="https://user-images.githubusercontent.com/9029009/105703616-6d68ec00-5f05-11eb-8bd9-b4d4e4372297.png">
