### PR TITLE
Explicitly copy from template1

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,6 +18,7 @@ test:
   <<: *default
   database: email-alert-api_test
   url: <%= ENV["TEST_DATABASE_URL"] %>
+  template: template1
 
 production:
   <<: *default


### PR DESCRIPTION
Necessary for when this is called by the ci agent as part of the gds-api-adapters pact verification run. CI Agent runs without the permission to install the uuid-ossp extension. You can manually create the extension in template1 and have it copied into all the new databases by default, but rails ignores this unless you explicitly tell it to use template1.

Needed for this to work: https://github.com/alphagov/gds-api-adapters/pull/1152

https://trello.com/c/YZ1pEayS/1331-add-contract-tests-to-email-alert-api