### PR TITLE
Import email-alert-api docs into email-alert-api/docs

### DIFF
--- a/docs/bulk-email.md
+++ b/docs/bulk-email.md
@@ -1,0 +1,47 @@
+# Send a bulk email
+
+Sometimes it may be necessary to send a bulk email to many subscribers at once.
+There is [a Rake task in email-alert-api][rake-task] to perform this task and
+it's [available as a job in Jenkins][send-bulk-production].
+
+[rake-task]: https://github.com/alphagov/email-alert-api/blob/3a3eaaa59e71e03427021ba730c626ecdf107ccd/lib/tasks/bulk.rake#L2-L9
+
+## 1. Prepare the content
+
+You'll need:
+
+- Email subject line
+- Email body text
+
+The body text can contain [a limited subset of markdown][notify-markdown]. A footer will be automatically appended to the body text. The footer will have links to unsubscribe and manage subscriptions. We should always provide users with these options, to help avoid our emails being marked as spam.
+
+Any occurrence of `%LISTURL%` in the body text will be substituted with the URL of the subscriber list, or an empty string if it has none. This is useful when sending the same email across many lists, where the content of the email needs to link to the specific page on GOV.UK associated with the list. You should check the lists you want to send a bulk email for, to see if they have a URL populated (it's a recent addition).
+
+[notify-markdown]: https://www.notifications.service.gov.uk/using-notify/guidance/edit-and-format-messages
+
+## 2. Get the subscriber lists
+
+Next you'll need to get the IDs of all the subscriber lists to send the email
+out to. This will require querying the email-alert-api `SubscriberList` model.
+
+For example, to get the IDs of all the subscriber lists for travel advice, you
+could use the following query:
+
+```rb
+> SubscriberList.where("links->'countries' IS NOT NULL").pluck(:id)
+```
+
+## 3. Send a test email
+
+Use [the Send bulk emails job in Staging][send-bulk-staging] to send the email.
+
+**Make sure you know [how to receive emails in Staging][staging-emails].**
+
+[send-bulk-staging]: https://deploy.blue.staging.govuk.digital/job/send-bulk-email/
+[staging-emails]: /manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html
+
+## 4. Send the real email
+
+Use [the Send bulk emails job in Production][send-bulk-production] to send the email.
+
+[send-bulk-production]: https://deploy.blue.production.govuk.digital/job/send-bulk-email/

--- a/docs/load-test-email-alert-api.md
+++ b/docs/load-test-email-alert-api.md
@@ -1,0 +1,19 @@
+# Load test Email Alert API
+
+You may wish to load test Email Alert API to get a realistic idea of how the
+system performs when it has a large quantity of emails to create and send.
+This can be useful to provide data on where the system may have performance
+bottlenecks.
+
+To perform a load test you will need:
+
+- A mechanism to artificially create a quantity of work for Email Alert API to
+  do - we previously had a number of [rake tasks][] to allow this;
+- An approach to simulate the delay of an actual request to Notify - we
+  previously used a `Kernel.sleep(0.1)` to apply this.
+
+When performing the test you should inform the `#govuk-2ndline`
+channel as they may see alerts during it.
+
+[rake tasks]: https://github.com/alphagov/email-alert-api/pull/1494
+[clear-queues]: https://github.com/alphagov/email-alert-api/blob/17d54964063256a6769189bc5fd6d4cf61a9d40f/lib/tasks/load_testing.rake#L18-L21

--- a/docs/receiving-emails-from-email-alert-api-in-integration-and-staging.md
+++ b/docs/receiving-emails-from-email-alert-api-in-integration-and-staging.md
@@ -1,0 +1,47 @@
+# Receive emails from Email Alert API in Integration and Staging
+
+In order to test receiving real emails from Email Alert API we have configured
+Google groups for the integration and staging environments. Emails
+sent to addresses other than those of these groups will be
+[written to a logfile][logging-emails].
+
+## In Integration
+
+In Integration there is the [Email Alert API Integration Google
+group][integration-group]. It has an email address of
+`email-alert-api-integration@digital.cabinet-office.gov.uk`.
+
+This account can be used to sign up to subscriptions on
+https://www.integration.publishing.service.gov.uk/.
+
+## In Staging
+
+In Staging there is the [Email Alert API Staging Google
+group][staging-group]. It has an email address of
+`email-alert-api-staging@digital.cabinet-office.gov.uk`.
+
+This account can be used to sign up to subscriptions on
+https://www.staging.publishing.service.gov.uk/.
+
+## How to use
+
+To use these Google groups you need to interact with the Email Alert system
+using the group email as your email address. For example, if you wanted to test
+receiving the content change alerts for travel advice, you can
+[sign-up to receive travel advice][travel-advice] with the group email address.
+Your next step would be to check the Google group for
+an email to confirm the subscription. Once confirmed, you can then publish
+a change in [Travel Advice Publisher][] to generate the content change
+alert email.
+
+If you are testing over multiple days, bear in mind that each night the
+databases in Integration and Staging are reset due to the [data sync][].
+This will mean that any test subscriptions you've created will be lost and
+you'll need to recreate them.
+
+[logging-emails]: https://github.com/alphagov/email-alert-api/blob/006afa2ee6c35631b83b16519f8af2c6c2ea5c59/app/services/send_email_service/send_pseudo_email.rb#L10-L20
+[integration-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/g/email-alert-api-integration
+[travel-advice]: https://www.integration.publishing.service.gov.uk/foreign-travel-advice/thailand/email-signup
+[Travel Advice Publisher]: https://travel-advice-publisher.integration.publishing.service.gov.uk/admin/countries/thailand
+[staging-group]: https://groups.google.com/a/digital.cabinet-office.gov.uk/g/email-alert-api-staging
+[data sync]: /manual/govuk-env-sync.html


### PR DESCRIPTION
Importing from the govuk-developer-docs so that the docs can live
closer to the code, making it easier to make changes to both at
the same time, as well as to have relevant email-alert-api docs
locally when checking out the repo. This was not possible prior to
https://github.com/alphagov/govuk-developer-docs/pull/2910, which
enabled external doc importing into the govuk-developer-docs.

Future devs can dig into the commit history of the govuk-developer-docs
versions of these files at these URLs:

- https://github.com/alphagov/govuk-developer-docs/blame/2289779c12930502177bc2d43c10dd385c834c90/source/manual/load-test-email-alert-api.html.md
- https://github.com/alphagov/govuk-developer-docs/blame/2289779c12930502177bc2d43c10dd385c834c90/source/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html.md
- https://github.com/alphagov/govuk-developer-docs/blame/2289779c12930502177bc2d43c10dd385c834c90/source/manual/bulk-email.html.md