### PR TITLE
Link subscribers to a GOV.UK Account & add endpoints to manage them

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     post "/subscriptions/auth-token", to: "subscriptions_auth_token#auth_token"
 
     post "/subscribers/govuk-account", to: "subscribers_govuk_account#authenticate"
+    post "/subscribers/govuk-account/link", to: "subscribers_govuk_account#link_subscriber_to_account"
 
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     post "/subscribers/auth-token", to: "subscribers_auth_token#auth_token"
     post "/subscriptions/auth-token", to: "subscriptions_auth_token#auth_token"
 
+    get  "/subscribers/govuk-account/:govuk_account_id", to: "subscribers_govuk_account#show"
     post "/subscribers/govuk-account", to: "subscribers_govuk_account#authenticate"
     post "/subscribers/govuk-account/link", to: "subscribers_govuk_account#link_subscriber_to_account"
 

--- a/db/migrate/20210629083707_add_govuk_account_id_to_subscribers.rb
+++ b/db/migrate/20210629083707_add_govuk_account_id_to_subscribers.rb
@@ -1,0 +1,6 @@
+class AddGovukAccountIdToSubscribers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subscribers, :govuk_account_id, :string
+    add_index :subscribers, :govuk_account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_08_161920) do
+ActiveRecord::Schema.define(version: 2021_06_29_083707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,7 +142,9 @@ ActiveRecord::Schema.define(version: 2021_06_08_161920) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "signon_user_uid"
+    t.string "govuk_account_id"
     t.index "lower((address)::text)", name: "index_subscribers_on_lower_address", unique: true
+    t.index ["govuk_account_id"], name: "index_subscribers_on_govuk_account_id"
   end
 
   create_table "subscription_contents", force: :cascade do |t|

--- a/docs/api.md
+++ b/docs/api.md
@@ -276,6 +276,26 @@ The 403 and 200 responses may optionally have a
 `govuk_account_session` response field, which should replace the value
 in the user's session.
 
+### `GET /subscribers/govuk-account/:id`
+
+Looks for a subscriber with a matching GOV.UK Account ID (as
+previously set by `POST /subscribers/govuk-account/link`) and, if
+there is one, returns it in the form:
+
+```json
+{
+  "subscriber": {
+    "id": 1,
+    "govuk_account_id": "user-id",
+    "address": "test@example.com",
+    "created_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+    "updated_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+  }
+}
+```
+
+Returns a 404 if there is no matching subscriber.
+
 ## Healthcheck
 
 A queue health check endpoint is available at `/healthcheck`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -243,6 +243,39 @@ The 403 and 200 responses may optionally have a
 `govuk_account_session` response field, which should replace the value
 in the user's session.
 
+### `POST /subscribers/govuk-account/link`
+
+```json
+{
+  "govuk_account_session": "session-token-from-account-header"
+}
+```
+
+Looks up a GOV.UK Account and finds or creates a subscriber (in the
+same way as `POST /subscribers/govuk-account`), and stores the GOV.UK
+Account ID against the subscriber record.  Returns the subscriber in
+the form:
+
+```json
+{
+  "subscriber": {
+    "id": 1,
+    "govuk_account_id": "user-id",
+    "address": "test@example.com",
+    "created_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+    "updated_at": "Wed, 07 Mar 2018 17:04:28 UTC +00:00",
+  }
+}
+```
+
+Returns a 401 if the account session identifier is invalid.
+
+Returns a 403 if the account's email address is not verified.
+
+The 403 and 200 responses may optionally have a
+`govuk_account_session` response field, which should replace the value
+in the user's session.
+
 ## Healthcheck
 
 A queue health check endpoint is available at `/healthcheck`.

--- a/spec/integration/subscribers_govuk_account_spec.rb
+++ b/spec/integration/subscribers_govuk_account_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe "Subscribers GOV.UK account", type: :request do
       expect(data[:subscriber][:id]).to eq(subscriber.id)
     end
 
+    context "when the subscriber is linked to a GOV.UK Account" do
+      let(:subscriber) { create(:subscriber, address: subscriber_email, govuk_account_id: "govuk-account-id") }
+
+      it "returns the GOV.UK Account ID" do
+        post path, params: params
+        expect(response.status).to eq(200)
+        expect(data[:subscriber][:id]).to eq(subscriber.id)
+        expect(data[:subscriber][:govuk_account_id]).to eq(subscriber.govuk_account_id)
+      end
+    end
+
     context "when the subscriber does not exist" do
       let(:subscriber_email) { "different@example.com" }
 

--- a/spec/integration/subscribers_govuk_account_spec.rb
+++ b/spec/integration/subscribers_govuk_account_spec.rb
@@ -72,6 +72,26 @@ RSpec.describe "Subscribers GOV.UK account", type: :request do
     end
   end
 
+  describe "fetching a user by GOV.UK Account ID" do
+    let(:path) { "/subscribers/govuk-account/#{govuk_account_id}" }
+
+    it "returns a 404" do
+      get path
+      expect(response.status).to eq(404)
+    end
+
+    context "when the subscriber is linked to a GOV.UK Account" do
+      let(:subscriber) { create(:subscriber, address: subscriber_email, govuk_account_id: govuk_account_id) }
+
+      it "returns the subscriber" do
+        get path
+        expect(response.status).to eq(200)
+        expect(data[:subscriber][:id]).to eq(subscriber.id)
+        expect(data[:subscriber][:govuk_account_id]).to eq(subscriber.govuk_account_id)
+      end
+    end
+  end
+
   describe "authenticating a user" do
     let(:path) { "/subscribers/govuk-account" }
 

--- a/spec/integration/subscribers_govuk_account_spec.rb
+++ b/spec/integration/subscribers_govuk_account_spec.rb
@@ -3,56 +3,27 @@ require "gds_api/test_helpers/account_api"
 RSpec.describe "Subscribers GOV.UK account", type: :request do
   include GdsApi::TestHelpers::AccountApi
 
-  before { login_with_internal_app }
+  let(:params) { { govuk_account_session: govuk_account_session } }
+  let(:govuk_account_session) { "session identifier" }
 
-  describe "authenticating a user" do
-    let(:path) { "/subscribers/govuk-account" }
-    let(:params) { { govuk_account_session: govuk_account_session } }
-    let(:govuk_account_session) { "session identifier" }
+  let(:govuk_account_id) { "internal-user-id" }
+  let(:email) { "test@example.com" }
+  let(:email_verified) { true }
 
-    let(:email) { "test@example.com" }
-    let(:email_verified) { true }
+  let(:subscriber_email) { email }
+  let!(:subscriber) { create(:subscriber, address: subscriber_email) }
 
-    let(:subscriber_email) { email }
-    let!(:subscriber) { create(:subscriber, address: subscriber_email) }
+  before do
+    login_with_internal_app
 
-    before do
-      stub_account_api_has_attributes(
-        attributes: %i[email email_verified],
-        values: {
-          "email" => email,
-          "email_verified" => email_verified,
-        }.compact,
-      )
-    end
+    stub_account_api_user_info(
+      id: govuk_account_id,
+      email: email,
+      email_verified: email_verified,
+    )
+  end
 
-    it "returns the subscriber" do
-      post path, params: params
-      expect(response.status).to eq(200)
-      expect(data[:subscriber][:id]).to eq(subscriber.id)
-    end
-
-    context "when the subscriber is linked to a GOV.UK Account" do
-      let(:subscriber) { create(:subscriber, address: subscriber_email, govuk_account_id: "govuk-account-id") }
-
-      it "returns the GOV.UK Account ID" do
-        post path, params: params
-        expect(response.status).to eq(200)
-        expect(data[:subscriber][:id]).to eq(subscriber.id)
-        expect(data[:subscriber][:govuk_account_id]).to eq(subscriber.govuk_account_id)
-      end
-    end
-
-    context "when the subscriber does not exist" do
-      let(:subscriber_email) { "different@example.com" }
-
-      it "creates the subscriber" do
-        post path, params: params
-        expect(response.status).to eq(200)
-        expect(data[:subscriber][:id]).not_to eq(subscriber.id)
-      end
-    end
-
+  shared_examples "validates the user info response" do
     context "when the email address has not been verified" do
       let(:email_verified) { false }
 
@@ -82,7 +53,7 @@ RSpec.describe "Subscribers GOV.UK account", type: :request do
 
     context "when the session is invalid" do
       before do
-        stub_account_api_unauthorized_has_attributes(attributes: %i[email email_verified])
+        stub_account_api_unauthorized_user_info
       end
 
       it "returns a 401" do
@@ -97,6 +68,78 @@ RSpec.describe "Subscribers GOV.UK account", type: :request do
       it "returns a 422" do
         post path, params: params
         expect(response.status).to eq(422)
+      end
+    end
+  end
+
+  describe "authenticating a user" do
+    let(:path) { "/subscribers/govuk-account" }
+
+    include_examples "validates the user info response"
+
+    it "returns the subscriber" do
+      post path, params: params
+      expect(response.status).to eq(200)
+      expect(data[:subscriber][:id]).to eq(subscriber.id)
+    end
+
+    context "when the subscriber is linked to a GOV.UK Account" do
+      let(:subscriber) { create(:subscriber, address: subscriber_email, govuk_account_id: "govuk-account-id") }
+
+      it "returns the GOV.UK Account ID" do
+        post path, params: params
+        expect(response.status).to eq(200)
+        expect(data[:subscriber][:id]).to eq(subscriber.id)
+        expect(data[:subscriber][:govuk_account_id]).to eq(subscriber.govuk_account_id)
+      end
+    end
+
+    context "when the subscriber does not exist" do
+      let(:subscriber_email) { "different@example.com" }
+
+      it "creates the subscriber" do
+        post path, params: params
+        expect(response.status).to eq(200)
+        expect(data[:subscriber][:id]).not_to eq(subscriber.id)
+      end
+    end
+  end
+
+  describe "linking to an account" do
+    let(:path) { "/subscribers/govuk-account/link" }
+
+    include_examples "validates the user info response"
+
+    it "returns the subscriber" do
+      post path, params: params
+      expect(response.status).to eq(200)
+      expect(data[:subscriber][:id]).to eq(subscriber.id)
+    end
+
+    it "records the GOV.UK Account ID" do
+      post path, params: params
+      expect(response.status).to eq(200)
+      expect(data[:subscriber][:govuk_account_id]).to eq(govuk_account_id)
+    end
+
+    context "when the subscriber is linked to another GOV.UK Account" do
+      let(:subscriber) { create(:subscriber, address: subscriber_email, govuk_account_id: "govuk-account-id") }
+
+      it "replaces the old GOV.UK Account ID" do
+        post path, params: params
+        expect(response.status).to eq(200)
+        expect(data[:subscriber][:id]).to eq(subscriber.id)
+        expect(data[:subscriber][:govuk_account_id]).to eq(govuk_account_id)
+      end
+    end
+
+    context "when the subscriber does not exist" do
+      let(:subscriber_email) { "different@example.com" }
+
+      it "creates the subscriber" do
+        post path, params: params
+        expect(response.status).to eq(200)
+        expect(data[:subscriber][:id]).not_to eq(subscriber.id)
       end
     end
   end


### PR DESCRIPTION
This PR adds a `govuk_account_id` field to the `Subscriber` model, which gets returned from all the endpoints which return a `Subscriber`  (by virtue of not excluding it in `as_json`), and adds two endpoints to manage such users:

- `POST /subscribers/govuk-account/link` (with a `govuk_account_session`) looks up the GOV.UK Account and subscriber (in the same way as the auth endpoint), and then "links" them by saving the `govuk_account_id` against the `Subscriber` record.
- `GET /subscribers/govuk-account/:govuk_account_id` (without a `govuk_account_session`) looks up a subscriber by `govuk_account_id` and returns it if there is one.

The former endpoint will be called when we migrate a user over.  The latter endpoint will be used by account-api to know whether to update a user's email address:

1. User changes email address in Identity Provider
2. Identity Provider notifies Account API
3. Account API queries Email Alert API for the subscriber
4. If there is one, Account API calls Email Alert API to update the
address of the subscriber

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)