### PR TITLE
Improved output for bulk email rake task

### DIFF
--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -1,14 +1,15 @@
 namespace :bulk_email do
   desc "Send a bulk email to many subscriber lists"
   task :for_lists, [] => :environment do |_t, args|
+    subscriber_lists = SubscriberList.where(id: args.extras)
     email_ids = BulkSubscriberListEmailBuilder.call(
       subject: ENV.fetch("SUBJECT"),
       body: ENV.fetch("BODY"),
-      subscriber_lists: SubscriberList.where(id: args.extras),
+      subscriber_lists: subscriber_lists,
     )
     email_ids.each do |id|
       SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate)
     end
-    puts "Sending #{email_ids.count} emails"
+    puts "Sending #{email_ids.count} emails to subscribers on the following lists: #{subscriber_lists.pluck(:slug).join(', ')}"
   end
 end

--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -9,5 +9,6 @@ namespace :bulk_email do
     email_ids.each do |id|
       SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate)
     end
+    puts "Sending #{email_ids.count} emails"
   end
 end

--- a/spec/lib/tasks/bulk_email_spec.rb
+++ b/spec/lib/tasks/bulk_email_spec.rb
@@ -39,5 +39,14 @@ RSpec.describe "bulk_email" do
 
       Rake::Task["bulk_email:for_lists"].invoke(subscriber_list.id)
     end
+
+    it "states how many emails are being sent" do
+      subscriber_list = create(:subscriber_list)
+      allow(BulkSubscriberListEmailBuilder).to receive(:call)
+        .and_return([1, 2])
+
+      expect { Rake::Task["bulk_email:for_lists"].invoke(subscriber_list.id) }
+        .to output(/Sending 2 emails/).to_stdout
+    end
   end
 end

--- a/spec/lib/tasks/bulk_email_spec.rb
+++ b/spec/lib/tasks/bulk_email_spec.rb
@@ -40,13 +40,16 @@ RSpec.describe "bulk_email" do
       Rake::Task["bulk_email:for_lists"].invoke(subscriber_list.id)
     end
 
-    it "states how many emails are being sent" do
-      subscriber_list = create(:subscriber_list)
+    it "states how many emails are being sent, and to where" do
+      subscriber_list1 = create(:subscriber_list)
+      subscriber_list2 = create(:subscriber_list)
       allow(BulkSubscriberListEmailBuilder).to receive(:call)
-        .and_return([1, 2])
+        .and_return([1, 2, 3, 4, 5])
 
-      expect { Rake::Task["bulk_email:for_lists"].invoke(subscriber_list.id) }
-        .to output(/Sending 2 emails/).to_stdout
+      expect { Rake::Task["bulk_email:for_lists"].invoke(subscriber_list1.id, subscriber_list2.id) }
+        .to output(
+          /Sending 5 emails to subscribers on the following lists: #{subscriber_list1.slug}, #{subscriber_list2.slug}/,
+        ).to_stdout
     end
   end
 end


### PR DESCRIPTION
This improves the output for the given rake task, which otherwise was very uninformative. See commits for details.

Trello: https://trello.com/c/qqxUkxPX/2489-2-send-email-to-all-gds-department-subscribers-pointing-them-to-cddo-alerts