### PR TITLE
Add endpoint to unsubscribe all users from a list

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -24,6 +24,7 @@ class Subscription < ApplicationRecord
     unpublished: 5, # Unused since 5eeda132 (can be removed after a year)
     bulk_immediate_to_digest: 6, # Potentially unused (for a one-off migration)
     subscriber_merged: 7,
+    bulk_unsubscribed: 8,
   }, _prefix: :ended
 
   scope :active, -> { where(ended_at: nil) }

--- a/app/queries/subscriber_lists_by_criteria_query.rb
+++ b/app/queries/subscriber_lists_by_criteria_query.rb
@@ -19,6 +19,7 @@ private
   attr_reader :initial_scope, :criteria_rules
 
   def rule_condition(scope, rule)
+    return scope.where(id: rule[:id]) if rule[:id]
     return type_rule(scope, **rule) if rule[:type]
     return any_of_rule(scope, rule[:any_of]) if rule[:any_of]
     return all_of_rule(scope, rule[:all_of]) if rule[:all_of]

--- a/app/services/bulk_unsubscribe_list_service.rb
+++ b/app/services/bulk_unsubscribe_list_service.rb
@@ -1,0 +1,34 @@
+class BulkUnsubscribeListService
+  include Callable
+
+  attr_reader :subscriber_list, :params, :govuk_request_id, :user
+
+  def initialize(subscriber_list:, params:, govuk_request_id:, user: nil)
+    @subscriber_list = subscriber_list
+    @params = params
+    @govuk_request_id = govuk_request_id
+    @user = user
+  end
+
+  def call
+    message = Message.create!(message_params) if message_params
+    Metrics.message_created if message
+    BulkUnsubscribeListWorker.perform_async(
+      subscriber_list.id,
+      message&.id,
+    )
+  end
+
+  def message_params
+    return unless params[:body]
+
+    params
+      .slice(:body, :sender_message_id)
+      .merge(
+        title: subscriber_list.title,
+        criteria_rules: [{ id: subscriber_list.id }],
+        govuk_request_id: govuk_request_id,
+        signon_user_uid: user&.uid,
+      )
+  end
+end

--- a/app/validators/criteria_schema_validator.rb
+++ b/app/validators/criteria_schema_validator.rb
@@ -21,6 +21,14 @@ private
             {
               "type" => "object",
               "additionalProperties" => false,
+              "requires" => %w[id],
+              "properties" => {
+                "id" => { "type" => "integer" },
+              },
+            },
+            {
+              "type" => "object",
+              "additionalProperties" => false,
               "required" => %w[type key value],
               "properties" => {
                 "type" => { "enum" => %w[tag] },

--- a/app/workers/bulk_unsubscribe_list_worker.rb
+++ b/app/workers/bulk_unsubscribe_list_worker.rb
@@ -1,0 +1,14 @@
+class BulkUnsubscribeListWorker < ApplicationWorker
+  sidekiq_options queue: :process_and_generate_emails
+
+  def perform(subscriber_list_id, message_id)
+    run_with_advisory_lock(SubscriberList, subscriber_list_id) do
+      ProcessMessageWorker.new.perform(message_id) if message_id
+
+      Subscription.active.where(subscriber_list_id: subscriber_list_id).update_all(
+        ended_reason: :bulk_unsubscribed,
+        ended_at: Time.zone.now,
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
     get "/subscriber-lists", to: "subscriber_lists#index"
     get "/subscriber-lists/:slug", to: "subscriber_lists#show"
+    post "/subscriber-lists/:slug/bulk-unsubscribe", to: "subscriber_lists#bulk_unsubscribe"
 
     resources :content_changes, only: %i[create], path: "content-changes"
     resources :messages, only: %i[create]

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,8 @@ Gets a stored subscriber list that's relevant to just the `cabinet-office` organ
 }
 ```
 
+Returns a `404 Not Found` if there is no such list.
+
 ### `POST /subscriber-lists`
 
 ```json
@@ -62,6 +64,39 @@ The following fields are accepted:
   for subscriptions to individual pages or pieces of guidance.
 
 [valid tags]: https://github.com/alphagov/email-alert-api/blob/b6428880aa730e316803d7129db3ec47304e933b/lib/valid_tags.rb
+
+### `GET /subscriber-lists/xxx`
+
+Gets the stored subscriber list with the given ID.
+
+It will respond with the JSON response for the `GET` call above.
+
+Returns a `404 Not Found` if there is no such list.
+
+### `POST /subscriber-lists/xxx/bulk-unsubscribe`
+
+Unsubscribes all subscribers from that list, and optionally sends an email to them.
+
+```json
+{
+  "sender_message_id": "bfeee5a9-20c2-44ec-8162-f14dde721c21",
+  "body": "Message body here"
+}
+```
+
+The following fields are accepted on this endpoint:
+`sender_message_id`, `body`.
+
+It will respond with `202 Accepted` (the call is queued).  When it is
+processed, all users then-subscribed to the list will be sent an
+immediate email (if the `body` is given) and be unsubscribed.
+
+Returns a `422 Unprocessable Entity` if `body` is given but
+`sender_message_id` is not.
+
+Returns a `409 Conflict` if `sender_message_id` has already been used.
+
+Returns a `404 Not Found` if there is no such list.
 
 ### `POST /content-changes`
 

--- a/spec/integration/bulk_unsubscribe_spec.rb
+++ b/spec/integration/bulk_unsubscribe_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe "Destroying a subscriber list", type: :request do
+  let!(:subscriber_list) { create(:subscriber_list) }
+
+  context "with authentication and authorisation" do
+    before do
+      login_with_internal_app
+    end
+
+    it "requires a valid subscriber list" do
+      post "/subscriber-lists/not-the-real-slug/bulk-unsubscribe", headers: json_headers
+      expect(response.status).to eq(404)
+    end
+
+    it "returns a 202" do
+      post "/subscriber-lists/#{subscriber_list.slug}/bulk-unsubscribe", headers: json_headers
+      expect(response.status).to eq(202)
+    end
+
+    context "when message parameters are given" do
+      let(:sender_message_id) { Digest::UUID.uuid_v5(content_id, public_updated_at) }
+      let(:content_id) { SecureRandom.uuid }
+      let(:public_updated_at) { "2022-01-13" }
+      let(:message_params) { { body: "it's gone!", sender_message_id: sender_message_id } }
+
+      it "creates a message to send" do
+        expect { post "/subscriber-lists/#{subscriber_list.slug}/bulk-unsubscribe", params: message_params.to_json, headers: json_headers }.to change(Message, :count)
+
+        message = Message.order(:created_at).last
+        expect(message&.criteria_rules).to eq([{ id: subscriber_list.id }])
+        expect(message&.body).to eq(message_params[:body])
+      end
+
+      context "when there is a subscriber" do
+        before do
+          post "/subscriptions", params: { subscriber_list_id: subscriber_list.id, address: subscriber.address, frequency: "immediately" }.to_json, headers: json_headers
+        end
+
+        let!(:subscriber) { create(:subscriber) }
+
+        it "unsubscribes them" do
+          post "/subscriber-lists/#{subscriber_list.slug}/bulk-unsubscribe", headers: json_headers
+          expect(subscriber.active_subscriptions.count).to eq(0)
+        end
+      end
+
+      context "when no sender_message_id is given" do
+        let(:sender_message_id) { nil }
+
+        it "returns a 422" do
+          expect { post "/subscriber-lists/#{subscriber_list.slug}/bulk-unsubscribe", params: message_params.to_json, headers: json_headers }.not_to change(Message, :count)
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "when the unsubscribe has already been requested" do
+        before do
+          create(:message, sender_message_id: sender_message_id)
+        end
+
+        it "returns a 409" do
+          expect { post "/subscriber-lists/#{subscriber_list.slug}/bulk-unsubscribe", params: message_params.to_json, headers: json_headers }.not_to change(Message, :count)
+          expect(response.status).to eq(409)
+        end
+      end
+    end
+  end
+
+  context "without authentication" do
+    it "returns 401" do
+      without_login do
+        post "/subscriber-lists/#{subscriber_list.slug}/bulk-unsubscribe", headers: json_headers
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  context "without authorisation" do
+    it "returns 403" do
+      login_with_signin
+      post "/subscriber-lists/#{subscriber_list.slug}/bulk-unsubscribe", headers: json_headers
+
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/queries/subscriber_lists_by_criteria_query_spec.rb
+++ b/spec/queries/subscriber_lists_by_criteria_query_spec.rb
@@ -1,5 +1,19 @@
 RSpec.describe SubscriberListsByCriteriaQuery do
   describe ".call" do
+    it "can match an ID" do
+      list = create(:subscriber_list, tags: { format: { any: %w[match] } })
+      create(:subscriber_list, tags: { format: { any: %w[no-match] } })
+
+      result = described_class.call(
+        SubscriberList,
+        [
+          { id: list.id },
+        ],
+      )
+
+      expect(result).to contain_exactly(list)
+    end
+
     it "can match a tag" do
       list = create(:subscriber_list, tags: { format: { any: %w[match] } })
       create(:subscriber_list, tags: { format: { any: %w[no-match] } })

--- a/spec/services/bulk_unsubscribe_list_service_spec.rb
+++ b/spec/services/bulk_unsubscribe_list_service_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe BulkUnsubscribeListService do
+  describe ".call" do
+    let(:params) { {} }
+
+    let(:subscriber_list) { create(:subscriber_list) }
+
+    let(:govuk_request_id) { SecureRandom.uuid }
+
+    it "queues a job" do
+      expect(BulkUnsubscribeListWorker).to receive(:perform_async)
+
+      described_class.call(subscriber_list: subscriber_list, params: params, govuk_request_id: govuk_request_id)
+    end
+
+    it "does not create a Message" do
+      expect { described_class.call(subscriber_list: subscriber_list, params: params, govuk_request_id: govuk_request_id) }.not_to change(Message, :count)
+    end
+
+    context "when a body is given" do
+      let(:params) do
+        {
+          body: "Message body",
+        }
+      end
+
+      it "creates a Message" do
+        expect { described_class.call(subscriber_list: subscriber_list, params: params, govuk_request_id: govuk_request_id) }.to change(Message, :count).by(1)
+
+        expect(Message.last).to have_attributes(
+          title: subscriber_list.title,
+          body: "Message body",
+          criteria_rules: [{ id: subscriber_list.id }],
+        )
+      end
+
+      context "when a user is given" do
+        let(:user) { create(:user) }
+
+        it "stores the user" do
+          described_class.call(subscriber_list: subscriber_list, params: params, govuk_request_id: govuk_request_id, user: user)
+
+          expect(Message.last.signon_user_uid).to eq(user.uid)
+        end
+      end
+    end
+  end
+end

--- a/spec/workers/bulk_unsubscribe_list_worker_spec.rb
+++ b/spec/workers/bulk_unsubscribe_list_worker_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe BulkUnsubscribeListWorker do
+  let(:message) { nil }
+
+  let!(:subscriber_list) { create(:subscriber_list) }
+
+  let!(:subscriber) do
+    create(:subscriber).tap do |subscriber|
+      create(:subscription, subscriber: subscriber, subscriber_list: subscriber_list)
+    end
+  end
+
+  let!(:other_subscriber) do
+    create(:subscriber).tap do |subscriber|
+      other_list = create(:subscriber_list)
+      create(:subscription, subscriber: subscriber, subscriber_list: other_list)
+    end
+  end
+
+  describe "#perform" do
+    it "unsubscribes members of the subscriber list" do
+      expect { described_class.new.perform(subscriber_list.id, message&.id) }.to(change { subscriber.ended_subscriptions.count })
+    end
+
+    it "does not unsubscribe users from other subscriber lists" do
+      expect { described_class.new.perform(subscriber_list.id, message&.id) }.not_to(change { other_subscriber.ended_subscriptions.count })
+    end
+
+    context "when a message is given" do
+      let(:message) do
+        create(
+          :message,
+          criteria_rules: [{ id: subscriber_list.id }],
+        )
+      end
+
+      it "delegates to ProcessMessageWorker" do
+        doub = instance_double(ProcessMessageWorker)
+        expect(doub).to receive(:perform).with(message.id)
+
+        expect(ProcessMessageWorker).to receive(:new).and_return(doub)
+
+        described_class.new.perform(subscriber_list.id, message.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're going to use this with the single-page notifications feature to
alert a user when a page is removed or redirected, and remove their
now-dead current subscription.

I went back and forth on the naming for this a bit.  I originally used
"destroy", but actually we're not destroying the list here, we're just
unsubscribing everyone and (optionally) sending an email.  We could
destroy the list, but there isn't really any need to, as it'll be
cleared out by the HistoricDataDeletionWorker - and in fact I'm wary
of adding a new way of deleting data when there is already an
established pattern people may expect to hold.

So I went for "bulk-unsubscribe" instead.

If a message body is given, a sender_message_id is also required.
This is to ensure we don't send multiple unsubscribe emails if the
same publishing event is processed twice (this matches the behaviour
of content changes).  But the sender_message_id has to be a UUID.

To generate this UUID, generate a v5 UUID with:

- namespace: content_id
- name: public_updated_at

ActiveSupport has a helpful Digest::UUID.uuid_v5 method to do this.

---

[Trello card](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)