### PR TITLE
Decouple Raven from Email-alert-api

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
-Raven.configure do |config|
+GovukError.configure do |config|
   config.excluded_exceptions += %w[
     RatelimitExceededError
   ]


### PR DESCRIPTION
Removed direct references to Raven object and remaned appropriately

Trello: https://trello.com/c/S1QvqyCE/2459-decouple-govuk-apps-from-raven-3