### PR TITLE
Add an endpoint to authenticate a subscriber using a GOV.UK Account

### DIFF
--- a/app/controllers/subscribers_govuk_account_controller.rb
+++ b/app/controllers/subscribers_govuk_account_controller.rb
@@ -1,0 +1,41 @@
+class SubscribersGovukAccountController < ApplicationController
+  before_action :validate_params
+
+  def authenticate
+    account_response = GdsApi.account_api.get_attributes(
+      attributes: %i[email email_verified],
+      govuk_account_session: expected_params[:govuk_account_session],
+    )
+
+    email_verified = account_response.dig("values", "email_verified")
+    email = account_response.dig("values", "email")
+
+    api_response = { govuk_account_session: account_response["govuk_account_session"] }.compact
+
+    render status: :forbidden, json: api_response and return unless email_verified
+    render status: :not_found, json: api_response and return unless email
+
+    subscriber = Subscriber.find_by_address(email)
+    render status: :not_found, json: api_response and return unless subscriber
+
+    render json: api_response.merge(subscriber: subscriber)
+  rescue GdsApi::HTTPUnauthorized
+    head :unauthorized
+  end
+
+private
+
+  def expected_params
+    params.permit(:govuk_account_session)
+  end
+
+  def validate_params
+    ParamsValidator.new(expected_params).validate!
+  end
+
+  class ParamsValidator < OpenStruct
+    include ActiveModel::Validations
+
+    validates :govuk_account_session, presence: true
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
     post "/subscribers/auth-token", to: "subscribers_auth_token#auth_token"
     post "/subscriptions/auth-token", to: "subscriptions_auth_token#auth_token"
 
+    post "/subscribers/govuk-account", to: "subscribers_govuk_account#authenticate"
+
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
 
     get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }

--- a/docs/api.md
+++ b/docs/api.md
@@ -209,6 +209,38 @@ destination with a query string of token and a [JWT](https://jwt.io/) token.
 Returns a 201 status code on success or 404 if the subscriber is not known
 to Email Alert API.
 
+### `POST /subscribers/govuk-account`
+
+```json
+{
+  "govuk_account_session": "session-token-from-account-header"
+}
+```
+
+Checks if the given GOV.UK account has a verified email address which
+matches a subscriber and, if so, returns the subscriber in the form
+
+```json
+{
+  "subscriber": {
+    "id": 1,
+    "address": "test@example.com",
+    "created_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+    "updated_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+  }
+}
+```
+
+Returns a 401 if the account session identifier is invalid.
+
+Returns a 403 if the account's email address is not verified.
+
+Returns a 404 if there is no matching subscriber.
+
+The 403, 404, and 200 responses may optionally have a
+`govuk_account_session` response field, which should replace the value
+in the user's session.
+
 ## Healthcheck
 
 A queue health check endpoint is available at `/healthcheck`.

--- a/spec/integration/subscribers_govuk_account_spec.rb
+++ b/spec/integration/subscribers_govuk_account_spec.rb
@@ -1,0 +1,91 @@
+require "gds_api/test_helpers/account_api"
+
+RSpec.describe "Subscribers GOV.UK account", type: :request do
+  include GdsApi::TestHelpers::AccountApi
+
+  before { login_with_internal_app }
+
+  describe "authenticating a user" do
+    let(:path) { "/subscribers/govuk-account" }
+    let(:params) { { govuk_account_session: govuk_account_session } }
+    let(:govuk_account_session) { "session identifier" }
+
+    let(:email) { "test@example.com" }
+    let(:email_verified) { true }
+
+    let(:subscriber_email) { email }
+    let!(:subscriber) { create(:subscriber, address: subscriber_email) }
+
+    before do
+      stub_account_api_has_attributes(
+        attributes: %i[email email_verified],
+        values: {
+          "email" => email,
+          "email_verified" => email_verified,
+        }.compact,
+      )
+    end
+
+    it "returns the subscriber" do
+      post path, params: params
+      expect(response.status).to eq(200)
+      expect(data[:subscriber][:id]).to eq(subscriber.id)
+    end
+
+    context "when the subscriber does not exist" do
+      let(:subscriber_email) { "different@example.com" }
+
+      it "returns a 404" do
+        post path, params: params
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when the email address has not been verified" do
+      let(:email_verified) { false }
+
+      it "returns a 403" do
+        post path, params: params
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when the email attribute is missing" do
+      let(:email) { nil }
+
+      it "returns a 404" do
+        post path, params: params
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when the email_verified attribute is missing" do
+      let(:email_verified) { nil }
+
+      it "and returns a 403" do
+        post path, params: params
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when the session is invalid" do
+      before do
+        stub_account_api_unauthorized_has_attributes(attributes: %i[email email_verified])
+      end
+
+      it "returns a 401" do
+        post path, params: params
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when the govuk_account_session is missing" do
+      let(:govuk_account_session) { nil }
+
+      it "returns a 422" do
+        post path, params: params
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a new endpoint

    POST /subscribers/govuk-account

Which takes a `govuk_account_session` parameter, fetches the `email`
and `email_verified` attributes from account-api, and returns:

- 401 if the session identifier is invalid

- 403 if `email_verified` is false

- 404 if there is no subscriber with the same `email`

- 200 and the subscriber details otherwise

The 403, 404, and 200 responses may also include a new
`govuk_account_session` in the JSON response body.

---

[Trello card](https://trello.com/c/qPIGG5rp/872-backend-work-to-allow-logging-in-to-email-alert-api-with-an-account)