### PR TITLE
Convert to date in SubscriberListsReport

### DIFF
--- a/lib/reports/subscriber_lists_report.rb
+++ b/lib/reports/subscriber_lists_report.rb
@@ -2,7 +2,7 @@ class Reports::SubscriberListsReport
   attr_reader :date, :slugs, :tags_pattern, :links_pattern, :headers
 
   def initialize(date, slugs: "", tags_pattern: nil, links_pattern: nil, headers: nil)
-    @date = Time.zone.parse(date)
+    @date = Date.parse(date)
     @slugs = slugs.split(",")
     @tags_pattern = tags_pattern
     @links_pattern = links_pattern
@@ -31,7 +31,6 @@ private
   end
 
   def validate_date
-    raise "Invalid date" if date.blank?
     raise "Date must be in the past" if date >= Time.zone.today
     raise "Date must be within a year old" if date <= 1.year.ago
   end

--- a/spec/lib/reports/subscriber_lists_report_spec.rb
+++ b/spec/lib/reports/subscriber_lists_report_spec.rb
@@ -90,11 +90,6 @@ RSpec.describe Reports::SubscriberListsReport do
       .to raise_error("Lists not found for slugs: other-list,list")
   end
 
-  it "raises an error if the date is invalid" do
-    expect { described_class.new("blahhh").call }
-      .to raise_error("Invalid date")
-  end
-
   it "raises an error if the date isn't in the past" do
     expect { described_class.new(Time.zone.today.to_s).call }
       .to raise_error("Date must be in the past")


### PR DESCRIPTION
A time-at-midnight-with-a-timezone compares as less than a date:

    irb(main):001:0> with_ts = Time.zone.parse(Time.zone.today.to_s)
    => Mon, 29 Mar 2021 00:00:00.000000000 BST +01:00

    irb(main):002:0> without_ts = Time.zone.today
    => Mon, 29 Mar 2021

    irb(main):003:0> with_ts < without_ts
    => true

So the check that the date must be in the past isn't working right: a
test that `Time.zone.today` gets rejected is failing, because the time
is being converted through `to_s`/`Time.zone.parse`, and ends up as
comparing less than its original value.

This report uses the date, not the time, so convert the input back
into a timezone-less date object.

Using `Time.zone.today.in_time_zone` for the comparison instead also
works.  I don't think there's a difference in practice, because the
`@date` gets used in database queries in the context of
`beginning_of_day` and `end_of_day`, which are timezone aware:

    irb(main):001:0> Time.zone.today.beginning_of_day
    => Mon, 29 Mar 2021 00:00:00.000000000 BST +01:00
    irb(main):002:0> Time.zone.today.in_time_zone.beginning_of_day
    => Mon, 29 Mar 2021 00:00:00.000000000 BST +01:00

    irb(main):003:0> Time.zone.today.end_of_day
    => Mon, 29 Mar 2021 23:59:59.999999999 BST +01:00
    irb(main):004:0> Time.zone.today.in_time_zone.end_of_day
    => Mon, 29 Mar 2021 23:59:59.999999999 BST +01:00