### PR TITLE
Destroy all Brexit checker subscriber lists

### DIFF
--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -133,4 +133,12 @@ namespace :support do
       end
     end
   end
+
+  desc "Destroy all Brexit checker subscriptions"
+  task destroy_all_brexit_checker_subscriptions: :environment do
+    brexit_subscriber_lists = SubscriberList.where("tags ->> 'brexit_checklist_criteria' IS NOT NULL")
+
+    puts "Destroying #{brexit_subscriber_lists.count} subscriber #{'list'.pluralize(brexit_subscriber_lists.count)}"
+    brexit_subscriber_lists.destroy_all
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,6 +111,10 @@ FactoryBot.define do
       tags { { format: %w[medical_safety_alert], alert_type: %w[devices drugs field-safety-notices company-led-drugs] } }
     end
 
+    trait :brexit_checker do
+      tags { { brexit_checklist_criteria: { any: %w[old other] } } }
+    end
+
     trait :for_single_page_subscription do
       content_id { SecureRandom.uuid }
       url { "/an/example/page" }
@@ -157,6 +161,10 @@ FactoryBot.define do
 
     trait :unpublished do
       ended_reason { "unpublished" }
+    end
+
+    trait :brexit_checker do
+      subscriber_list { build(:subscriber_list, :brexit_checker) }
     end
   end
 

--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -80,4 +80,32 @@ RSpec.describe "support" do
       end
     end
   end
+
+  describe "destroy_all_brexit_checker_subscriptions" do
+    before do
+      Rake::Task["support:destroy_all_brexit_checker_subscriptions"].reenable
+    end
+
+    it "destroys all Brexit checker subscriptions" do
+      subscription = create :subscription, :brexit_checker
+      subscriber_list = subscription.subscriber_list
+
+      expect {
+        Rake::Task["support:destroy_all_brexit_checker_subscriptions"].invoke
+      }.to change { SubscriberList.exists?(subscriber_list.id) }.to(false)
+
+      expect(Subscription.exists?(subscription.id)).to be false
+    end
+
+    it "only destroys Brexit checker subscriptions" do
+      create :subscription, :brexit_checker
+      subscription = create :subscription
+
+      expect {
+        Rake::Task["support:destroy_all_brexit_checker_subscriptions"].invoke
+      }.to output("Destroying 1 subscriber list\n").to_stdout
+
+      expect(Subscription.exists?(subscription.id)).to be true
+    end
+  end
 end


### PR DESCRIPTION
We [deactivated all the subscriptions last week](https://github.com/alphagov/email-alert-api/pull/1681).

This now allows us to delete the subscriber lists, subscriptions and subscription contents from the database. The subscriber lists in particular are the bulk of the content in that table.

We could do a couple of delete statements to achieve the same sort of thing more quickly but it's not important for this to be a fast script. (It'll run individual delete statements for each row.) What's more important is to avoid locking on the production database as this may cause disruption to other activities. The other benefit of using `destroy` is that it removes the related objects through `dependent: :destroy` annotations on the models without us having to worry about it.