### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,5 @@ library("govuk")
 
 node("postgresql-9.6") {
   govuk.setEnvar("TEST_DATABASE_URL", "postgresql://email-alert-api:email-alert-api@localhost/email-alert-api_test")
-  govuk.buildProject(
-    rubyLintDiff: false
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
The RubyLintDiff argument no longer has any affect.