### PR TITLE
Report on single page notificaiton subscription figures

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -144,3 +144,24 @@ bundle exec rake 'report:csv_subscriber_lists[<url>, <active_on_date>]'
 
 The active_on_date should be in ISO8601 format, for example 2022-03-03T12:12:16+00:00.
 The time will always be rounded to the end of the day, even if that is in the future.
+
+## Get a report of single page notification subscriber lists by active subscriber count
+
+This report provides a count of all subscriber lists with a content ID, followed by individual subscriber lists ordered by active subscriber count.
+
+```bash
+bundle exec rake 'report:single_page_notifications_top_subscriber_lists'
+```
+
+By default output is limited to only show the top 25 lists by active subscriber count. However
+that can be overridden to increase or decrease the output number.
+
+```bash
+bundle exec rake 'report:single_page_notifications_top_subscriber_lists[5]'
+```
+
+You can run the task on Jenkins with the following links:
+
+- [Integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:single_page_notifications_top_subscriber_lists) - Only really useful for testing
+- [Staging](https://deploy.blue.staging.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:single_page_notifications_top_subscriber_lists) - Data will be a snapshot from last replication
+- [Production](https://deploy.blue.production.govuk.digital/job/run-rake-task/parambuild/?TARGET_APPLICATION=email-alert-api&MACHINE_CLASS=email_alert_api&RAKE_TASK=report:single_page_notifications_top_subscriber_lists) - Live data

--- a/lib/reports/single_page_notifications_report.rb
+++ b/lib/reports/single_page_notifications_report.rb
@@ -1,0 +1,65 @@
+class Reports::SinglePageNotificationsReport
+  attr_reader :report_time
+
+  def initialize(limit = 25)
+    @limit = limit.to_i
+    @report_time = Time.zone.now
+  end
+
+  def call
+    [
+      report_on_total_lists,
+      *report_on_top_lists,
+    ]
+  end
+
+private
+
+  attr_reader :limit
+
+  def report_on_total_lists
+    "There are #{subscriber_list_with_content_ids.count} subscription lists with content_ids as of #{report_time}\n"
+  end
+
+  def report_on_top_lists
+    [
+      "Top #{limit} lists by active subscriber count are:\n",
+      *subscriber_lists_by_active_sub_count,
+    ]
+  end
+
+  def subscriber_lists_by_active_sub_count
+    subscriber_list_with_content_ids.map { |list| gather_data(list) }
+                                    .sort_by { |list| list[:active_subscribers] }
+                                    .last(limit)
+                                    .map { |list| present(list) }
+                                    .reverse
+                                    .flatten
+  end
+
+  def subscriber_list_with_content_ids
+    @subscriber_list_with_content_ids ||= SubscriberList.where.not(content_id: nil)
+  end
+
+  def gather_data(subscriber_list)
+    {
+      title: subscriber_list.title,
+      url: subscriber_list.url,
+      active_subscribers: active_subscribers(subscriber_list),
+    }
+  end
+
+  def present(subscriber_list)
+    <<~TEXT
+      Title: #{subscriber_list[:title]}
+      URL: #{subscriber_list[:url]}
+      Has #{subscriber_list[:active_subscribers]} Active Subscribers
+    TEXT
+  end
+
+  def active_subscribers(subscriber_list)
+    subscriber_list.subscriptions
+      .active_on(@report_time)
+      .count
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -23,4 +23,9 @@ namespace :report do
       args[:active_on_date],
     ).call
   end
+
+  desc "Output a report of top single page notification subscriber lists"
+  task :single_page_notifications_top_subscriber_lists, %i[limit] => :environment do |_t, args|
+    puts Reports::SinglePageNotificationsReport.new(args[:limit] || 25).call.join("\n")
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -113,7 +113,15 @@ FactoryBot.define do
 
     trait :for_single_page_subscription do
       content_id { SecureRandom.uuid }
-      url { "/an/example/page" }
+      sequence(:url) { |n| "/an/example/page-#{n}" }
+      transient do
+        subscriber_count { (0..3).to_a.sample }
+      end
+
+      after(:create) do |list, evaluator|
+        list = build_list(:subscriber, evaluator.subscriber_count, subscriber_lists: [list])
+        list.each { |item| item.save!(validate: false) }
+      end
     end
 
     factory :subscriber_list_with_invalid_tags do

--- a/spec/lib/reports/single_page_notifications_report_spec.rb
+++ b/spec/lib/reports/single_page_notifications_report_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Reports::SinglePageNotificationsReport do
+  before do
+    @single_page_notifications_sub_list = FactoryBot.create_list(:subscriber_list, 26, :for_single_page_subscription)
+    @other_sub_list = FactoryBot.create(:subscriber_list)
+  end
+
+  describe "#call" do
+    let(:report) { Reports::SinglePageNotificationsReport.new }
+
+    it "the first line reports total active subscriptions for subscriber lists with a content_id" do
+      expect(report.call[0]).to eq("There are 26 subscription lists with content_ids as of #{report.report_time}\n")
+    end
+
+    it "sorts active subscriptions, from most subscribed to least subscribed" do
+      subscriber_counts = report.call[2..].map { |row| row.split("Has ").last.split(" Active").first.to_i }
+      expect(subscriber_counts.first > subscriber_counts.last).to be true
+    end
+
+    it "reports on subscriber counts for individual subscriber lists with a content_id" do
+      reported_list_titles = report.call[2..].map { |row| row.split("\n").first.split("Title: ").last }
+      all_list_titles = @single_page_notifications_sub_list.map(&:title)
+      expect(reported_list_titles - all_list_titles).to be_empty
+    end
+
+    it "does not report on subscriber lists without a content_id" do
+      reported_list_titles = report.call[2..].map { |row| row.split("\n").first.split("Title: ").last }
+      expect(reported_list_titles).not_to include(@other_sub_list.title)
+    end
+
+    it "limits output to top 25 subscriber lists by subscription count" do
+      report_output = report.call
+
+      expect(report_output[1]).to eq("Top 25 lists by active subscriber count are:\n")
+      expect(report_output[2..].count).to eq(25)
+    end
+
+    context "when provided with a limit of 5" do
+      let(:report) { Reports::SinglePageNotificationsReport.new(5) }
+
+      it "limits output to top 5 subscriptions" do
+        report_output = report.call
+
+        expect(report_output[1]).to eq("Top 5 lists by active subscriber count are:\n")
+        expect(report_output[2..].count).to eq(5)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -26,4 +26,11 @@ RSpec.describe "report" do
         .to output.to_stdout
     end
   end
+
+  describe "single_page_notifications_top_subscriber_lists" do
+    it "outputs a report of single page notification subscriber lists" do
+      expect { Rake::Task["report:single_page_notifications_top_subscriber_lists"].invoke }
+        .to output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/Lz5wJCHC/1301-put-single-page-notification-subscription-reports-into-a-rake-task)

We ran some reports last week to better understand traffic spikes.
I've moved the reports I ran into tested report classes and have provided a rake task for easy future reuse.