### PR TITLE
Bump gds-api-adapters to 72.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.3)
-    gds-api-adapters (71.9.0)
+    gds-api-adapters (72.0.0)
       addressable
       link_header
       null_logger


### PR DESCRIPTION
Want to make sure that Sentry continues to group issues as it should. As email alert API is already using the govuk_app_config pre-release, this will be the first test of that with the new fingerprinting tweak.

Trello: https://trello.com/c/8qzKKfNp/2588-release-new-major-version-for-govukappconfig-2