### PR TITLE
Use text type for long varchar database fields

### DIFF
--- a/db/migrate/20220105173124_use_text_for_long_subscriber_lists_columns.rb
+++ b/db/migrate/20220105173124_use_text_for_long_subscriber_lists_columns.rb
@@ -1,0 +1,15 @@
+class UseTextForLongSubscriberListsColumns < ActiveRecord::Migration[6.1]
+  def up
+    change_table :subscriber_lists, bulk: true do |t|
+      t.change :title, :text
+      t.change :url, :text
+    end
+  end
+
+  def down
+    change_table :subscriber_lists, bulk: true do |t|
+      t.change :title, :string
+      t.change :url, :string
+    end
+  end
+end

--- a/db/migrate/20220105174025_use_text_for_long_emails_columns.rb
+++ b/db/migrate/20220105174025_use_text_for_long_emails_columns.rb
@@ -1,0 +1,9 @@
+class UseTextForLongEmailsColumns < ActiveRecord::Migration[6.1]
+  def up
+    change_column :emails, :subject, :text
+  end
+
+  def down
+    change_column :emails, :subject, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_29_083707) do
+ActiveRecord::Schema.define(version: 2022_01_05_174025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2021_06_29_083707) do
   end
 
   create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string "subject", null: false
+    t.text "subject", null: false
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -114,7 +114,7 @@ ActiveRecord::Schema.define(version: 2021_06_29_083707) do
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
-    t.string "title", null: false
+    t.text "title", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "document_type", default: "", null: false
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2021_06_29_083707) do
     t.string "government_document_supertype", default: "", null: false
     t.string "signon_user_uid"
     t.string "slug", null: false
-    t.string "url"
+    t.text "url"
     t.string "tags_digest"
     t.string "links_digest"
     t.uuid "content_id"


### PR DESCRIPTION
Trello: https://trello.com/c/GRGnnikf/63-plan-production-upgrade-for-email-alert-api-postgresql-database

This change has been made to resolve a problem experienced when using
this application with AWS Database Migration Service. We have that when
the schema has these has VARCHAR type the service will only migrate the
first 510 characters, whereas if they are TEXT there are no problems.

Aside from the above this change has very little impact on the
application, behind the scenes PostgreSQL represents VARCHAR and TEXT
very similarly [1]. Arguably TEXT is a more semantic choice for these long
values.

[1]: https://stackoverflow.com/questions/4848964/difference-between-text-and-varchar-character-varying