### PR TITLE
Fix sending unsubscribe notifications immediately

### DIFF
--- a/app/queries/digest_items_query.rb
+++ b/app/queries/digest_items_query.rb
@@ -45,6 +45,7 @@ private
       .select("messages.*, subscriptions.id AS subscription_id")
       .joins(matched_messages: { subscriber_list: :subscriptions })
       .where(subscriptions: { id: subscriptions })
+      .where(messages: { override_subscription_frequency_to_immediate: false })
       .where("messages.created_at >= ?", digest_run.starts_at)
       .where("messages.created_at < ?", digest_run.ends_at)
       .uniq(&:id)

--- a/app/services/bulk_unsubscribe_list_service.rb
+++ b/app/services/bulk_unsubscribe_list_service.rb
@@ -30,6 +30,7 @@ class BulkUnsubscribeListService
         govuk_request_id: govuk_request_id,
         signon_user_uid: user&.uid,
         omit_footer_unsubscribe_link: true,
+        override_subscription_frequency_to_immediate: true,
       )
   end
 end

--- a/app/services/immediate_email_generation_service.rb
+++ b/app/services/immediate_email_generation_service.rb
@@ -29,9 +29,17 @@ private
       scope = Subscription.for_content_change(content) if content.is_a?(ContentChange)
       scope = Subscription.for_message(content) if content.is_a?(Message)
 
+      override_subscription_frequency_to_immediate =
+        if content.respond_to?(:override_subscription_frequency_to_immediate)
+          content.override_subscription_frequency_to_immediate
+        else
+          false
+        end
+
+      scope = scope.immediately unless override_subscription_frequency_to_immediate
+
       scope
         .active
-        .immediately
         .dedup_by_subscriber
         .each_slice(BATCH_SIZE)
         .map do |subscription_ids|

--- a/app/services/immediate_email_generation_service/batch.rb
+++ b/app/services/immediate_email_generation_service/batch.rb
@@ -42,10 +42,15 @@ class ImmediateEmailGenerationService
                      subscription_id: subscription_ids }.compact
         covered_by_earlier_attempts = SubscriptionContent.where(criteria)
                                                          .pluck(:subscription_id)
-        Subscription.active
-                    .immediately
-                    .includes(:subscriber_list, :subscriber)
-                    .where(id: subscription_ids - covered_by_earlier_attempts)
+        scope =
+          if override_subscription_frequency_to_immediate
+            Subscription
+          else
+            Subscription.immediately
+          end
+        scope.active
+             .includes(:subscriber_list, :subscriber)
+             .where(id: subscription_ids - covered_by_earlier_attempts)
       end
     end
 
@@ -55,6 +60,14 @@ class ImmediateEmailGenerationService
 
     def message
       content if content.is_a?(Message)
+    end
+
+    def override_subscription_frequency_to_immediate
+      if content.respond_to?(:override_subscription_frequency_to_immediate)
+        content.override_subscription_frequency_to_immediate
+      else
+        false
+      end
     end
   end
 end

--- a/db/migrate/20220119090527_add_override_subscription_frequency_to_immediate_to_message.rb
+++ b/db/migrate/20220119090527_add_override_subscription_frequency_to_immediate_to_message.rb
@@ -1,0 +1,5 @@
+class AddOverrideSubscriptionFrequencyToImmediateToMessage < ActiveRecord::Migration[6.1]
+  def change
+    add_column :messages, :override_subscription_frequency_to_immediate, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_17_130900) do
+ActiveRecord::Schema.define(version: 2022_01_19_090527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2022_01_17_130900) do
     t.datetime "updated_at", null: false
     t.json "criteria_rules"
     t.boolean "omit_footer_unsubscribe_link", default: false, null: false
+    t.boolean "override_subscription_frequency_to_immediate", default: false, null: false
     t.index ["sender_message_id"], name: "index_messages_on_sender_message_id", unique: true
   end
 

--- a/spec/queries/digest_items_query_spec.rb
+++ b/spec/queries/digest_items_query_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe DigestItemsQuery do
           )
       end
 
+      it "excludes overridden-immediate messages" do
+        create(
+          :message,
+          :matched,
+          subscriber_list: subscriber_list,
+          created_at: digest_run.starts_at,
+          override_subscription_frequency_to_immediate: true,
+        )
+
+        message = create(
+          :message,
+          :matched,
+          subscriber_list: subscriber_list,
+          created_at: digest_run.starts_at,
+        )
+
+        expect(results.count).to eq(1)
+        expect(results.first.to_h)
+          .to match(
+            subscription: subscription,
+            content: [message],
+          )
+      end
+
       it "returns the content ordered by created_at time" do
         content_change1 = create(
           :content_change,

--- a/spec/services/immediate_email_generation_service/batch_spec.rb
+++ b/spec/services/immediate_email_generation_service/batch_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe ImmediateEmailGenerationService::Batch do
         expect(ImmediateEmailBuilder).to_not receive(:call)
         instance.generate_emails
       end
+
+      context "when the content is a message with override_subscription_frequency_to_immediate set to true" do
+        let(:content) { create(:message, override_subscription_frequency_to_immediate: true) }
+
+        it "uses ImmediateEmailBuilder to build emails" do
+          expect(ImmediateEmailBuilder).to receive(:call)
+           .with(content, subscriptions)
+           .and_call_original
+
+          instance.generate_emails
+        end
+      end
     end
 
     context "when only some of the emails were generated due to a failure" do


### PR DESCRIPTION
We use the message machinery to send a notification to single-page
subscribers when the page gets unpublished and we unsubscribe them
from it.

We need these emails to go out immediately so we know when to
unsubscribe the user.  So in this commit, I add an
`override_subscription_frequency_to_immediate` field to the `messages`
table, and use that to skip the frequency scope check in the
`ImmediateEmailGenerationService`.

Alternative approaches would be:

- We could change the frequency of the `Subscription` when we process
the bulk-unsubscription.  This doesn't feel in keeping with the spirit
of email-alert-api, where normally data is not mutated in cases like
that.

- We could include unsubscription notifications in batches.  But then
we don't know when we can end the subscription (worst case we have to
wait a week), and if the page is gone anyway the other updates in the
batch are likely useless.

I think this is a least-bad approach.  But it is a feature we should
be careful not to abuse for other purposes.  We offer users frequency
controls for a reason.

---

[Trello card](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)