### PR TITLE
Add optional `description` field to SubscriberLists

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -26,6 +26,7 @@ class SubscriberListsController < ApplicationController
       url: params.fetch(:url, nil),
       matching_criteria: find_exact_query_params,
       user: current_user,
+      description: params.fetch(:description, nil),
     )
 
     render json: subscriber_list.to_json

--- a/app/services/create_subscriber_list_service.rb
+++ b/app/services/create_subscriber_list_service.rb
@@ -1,11 +1,12 @@
 class CreateSubscriberListService
   include Callable
 
-  def initialize(title:, url:, matching_criteria:, user:)
+  def initialize(title:, url:, matching_criteria:, user:, description: nil)
     @title = title
     @url = url
     @matching_criteria = matching_criteria
     @user = user
+    @description = description
   end
 
   def call
@@ -18,7 +19,7 @@ class CreateSubscriberListService
 
 private
 
-  attr_reader :title, :url, :matching_criteria, :user
+  attr_reader :title, :url, :matching_criteria, :user, :description
 
   def subscriber_list_params
     matching_criteria.merge(
@@ -26,6 +27,7 @@ private
       slug: slug,
       url: url,
       signon_user_uid: user.uid,
+      description: description,
     )
   end
 

--- a/db/migrate/20220121161623_add_description_column_to_subscriber_lists.rb
+++ b/db/migrate/20220121161623_add_description_column_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddDescriptionColumnToSubscriberLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subscriber_lists, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_090527) do
+ActiveRecord::Schema.define(version: 2022_01_21_161623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_090527) do
     t.string "tags_digest"
     t.string "links_digest"
     t.uuid "content_id"
+    t.text "description"
     t.index ["content_id"], name: "index_subscriber_lists_on_content_id"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -98,6 +98,19 @@ RSpec.describe "Creating a subscriber list", type: :request do
       end
     end
 
+    context "with a description" do
+      it "returns a list with a description" do
+        create_subscriber_list(
+          { "description": "A description" },
+        )
+
+        expect(response.status).to eq(200)
+        expect(response_subscriber_list).to include(
+          "description" => "A description",
+        )
+      end
+    end
+
     def create_subscriber_list(payload = {})
       defaults = {
         title: "This is a sample title",


### PR DESCRIPTION
We want to save the page summary for single page subscription lists so that we can include it in emails to users who have signed up for updates to pages without needing to look the summary up in the content store. This is particularly important for the emails we send when a page is unpublished, as by the time we send the email the page has already been removed from the live content store so we're unable to look up a summary.

This PR adds an optional `description` field to the `SubscriberList` table where we can store this summary and updates the  `create` endpoint and the `CreateSubscriberListService` to pass a new `description` param through to the model when called.

Note, the `description` field has existed previously, but it was removed and replaced by the URL field in https://github.com/alphagov/email-alert-api/pull/1527 as only the Brexit checker emails were using it and they all had the same description. We have a need for it again, so it's fine to bring it back.

[Trello](https://trello.com/c/dm5ZxFVB/1226-pass-through-page-descriptions-to-subscriberlists-on-major-minor-publishing-change) 