### PR TITLE
When logging in with a GOV.UK account, find or create the subscriber

### DIFF
--- a/app/controllers/subscribers_govuk_account_controller.rb
+++ b/app/controllers/subscribers_govuk_account_controller.rb
@@ -13,10 +13,9 @@ class SubscribersGovukAccountController < ApplicationController
     api_response = { govuk_account_session: account_response["govuk_account_session"] }.compact
 
     render status: :forbidden, json: api_response and return unless email_verified
-    render status: :not_found, json: api_response and return unless email
+    render status: :forbidden, json: api_response and return unless email
 
-    subscriber = Subscriber.find_by_address(email)
-    render status: :not_found, json: api_response and return unless subscriber
+    subscriber = Subscriber.resilient_find_or_create(email, signon_user_uid: current_user.uid)
 
     render json: api_response.merge(subscriber: subscriber)
   rescue GdsApi::HTTPUnauthorized

--- a/docs/api.md
+++ b/docs/api.md
@@ -239,9 +239,7 @@ Returns a 401 if the account session identifier is invalid.
 
 Returns a 403 if the account's email address is not verified.
 
-Returns a 404 if there is no matching subscriber.
-
-The 403, 404, and 200 responses may optionally have a
+The 403 and 200 responses may optionally have a
 `govuk_account_session` response field, which should replace the value
 in the user's session.
 

--- a/spec/integration/subscribers_govuk_account_spec.rb
+++ b/spec/integration/subscribers_govuk_account_spec.rb
@@ -35,9 +35,10 @@ RSpec.describe "Subscribers GOV.UK account", type: :request do
     context "when the subscriber does not exist" do
       let(:subscriber_email) { "different@example.com" }
 
-      it "returns a 404" do
+      it "creates the subscriber" do
         post path, params: params
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(200)
+        expect(data[:subscriber][:id]).not_to eq(subscriber.id)
       end
     end
 
@@ -53,9 +54,9 @@ RSpec.describe "Subscribers GOV.UK account", type: :request do
     context "when the email attribute is missing" do
       let(:email) { nil }
 
-      it "returns a 404" do
+      it "returns a 403" do
         post path, params: params
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
     end
 


### PR DESCRIPTION
We've decided that the states "no subscriber exists" and "a subscriber
with no subscriptions exists" should be the same.

To remove the 404 status, I've changed the no-email case to return a
403.  This case will only happen if the account-api doesn't have that
attribute, which could only be the case for a brief period after the
user registers, in which case they won't be verified either.

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)