### PR TITLE
(WIP) notify subscribers when subscription list content is unpublished

### DIFF
--- a/app/builders/unpublication_notification_builder.rb
+++ b/app/builders/unpublication_notification_builder.rb
@@ -1,0 +1,112 @@
+class UnpublicationNotificationBuilder
+  include Callable
+
+  BATCH_SIZE = 5000
+
+  def initialize(subscriber_list:, notification_template:)
+    @subscriber_list = subscriber_list
+    @notification_template = notification_template
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      batches.flat_map do |subscription_ids|
+        records = records_for_batch(subscription_ids)
+        records.empty? ? [] : Email.insert_all!(records).pluck("id")
+      end
+    end
+  end
+
+private
+
+  attr_reader :notification_template
+
+  def subject
+    "Update from GOV.UK for: #{page_title}"
+  end
+
+  def body
+    <<~BODY
+      #{title_and_optional_url}
+
+      ---
+
+      #{presented_results}
+
+      #{I18n.t("emails.unpublication_notification.footer_notice")}
+    BODY
+  end
+
+  def content_item
+    # TODO - content_id is not going to be enough, we're going to need more information.
+    # Specifically:
+    # - time_content_updated (2/3 cases)
+    # - page_summary
+    # - title
+    # - url
+    # - alternative_url
+    #
+    # Initially the plan was to pass the ID through here and then see if we could query the content
+    # store to pull the data up here. However I'm now wonder creating a new interdependcy at this point
+    # is the best way? Our other option would be to either emit the data we need as a part of the event
+    # from publishing_api and pass it along in the POST requets...
+    # Or perhaps email-alert-service could gather the information and post it along?
+    content_id = subscriber_list.content_id
+    # content_item = Services
+  end
+
+  def title_and_optional_url
+    result = title
+
+    # @TODO - check what this URL might be for each case
+    # In the content doc: https://docs.google.com/document/d/1xUxJ3GbGzZwUIvuY2b-D-mMCxGMDqCv5pD9ensoaMDc/edit#
+    # It seems we have based these off change notifications.
+    # However, here, what this URL / title is is less clear?
+    # Should it reflect what the page was called / the old URL? Or does it reflect
+    # the newly updated data?
+    # In either case, will there actually be a content item we can query or will it have been moved to the draft stack?
+    source_url = SourceUrlPresenter.call(
+      subscriber_list.url,
+      utm_source: subscriber_list.slug,
+      utm_content: "confirmation",
+    )
+
+    result += "\n\n#{source_url}" if source_url
+    result
+  end
+
+  def presented_results
+    changes = content.map do |item|
+      UnsubscriptionNotificationPresenter.call(content_item, notification_template)
+    end
+
+    changes.join("\n\n---\n\n").strip
+  end
+
+  def records_for_batch(subscription_ids)
+    subscriptions = Subscription
+      .includes(:subscriber, :subscriber_list)
+      .find(subscription_ids)
+
+      subscriptions.map do |subscription|
+      subscriber = subscription.subscriber
+
+      {
+        address: subscriber.address,
+        subject: subject,
+        body: body,
+        subscriber_id: subscriber.id,
+        created_at: now,
+        updated_at: now,
+      }
+    end
+  end
+
+  def batches
+    Subscription
+      .active
+      .where(subscriber_list: subscriber_list)
+      .dedup_by_subscriber
+      .each_slice(BATCH_SIZE)
+  end
+end

--- a/app/controllers/unpublication_notifications.rb
+++ b/app/controllers/unpublication_notifications.rb
@@ -1,0 +1,24 @@
+class UnpublicationNotifications < ApplicationController
+  ALLOWED_NOTIFICATION_TEMPLATE = ["default"]
+
+  def create
+    head :bad_request and return unless allowed_notification_template?(params[:notification_template])
+    head :not_found and return unless subscription_list
+
+    email = UnpublicationNotificationBuilder.call(notification_template: params[:notification_template])
+    SendEmailWorker.perform_async_in_queue(email.id, queue: :send_email_transactional)
+
+    # Send Unsubscription Notification
+    # Delete subscriber list
+  end
+
+private
+
+  def subscription_list
+    @subscription_list ||= SubscriberList.where(content_id: params[:content_id]))
+  end
+
+  def allowed_notification_template?(notification_template)
+    ALLOWED_NOTIFICATION_TEMPLATE.include?(notification_template)
+  end
+end

--- a/app/presenters/unpublication_notification_presenter.rb
+++ b/app/presenters/unpublication_notification_presenter.rb
@@ -1,0 +1,95 @@
+
+  class UnsubscriptionNotificationPresenter
+    include Callable
+
+    EMAIL_DATE_FORMAT = "%l:%M%P, %-d %B %Y".freeze
+
+    def initialize(content_item, notification_template)
+      @content_item = content_item
+      @alternative_url = content_item["alternative_url"]
+      @notification_template = notification_template
+    end
+
+    def call
+      [
+        page_summary,
+        change_made,
+        time_updated
+      ].compact.join("\n\n")
+    end
+
+  private
+
+  attr_reader :notification_template, :alternative_url
+
+    def page_summary
+      <<~PAGE_SUMMARY
+        Page summary:
+        #{page_summary_content}
+      PAGE_SUMMARY
+    end
+
+    def change_made
+      <<~CHANGE_MADE
+        Change made:
+        #{change_made_content}
+      CHANGE_MADE
+    end
+
+    def time_updated
+      if published_in_error?
+        <<~TIME_UPDATED
+          Time:
+          #{time_updated_content}
+        TIME_UPDATED
+      end
+    end
+
+    def published_in_error?
+      [
+        :publish_in_error_no_url,
+        :publish_in_error_alt_url,
+      ].include?(notification_template)
+    end
+
+    def provides_alternative_url?
+      [
+        :publish_in_error_alt_url,
+        :page_consolidated
+      ].include?(notification_template)
+    end
+
+    def change_made_content
+      I18n.t(
+        "emails.unpublication_notification.#{notification_template}.change_made",
+        alternative_url: alternative_url
+      )
+    end
+
+    def page_summary_content
+      # @TODO
+      # I'm not clear where this comes from.
+      # in the content_change_presenter.rb L64 sees it processed as markdown.
+      # However this comes from a content_change event. We're not processing those,
+      # Instead we'd hoped to get everything we wanted fromt he content item.
+      #
+      # Will need to work out if we can get a similar summary from the content_item
+      # Possibly by looking into where the change notification gets it from?
+      #
+      # If we passed it through on the content_item we could lose this method and
+      # do something in the initalizer like: @page_summary_content = content_item.page_summary_content
+    end
+
+    def time_updated_content
+      # @TODO, presumably off the content_item?
+      # Must confirm that the content item will always have an appropraite value in the two cases:
+      # - publish_in_error_no_url
+      # - publish_in_error_alt_url
+      # Note content_change_presenter#L42 here, might be useful:
+      # content_change.public_updated_at.strftime(EMAIL_DATE_FORMAT).strip
+      # have included EMAIL_DATE_FORMAT above
+      #
+      # If we passed it through on the content_item we could lose this method and
+      # do something in the initalizer like: @page_summary_content = content_item.page_summary_content
+    end
+  end

--- a/config/locales/unpublication_notification.yml
+++ b/config/locales/unpublication_notification.yml
@@ -1,0 +1,10 @@
+en:
+  emails:
+    unpublication_notification:
+      footer_notice: ^You’ve been automatically unsubscribed from this page because it was removed.
+      publish_in_error_no_url:
+        change_made: "This page was removed from GOV.UK because it was published in error."
+      publish_in_error_alt_url:
+        change_made: "This page was removed from GOV.UK because it was published in error. It's been replaced by: [%{alternative_url}]"
+      page_consolidated:
+        change_made: "This page was removed from GOV.UK. It’s been replaced by: %{alternative_url}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
 
     post "/unsubscribe/:id", to: "unsubscribe#unsubscribe"
 
+    post "/unpublication_notification", to: "unpublication_notifications#create"
+
     get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
     get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::SidekiqRedis,

--- a/docs/api.md
+++ b/docs/api.md
@@ -302,6 +302,32 @@ there is one, returns it in the form:
 
 Returns a 404 if there is no matching subscriber.
 
+### `POST /unpublication_notification`
+
+Looks up a subscription list by content ID. If there are subscribers
+notify them the item they were subscribed to has been unpublished and remove their subscription.
+
+Optionally pass a notification_template parameter to customise the
+notification to users, providing more information about the type
+of unpublication (for example publishing in error)
+
+```json
+{
+  "content_id": "4da7a6a7-c8f7-482e-aeb9-a26cea90780c",
+  "notification_template": "default"
+}
+```
+
+Allowed notification types are:
+- "default" - Generic unsubscription notification with no further details
+
+Returns a 202 if the request is accepted, and emails are queued.
+
+Returns a 400 if the notification_template does not match any
+known templates.
+
+Returns a 404 if the content_id cannot be matched to any subscription_list.
+
 ## Healthcheck
 
 A queue health check endpoint is available at `/healthcheck`.

--- a/spec/builders/unpublication_notification_email_builder_spec.rb
+++ b/spec/builders/unpublication_notification_email_builder_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe SubscriptionConfirmationEmailBuilder do
+  describe ".call" do
+    # @todo
+  end
+end

--- a/spec/integration/unpublication_notification_spec.rb
+++ b/spec/integration/unpublication_notification_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe "Unpublication Notification", type: :request do
+  let(:content_id) { SecureRandom.uuid }
+  let(:params) {
+    {
+      content_id: content_id,
+      notification_template: "default"
+    }
+  }
+  let(:unpublication_notification_path) { "/unpublication_notification" }
+
+  context "with authentication and authorisation" do
+    before { login_with_internal_app }
+
+    describe "POST" do
+      it "returns 202" do
+        post unpublication_notification_path, params: params
+        expect(response.status).to eq(202)
+      end
+
+      it "creates an email" do
+        expect { post unpublication_notification_path, params: params }.to change { Email.count }.by(1)
+      end
+
+      it "sends the email" do
+        expect(SendEmailWorker).to receive(:perform_async_in_queue)
+        post unpublication_notification_path, params: params
+      end
+
+      it "sends an email with the correct notification template" do
+        post unpublication_notification_path, params: params
+        expect(Email.count).to be 1
+
+        expect(Email.last.body).to eq("@TODO")
+      end
+
+      it "removes the subscription list" do
+        expect { post unpublication_notification_path, params: params }.to change { SubscriptionList.count }.by(-1)
+      end
+    end
+
+    context "when the notification template does not exist" do
+      it "returns 400" do
+        post unpublication_notification_path, params: params
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when the subscription list cannot be found" do
+      it "returns 404 if the subscription list does not exists" do
+        post unpublication_notification_path, params: params
+        expect(response.status).to eq(202)
+      end
+    end
+  end
+
+  context "without authentication" do
+    it "returns a 401" do
+      without_login do
+        post unpublication_notification_path, params: params
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  context "without authorisation" do
+    it "returns a 403" do
+      login_with_signin
+      post unpublication_notification_path, params: params
+      expect(response.status).to eq(403)
+    end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

WIP - notes and all so we remember what we were doing in the new year!

See also:
- https://github.com/alphagov/gds-api-adapters/pull/1124
- https://github.com/alphagov/email-alert-service/pull/481