### PR TITLE
Update confirmation email content

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -28,7 +28,7 @@ private
     <<~BODY
       # You’ve subscribed to GOV.UK emails
 
-      #{I18n.t!("emails.confirmation.frequency.#{subscription.frequency}")}
+      #{frequency}
 
       #{title_and_optional_url}
 
@@ -68,5 +68,10 @@ private
       utm_source: subscriber_list.slug,
       utm_content: subscription.frequency,
     )
+  end
+
+  def frequency
+    subscription_type = subscriber_list.content_id.present? ? "page" : "topic"
+    I18n.t!("emails.confirmation.frequency.#{subscription_type}.#{subscription.frequency}")
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,9 +7,14 @@ en:
         immediately: You’ll get an email each time we add or update a page
     confirmation:
       frequency:
-        daily: "You’ll get one email a day from GOV.UK about:"
-        weekly: "You’ll get one email a week from GOV.UK about:"
-        immediately: "You’ll get an email from GOV.UK each time we add or update a page about:"
+        topic:
+          daily: "You’ll get one email a day from GOV.UK about:"
+          weekly: "You’ll get one email a week from GOV.UK about:"
+          immediately: "You’ll get an email from GOV.UK each time we add or update a page about:"
+        page:
+          daily: "You’ll get one email a day from GOV.UK about:"
+          weekly: "You’ll get one email a week from GOV.UK about:"
+          immediately: "You’ll get an email from GOV.UK each time there’s an update to:"
     digests:
       daily:
         subject: "Daily update from GOV.UK for: %{title}"

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
           <<~BODY,
             # You’ve subscribed to GOV.UK emails
 
-            #{I18n.t!('emails.confirmation.frequency.immediately')}
+            #{I18n.t!('emails.confirmation.frequency.topic.immediately')}
 
             My List
 
@@ -44,6 +44,15 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
           BODY
         )
       end
+
+      context "when the subscription is to a single page" do
+        let(:subscriber_list) { build(:subscriber_list, :with_content_id) }
+        let(:subscription) { build(:subscription, subscriber_list: subscriber_list, frequency: "immediately") }
+
+        it "includes the content for a single page email" do
+          expect(email.body).to include(I18n.t!("emails.confirmation.frequency.page.immediately"))
+        end
+      end
     end
 
     %w[daily weekly].each do |frequency|
@@ -52,7 +61,7 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
 
         it "creates an email" do
           expect(email.body).to include(
-            I18n.t!("emails.confirmation.frequency.#{frequency}"),
+            I18n.t!("emails.confirmation.frequency.topic.#{frequency}"),
           )
         end
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,6 +111,10 @@ FactoryBot.define do
       tags { { format: %w[medical_safety_alert], alert_type: %w[devices drugs field-safety-notices company-led-drugs] } }
     end
 
+    trait :with_content_id do
+      content_id { SecureRandom.uuid }
+    end
+
     factory :subscriber_list_with_invalid_tags do
       tags do
         {


### PR DESCRIPTION
For single page notifications. The text for the `immediate` frequency
didn't make sense for single page subscriptions because there will never
be a case where a page is added to a single page subscription.

[Trello](https://trello.com/c/ZZ3TEybY/1163-update-content-for-frequency-of-single-page-subscription-emails)