### PR TITLE
Add rake task to add descriptions to single page subscriber lists

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -7,4 +7,8 @@ module Services
     @accounts_emails ||=
       File.readlines(Rails.root.join("config/bulk_email/email_addresses.txt"), chomp: true)
   end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.new.find("content-store"))
+  end
 end

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -76,4 +76,14 @@ namespace :data_migration do
       puts "Updated #{args[:key]} in #{list.title} to #{new_criteria}"
     end
   end
+
+  desc "Fetch descriptions for single page subscription lists which don't have descriptions"
+  task fetch_subscriber_list_descriptions: :environment do |_t, _args|
+    SubscriberList.where.not(content_id: nil).where(description: nil).find_each do |list|
+      new_description = Services.content_store.content_item(list.url)["description"]
+      list.update!(description: new_description)
+
+      puts "Subscriber list for #{list.url} updated with new description"
+    end
+  end
 end

--- a/spec/lib/tasks/data_migration_spec.rb
+++ b/spec/lib/tasks/data_migration_spec.rb
@@ -1,4 +1,8 @@
+require "gds_api/test_helpers/content_store"
+
 RSpec.describe "data_migration" do
+  include GdsApi::TestHelpers::ContentStore
+
   describe "update_subscriber_list_tag" do
     before do
       Rake::Task["data_migration:update_subscriber_list_tag"].reenable
@@ -32,6 +36,20 @@ RSpec.describe "data_migration" do
       expect {
         Rake::Task["data_migration:update_subscriber_list_slug"].invoke(list.slug, "new-slug")
       }.to output.to_stdout
+    end
+  end
+
+  describe "fetch_subscriber_list_descriptions" do
+    before do
+      Rake::Task["data_migration:fetch_subscriber_list_descriptions"].reenable
+      stub_content_store_has_item("/an/example/page")
+    end
+
+    it "updates the subscriber list description" do
+      list = create(:subscriber_list, :for_single_page_subscription)
+
+      Rake::Task["data_migration:fetch_subscriber_list_descriptions"].invoke
+      expect(list.reload.description).to eq("Description for /an/example/page")
     end
   end
 end


### PR DESCRIPTION
We added an optional description field to subscriber lists in [[1]]. We
intend to use the page summary as this description for single page
subscriber lists, and will include it in some emails.

New single page lists get the description passed through from email
alert frontend when the list is created, but it's null for any that
existed before this change.

Add a rake task that iterates over all the single page subscriber lists
and fetches the description from content store so every single page 
list has a description.

[Trello](https://trello.com/c/dm5ZxFVB/1226-pass-through-page-descriptions-to-subscriberlists-on-major-minor-publishing-change)

[1]: https://github.com/alphagov/email-alert-api/pull/1705
