### PR TITLE
Fix remaining use of "Manage" in email footer

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -35,7 +35,7 @@ private
 
       [Unsubscribe](#{unsubscribe_url})
 
-      [Manage your email preferences](#{manage_url})
+      [Change your email preferences](#{manage_url})
     BODY
   end
 

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
 
             [Unsubscribe](unsubscribe_url)
 
-            [Manage your email preferences](manage_url)
+            [Change your email preferences](manage_url)
           BODY
         )
       end


### PR DESCRIPTION
https://trello.com/c/l2cC0fY4/678-update-sign-in-journey-email-screens-to-match-design

This was left over from f2204b05.