### PR TITLE
Allow merging subscribers on address clash

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,6 +12,7 @@ class Subscription < ApplicationRecord
     imported: 2, # Historical (from govDelivery migration)
     subscriber_list_changed: 3,
     bulk_immediate_to_digest: 4, # Historical (for a one-off migration)
+    subscriber_merged: 5,
   }, _prefix: true
 
   enum ended_reason: {
@@ -22,6 +23,7 @@ class Subscription < ApplicationRecord
     marked_as_spam: 4,
     unpublished: 5, # Unused since 5eeda132 (can be removed after a year)
     bulk_immediate_to_digest: 6, # Potentially unused (for a one-off migration)
+    subscriber_merged: 7,
   }, _prefix: :ended
 
   scope :active, -> { where(ended_at: nil) }

--- a/app/services/merge_subscribers_service.rb
+++ b/app/services/merge_subscribers_service.rb
@@ -1,0 +1,56 @@
+class MergeSubscribersService
+  include Callable
+
+  def initialize(subscriber_to_keep:, subscriber_to_absorb:, current_user:)
+    @subscriber_to_keep = subscriber_to_keep
+    @subscriber_to_absorb = subscriber_to_absorb
+    @current_user = current_user
+  end
+
+  def call
+    return unless subscriber_to_absorb
+
+    merge_subscribers!
+    subscriber_to_absorb.update!(address: nil, updated_at: Time.zone.now)
+  end
+
+private
+
+  attr_reader :subscriber_to_keep, :subscriber_to_absorb, :current_user
+
+  def merge_subscribers!
+    active_subscriptions = subscriptions_by_list(subscriber_to_keep.active_subscriptions)
+
+    subscriber_to_absorb.active_subscriptions.each do |other|
+      keep_most_frequent(
+        active_subscriptions[other.subscriber_list_id],
+        other,
+      )
+    end
+  end
+
+  def subscriptions_by_list(subscriptions)
+    subscriptions.index_by(&:subscriber_list_id)
+  end
+
+  def keep_most_frequent(original, other)
+    if original
+      if original.frequency <= other.frequency
+        other.end(reason: :subscriber_merged)
+        return original
+      else
+        original.end(reason: :subscriber_merged)
+      end
+    end
+
+    other.end(reason: :subscriber_merged)
+    new_subscription = CreateSubscriptionService.call(
+      other.subscriber_list,
+      subscriber_to_keep,
+      other.frequency,
+      current_user,
+    )
+    new_subscription.update!(source: :subscriber_merged)
+    new_subscription
+  end
+end

--- a/spec/integration/subscribers_spec.rb
+++ b/spec/integration/subscribers_spec.rb
@@ -92,6 +92,21 @@ RSpec.describe "Subscriptions", type: :request do
           patch "/subscribers/#{subscriber.id}", params: { new_address: "new-test@example.com" }
           expect(response.status).to eq(422)
         end
+
+        context "when on_conflict=merge" do
+          it "changes the email address if the new email address is valid" do
+            patch "/subscribers/#{subscriber.id}", params: { new_address: "new-test@example.com", on_conflict: "merge" }
+            expect(response.status).to eq(200)
+            expect(data[:subscriber][:address]).to eq("new-test@example.com")
+          end
+
+          it "merges the subscribers if the new email address is not unique" do
+            clashing_subscriber = create :subscriber, address: "new-test@example.com"
+            patch "/subscribers/#{subscriber.id}", params: { new_address: "new-test@example.com", on_conflict: "merge" }
+            expect(response.status).to eq(200)
+            expect(clashing_subscriber.reload.address).to be_nil
+          end
+        end
       end
 
       context "without an existing subscriber" do

--- a/spec/services/merge_subscribers_service_spec.rb
+++ b/spec/services/merge_subscribers_service_spec.rb
@@ -1,0 +1,159 @@
+RSpec.describe MergeSubscribersService do
+  let(:user) { create :user }
+
+  describe ".call" do
+    let(:subscriber_to_keep) { create(:subscriber) }
+    let(:subscriber_to_absorb) { create(:subscriber) }
+
+    it "does not change the subscriptions for subscriber_to_keep" do
+      expect { merge_subscribers! }.to_not(change { kept_subscriptions })
+    end
+
+    it "nullifies subscriber_to_absorb" do
+      merge_subscribers!
+      expect(subscriber_to_absorb.reload.address).to be_nil
+    end
+
+    context "when subscriber_to_keep has active subscriptions" do
+      let!(:active_subscriptions_to_keep) do
+        create_list(:subscription, 5, subscriber: subscriber_to_keep)
+      end
+
+      it "does not change the subscriptions" do
+        expect { merge_subscribers! }.to_not(change { kept_subscriptions })
+      end
+
+      context "when subscriber_to_absorb has active subscriptions" do
+        let!(:active_subscriptions_to_absorb) do
+          create_list(:subscription, 5, subscriber: subscriber_to_absorb)
+        end
+
+        it "adds the active subscriptions to subscriber_to_keep" do
+          merge_subscribers!
+          expect(kept_subscriptions[:active]).to include(*active_subscriptions_to_keep.map { |sub| subscription_hash(sub) })
+          expect(kept_subscriptions[:active]).to include(*active_subscriptions_to_absorb.map { |sub| subscription_hash(sub).merge(subscriber_id: subscriber_to_keep.id) })
+        end
+
+        it "marks the absorbed active subscriptions as ended" do
+          merge_subscribers!
+          expect(subscriber_to_absorb.active_subscriptions.count).to be(0)
+        end
+
+        context "when both subscribers have a subscription for the same topic" do
+          let(:less_frequent_subscription) { active_subscriptions_to_keep[0] }
+
+          let!(:more_frequent_subscription) do
+            create(
+              :subscription,
+              subscriber: subscriber_to_absorb,
+              subscriber_list: less_frequent_subscription.subscriber_list,
+              frequency: Frequency::DAILY,
+            )
+          end
+
+          before { less_frequent_subscription.update!(frequency: Frequency::WEEKLY) }
+
+          it "keeps the most frequent" do
+            merge_subscribers!
+            expect(kept_subscriptions[:active]).to include(subscription_hash(more_frequent_subscription).merge(subscriber_id: subscriber_to_keep.id))
+          end
+        end
+      end
+
+      context "when subscriber_to_absorb has ended subscriptions" do
+        let!(:ended_subscriptions_to_absorb) do
+          create_list(:subscription, 5, :ended, subscriber: subscriber_to_absorb)
+        end
+
+        it "does not change the subscriptions" do
+          expect { merge_subscribers! }.not_to(change { kept_subscriptions })
+        end
+      end
+    end
+
+    context "when subscriber_to_keep has ended subscriptions" do
+      let!(:ended_subscriptions_to_keep) do
+        create_list(:subscription, 5, :ended, subscriber: subscriber_to_keep)
+      end
+
+      it "does not change the subscriptions" do
+        expect { merge_subscribers! }.to_not(change { kept_subscriptions })
+      end
+
+      context "when subscriber_to_absorb has active subscriptions" do
+        let!(:active_subscriptions_to_absorb) do
+          create_list(:subscription, 5, subscriber: subscriber_to_absorb)
+        end
+
+        it "adds the active subscriptions to subscriber_to_keep" do
+          merge_subscribers!
+          expect(kept_subscriptions[:active]).to contain_exactly(*active_subscriptions_to_absorb.map { |sub| subscription_hash(sub).merge(subscriber_id: subscriber_to_keep.id) })
+        end
+      end
+
+      context "when subscriber_to_absorb has ended subscriptions" do
+        let!(:ended_subscriptions_to_absorb) do
+          create_list(:subscription, 5, :ended, subscriber: subscriber_to_absorb)
+        end
+
+        it "does not change the subscriptions" do
+          expect { merge_subscribers! }.not_to(change { kept_subscriptions })
+        end
+      end
+    end
+
+    context "when subscriber_to_absorb has active subscriptions" do
+      let!(:active_subscriptions_to_absorb) do
+        create_list(:subscription, 5, subscriber: subscriber_to_absorb)
+      end
+
+      it "adds the active subscriptions to subscriber_to_keep" do
+        merge_subscribers!
+        expect(kept_subscriptions[:active]).to contain_exactly(*active_subscriptions_to_absorb.map { |sub| subscription_hash(sub).merge(subscriber_id: subscriber_to_keep.id) })
+      end
+    end
+
+    context "when subscriber_to_absorb has ended subscriptions" do
+      let!(:ended_subscriptions_to_absorb) do
+        create_list(:subscription, 5, :ended, subscriber: subscriber_to_absorb)
+      end
+
+      it "does not change the subscriptions" do
+        expect { merge_subscribers! }.not_to(change { kept_subscriptions })
+      end
+    end
+
+    context "when subscriber_to_absorb is not present" do
+      let(:subscriber_to_absorb) { nil }
+
+      it "gracefully terminates" do
+        merge_subscribers!
+      end
+    end
+
+    def subscription_hash(subscription)
+      subscription.reload
+      {
+        subscriber_id: subscription.subscriber_id,
+        subscriber_list_id: subscription.subscriber_list_id,
+        frequency: subscription.frequency,
+      }
+    end
+
+    def kept_subscriptions
+      subscriber_to_keep.reload
+      {
+        active: subscriber_to_keep.active_subscriptions.map { |sub| subscription_hash(sub) },
+        ended: subscriber_to_keep.ended_subscriptions.map { |sub| subscription_hash(sub) },
+      }
+    end
+
+    def merge_subscribers!
+      described_class.call(
+        subscriber_to_keep: subscriber_to_keep,
+        subscriber_to_absorb: subscriber_to_absorb,
+        current_user: user,
+      )
+    end
+  end
+end


### PR DESCRIPTION
As part of bringing notifications and accounts together, we need to be
able to automatically handle the case where a user:

1. Has notifications set up for `foo` and `bar`
2. Registers a GOV.UK account to manage their notifications for `foo`
3. Changes the email address of their account to `bar`

Currently, email-alert-api will reject this change: it doesn't let you
change to an email address that's already in use.

But for the change to become active, the user has proven to the
account that they own both `foo` (we're not letting them do any
notifications things without confirming their email address) *and*
`bar` (we won't update the address until it's been confirmed).

We've decided in this case to merge the two subscribers in
email-alert-api.  This is pretty straightforward, other than the case
where both subscribers have an active subscription to the same topic,
with different frequencies.  We've decided to keep the most frequent
if that happens.  The other is marked as ended with a new
`subscriber_merged` reason, so we can see how much this happens.

This new behaviour is only used if `on_conflict=merge` is passed along
as a parameter.  We'll make account-api do that, but
email-alert-frontend will retain the old behaviour.

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)