### PR TITLE
Specify `reason` param when calling Subscription.end

### DIFF
--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -71,7 +71,7 @@ namespace :support do
     else
       active_subscription = Subscription.active.find_by(subscriber_list: subscriber_list, subscriber: subscriber)
       if active_subscription
-        active_subscription.end(:unsubscribed)
+        active_subscription.end(reason: :unsubscribed)
         puts "Unsubscribing from #{email_address} from #{subscriber_list_slug}"
       else
         puts "Subscriber #{email_address} already unsubscribed from #{subscriber_list_slug}"


### PR DESCRIPTION
This PR changes the call to `Subscription.end` to specify the required param `reason`, which has been failing during recent runs of the `unsubscribe_single_subscription` task with the error `rake aborted! ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: reason)`.

Calling `Subscription.end` specifying `reasons` brings this usage [inline with others](https://github.com/alphagov/email-alert-api/search?q=.end%28reason).