### PR TITLE
Standardise name of further docs section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 bundle exec rake
 ```
 
-### Manuals and decisions
+### Further documentation
 
 Check the [docs/](docs/) directory for detailed instructions, decisions and other documentation.
 


### PR DESCRIPTION
This matches all of our other repos and the dev docs template [1].

[1]: https://docs.publishing.service.gov.uk/manual/setting-up-new-rails-app.html#replace-the-default-readme-md