### PR TITLE
Permit subscribing to subscriberlists tagged `product_alert_type`

### DIFF
--- a/lib/valid_tags.rb
+++ b/lib/valid_tags.rb
@@ -53,6 +53,7 @@ class ValidTags
     outcome_type
     personal_data
     policies
+    product_alert_type
     public_sector_procurement
     railway_type
     regions


### PR DESCRIPTION
Inspired by #1664.

Trello: https://trello.com/c/ojsFViiX/2746-create-new-specialist-document-and-finder-product-safety-alerts-unsafe-products-and-recalls-3