### PR TITLE
Gracefully handle if account id is listed but account-api doesn't have that record

### DIFF
--- a/spec/workers/nullify_subscribers_worker_spec.rb
+++ b/spec/workers/nullify_subscribers_worker_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe NullifySubscribersWorker do
           subject.perform
           expect(stub).to have_been_made
         end
+
+        it "gracefully handles account-apit record missing, nullifies both local accounts" do
+          create(:subscriber, govuk_account_id: "sub", created_at: nullifyable_time)
+          stub = stub_account_api_delete_user_by_subject_identifier_does_not_exist(subject_identifier: "sub")
+          expect { subject.perform }
+            .to change { Subscriber.nullified.count }.by(2)
+          expect(stub).to have_been_made
+        end
       end
 
       it "doesn't nullify subscribers with recently ended subscriptions" do


### PR DESCRIPTION
(It appears that many nullifyable Subscribers point to account-api accounts that don't exist. Change handles that gracefully, instead of crashing the worker and preventing it clearing up data).

This was previously masked by a configuration error that prevented email-alert-api talking to account-api at all.

( see here: https://trello.com/c/058hgQoD/1402-fix-httpforbidden-errors-in-email-alert-api )

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
