### PR TITLE
Allow subscriber list description to be updated

### DIFF
--- a/app/controllers/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber_lists_controller.rb
@@ -77,7 +77,7 @@ class SubscriberListsController < ApplicationController
 private
 
   def updatable_parameters
-    [:title]
+    %i[title description]
   end
 
   def convert_legacy_params(link_or_tags)

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,12 +81,14 @@ It requires at least one parameter to update.
 ```json
 {
   "title": "A new Subscriber list title",
+  "description": "A new subscriber list description",
 }
 ```
 
 The following fields are accepted:
 - title: The title of this particular list, which will be shown to the user;
   email sent to a user;
+- description: A description of the content this list represents, used by [email-alert-service](https://github.com/alphagov/email-alert-service) to construct emails when a page is unpublished. 
 
 Any additional parameters will be ignored.
 

--- a/spec/integration/update_subscription_list_spec.rb
+++ b/spec/integration/update_subscription_list_spec.rb
@@ -34,6 +34,36 @@ RSpec.describe "Updating a subscriber list", type: :request do
       expect(response.status).to eq(422)
     end
 
+    context "when a description is provided" do
+      let(:update_params) do
+        {
+          "description" => "A new list description",
+        }
+      end
+
+      it "returns the subscriber list with an updated description" do
+        patch update_subscriber_lists_path, params: update_params.to_json, headers: json_headers
+
+        expect(JSON.parse(response.body).dig("subscriber_list", "description")).to eq(update_params["description"])
+      end
+    end
+
+    context "when a both a title and description are provided" do
+      let(:update_params) do
+        {
+          "title" => "A new title",
+          "description" => "A new list description",
+        }
+      end
+
+      it "returns the subscriber list with an updated title and description" do
+        patch update_subscriber_lists_path, params: update_params.to_json, headers: json_headers
+
+        expect(JSON.parse(response.body).dig("subscriber_list", "title")).to eq(update_params["title"])
+        expect(JSON.parse(response.body).dig("subscriber_list", "description")).to eq(update_params["description"])
+      end
+    end
+
     context "for an unknown subscriber list" do
       let(:slug) { "not-a-real-slug" }
 


### PR DESCRIPTION
We will be extending the queue processors added in [[1]] to also check
for updates to a page's description and pass these through to the API
to be stored for use in some emails.

Before we can do that, we need to add `description` to the list of
updateable parameters in the API.

[Trello](https://trello.com/c/dm5ZxFVB/1226-pass-through-page-descriptions-to-subscriberlists-on-major-minor-publishing-change)

[1]: https://github.com/alphagov/email-alert-service/pull/493