### PR TITLE
Bump govuk_app_config to version 4.0.0.pre.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "bootsnap", require: false
 gem "faraday"
 gem "gds-api-adapters"
 gem "gds-sso"
-gem "govuk_app_config"
+gem "govuk_app_config", "4.0.0.pre.3"
 gem "govuk_document_types"
 gem "govuk_sidekiq"
 gem "json-schema"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     byebug (11.1.3)
     climate_control (0.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -89,9 +89,19 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.1.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     ffi (1.13.1)
     fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -113,9 +123,10 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_app_config (3.1.1)
+    govuk_app_config (4.0.0.pre.3)
       logstasher (>= 1.2.2, < 2.2.0)
-      sentry-raven (~> 3.1.1)
+      sentry-rails (~> 4.5.0)
+      sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
     govuk_document_types (0.9.3)
@@ -136,7 +147,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.1)
-    kgio (2.11.3)
+    kgio (2.11.4)
     link_header (0.0.8)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -230,7 +241,7 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rainbow (3.0.0)
-    raindrops (0.19.1)
+    raindrops (0.19.2)
     rake (13.0.3)
     ratelimit (1.0.3)
       redis (>= 2.0.0)
@@ -299,8 +310,16 @@ GEM
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
-    sentry-raven (3.1.2)
+    sentry-rails (4.5.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.5.0)
+    sentry-ruby (4.5.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.5.1)
+    sentry-ruby-core (4.5.1)
+      concurrent-ruby
+      faraday
     sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -369,7 +388,7 @@ DEPENDENCIES
   faraday
   gds-api-adapters
   gds-sso
-  govuk_app_config
+  govuk_app_config (= 4.0.0.pre.3)
   govuk_document_types
   govuk_sidekiq
   json-schema

--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,3 +1,6 @@
 GovukError.configure do |config|
-  config.excluded_exceptions << "SendEmailService::NotifyCommunicationFailure"
+  config.excluded_exceptions += %w[
+    SendEmailService::NotifyCommunicationFailure
+    RatelimitExceededError
+  ]
 end

--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -3,4 +3,6 @@ GovukError.configure do |config|
     SendEmailService::NotifyCommunicationFailure
     RatelimitExceededError
   ]
+
+  config.rails.report_rescued_exceptions = false
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,0 @@
-GovukError.configure do |config|
-  config.rails_report_rescued_exceptions = false
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,3 @@
 GovukError.configure do |config|
-  config.excluded_exceptions += %w[
-    RatelimitExceededError
-  ]
-
   config.rails_report_rescued_exceptions = false
 end


### PR DESCRIPTION
This should resolve the datasync-related errors in Sentry we're
seeing for Email Alert API:

- https://sentry.io/organizations/govuk/issues/2410167402/?project=202220&referrer=slack
- https://sentry.io/organizations/govuk/issues/2410167395/?project=202220&referrer=slack

It also consolidates our GovukError config in one file.

Trello: https://trello.com/c/4JOuje6O/2546-fix-broken-data-sync-related-sentry-errors-not-being-ignored