### PR TITLE
Forbid logging in with an auth token for GOV.UK Account users

### DIFF
--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -3,6 +3,8 @@ class SubscribersAuthTokenController < ApplicationController
 
   def auth_token
     subscriber = Subscriber.find_by_address!(expected_params[:address])
+    head :forbidden and return if subscriber.linked_to_govuk_account?
+
     token = generate_token(subscriber)
     email = build_email(subscriber, token)
 

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -39,6 +39,10 @@ class Subscriber < ApplicationRecord
     (retries += 1) == 1 ? retry : raise
   end
 
+  def linked_to_govuk_account?
+    !govuk_account_id.nil?
+  end
+
   def nullified?
     address.nil?
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -209,9 +209,10 @@ Unsubscribes a subscriber from the provided subscription and returns `204 No Con
 ```
 
 This will trigger an email to the address specified with a link to the
-destination with a query string of token and a [JWT](https://jwt.io/) token.
-Returns a 201 status code on success or 404 if the subscriber is not known
-to Email Alert API.
+destination with a query string of token and a [JWT](https://jwt.io/)
+token.  Returns a 201 status code on success; a 403 status code if the
+subscriber is linked to a GOV.UK Account; or a 404 status code if the
+subscriber is not known to Email Alert API.
 
 ### `POST /subscribers/govuk-account`
 

--- a/spec/integration/subscribers_auth_token_spec.rb
+++ b/spec/integration/subscribers_auth_token_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe "Subscribers auth token", type: :request do
       )
     end
 
+    context "when the user is linked to a GOV.UK Account" do
+      before { subscriber.update!(govuk_account_id: "42") }
+
+      it "returns a 403" do
+        post path, params: params
+        expect(response.status).to eq(403)
+      end
+    end
+
     context "when it's a user we didn't previously know" do
       before { subscriber.delete }
 


### PR DESCRIPTION
We've decided that, if you have linked your Subscriber record to your
GOV.UK Account, then the account should be the only way to
authenticate yourself to get into email-alert-frontend.

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)