### PR TITLE
Add link to confirmation email for single page subscriptions

### DIFF
--- a/app/builders/subscription_confirmation_email_builder.rb
+++ b/app/builders/subscription_confirmation_email_builder.rb
@@ -42,7 +42,7 @@ private
   end
 
   def title_and_optional_url
-    result = subscriber_list.title
+    result = title
 
     source_url = SourceUrlPresenter.call(
       subscriber_list.url,
@@ -52,6 +52,10 @@ private
 
     result += "\n\n#{source_url}" if source_url
     result
+  end
+
+  def title
+    is_single_page_subscription? ? "[#{subscriber_list.title}](#{subscriber_list.url})" : subscriber_list.title
   end
 
   def unsubscribe_url
@@ -70,8 +74,12 @@ private
     )
   end
 
+  def is_single_page_subscription?
+    subscriber_list.content_id.present?
+  end
+
   def frequency
-    subscription_type = subscriber_list.content_id.present? ? "page" : "topic"
+    subscription_type = is_single_page_subscription? ? "page" : "topic"
     I18n.t!("emails.confirmation.frequency.#{subscription_type}.#{subscription.frequency}")
   end
 end

--- a/spec/builders/subscription_confirmation_email_builder_spec.rb
+++ b/spec/builders/subscription_confirmation_email_builder_spec.rb
@@ -46,11 +46,15 @@ RSpec.describe SubscriptionConfirmationEmailBuilder do
       end
 
       context "when the subscription is to a single page" do
-        let(:subscriber_list) { build(:subscriber_list, :with_content_id) }
+        let(:subscriber_list) { build(:subscriber_list, :for_single_page_subscription) }
         let(:subscription) { build(:subscription, subscriber_list: subscriber_list, frequency: "immediately") }
 
         it "includes the content for a single page email" do
           expect(email.body).to include(I18n.t!("emails.confirmation.frequency.page.immediately"))
+        end
+
+        it "makes the page title a link to the page" do
+          expect(email.body).to include("[#{subscriber_list.title}](#{subscriber_list.url})")
         end
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,8 +111,9 @@ FactoryBot.define do
       tags { { format: %w[medical_safety_alert], alert_type: %w[devices drugs field-safety-notices company-led-drugs] } }
     end
 
-    trait :with_content_id do
+    trait :for_single_page_subscription do
       content_id { SecureRandom.uuid }
+      url { "https://www.gov.uk/an/example/page" }
     end
 
     factory :subscriber_list_with_invalid_tags do


### PR DESCRIPTION
So that it's easy for users to get back to the page. Also rename the
factory trait added in #1679 - we are interested in the subscriber_list
being for a single page, not only that it has a content_id (which is a
side effect of being for a single page).

[Trello](https://trello.com/c/ZZ3TEybY/1163-update-content-for-frequency-of-single-page-subscription-emails)