### PR TITLE
Configure pact tests provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp
 /log/*
 !/log/.gitkeep
 coverage
+spec/reports/pacts

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,10 @@ group :test do
 end
 
 group :development, :test do
+  gem "database_cleaner"
   gem "listen"
+  gem "pact", require: false
+  gem "pact_broker-client"
   gem "pry-byebug"
   gem "rspec-rails"
   gem "rubocop-govuk", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    awesome_print (1.9.2)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -80,7 +81,14 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     diff-lcs (1.5.0)
+    dig_rb (1.0.1)
     digest (3.1.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -90,6 +98,8 @@ GEM
     erubi (1.10.0)
     et-orbi (1.2.7)
       tzinfo
+    expgen (0.1.1)
+      parslet
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -100,6 +110,8 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
     ffi (1.15.5)
+    filelock (1.1.1)
+    find_a_port (1.0.1)
     fugit (1.5.3)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
@@ -144,8 +156,12 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.2)
     json-schema (3.0.0)
       addressable (>= 2.8)
     jwt (2.3.0)
@@ -211,9 +227,40 @@ GEM
     omniauth-oauth2 (1.7.2)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    pact (1.62.0)
+      pact-mock_service (~> 3.0, >= 3.3.1)
+      pact-support (~> 1.16, >= 1.16.9)
+      rack-test (>= 0.6.3, < 2.0.0)
+      rspec (~> 3.0)
+      term-ansicolor (~> 1.0)
+      thor (>= 0.20, < 2.0)
+      webrick (~> 1.3)
+    pact-mock_service (3.10.0)
+      filelock (~> 1.1)
+      find_a_port (~> 1.0.1)
+      json
+      pact-support (~> 1.16, >= 1.16.4)
+      rack (~> 2.0)
+      rspec (>= 2.14)
+      term-ansicolor (~> 1.0)
+      thor (>= 0.19, < 2.0)
+      webrick (~> 1.3)
+    pact-support (1.18.0)
+      awesome_print (~> 1.9)
+      diff-lcs (~> 1.4)
+      expgen (~> 0.1)
+      rainbow (~> 3.1.1)
+    pact_broker-client (1.64.0)
+      dig_rb (~> 1.0)
+      httparty (~> 0.18.1)
+      rake (~> 13.0)
+      table_print (~> 1.5)
+      term-ansicolor (~> 1.7)
+      thor (>= 0.20, < 2.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    parslet (2.0.0)
     pg (1.3.5)
     plek (4.0.0)
     prometheus_exporter (2.0.3)
@@ -282,6 +329,10 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -359,9 +410,15 @@ GEM
     simplecov_json_formatter (0.1.4)
     statsd-ruby (1.5.0)
     strscan (3.0.3)
+    sync (0.5.0)
+    table_print (1.5.7)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
     thor (1.2.1)
     tilt (2.0.10)
     timeout (0.3.0)
+    tins (1.31.1)
+      sync
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -393,6 +450,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   climate_control
+  database_cleaner
   equivalent-xml
   factory_bot_rails
   faraday
@@ -407,6 +465,8 @@ DEPENDENCIES
   listen
   nokogiri
   notifications-ruby-client
+  pact
+  pact_broker-client
   pg
   plek
   pry-byebug

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,13 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
+begin
+  require "pact/tasks"
+rescue LoadError
+  # Pact isn't available in all environments
+end
+
 unless Rails.env.production?
   Rake::Task[:default].clear
-  task default: %i[lint spec]
+  task default: %i[lint spec pact:verify]
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,0 +1,106 @@
+require "pact/provider/rspec"
+require "webmock/rspec"
+require "factory_bot_rails"
+require "database_cleaner/active_record"
+
+require "plek"
+require "gds_api/test_helpers/account_api"
+
+require ::File.expand_path("../../config/environment", __dir__)
+
+Pact.configure do |config|
+  config.reports_dir = "spec/reports/pacts"
+  config.include WebMock::API
+  config.include WebMock::Matchers
+  config.include FactoryBot::Syntax::Methods
+  config.include GdsApi::TestHelpers::AccountApi
+end
+
+WebMock.allow_net_connect!
+DatabaseCleaner.allow_remote_database_url = true
+
+def url_encode(str)
+  ERB::Util.url_encode(str)
+end
+
+Pact.service_provider "Email Alert API" do
+  honours_pact_with "GDS API Adapters" do
+    if ENV["PACT_URI"]
+      pact_uri(ENV["PACT_URI"])
+    else
+      base_url = "https://pact-broker.cloudapps.digital"
+      path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+      version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-main'))}"
+
+      pact_uri("#{base_url}/#{path}/#{version_modifier}")
+    end
+  end
+end
+
+Pact.provider_states_for "GDS API Adapters" do
+  set_up do
+    DatabaseCleaner.clean_with :truncation
+    GDS::SSO.test_user = create(:user, permissions: %w[internal_app])
+  end
+
+  provider_state "a subscription with the uuid 719efe7b-00d0-4168-ac30-99fe6093e3fc exists" do
+    set_up do
+      create(
+        :subscription,
+        id: "719efe7b-00d0-4168-ac30-99fe6093e3fc",
+        subscriber_list: create(:subscriber_list),
+        subscriber: create(:subscriber, id: 1, address: "test@example.com"),
+        frequency: :immediately,
+      )
+    end
+  end
+
+  provider_state "a subscriber list with the tag topic: motoring/road_rage exists" do
+    set_up do
+      create(:subscriber_list)
+    end
+  end
+
+  provider_state "a subscriber list with slug title-1 exists" do
+    set_up do
+      create(:subscriber_list, slug: "title-1")
+    end
+  end
+
+  provider_state "a content change with content_id 5fc8fb2b-c0b1-4490-99cb-c987a53afb75 exists" do
+    set_up do
+      create(
+        :content_change,
+        content_id: "5fc8fb2b-c0b1-4490-99cb-c987a53afb75",
+        public_updated_at: "2022-01-01 00:00:00 +0000",
+      )
+    end
+  end
+
+  provider_state "a subscriber exists" do
+    set_up do
+      create(:subscriber, id: 1, address: "test@example.com")
+    end
+  end
+
+  provider_state "a verified govuk_account_session exists with a matching subscriber" do
+    set_up do
+      stub_account_api_user_info(
+        id: "internal-user-id",
+        email: "test@example.com",
+        email_verified: true,
+      )
+      create(:subscriber, id: 1, address: "test@example.com")
+    end
+  end
+
+  provider_state "a govuk_account_session exists but isn't verified" do
+    set_up do
+      stub_account_api_user_info(
+        id: "internal-user-id",
+        email: "test@example.com",
+        email_verified: false,
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/YZ1pEayS/1331-add-contract-tests-to-email-alert-api

Pact consumer branch: [add-email-alert-api-pact-tests](https://github.com/alphagov/gds-api-adapters/tree/add-email-alert-api-pact-tests) 

Consumer PR: https://github.com/alphagov/gds-api-adapters/pull/1148