### PR TITLE
Add task unsubscribing all from Brexit checker

### DIFF
--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -91,6 +91,16 @@ namespace :support do
     end
   end
 
+  desc "Unsubscribe all Brexit checker subscriptions"
+  task unsubscribe_all_brexit_checker_subscriptions: :environment do
+    unsubscribe_time = Time.zone.now
+
+    brexit_subscriptions = Subscription.joins(:subscriber_list).where("ended_at IS NULL").where("subscriber_lists.tags ->> 'brexit_checklist_criteria' IS NOT NULL")
+
+    puts "Unsubscribing #{brexit_subscriptions.count} subscriptions"
+    brexit_subscriptions.update_all(ended_reason: :unsubscribed, ended_at: unsubscribe_time)
+  end
+
   desc "Query the Notify API for email(s) by email ID"
   task :get_notifications_from_notify_by_email_id, [:id] => :environment do |_t, args|
     NotificationsFromNotify.call(args[:id])

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,6 +111,10 @@ FactoryBot.define do
       tags { { format: %w[medical_safety_alert], alert_type: %w[devices drugs field-safety-notices company-led-drugs] } }
     end
 
+    trait :brexit_checker do
+      tags { { brexit_checklist_criteria: { any: %w[old other] } } }
+    end
+
     trait :with_content_id do
       content_id { SecureRandom.uuid }
     end
@@ -138,6 +142,10 @@ FactoryBot.define do
     subscriber
     subscriber_list
     frequency { Frequency::IMMEDIATELY }
+
+    trait :brexit_checker do
+      subscriber_list { build(:subscriber_list, :brexit_checker) }
+    end
 
     trait :immediately
 


### PR DESCRIPTION
The Brexit checker has been retired and will not be sending out any further updates. Because of these, we're closing all the subscriptions.

Once we're totally happy, then we'll delete them altogether, but we're not quite there yet.

This task is intended to be short-lived!