### PR TITLE
Bugfix: Fetch content changes for digest uniquely by subscription

### DIFF
--- a/app/queries/digest_items_query.rb
+++ b/app/queries/digest_items_query.rb
@@ -35,7 +35,8 @@ private
       .where(subscriptions: { id: subscriptions })
       .where("content_changes.created_at >= ?", digest_run.starts_at)
       .where("content_changes.created_at < ?", digest_run.ends_at)
-      .uniq(&:content_id)
+      .order(created_at: :desc)
+      .uniq { |content| [content.content_id, content.subscription_id] }
       .group_by(&:subscription_id)
   end
 


### PR DESCRIPTION
This fixes a bug that would prevent a content change appearing in
a digest email.

Explanation:

Say you have two subscriptions `A` and `B`, and a piece of content `C`
that is changed twice in a week, generating content changes `Ca` and
`Cb`.

The query currently attempts to ensure that content change `Ca` is
not included in the digest, since we just want the most recent
content change, to keep emails short and sweet (and another reason
related to batching digests into a single email which I will get back
to).

The query uses `uniq(&:content_id)` to do ensure a piece of content
appears once in an email, even if there have been many changes to it.

However, the effect of this is that while change `Ca` is omitted from both
weekly digest emails (for subscriptions `A` and `B`), change `Cb` is
also omitted from the digest email for subscription `B`.

Fix:

To fix this I've changed the query so that content changes are distinct
based on content id and subscription id. Now change `Cb` will appear
in both digest emails for subscription `A` and `B`.

Addendum:

We had a user write in who experienced exactly this situation I described
above. It was pretty confusing to debug, and confusing for our subscriber
too!

I think folks will only have started noticing this in December, when
we stopped batching weekly digests into single emails [1]. Since,
even if one subscription didn't include the content change, the other
one would.

Corresponding ticket: https://govuk.zendesk.com/agent/tickets/4494504

[1] https://github.com/alphagov/email-alert-api/pull/1524