### PR TITLE
Omit footer unsubscribe link in bulk-unsubscription emails

### DIFF
--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -51,12 +51,20 @@ private
 
       ---
 
-      #{FooterPresenter.call(subscriber, subscription)}
+      #{FooterPresenter.call(subscriber, subscription, omit_unsubscribe_link: omit_footer_unsubscribe_link)}
     BODY
   end
 
   def middle_section(subscription)
     presenter = "#{content.class.name}Presenter".constantize
     presenter.call(content, subscription)
+  end
+
+  def omit_footer_unsubscribe_link
+    if content.respond_to?(:omit_footer_unsubscribe_link)
+      content.omit_footer_unsubscribe_link
+    else
+      false
+    end
   end
 end

--- a/app/presenters/footer_presenter.rb
+++ b/app/presenters/footer_presenter.rb
@@ -1,10 +1,11 @@
 class FooterPresenter
   include Callable
 
-  def initialize(subscriber, subscription)
+  def initialize(subscriber, subscription, omit_unsubscribe_link: false)
     @subscription = subscription
     @subscriber = subscriber
     @subscriber_list = subscription.subscriber_list
+    @omit_unsubscribe_link = omit_unsubscribe_link
   end
 
   def call
@@ -15,9 +16,7 @@ class FooterPresenter
 
       #{subscriber_list.title}
 
-      [Unsubscribe](#{unsubscribe_url})
-
-      [Change your email preferences](#{manage_url})
+      #{unsubscribe_and_change}
     FOOTER
 
     result.strip
@@ -25,7 +24,16 @@ class FooterPresenter
 
 private
 
-  attr_reader :subscription, :subscriber, :subscriber_list
+  attr_reader :subscription, :subscriber, :subscriber_list, :omit_unsubscribe_link
+
+  def unsubscribe_and_change
+    result = "[Change your email preferences](#{manage_url})"
+    unless omit_unsubscribe_link
+      result = "[Unsubscribe](#{unsubscribe_url})\n\n#{result}"
+    end
+
+    result
+  end
 
   def unsubscribe_url
     PublicUrls.unsubscribe(

--- a/app/services/bulk_unsubscribe_list_service.rb
+++ b/app/services/bulk_unsubscribe_list_service.rb
@@ -29,6 +29,7 @@ class BulkUnsubscribeListService
         criteria_rules: [{ id: subscriber_list.id }],
         govuk_request_id: govuk_request_id,
         signon_user_uid: user&.uid,
+        omit_footer_unsubscribe_link: true,
       )
   end
 end

--- a/db/migrate/20220117130900_add_omit_footer_unsubscribe_link_to_messages.rb
+++ b/db/migrate/20220117130900_add_omit_footer_unsubscribe_link_to_messages.rb
@@ -1,0 +1,5 @@
+class AddOmitFooterUnsubscribeLinkToMessages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :messages, :omit_footer_unsubscribe_link, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_174025) do
+ActiveRecord::Schema.define(version: 2022_01_17_130900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 2022_01_05_174025) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "criteria_rules"
+    t.boolean "omit_footer_unsubscribe_link", default: false, null: false
     t.index ["sender_message_id"], name: "index_messages_on_sender_message_id", unique: true
   end
 

--- a/spec/presenters/footer_presenter_spec.rb
+++ b/spec/presenters/footer_presenter_spec.rb
@@ -3,9 +3,10 @@ RSpec.describe FooterPresenter do
     let(:subscriber) { create(:subscriber) }
     let(:frequency) { "immediately" }
     let(:subscription) { create(:subscription, frequency: frequency) }
+    let(:omit_unsubscribe_link) { false }
 
     let(:footer) do
-      described_class.call(subscriber, subscription)
+      described_class.call(subscriber, subscription, omit_unsubscribe_link: omit_unsubscribe_link)
     end
 
     before do
@@ -37,6 +38,24 @@ RSpec.describe FooterPresenter do
       FOOTER
 
       expect(footer).to eq(expected.strip)
+    end
+
+    context "when omit_unsubscribe_link is true" do
+      let(:omit_unsubscribe_link) { true }
+
+      it "omits the unsubscribe link" do
+        expected = <<~FOOTER
+          # Why am I getting this email?
+
+          #{I18n.t!('emails.footer.immediately')}
+
+          #{subscription.subscriber_list.title}
+
+          [Change your email preferences](manage_url)
+        FOOTER
+
+        expect(footer).to eq(expected.strip)
+      end
     end
 
     %w[weekly daily].each do |frequency|

--- a/spec/services/bulk_unsubscribe_list_service_spec.rb
+++ b/spec/services/bulk_unsubscribe_list_service_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe BulkUnsubscribeListService do
           title: subscriber_list.title,
           body: "Message body",
           criteria_rules: [{ id: subscriber_list.id }],
+          omit_footer_unsubscribe_link: true,
         )
       end
 


### PR DESCRIPTION
When we send one of these notifications, the user has already been
automatically unsubscribed from the list.  Including a separate
unsubscribe link in the footer is confusing (as we've just told the
user in the body that they've been unsubscribed), so we don't want
those.

---

[Trello card](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)