### PR TITLE
Single content notifications

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -41,6 +41,7 @@ private
 
   def find_exact_query_params
     {
+      content_id: params.fetch(:content_id, nil),
       tags: convert_legacy_params(params.permit(tags: {}).to_h.fetch(:tags, {})),
       links: convert_legacy_params(params.permit(links: {}).to_h.fetch(:links, {})),
       document_type: params.fetch(:document_type, ""),

--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -2,6 +2,7 @@ class FindExactQuery
   class InvalidFindCriteria < StandardError; end
 
   def initialize(
+    content_id:,
     tags:,
     links:,
     document_type:,
@@ -9,6 +10,7 @@ class FindExactQuery
     government_document_supertype:,
     slug: nil
   )
+    @content_id = content_id.presence
     @tags = tags.deep_symbolize_keys
     @links = links.deep_symbolize_keys
     @document_type = document_type
@@ -29,6 +31,7 @@ private
   def base_scope
     @base_scope ||= begin
       scope = SubscriberList
+        .where(content_id: @content_id)
         .where(document_type: @document_type)
         .where(email_document_supertype: @email_document_supertype)
         .where(government_document_supertype: @government_document_supertype)

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -1,5 +1,6 @@
 class SubscriberListQuery
-  def initialize(tags:, links:, document_type:, email_document_supertype:, government_document_supertype:)
+  def initialize(content_id:, tags:, links:, document_type:, email_document_supertype:, government_document_supertype:)
+    @content_id = content_id
     @tags = tags.symbolize_keys
     @links = links.symbolize_keys
     @document_type = document_type
@@ -11,7 +12,7 @@ class SubscriberListQuery
     @lists ||= (
       lists_matched_on_links +
       lists_matched_on_tags +
-      lists_matched_on_document_type_only
+      lists_matched_without_links_or_tags
     ).uniq(&:id)
   end
 
@@ -25,12 +26,13 @@ private
     MatchedForNotification.new(query_field: :links, scope: base_scope).call(@links)
   end
 
-  def lists_matched_on_document_type_only
+  def lists_matched_without_links_or_tags
     FindWithoutLinksAndTags.new(scope: base_scope).call
   end
 
   def base_scope
     SubscriberList
+      .where(content_id: [nil, @content_id])
       .where(document_type: ["", @document_type])
       .where(email_document_supertype: ["", @email_document_supertype])
       .where(government_document_supertype: ["", @government_document_supertype])

--- a/app/queries/subscriber_lists_by_criteria_query.rb
+++ b/app/queries/subscriber_lists_by_criteria_query.rb
@@ -41,21 +41,27 @@ private
   end
 
   def type_rule(scope, type:, key:, value:)
-    field = case type
-            when "tag" then "tags"
-            when "link" then "links"
-            else
-              raise "Unexpected rule type: #{type}"
-            end
+    hash_rule_to_scope = lambda do |field|
+      # we only apply this rule to SubscriberList tagged to "any", it didn't seem
+      # to make logical sense to apply this to "all" ones
+      scope.where(
+        ":value IN (SELECT json_array_elements(#{field}->:key->'any')::text)",
+        key: key,
+        # Postgres returns a string in double quotes where other double quote
+        # characters are escaped
+        value: %("#{value.gsub('"', '\\"')}"),
+      )
+    end
 
-    # we only apply this rule to SubscriberList tagged to "any", it didn't seem
-    # to make logical sense to apply this to "all" ones
-    scope.where(
-      ":value IN (SELECT json_array_elements(#{field}->:key->'any')::text)",
-      key: key,
-      # Postgres returns a string in double quotes where other double quote
-      # characters are escaped
-      value: %("#{value.gsub('"', '\\"')}"),
-    )
+    case type
+    when "tag"
+      hash_rule_to_scope.call("tags")
+    when "link"
+      hash_rule_to_scope.call("links")
+    when "content_id"
+      scope.where(content_id: value)
+    else
+      raise "Unexpected rule type: #{type}"
+    end
   end
 end

--- a/app/services/matched_content_change_generation_service.rb
+++ b/app/services/matched_content_change_generation_service.rb
@@ -29,6 +29,7 @@ private
 
   def subscriber_lists
     @subscriber_lists ||= SubscriberListQuery.new(
+      content_id: content_change.content_id,
       tags: content_change.tags,
       links: content_change.links,
       document_type: content_change.document_type,

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "fd560cd836e0d365f3f8c834b65e28b64c1ffc42fa0d6d3038ec4b0751f71786",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/queries/subscriber_lists_by_criteria_query.rb",
+      "line": 48,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "scope.where(\":value IN (SELECT json_array_elements(#{field}->:key->'any')::text)\", :key => key, :value => (\"\\\"#{value.gsub(\"\\\"\", \"\\\\\\\"\")}\\\"\"))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SubscriberListsByCriteriaQuery",
+        "method": "type_rule"
+      },
+      "user_input": "field",
+      "confidence": "Weak",
+      "note": ""
+    }
+  ],
+  "updated": "2021-06-25 10:58:12 +0100",
+  "brakeman_version": "5.0.4"
+}

--- a/db/migrate/20210608161920_add_content_id_to_subscriber_lists.rb
+++ b/db/migrate/20210608161920_add_content_id_to_subscriber_lists.rb
@@ -1,0 +1,6 @@
+class AddContentIdToSubscriberLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subscriber_lists, :content_id, :uuid
+    add_index :subscriber_lists, :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_09_090225) do
+ActiveRecord::Schema.define(version: 2021_06_08_161920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,8 @@ ActiveRecord::Schema.define(version: 2021_03_09_090225) do
     t.string "url"
     t.string "tags_digest"
     t.string "links_digest"
+    t.uuid "content_id"
+    t.index ["content_id"], name: "index_subscriber_lists_on_content_id"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
     t.index ["government_document_supertype"], name: "index_subscriber_lists_on_government_document_supertype"

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@ Gets a stored subscriber list that's relevant to just the `cabinet-office` organ
     "title": "Title of topic",
     "gov_delivery_id": "123",
     "document_type": "",
+    "content_id": "",
     "created_at": "20141010T12:00:00",
     "updated_at": "20141010T12:00:00",
     "tags": {
@@ -57,6 +58,8 @@ The following fields are accepted:
   changes that share the corresponding field;
 - government_document_supertype: A field that can be used to match with
   content changes that share the corresponding field.
+- content_id: A field that can be used to match with a single content item
+  for subscriptions to individual pages or pieces of guidance.
 
 [valid tags]: https://github.com/alphagov/email-alert-api/blob/b6428880aa730e316803d7129db3ec47304e933b/lib/valid_tags.rb
 
@@ -130,6 +133,7 @@ Gets a subscriber's subscriptions, in the form:
         "created_at": "Thu, 01 Aug 2013 12:53:34 UTC +00:00",
         "updated_at": "Tue, 13 Mar 2018 15:11:29 UTC +00:00",
         "document_type": "",
+        "content_id": "",
         "tags": {},
         "links": {
           "organisations": ["9adfc4ed-9f6c-4976-a6d8-18d34356367c"]

--- a/spec/features/single_content_item_notification_spec.rb
+++ b/spec/features/single_content_item_notification_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe "Creating subscriber lists for single content items", type: :request do
+  scenario "creating and querying subscriber lists" do
+    given_i_am_authenticated
+    i_can_create_a_subscriber_list_with_a_content_id_param
+    i_can_query_an_existing_subscriber_list_with_a_content_id_param
+    i_recieve_404_when_querying_a_content_id_that_has_no_subscriber_list
+  end
+
+  def i_can_query_an_existing_subscriber_list_with_a_content_id_param
+    response = lookup_subscriber_list_by_content_id("7c615f50-d48e-47a9-82be-6181559198ed")
+    content_id_is_in_returned_payload(response, "7c615f50-d48e-47a9-82be-6181559198ed")
+  end
+
+  def i_can_create_a_subscriber_list_with_a_content_id_param
+    response = create_subscriber_list({ content_id: "7c615f50-d48e-47a9-82be-6181559198ed" })
+    content_id_is_in_returned_payload(response, "7c615f50-d48e-47a9-82be-6181559198ed")
+  end
+
+  def i_recieve_404_when_querying_a_content_id_that_has_no_subscriber_list
+    lookup_subscriber_list_by_content_id("4610043b-2787-4933-bcc1-7e2e02685ab6", expected_status: 404)
+  end
+
+  def content_id_is_in_returned_payload(response, content_id)
+    expect(response).to include(content_id: content_id)
+  end
+
+  def given_i_am_authenticated
+    login_with(%w[internal_app status_updates])
+  end
+
+  def parameters_with_content_id
+    { title: "Example", content_id: "7c615f50-d48e-47a9-82be-6181559198ed", tags: {}, links: {} }
+  end
+
+  def lookup_subscriber_list_by_content_id(content_id, expected_status: 200)
+    get "/subscriber-lists?content_id=#{content_id}"
+    expect(response.status).to eq(expected_status)
+    data[:subscriber_list]
+  end
+end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
+    context "with content_id" do
+      it "returns the content subscriber list by content_id" do
+        create_subscriber_list(
+          { "content_id": "7c615f50-d48e-47a9-82be-6181559198ed" },
+        )
+        expect(response.status).to eq(200)
+
+        expect(SubscriberList.count).to eq(1)
+
+        expect(response_subscriber_list).to include(
+          "content_id" => "7c615f50-d48e-47a9-82be-6181559198ed",
+        )
+      end
+    end
+
     context "an existing subscriber list" do
       it "returns the existing list" do
         2.times.each { create_subscriber_list }

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe FindExactQuery do
       expect(query.exact_match).to eq(subscriber_list)
     end
 
+    it "matched when subscriber list has the same tags and matching content_id" do
+      query = build_query(links: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      subscriber_list = create_subscriber_list(links: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      expect(query.exact_match).to eq(subscriber_list)
+    end
+
     it "not matched when subscriber list has different links" do
       query = build_query(links: { policies: { any: %w[aa-11] } })
       _subscriber_list = create_subscriber_list(links: { policies: { any: %w[11-aa] } })
@@ -128,6 +134,12 @@ RSpec.describe FindExactQuery do
     it "not matched on document type - even if they match" do
       query = build_query(links: { policies: { any: %w[aa-11] } }, document_type: "travel_advice")
       _subscriber_list = create_subscriber_list(document_type: "travel_advice")
+      expect(query.exact_match).to be_nil
+    end
+
+    it "not matched on content_id - even if they match" do
+      query = build_query(links: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      _subscriber_list = create_subscriber_list(content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       expect(query.exact_match).to be_nil
     end
   end
@@ -241,6 +253,12 @@ RSpec.describe FindExactQuery do
       expect(query.exact_match).to eq(subscriber_list)
     end
 
+    it "matched when subscriber list has the same tags and matching content_id" do
+      query = build_query(tags: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      subscriber_list = create_subscriber_list(tags: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      expect(query.exact_match).to eq(subscriber_list)
+    end
+
     it "not matched when subscriber list has different tags" do
       query = build_query(tags: { policies: { any: %w[beer] } })
       _subscriber_list = create_subscriber_list(tags: { policies: { any: %w[cider] } })
@@ -256,6 +274,12 @@ RSpec.describe FindExactQuery do
     it "not matched on document type - even if they match" do
       query = build_query(tags: { policies: { any: %w[beer] } }, document_type: "travel_advice")
       _subscriber_list = create_subscriber_list(document_type: "travel_advice")
+      expect(query.exact_match).to be_nil
+    end
+
+    it "not matched on content_id - even if they match" do
+      query = build_query(tags: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      _subscriber_list = create_subscriber_list(content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       expect(query.exact_match).to be_nil
     end
   end
@@ -290,8 +314,27 @@ RSpec.describe FindExactQuery do
     expect(query.exact_match).to be_nil
   end
 
+  it "matched on content_id only" do
+    query = build_query(content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+    subscriber_list = create_subscriber_list(content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+    expect(query.exact_match).to eq(subscriber_list)
+  end
+
+  it "not matched on different content_id" do
+    query = build_query(content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+    _subscriber_list = create_subscriber_list(content_id: "ef8a3fd2-2b15-4c0e-a2d4-2a34187f337a")
+    expect(query.exact_match).to be_nil
+  end
+
+  it "matched on blank content_id" do
+    query = build_query(content_id: "")
+    subscriber_list = create_subscriber_list(content_id: nil)
+    expect(query.exact_match).to eq(subscriber_list)
+  end
+
   def build_query(params = {})
     defaults = {
+      content_id: nil,
       tags: {},
       links: {},
       document_type: "",
@@ -304,6 +347,7 @@ RSpec.describe FindExactQuery do
 
   def create_subscriber_list(params = {})
     defaults = {
+      content_id: nil,
       tags: {},
       links: {},
       document_type: "",

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe SubscriberListQuery do
   subject do
     described_class.new(
+      content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
       tags: { policies: %w[eggs] },
       links: { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] },
       document_type: "travel_advice",
@@ -10,6 +11,9 @@ RSpec.describe SubscriberListQuery do
   end
 
   shared_examples "#links matching" do |tags_or_links|
+    it { is_included_in_links tags_or_links, content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
+    it { is_excluded_from_links tags_or_links, content_id: "00000000-0000-0000-0000-000000000000" }
+    it { is_included_in_links tags_or_links, content_id: "" }
     it { is_included_in_links tags_or_links, document_type: "travel_advice" }
     it { is_excluded_from_links tags_or_links, document_type: "other" }
     it { is_included_in_links tags_or_links, email_document_supertype: "publications" }
@@ -20,6 +24,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_included_in_links(
         tags_or_links,
+        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
         email_document_supertype: "publications",
         government_document_supertype: "news_stories",
@@ -29,6 +34,27 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
+        content_id: "00000000-0000-0000-0000-000000000000",
+        document_type: "travel_advice",
+        email_document_supertype: "publications",
+        government_document_supertype: "news_stories",
+      )
+    end
+
+    it do
+      is_included_in_links(
+        tags_or_links,
+        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
+        document_type: "travel_advice",
+        email_document_supertype: "publications",
+        government_document_supertype: "news_stories",
+      )
+    end
+
+    it do
+      is_excluded_from_links(
+        tags_or_links,
+        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "other",
         email_document_supertype: "publications",
         government_document_supertype: "news_stories",
@@ -38,6 +64,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
+        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
         email_document_supertype: "other",
         government_document_supertype: "news_stories",
@@ -47,6 +74,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
+        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
         email_document_supertype: "publications",
         government_document_supertype: "other",
@@ -148,6 +176,7 @@ RSpec.describe SubscriberListQuery do
 
   def defaults
     {
+      content_id: nil,
       links: {},
       tags: {},
       document_type: "",


### PR DESCRIPTION
[Trello](https://trello.com/c/3oXvMEPj/875-backend-work-to-allow-signing-up-to-notifications-for-a-single-content-item)

We are experimenting with allowing users to montior single pages for changes.
This will require a new kind of subscription list which can be created, queried and trigger content change notifications based on `content_id`

That's what this PR adds.