### PR TITLE
Brexit checker retirement email

### DIFF
--- a/app/builders/bulk_subscriber_list_email_builder_with_account.rb
+++ b/app/builders/bulk_subscriber_list_email_builder_with_account.rb
@@ -1,0 +1,5 @@
+class BulkSubscriberListEmailBuilderWithAccount < BulkSubscriberListEmailBuilder
+  def filter_subscriptions(subscriptions)
+    subscriptions.select { |sub| Services.accounts_emails.include?(sub.subscriber.address) }
+  end
+end

--- a/config/bulk_email/email_addresses.txt
+++ b/config/bulk_email/email_addresses.txt
@@ -1,0 +1,1 @@
+test@example.com

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -2,4 +2,9 @@ module Services
   def self.rate_limiter
     @rate_limiter ||= Ratelimit.new("email-alert-api:deliveries")
   end
+
+  def self.accounts_emails
+    @accounts_emails ||=
+      File.readlines(Rails.root.join("config/bulk_email/email_addresses.txt"), chomp: true)
+  end
 end

--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -1,5 +1,5 @@
 namespace :bulk_email do
-  desc "Send a bulk email to many subscriber lists"
+  desc "Send a bulk email to many subscriber lists. Any email addresses in config/bulk_email/email_addresses.txt will be skipped."
   task :for_lists, [] => :environment do |_t, args|
     subscriber_lists = SubscriberList.where(id: args.extras)
     email_ids = BulkSubscriberListEmailBuilder.call(

--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -12,4 +12,18 @@ namespace :bulk_email do
     end
     puts "Sending #{email_ids.count} emails to subscribers on the following lists: #{subscriber_lists.pluck(:slug).join(', ')}"
   end
+
+  desc "Send a bulk email to many subscriber lists but only if the subscriber's email addresses are in config/bulk_email/email_addresses.txt."
+  task :for_lists_and_explicitly_including_addresses, [] => :environment do |_t, args|
+    subscriber_lists = SubscriberList.where(id: args.extras)
+    email_ids = BulkSubscriberListEmailBuilderWithAccount.call(
+      subject: ENV.fetch("SUBJECT"),
+      body: ENV.fetch("BODY"),
+      subscriber_lists: subscriber_lists,
+    )
+    email_ids.each do |id|
+      SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate)
+    end
+    puts "Sending #{email_ids.count} emails to subscribers on the following lists: #{subscriber_lists.pluck(:slug).join(', ')}"
+  end
 end

--- a/spec/builders/bulk_subscriber_list_email_builder_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_spec.rb
@@ -68,5 +68,20 @@ RSpec.describe BulkSubscriberListEmailBuilder do
         expect(Email.count).to eq(1)
       end
     end
+
+    context "with rejected subscribers in /config/accounts/email_addresses.txt" do
+      let(:excluded_subscriber) { create(:subscriber, address: "test@example.com") }
+      let(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.first) }
+
+      before do
+        create(:subscription, subscriber: excluded_subscriber, subscriber_list: subscriber_lists.first)
+      end
+
+      it "should only create emails for subscribers not in the file" do
+        expect(email).to be_present
+        expect(Email.count).to eq(1)
+        expect(Email.first.address).not_to eq("test@example.com")
+      end
+    end
   end
 end

--- a/spec/builders/bulk_subscriber_list_email_builder_with_account_spec.rb
+++ b/spec/builders/bulk_subscriber_list_email_builder_with_account_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe BulkSubscriberListEmailBuilderWithAccount do
+  describe ".call" do
+    let(:subscriber) { create(:subscriber, address: "test@example.com") }
+
+    let(:subscriber_lists) do
+      [create(:subscriber_list, title: "My List"), create(:subscriber_list)]
+    end
+
+    let(:email) do
+      email_ids = described_class.call(
+        subject: "email subject",
+        body: "email body",
+        subscriber_lists: subscriber_lists,
+      )
+
+      Email.find(email_ids).first
+    end
+
+    before do
+      allow(BulkEmailBodyPresenter).to receive(:call)
+        .with("email body", subscriber_lists.first)
+        .and_return("presented body")
+
+      allow(FooterPresenter).to receive(:call)
+        .with(subscriber, subscription)
+        .and_return("presented_footer")
+    end
+
+    context "with one subscription" do
+      let(:subscription) do
+        create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.first)
+      end
+
+      it "creates an email" do
+        expect(email.subject).to eq("email subject")
+
+        expect(email.body).to eq <<~BODY
+          presented body
+
+          ---
+
+          presented_footer
+        BODY
+      end
+    end
+
+    context "with an ended subscription" do
+      let(:subscription) do
+        create(:subscription, :ended, subscriber_list: subscriber_lists.first)
+      end
+
+      it "creates no emails" do
+        expect(email).to be_nil
+      end
+    end
+
+    context "with many subscriptions" do
+      let(:subscription) do
+        create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.first, created_at: 1.hour.ago)
+      end
+
+      before do
+        create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.second, created_at: 2.days.ago)
+      end
+
+      it "should only create one email per subscriber" do
+        expect(email).to be_present
+        expect(Email.count).to eq(1)
+      end
+    end
+
+    context "with rejected subscribers in /config/accounts/email_addresses.txt" do
+      let(:excluded_subscriber) { create(:subscriber) }
+      let(:subscription) { create(:subscription, subscriber: subscriber, subscriber_list: subscriber_lists.first) }
+
+      before do
+        create(:subscription, subscriber: excluded_subscriber, subscriber_list: subscriber_lists.first)
+      end
+
+      it "should only create emails for subscribers not in the file" do
+        expect(email).to be_present
+        expect(Email.count).to eq(1)
+        expect(Email.first.address).to eq("test@example.com")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to be able to send separate emails to subscribers who have an account and those who don't, as the behaviour of the checker is different.

In the first commit we introduce the ability to filter out any emails that are in a particular file. We could do this by querying the account API, but that would be extremely slow.

In the second commit we create another task that is identical to the first one, but allows us to only send an email if the same email address file _includes_ their address. In this way, we will split the emails, and only send one email per address.

This will be reverted by the end of the month when the Brexit checker gets retired.