### PR TITLE
Email subscriptions for document collections

### DIFF
--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -2,7 +2,7 @@ class SubscriberListQuery
   def initialize(content_id:, tags:, links:, document_type:, email_document_supertype:, government_document_supertype:)
     @content_id = content_id
     @tags = tags.symbolize_keys
-    @links = links.symbolize_keys
+    @links = links.deep_symbolize_keys
     @document_type = document_type
     @email_document_supertype = email_document_supertype
     @government_document_supertype = government_document_supertype
@@ -12,27 +12,42 @@ class SubscriberListQuery
     @lists ||= (
       lists_matched_on_links +
       lists_matched_on_tags +
-      lists_matched_without_links_or_tags
+      lists_matched_without_links_or_tags +
+      lists_matched_on_document_collection_id
     ).uniq(&:id)
   end
 
 private
 
-  def lists_matched_on_tags
-    MatchedForNotification.new(query_field: :tags, scope: base_scope).call(@tags)
+  def lists_matched_on_tags(content_id = @content_id)
+    MatchedForNotification.new(query_field: :tags, scope: base_scope(content_id)).call(@tags)
   end
 
-  def lists_matched_on_links
-    MatchedForNotification.new(query_field: :links, scope: base_scope).call(@links)
+  def lists_matched_on_links(content_id = @content_id)
+    MatchedForNotification.new(query_field: :links, scope: base_scope(content_id)).call(@links)
   end
 
-  def lists_matched_without_links_or_tags
-    FindWithoutLinksAndTags.new(scope: base_scope).call
+  def lists_matched_without_links_or_tags(content_id = @content_id)
+    FindWithoutLinksAndTags.new(scope: base_scope(content_id)).call
   end
 
-  def base_scope
+  def lists_matched_on_document_collection_id
+    return [] unless document_collection_ids
+
+    document_collection_ids.flat_map do |id|
+      lists_matched_on_tags(id) +
+        lists_matched_on_links(id) +
+        lists_matched_without_links_or_tags(id)
+    end
+  end
+
+  def document_collection_ids
+    @links[:document_collections].presence
+  end
+
+  def base_scope(content_id)
     SubscriberList
-      .where(content_id: [nil, @content_id])
+      .where(content_id: [nil, content_id])
       .where(document_type: ["", @document_type])
       .where(email_document_supertype: ["", @email_document_supertype])
       .where(government_document_supertype: ["", @government_document_supertype])

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe SubscriberListQuery do
       links: {
         policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467],
         taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448],
-        document_collections: [
-          { content_id: document_collection_id },
-        ],
+        document_collections: [document_collection_id],
       },
       document_type: "travel_advice",
       email_document_supertype: "publications",
@@ -20,7 +18,8 @@ RSpec.describe SubscriberListQuery do
   end
 
   shared_examples "#links matching" do |tags_or_links|
-    it { is_included_in_links tags_or_links, content_id: content_id }
+    it { is_included_in_links tags_or_links, content_id: }
+    it { is_included_in_links tags_or_links, content_id: document_collection_id }
     it { is_excluded_from_links tags_or_links, content_id: "00000000-0000-0000-0000-000000000000" }
     it { is_included_in_links tags_or_links, content_id: "" }
     it { is_included_in_links tags_or_links, document_type: "travel_advice" }

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -1,9 +1,18 @@
 RSpec.describe SubscriberListQuery do
+  let(:content_id) { "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
+  let(:document_collection_id) { "5f6222fe-7631-11e4-a3cb-005056011aef" }
+
   subject do
     described_class.new(
-      content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
+      content_id:,
       tags: { policies: %w[eggs] },
-      links: { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] },
+      links: {
+        policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467],
+        taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448],
+        document_collections: [
+          { content_id: document_collection_id },
+        ],
+      },
       document_type: "travel_advice",
       email_document_supertype: "publications",
       government_document_supertype: "news_stories",
@@ -11,7 +20,7 @@ RSpec.describe SubscriberListQuery do
   end
 
   shared_examples "#links matching" do |tags_or_links|
-    it { is_included_in_links tags_or_links, content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
+    it { is_included_in_links tags_or_links, content_id: content_id }
     it { is_excluded_from_links tags_or_links, content_id: "00000000-0000-0000-0000-000000000000" }
     it { is_included_in_links tags_or_links, content_id: "" }
     it { is_included_in_links tags_or_links, document_type: "travel_advice" }
@@ -24,7 +33,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_included_in_links(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
+        content_id:,
         document_type: "travel_advice",
         email_document_supertype: "publications",
         government_document_supertype: "news_stories",
@@ -44,7 +53,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_included_in_links(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
+        content_id:,
         document_type: "travel_advice",
         email_document_supertype: "publications",
         government_document_supertype: "news_stories",
@@ -54,7 +63,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
+        content_id:,
         document_type: "other",
         email_document_supertype: "publications",
         government_document_supertype: "news_stories",
@@ -64,7 +73,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
+        content_id:,
         document_type: "travel_advice",
         email_document_supertype: "other",
         government_document_supertype: "news_stories",
@@ -74,7 +83,7 @@ RSpec.describe SubscriberListQuery do
     it do
       is_excluded_from_links(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
+        content_id:,
         document_type: "travel_advice",
         email_document_supertype: "publications",
         government_document_supertype: "other",


### PR DESCRIPTION
When a user signs up to alerts on a document collection, research
has shown an expectation of being notified when changes are made to
documents within that collection.

The relationship between a document collection and the documents it
contains is stored in the links attribute sent to this application by
email alert service. See [1]

The current logic that matches subscriber lists to a content change
matches on content ID AND tags or links. This code was added in [2] when we began
supporting single page email notifications. I've followed that pattern here. eg
if the ContentChange has tags as well as a content id, the SubscriberListQuery will
only match it to a subscriber list if it matches on the tags AND the content ID.

In the case of a user being subscribed to a single page AND a collection
that includes that page, they will recieve two emails.

[1] https://github.com/alphagov/email-alert-service/pull/577
[2] https://github.com/alphagov/email-alert-api/commit/069ef4eafe87b751ce7cf352f8137b7bd99ac0fd

Trello https://trello.com/c/tJvdhfdd/1455-support-topic-like-subscriptions-for-document-collections-email-alert-api-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
