### PR TITLE
Revert "Bump govuk_app_config to version 4.0.0.pre.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "bootsnap", require: false
 gem "faraday"
 gem "gds-api-adapters"
 gem "gds-sso"
-gem "govuk_app_config", "4.0.0.pre.3"
+gem "govuk_app_config"
 gem "govuk_document_types"
 gem "govuk_sidekiq"
 gem "json-schema"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     byebug (11.1.3)
     climate_control (0.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -89,19 +89,9 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.4.2)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+      ruby2_keywords
     ffi (1.13.1)
     fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -123,10 +113,9 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_app_config (4.0.0.pre.3)
+    govuk_app_config (3.1.1)
       logstasher (>= 1.2.2, < 2.2.0)
-      sentry-rails (~> 4.5.0)
-      sentry-ruby (~> 4.5.0)
+      sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
     govuk_document_types (0.9.3)
@@ -147,7 +136,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.1)
-    kgio (2.11.4)
+    kgio (2.11.3)
     link_header (0.0.8)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -241,7 +230,7 @@ GEM
       rake (>= 0.8.7)
       thor (~> 1.0)
     rainbow (3.0.0)
-    raindrops (0.19.2)
+    raindrops (0.19.1)
     rake (13.0.3)
     ratelimit (1.0.3)
       redis (>= 2.0.0)
@@ -310,16 +299,8 @@ GEM
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
-    sentry-rails (4.5.1)
-      railties (>= 5.0)
-      sentry-ruby-core (~> 4.5.0)
-    sentry-ruby (4.5.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-raven (3.1.2)
       faraday (>= 1.0)
-      sentry-ruby-core (= 4.5.1)
-    sentry-ruby-core (4.5.1)
-      concurrent-ruby
-      faraday
     sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -388,7 +369,7 @@ DEPENDENCIES
   faraday
   gds-api-adapters
   gds-sso
-  govuk_app_config (= 4.0.0.pre.3)
+  govuk_app_config
   govuk_document_types
   govuk_sidekiq
   json-schema

--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,8 +1,3 @@
 GovukError.configure do |config|
-  config.excluded_exceptions += %w[
-    SendEmailService::NotifyCommunicationFailure
-    RatelimitExceededError
-  ]
-
-  config.rails.report_rescued_exceptions = false
+  config.excluded_exceptions << "SendEmailService::NotifyCommunicationFailure"
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,7 @@
+GovukError.configure do |config|
+  config.excluded_exceptions += %w[
+    RatelimitExceededError
+  ]
+
+  config.rails_report_rescued_exceptions = false
+end


### PR DESCRIPTION
Reverts alphagov/email-alert-api#1629

Running `GovukError.notify(StandardError.new("test exception from Chris"))` in an app console now returns `nil` and no event is logged in Sentry. This command on pre-govuk_app_config-v4 applications works fine. Right now we're not logging any errors, so we should revert this change.

Apologies!

https://trello.com/c/4JOuje6O/2546-fix-broken-data-sync-related-sentry-errors-not-being-ignored