### PR TITLE
Fix links in emails for archived topics

### DIFF
--- a/lib/tasks/email_and_unsubscribe_archived_topics.rake
+++ b/lib/tasks/email_and_unsubscribe_archived_topics.rake
@@ -26,7 +26,7 @@ namespace :archived_topics do
 
           This topic has been archived. You will not get any more emails about it.
 
-          You can find more information about this topic at [#{topic[:redirect_title]}](#{topic[:redirect]}).
+          You can find more information about this topic at [#{topic[:redirect_title]}](https://www.gov.uk#{topic[:redirect]}).
         BODY
 
         puts "==============="

--- a/spec/lib/tasks/email_and_unsubscribe_archived_topics_spec.rb
+++ b/spec/lib/tasks/email_and_unsubscribe_archived_topics_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "archived_topics" do
     end
 
     let(:subs_list) { create(:subscriber_list, :archived_topic) }
+
     let(:body) do
       <<~BODY
         You asked GOV.UK to email you when we add or update a page about:
@@ -16,8 +17,8 @@ RSpec.describe "archived_topics" do
       BODY
     end
 
-    it "states the topic the emails are being sent to" do
-      expect { Rake::Task["archived_topics:email_and_unsubscribe"].invoke }.to output(include("Sending email for #{subs_list.url} (ID: #{subs_list.id})")).to_stdout
+    it "states the topic the emails are being sent to and a redirect URL" do
+      expect { Rake::Task["archived_topics:email_and_unsubscribe"].invoke }.to output(include("Sending email for #{subs_list.url} (ID: #{subs_list.id})")).to_stdout and output(include("https://www.gov.uk")).to_stdout
     end
 
     it "outputs the check message by default" do
@@ -28,7 +29,7 @@ RSpec.describe "archived_topics" do
       expect { Rake::Task["archived_topics:email_and_unsubscribe"].invoke }.to_not output(include("Destroying subscription list #{subs_list.url} (ID: #{subs_list.id})")).to_stdout
     end
 
-    it "does not attempt to destroy list with dry_run true (default)" do
+    it "will destroy list with dry_run true (default)" do
       expect { Rake::Task["archived_topics:email_and_unsubscribe"].invoke("run") }.to output(include("Destroying subscription list #{subs_list.url} (ID: #{subs_list.id})")).to_stdout
     end
   end


### PR DESCRIPTION
It was spotted that the emails we we've been sending don't have a proper fully qualified URL, but a relative path.

## Screenshots

### Before

<img width="1315" alt="Screenshot 2022-03-23 at 5 45 35 pm" src="https://user-images.githubusercontent.com/424772/159763191-084fe490-7a51-40ca-ba85-debd70736cbe.png">


### After

<img width="1315" alt="Screenshot 2022-03-23 at 5 44 36 pm" src="https://user-images.githubusercontent.com/424772/159763149-fb3e3fe4-27fe-43d3-bb5c-a5db14ec01bd.png">
