### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,19 +120,19 @@ GEM
       null_logger
       plek (>= 1.9.0)
       rest-client (~> 2.0)
-    gds-sso (17.1.0)
+    gds-sso (17.1.1)
       oauth2 (~> 2.0)
       omniauth (~> 2.1)
       omniauth-oauth2 (~> 1.8)
-      plek (~> 4.0)
+      plek (>= 4, < 6)
       rails (>= 6)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk_app_config (4.10.1)
+    govuk_app_config (4.11.0)
       logstasher (~> 2.1)
-      plek (~> 4)
+      plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)
       puma (>= 5.6, < 7.0)
       rack-proxy (~> 0.7)
@@ -259,8 +259,8 @@ GEM
       ast (~> 2.4.1)
     parslet (2.0.0)
     pg (1.4.5)
-    plek (4.1.0)
-    prometheus_exporter (2.0.3)
+    plek (5.0.0)
+    prometheus_exporter (2.0.5)
       webrick
     pry (0.14.1)
       coderay (~> 1.1)
@@ -274,7 +274,7 @@ GEM
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
-    rack-protection (3.0.2)
+    rack-protection (3.0.3)
       rack
     rack-proxy (0.7.4)
       rack
@@ -445,7 +445,7 @@ GEM
     websocket-extensions (0.1.5)
     with_advisory_lock (4.6.0)
       activerecord (>= 4.2)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   aarch64-linux


### PR DESCRIPTION
Updates Plek to 5, and govuk_apps_config and gds-sso so that they will allow Plek 5.

Created to replace: https://github.com/alphagov/email-alert-api/pull/1837

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
