### PR TITLE
Nullify govuk_account_id as well

### DIFF
--- a/app/workers/nullify_subscribers_worker.rb
+++ b/app/workers/nullify_subscribers_worker.rb
@@ -1,7 +1,7 @@
 class NullifySubscribersWorker < ApplicationWorker
   def perform
     run_with_advisory_lock(Subscriber, "nullify") do
-      nullifyable_subscribers.update_all(address: nil, updated_at: Time.zone.now)
+      nullifyable_subscribers.update_all(address: nil, govuk_account_id: nil, updated_at: Time.zone.now)
     end
   end
 


### PR DESCRIPTION
Subscribers get "nullified" if they don't have any active
subscriptions in the last 28 days.  We do this by setting the
`address` to `nil`.

But there are two problems which we have introduced by linking
Subscribers to GOV.UK accounts:

- If the user changes their email address, it'll be stored again -
un-nullifying the Subscriber.

- If the user signs in to email-alert-frontend, a Subscriber with
`address: nil` will be returned.

The former is potentially confusing as nullification is normally a
one-way process.

The latter is potentially confusing as we're interacting with a
Subscriber that has no address.

So, when nullifying a Subscriber, also get rid of their
`govuk_account_id`.