### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,11 +22,6 @@ Rails.application.routes.draw do
 
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
 
-    get "/healthcheck", to: GovukHealthcheck.rack_response(
-      GovukHealthcheck::SidekiqRedis,
-      GovukHealthcheck::ActiveRecord,
-    )
-
     get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
     get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::SidekiqRedis,


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
