### PR TITLE
Dockerised app for replatforming

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.dockerignore
+.git
+.gitignore
+.github
+Dockerfile
+Jenkinsfile
+README.md
+docs
+tmp

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,9 @@
 ---
 :verbose: false
 :concurrency: 32
-:logfile: ./log/sidekiq.json.log
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>
 :timeout: 4
 :max_retries: 9
 :queues:


### PR DESCRIPTION
Add Dockerfile which is standard we use for Ruby Apps
Add .dockerignore to keeps image clean
Adds Puma via govuk_app_config

https://trello.com/c/44ebF691/1026-publishing-journey-apps-migrations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
