### PR TITLE
Remove link from "double opt-in" email

### DIFF
--- a/app/builders/subscription_auth_email_builder.rb
+++ b/app/builders/subscription_auth_email_builder.rb
@@ -36,7 +36,6 @@ private
 
       Thanks 
       GOV.UK emails 
-      [https://www.gov.uk/help/update-email-notifications](https://www.gov.uk/help/update-email-notifications)
     BODY
   end
 

--- a/spec/builders/subscription_auth_email_builder_spec.rb
+++ b/spec/builders/subscription_auth_email_builder_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe SubscriptionAuthEmailBuilder do
 
           Thanks 
           GOV.UK emails 
-          [https://www.gov.uk/help/update-email-notifications](https://www.gov.uk/help/update-email-notifications)
         BODY
       )
     end


### PR DESCRIPTION
This was originally intended to be part of a standard transactional
footer, but we since decided against this in all other such emails
[1]. We've just changed the URL for the link, which is prompting a
removal of it here, as opposed to updating it to avoid a redirect.

[1]: https://github.com/alphagov/email-alert-api/commit/ad414433e77353097c055584514d7e1c80aab7d4#diff-2a2c736444a20e59b27c8585e61759e5c8a54d7a8eeb336c6636ab980d972750