### PR TITLE
Revise tech docs in README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,33 +33,21 @@ notification services. Currently supports only [GOV.UK Notify](https://www.notif
 
 ## Technical documentation
 
-### Dependencies
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
-* PostgreSQL database (9.3 or higher - requires `json` with `json_object_keys` method)
-* Redis (for [Sidekiq](http://sidekiq.org/))
-* GOV.UK Notify API key and other details (see
-  [`email_service.yml`](config/email_service.yml) for required fields)
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-### Running the application
-
-```bash
-bundle exec rails server
-```
+**Use GOV.UK Docker to run any commands that follow.**
 
 ### Running the test suite
 
 ```bash
-bundle exec rspec
+bundle exec rake
 ```
 
-## Documentation
+### Manuals and decisions
 
-- [Analytics](docs/analytics.md)
-- [API](docs/api.md)
-- [Data cleanup mechanisms](docs/data-cleanup-mechanisms.md)
-- [Matching content to subscriber lists](docs/matching-content-to-subscriber-lists.md)
-- [Support tasks](docs/support-tasks.md)
-- [ENV vars](docs/env-vars.md)
+Check the [docs/](docs/) directory for detailed instructions, decisions and other documentation.
 
 ## Licence
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-gem install foreman --conservative
-bundle install
-PORT=${PORT:-3088} foreman start


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This follows the pattern established in [1].

[1]: https://github.com/alphagov/content-publisher/pull/2257