### PR TITLE
Add special handling of validation errors.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,16 @@ class ApplicationController < ActionController::API
   before_action :authorise
 
   rescue_from ActiveRecord::RecordInvalid do |exception|
-    render json: { error: "Unprocessable Entity",
-                   details: exception.record&.errors&.messages },
-           status: :unprocessable_entity
+    render_unprocessable(exception.record&.errors&.messages)
   end
 
 private
+
+  def render_unprocessable(messages)
+    render json: { error: "Unprocessable Entity",
+                   details: messages },
+           status: :unprocessable_entity
+  end
 
   def authorise
     authorise_user!("internal_app")

--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -33,7 +33,8 @@ private
   end
 
   def validate_params
-    ParamsValidator.new(expected_params).validate!
+    validator = ParamsValidator.new(expected_params)
+    render_unprocessable(validator.errors.messages) unless validator.valid?
   end
 
   class ParamsValidator < OpenStruct

--- a/app/controllers/subscriptions_auth_token_controller.rb
+++ b/app/controllers/subscriptions_auth_token_controller.rb
@@ -26,7 +26,8 @@ class SubscriptionsAuthTokenController < ApplicationController
   end
 
   def validate_params
-    ParamsValidator.new(expected_params).validate!
+    validator = ParamsValidator.new(expected_params)
+    render_unprocessable(validator.errors.messages) unless validator.valid?
   end
 
   def expected_params


### PR DESCRIPTION
These validation errors are  part of the normal flow of the API's work - email-alert-frontend calls the API to do email address validation so that it's done in one place and is somewhat DRY. That means that if a validation fails we don't actually want it to go to Sentry.  This change stops this particular exception from bubbling up to the top, but renders the same status to the calling API as if it had.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
