### PR TITLE
Report on subs by url

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -110,12 +110,31 @@ Depending on the number of emails to send, the Rake task can take a few minutes 
 bundle exec rake 'support:resend_failed_emails:by_id[<email_one_id>,<email_two_id>]'
 ```
 
-## Get subscriber numbers for a list
+## Get subscriber list csv report
 
-To see the number of subscribers for a given list:
+To see a csv report for the number of subscribers for a given list:
 
 ```bash
 bundle exec rake 'report:csv_subscriber_lists[<on_date>] SLUGS=<list_slug>'
 ```
 
 The date should be in ISO8601 format, for example 2020-01-01.
+
+## Get a simple count of subscribers to a list by its URL
+
+To see a simple count of the number of subscribers for a given list:
+
+```bash
+bundle exec rake 'report:csv_subscriber_lists[<url>]'
+```
+This will always report on the number of active subscriptions for a given url, as of the end of today.
+
+You can also pass it a :active_on_datetime which will count how many active subscriptions there were at the end of the day on a particular date.
+(active is defined as created before that datetime and not with an "ended_on" datetime by the given date)
+
+```bash
+bundle exec rake 'report:csv_subscriber_lists[<url>, <active_on_date>]'
+```
+
+The active_on_date should be in ISO8601 format, for example 2022-03-03T12:12:16+00:00.
+The time will always be rounded to the end of the day, even if that is in the future.

--- a/lib/reports/subscriber_list_subscriber_count_report.rb
+++ b/lib/reports/subscriber_list_subscriber_count_report.rb
@@ -1,0 +1,33 @@
+class Reports::SubscriberListSubscriberCountReport
+  class BadDateError < StandardError; end
+
+  attr_reader :url, :active_on_date
+
+  def initialize(url, active_on_date = nil)
+    @url = url
+    @active_on_date = active_on_date || Time.zone.now.end_of_day
+  end
+
+  def call
+    list = SubscriberList.find_by_url(url)
+    if list
+      count = list.subscriptions
+          .active_on(formatted_date)
+          .count
+
+      "Subscriber list for #{url} had #{count} subscribers on #{formatted_date}."
+    else
+      "Subscriber list cannot be found with URL: #{url}"
+    end
+  rescue ArgumentError
+    "Cannot parse active_on_date, is this a valid ISO8601 date?: #{active_on_date}"
+  end
+
+private
+
+  def formatted_date
+    return active_on_date if active_on_date.instance_of?(ActiveSupport::TimeWithZone)
+
+    Time.zone.strptime(active_on_date, "%F").end_of_day
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -15,4 +15,12 @@ namespace :report do
   task potentially_dead_lists: :environment do
     puts Reports::PotentiallyDeadListsReport.new.call
   end
+
+  desc "Output a simple count of subscribers by the subscrber_list URL"
+  task :subscriber_list_subscriber_count, %i[url active_on_date] => :environment do |_t, args|
+    puts Reports::SubscriberListSubscriberCountReport.new(
+      args.fetch(:url),
+      args[:active_on_date],
+    ).call
+  end
 end

--- a/spec/lib/reports/subscriber_list_subscriber_count_report_spec.rb
+++ b/spec/lib/reports/subscriber_list_subscriber_count_report_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Reports::SubscriberListSubscriberCountReport do
+  let(:url) { "/url" }
+  let(:created_at) { 10.days.ago.midday }
+  let(:list) { create(:subscriber_list, created_at: created_at, title: "list 1", slug: "list-1", url: url) }
+
+  before { create_range_of_subscribers(list, created_at) }
+
+  context "when passed a URL that matches a subscriber list" do
+    let(:active_on_date) { Time.zone.now.end_of_day }
+
+    it "returns a count up to Time.zone.now if not provided a date, excluding ended subscriptions" do
+      expect(described_class.new(url).call).to include("Subscriber list for #{url} had 4 subscribers on #{active_on_date}.")
+    end
+
+    it "returns a count up to Time.zone.now if you provide a date as nil, excluding ended subscriptions" do
+      expect(described_class.new(url, nil).call).to include("Subscriber list for #{url} had 4 subscribers on #{active_on_date}.")
+    end
+
+    it "returns a count up to an active_on_date, excluding ended subscriptions" do
+      expect(described_class.new(url, active_on_date.advance(days: -1)).call).to eq("Subscriber list for #{url} had 3 subscribers on #{active_on_date.advance(days: -1)}.")
+    end
+  end
+
+  context "when passed a URL that does not match a subscriber list" do
+    it "it returns a useful message" do
+      expect(described_class.new("/nope").call).to eq("Subscriber list cannot be found with URL: /nope")
+    end
+  end
+
+  context "when passed a badly formatted date" do
+    it "it returns a useful message" do
+      expect(described_class.new(url, "20th of furberry").call).to eq("Cannot parse active_on_date, is this a valid ISO8601 date?: 20th of furberry")
+    end
+  end
+
+  def create_range_of_subscribers(list, created_at)
+    create(:subscription, :immediately, subscriber_list: list, created_at: created_at)
+    create(:subscription, :daily, subscriber_list: list, created_at: created_at)
+    create(:subscription, :weekly, subscriber_list: list, created_at: created_at)
+    create(:subscription, :ended, ended_at: created_at, subscriber_list: list)
+    create(:subscription, :ended, ended_at: created_at, ended_reason: :frequency_changed, subscriber_list: list)
+    create(:subscription, :immediately, subscriber_list: list, created_at: Time.zone.now)
+  end
+end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe "report" do
         .to output.to_stdout
     end
   end
+
+  describe "subscriber_list_subscriber_count" do
+    it "outputs a count of subscribers for subscriber lists" do
+      expect { Rake::Task["report:subscriber_list_subscriber_count"].invoke("/url") }
+        .to output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
 Add Reporting class for counting active subscribers to a list by URL

This should work across:
- Organisation pages ([one with some subs](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218128/console)!)
- Single page notifications (one [with no subs](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218127/console), one [with some](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218129/console))
- Taxon pages (tested on `/education` [see here](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218131/console), nb [/coronavirus](https://deploy.blue.staging.govuk.digital/job/run-rake-task/218130/console) does not work, i suspect there's special magic behind that taxon)

All these subscriber lists seem to have URLs, most often requests arrive
for subscriber stats from stakeholders who know the URL of a page.

Put it all in a rake task so we can run it on jenkins and update two things in the docs:

1. The existing stuff seems to export a much grander CSV, with lots of
data and that uses the existing matching functions. Clarify that a bit.

2. Document the new simple count by URL report.