### PR TITLE
Revert "Add task unsubscribing all from Brexit checker"

### DIFF
--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -91,16 +91,6 @@ namespace :support do
     end
   end
 
-  desc "Unsubscribe all Brexit checker subscriptions"
-  task unsubscribe_all_brexit_checker_subscriptions: :environment do
-    unsubscribe_time = Time.zone.now
-
-    brexit_subscriptions = Subscription.joins(:subscriber_list).where("ended_at IS NULL").where("subscriber_lists.tags ->> 'brexit_checklist_criteria' IS NOT NULL")
-
-    puts "Unsubscribing #{brexit_subscriptions.count} subscriptions"
-    brexit_subscriptions.update_all(ended_reason: :unsubscribed, ended_at: unsubscribe_time)
-  end
-
   desc "Query the Notify API for email(s) by email ID"
   task :get_notifications_from_notify_by_email_id, [:id] => :environment do |_t, args|
     NotificationsFromNotify.call(args[:id])

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,10 +111,6 @@ FactoryBot.define do
       tags { { format: %w[medical_safety_alert], alert_type: %w[devices drugs field-safety-notices company-led-drugs] } }
     end
 
-    trait :brexit_checker do
-      tags { { brexit_checklist_criteria: { any: %w[old other] } } }
-    end
-
     trait :with_content_id do
       content_id { SecureRandom.uuid }
     end
@@ -142,10 +138,6 @@ FactoryBot.define do
     subscriber
     subscriber_list
     frequency { Frequency::IMMEDIATELY }
-
-    trait :brexit_checker do
-      subscriber_list { build(:subscriber_list, :brexit_checker) }
-    end
 
     trait :immediately
 

--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -80,43 +80,4 @@ RSpec.describe "support" do
       end
     end
   end
-
-  describe "unsubscribe_all_brexit_checker_subscriptions" do
-    before do
-      Rake::Task["support:unsubscribe_all_brexit_checker_subscriptions"].reenable
-    end
-
-    it "ends all Brexit checker subscriptions" do
-      subscription = create :subscription, :brexit_checker
-
-      expect {
-        Rake::Task["support:unsubscribe_all_brexit_checker_subscriptions"].invoke
-      }.to output.to_stdout
-
-      expect(subscription.reload).to be_ended
-    end
-
-    it "does not update already unsubscribed subscriptions" do
-      ended_at = Time.zone.now - 1.week
-      subscription = create :subscription, :brexit_checker
-      subscription.update!(ended_at: ended_at)
-
-      expect {
-        Rake::Task["support:unsubscribe_all_brexit_checker_subscriptions"].invoke
-      }.to output("Unsubscribing 0 subscriptions\n").to_stdout
-
-      expect(subscription.ended_at).to be_within(1.second).of ended_at
-    end
-
-    it "only unsubscribes Brexit checker subscriptions" do
-      create :subscription, :brexit_checker
-      subscription = create :subscription
-
-      expect {
-        Rake::Task["support:unsubscribe_all_brexit_checker_subscriptions"].invoke
-      }.to output("Unsubscribing 1 subscriptions\n").to_stdout
-
-      expect(subscription.ended_at).to be_nil
-    end
-  end
 end


### PR DESCRIPTION
This has been run now, so we no longer need it.

Reverts alphagov/email-alert-api#1681