### PR TITLE
Delete nullified accounts from account API

### DIFF
--- a/app/workers/nullify_subscribers_worker.rb
+++ b/app/workers/nullify_subscribers_worker.rb
@@ -1,7 +1,10 @@
 class NullifySubscribersWorker < ApplicationWorker
   def perform
     run_with_advisory_lock(Subscriber, "nullify") do
-      nullifyable_subscribers.update_all(address: nil, govuk_account_id: nil, updated_at: Time.zone.now)
+      nullifyable_subscribers.each do |s|
+        GdsApi.account_api.delete_user_by_subject_identifier(subject_identifier: s.govuk_account_id) unless s.govuk_account_id.nil?
+        s.update!(address: nil, govuk_account_id: nil, updated_at: Time.zone.now)
+      end
     end
   end
 


### PR DESCRIPTION
The only use of the GOV.UK account on GOV.UK is for email notifications.
Therefore, to minimise us hoarding personal data we should delete a
user's GOV.UK account at the same time it's nullified in this app to
minimise data hoarding.

Update the nullify worker that removes old accounts with no active
subscriptions to also call account API if that subscriber record has
a `govuk_account_id`.