### PR TITLE
Add support for subscriber lists that match on reverse links

### DIFF
--- a/app/queries/find_exact_query.rb
+++ b/app/queries/find_exact_query.rb
@@ -22,36 +22,45 @@ class FindExactQuery
   def exact_match
     return find_exact(:links, @links) if @links.any?
     return find_exact(:tags, @tags) if @tags.any?
+    return find_exact(:content_id, @content_id) if @content_id.presence
 
-    FindWithoutLinksAndTags.new(scope: base_scope).call.first
+    FindWithoutLinksAndTagsAndContentId.new(scope: document_type_scope).call.first
   end
 
 private
 
   def base_scope
     @base_scope ||= begin
-      scope = SubscriberList
+      scope = document_type_scope
         .where(content_id: @content_id)
-        .where(document_type: @document_type)
-        .where(email_document_supertype: @email_document_supertype)
-        .where(government_document_supertype: @government_document_supertype)
       scope = scope.where(slug: @slug) if @slug.present?
       scope
     end
   end
 
+  def document_type_scope
+    SubscriberList
+      .where(document_type: @document_type)
+      .where(email_document_supertype: @email_document_supertype)
+      .where(government_document_supertype: @government_document_supertype)
+  end
+
   def find_exact(query_field, query)
-    raise ArgumentError, "query_field must be `:tags` or `:links`" unless %i[tags links].include?(query_field)
+    raise ArgumentError, "query_field must be `:tags` or `:links` or `:content_id`" unless %i[tags links content_id].include?(query_field)
 
     return if query.blank?
 
-    digest = HashDigest.new(query).generate
-
     case query_field
     when :tags
-      base_scope.find_by_tags_digest(digest)
+      base_scope.find_by_tags_digest(hash_digest(query))
     when :links
-      base_scope.find_by_links_digest(digest)
+      base_scope.find_by_links_digest(hash_digest(query))
+    when :content_id
+      base_scope.first
     end
+  end
+
+  def hash_digest(query)
+    HashDigest.new(query).generate
   end
 end

--- a/app/queries/find_without_links_and_tags.rb
+++ b/app/queries/find_without_links_and_tags.rb
@@ -1,9 +1,0 @@
-class FindWithoutLinksAndTags
-  def initialize(scope: SubscriberList)
-    @scope = scope
-  end
-
-  def call
-    @scope.where("tags::text = '{}'::text AND links::text = '{}'::text")
-  end
-end

--- a/app/queries/find_without_links_and_tags_and_content_id.rb
+++ b/app/queries/find_without_links_and_tags_and_content_id.rb
@@ -1,0 +1,9 @@
+class FindWithoutLinksAndTagsAndContentId
+  def initialize(scope: SubscriberList)
+    @scope = scope
+  end
+
+  def call
+    @scope.where("tags::text = '{}'::text AND links::text = '{}'::text AND content_id::text IS null")
+  end
+end

--- a/app/queries/subscriber_list_query.rb
+++ b/app/queries/subscriber_list_query.rb
@@ -12,27 +12,31 @@ class SubscriberListQuery
     @lists ||= (
       lists_matched_on_links +
       lists_matched_on_tags +
-      lists_matched_without_links_or_tags
+      lists_matched_on_document_type_only +
+      lists_matched_on_content_id
     ).uniq(&:id)
   end
 
 private
 
   def lists_matched_on_tags
-    MatchedForNotification.new(query_field: :tags, scope: base_scope).call(@tags)
+    MatchedForNotification.new(query_field: :tags, scope: document_type_scope).call(@tags)
   end
 
   def lists_matched_on_links
-    MatchedForNotification.new(query_field: :links, scope: base_scope).call(@links)
+    MatchedForNotification.new(query_field: :links, scope: document_type_scope).call(@links)
   end
 
-  def lists_matched_without_links_or_tags
-    FindWithoutLinksAndTags.new(scope: base_scope).call
+  def lists_matched_on_document_type_only
+    FindWithoutLinksAndTagsAndContentId.new(scope: document_type_scope).call
   end
 
-  def base_scope
+  def lists_matched_on_content_id
+    SubscriberList.where(content_id: @content_id)
+  end
+
+  def document_type_scope
     SubscriberList
-      .where(content_id: [nil, @content_id])
       .where(document_type: ["", @document_type])
       .where(email_document_supertype: ["", @email_document_supertype])
       .where(government_document_supertype: ["", @government_document_supertype])

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -272,4 +272,44 @@ RSpec.describe SubscriberListQuery do
       expect(query.lists).to include(list)
     end
   end
+
+  context "when a subscriber_list has a content id and links" do
+    let(:document_collection_id) { "4d74904a-e45e-47e4-921d-c9dc13c8c9de" }
+    let(:content_change_links) { { document_collections: [document_collection_id] } }
+    let(:subscriber_list_links) { { document_collections: { any: [document_collection_id] } } }
+    let(:unmatched_content_change_links) { { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467] } }
+    let(:unmatched_content_id) { "f05dc04b-ca95-4cca-9875-a7591d055467" }
+
+    it "includes lists that match on content id and match on links" do
+      content_change = build_content_change(links: content_change_links)
+      list = create_subscriber_list(links: subscriber_list_links)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "includes lists that match on content id but do not match on links" do
+      content_change = build_content_change(links: unmatched_content_change_links)
+      list = create_subscriber_list(links: subscriber_list_links, content_id:)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "includes lists that match on links but do not match on content id" do
+      content_change = build_content_change(links: content_change_links)
+      list = create_subscriber_list(links: subscriber_list_links, content_id: unmatched_content_id)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "exludes lists that do not match on content id and do not match on links" do
+      content_change = build_content_change(links: unmatched_content_change_links)
+      list = create_subscriber_list(links: subscriber_list_links, content_id: unmatched_content_id)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+  end
 end

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -252,4 +252,24 @@ RSpec.describe SubscriberListQuery do
       expect(query.lists).not_to include(list)
     end
   end
+
+  context "when a subscriber_list has content id and document type" do
+    let(:no_match_content_id) { "9376121a-b7bc-4521-b973-b63a72e0f1cf" }
+
+    it "includes lists that match on content id and document type" do
+      content_change = build_content_change(document_type_attributes)
+      list = create_subscriber_list(document_type_attributes.merge(content_id:))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "excludes lists that match on content id but do not match on document type" do
+      content_change = build_content_change(document_type_attributes)
+      list = create_subscriber_list(document_type_attributes.merge(content_id:, document_type: "other"))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+  end
 end

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -264,12 +264,12 @@ RSpec.describe SubscriberListQuery do
       expect(query.lists).to include(list)
     end
 
-    it "excludes lists that match on content id but do not match on document type" do
+    it "includes lists that match on content id but do not match on document type" do
       content_change = build_content_change(document_type_attributes)
       list = create_subscriber_list(document_type_attributes.merge(content_id:, document_type: "other"))
       query = described_class.new(**content_change)
 
-      expect(query.lists).not_to include(list)
+      expect(query.lists).to include(list)
     end
   end
 end

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -1,174 +1,23 @@
 RSpec.describe SubscriberListQuery do
+  let(:content_id) { "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
+  let(:tags) { { policies: %w[eggs] } }
+  let(:links) { { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] } }
+  let(:document_type) { "travel_advice" }
+  let(:email_document_supertype) { "publications" }
+  let(:government_document_supertype) { "news_stories" }
+
   let(:content_change_attributes) do
     {
-      content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
-      tags: { policies: %w[eggs] },
-      links: { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] },
-      document_type: "travel_advice",
-      email_document_supertype: "publications",
-      government_document_supertype: "news_stories",
+      content_id:,
+      tags: {},
+      links: {},
+      document_type: "",
+      email_document_supertype: "",
+      government_document_supertype: "",
     }
   end
 
-  subject { described_class.new(**content_change_attributes) }
-
-  shared_examples "#list matching" do |tags_or_links|
-    it { includes_subscriber_list(tags_or_links, document_type: "travel_advice") }
-    it { excludes_subscriber_list(tags_or_links, document_type: "other") }
-    it { includes_subscriber_list(tags_or_links, email_document_supertype: "publications") }
-    it { excludes_subscriber_list(tags_or_links, email_document_supertype: "other") }
-    it { includes_subscriber_list(tags_or_links, government_document_supertype: "news_stories") }
-    it { excludes_subscriber_list(tags_or_links, government_document_supertype: "other") }
-
-    it do
-      includes_subscriber_list(
-        tags_or_links,
-        document_type: "travel_advice",
-        email_document_supertype: "publications",
-        government_document_supertype: "news_stories",
-      )
-    end
-
-    it do
-      excludes_subscriber_list(
-        tags_or_links,
-        document_type: "other",
-        email_document_supertype: "publications",
-        government_document_supertype: "news_stories",
-      )
-    end
-
-    it do
-      excludes_subscriber_list(
-        tags_or_links,
-        document_type: "travel_advice",
-        email_document_supertype: "other",
-        government_document_supertype: "news_stories",
-      )
-    end
-
-    it do
-      excludes_subscriber_list(
-        tags_or_links,
-        document_type: "travel_advice",
-        email_document_supertype: "publications",
-        government_document_supertype: "other",
-      )
-    end
-  end
-
-  context "when matching has tags fields" do
-    it_behaves_like "#list matching", tags: { policies: { any: %w[eggs] } }, links: {}
-
-    it "excluded when non-matching tags" do
-      subscriber_list = create_subscriber_list(tags: { policies: { any: %w[apples] } })
-      expect(subject.lists).not_to include(subscriber_list)
-    end
-  end
-
-  context "when matching has links fields" do
-    it_behaves_like "#list matching",
-                    links: { policies: { any: %w[f05dc04b-ca95-4cca-9875-a7591d055467] },
-                             taxon_tree: { all: %w[f05dc04b-ca95-4cca-9875-a7591d055448] } },
-                    tags: {}
-
-    it "excluded when non-matching links" do
-      list_params = { links: { policies: { any: %w[f05dc04b-ca95-4cca-9875-a7591d055467] },
-                               taxon_tree: { all: %w[f05dc04b-ca95-4cca-9875-a7591d055448 f05dc04b-ca95-4cca-9875-a7591d055446] } } }
-      subscriber_list = create_subscriber_list(list_params)
-      expect(subject.lists).not_to include(subscriber_list)
-    end
-  end
-
-  context "when matching neither links or tags fields" do
-    it_behaves_like "#list matching", links: {}, tags: {}
-  end
-
-  context "when a content_purpose_supergroup is provided" do
-    let(:query_params) do
-      {
-        document_type: "travel_advice",
-        tags: { content_purpose_supergroup: "guidance_and_regulation" },
-      }
-    end
-
-    let(:query) { described_class.new(**default_list_attributes.merge(query_params)) }
-
-    it "includes subscriber lists where the content_purpose_supergroup is set to the desired value" do
-      list_params = { document_type: "travel_advice", tags: { content_purpose_supergroup: { any: %w[guidance_and_regulation] } } }
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
-
-      expect(query.lists).to include(subscriber_list)
-    end
-
-    it "includes subscriber lists even if the content_purpose_supergroup is nil, if the document_type is the same value" do
-      list_params = { document_type: "travel_advice" }
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
-
-      expect(query.lists).to include(subscriber_list)
-    end
-
-    it "includes subscriber lists where the content_purpose_supergroup is set to the same value" do
-      list_params = { tags: { content_purpose_supergroup: { any: %w[guidance_and_regulation] } } }
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
-
-      expect(query.lists).to include(subscriber_list)
-    end
-
-    it "excludes subscriber lists where the content_purpose_supergroup is set to a different value" do
-      list_params = { document_type: "travel_advice", tags: { content_purpose_supergroup: { any: %w[news_and_communications] } } }
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
-
-      expect(query.lists).not_to include(subscriber_list)
-    end
-
-    it "excludes subscriber lists where the content_purpose_supergroup is set to the same value but the document type is different" do
-      list_params = { tags: { content_purpose_supergroup: { any: %w[guidance_and_regulation] } }, document_type: "edition" }
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
-
-      expect(query.lists).not_to include(subscriber_list)
-    end
-  end
-
-  context "when a content_purpose_subgroup is provided" do
-    let(:query_params) { { tags: { content_purpose_subgroup: %w[updates_and_alerts] } } }
-    let(:query) { described_class.new(**default_list_attributes.merge(query_params)) }
-
-    it "includes subscriber lists where the content_purpose_subgroup is set to the desired value" do
-      list_params = { tags: { content_purpose_subgroup: { any: %w[updates_and_alerts] } } }
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
-
-      expect(query.lists).to include(subscriber_list)
-    end
-
-    it "excludes subscriber lists where the content_purpose_subgroup is set to a different value" do
-      list_params = { tags: { content_purpose_subgroup: { any: %w[speeches_and_statements] } } }
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
-
-      expect(query.lists).not_to include(subscriber_list)
-    end
-  end
-
-  context "when list has content id only" do
-    let(:matching_content_id) { "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
-    let(:no_match_content_id) { "9376121a-b7bc-4521-b973-b63a72e0f1cf" }
-
-    it "includes lists where the content id matches" do
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(content_id: matching_content_id))
-      expect(subject.lists).to include(subscriber_list)
-    end
-
-    it "excludes lists where the content id does not match" do
-      subscriber_list = create_subscriber_list(default_list_attributes.merge(content_id: no_match_content_id))
-      expect(subject.lists).not_to include(subscriber_list)
-    end
-  end
-
-  def create_subscriber_list(options)
-    create(:subscriber_list, options)
-  end
-
-  let(:default_list_attributes) do
+  let(:subscriber_list_attributes) do
     {
       content_id: nil,
       links: {},
@@ -179,13 +28,228 @@ RSpec.describe SubscriberListQuery do
     }
   end
 
-  def includes_subscriber_list(tags_or_links, additional_list_attributes)
-    subscriber_list = create_subscriber_list(default_list_attributes.merge(tags_or_links).merge(additional_list_attributes))
-    expect(subject.lists).to include(subscriber_list)
+  let(:document_type_attributes) do
+    {
+      document_type:,
+      email_document_supertype:,
+      government_document_supertype:,
+    }
   end
 
-  def excludes_subscriber_list(tags_or_links, additional_list_attributes)
-    subscriber_list = create_subscriber_list(default_list_attributes.merge(tags_or_links).merge(additional_list_attributes))
-    expect(subject.lists).not_to include(subscriber_list)
+  def create_subscriber_list(options = {})
+    create(:subscriber_list, subscriber_list_attributes.merge(**options))
+  end
+
+  def build_content_change(options = {})
+    content_change_attributes.merge(**options)
+  end
+
+  context "when a subscriber_list has document types only" do
+    it "includes lists that match on all document types" do
+      content_change = build_content_change(document_type_attributes)
+      list = create_subscriber_list(document_type_attributes)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "includes lists that match on document_type" do
+      content_change = build_content_change(document_type:)
+      list = create_subscriber_list(document_type:)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "includes lists that match on email_document_supertype" do
+      content_change = build_content_change(email_document_supertype:)
+      list = create_subscriber_list(email_document_supertype:)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "includes lists that match on government_document_supertype" do
+      content_change = build_content_change(government_document_supertype:)
+      list = create_subscriber_list(government_document_supertype:)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "excludes lists that don't match on document type" do
+      content_change = build_content_change(document_type_attributes)
+      list = create_subscriber_list(document_type_attributes.merge(document_type: "other"))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+
+    it "excludes lists that don't match on email_document_supertype" do
+      content_change = build_content_change(document_type_attributes)
+      list = create_subscriber_list(document_type_attributes.merge(email_document_supertype: "other"))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+
+    it "excludes lists that don't match on government_document_supertype" do
+      content_change = build_content_change(document_type_attributes)
+      list = create_subscriber_list(document_type_attributes.merge(government_document_supertype: "other"))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+  end
+
+  context "when a subscriber_list has document types and tags" do
+    let(:content_change_tags) { { policies: %w[eggs] } }
+    let(:list_tags) { { policies: { any: %w[eggs] } } }
+
+    it "includes lists that match on document types and tags" do
+      content_change = build_content_change(document_type_attributes.merge(tags: content_change_tags))
+      list = create_subscriber_list(document_type_attributes.merge(tags: list_tags))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "excludes lists that match on document type but do not match on tags" do
+      content_change = build_content_change(document_type_attributes.merge(tags: content_change_tags))
+      list = create_subscriber_list(document_type_attributes.merge(tags: { policies: { any: %w[cheese] } }))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+
+    it "exludes lists that match on tags but do not match on document types" do
+      unmatched_document_type_attributes = document_type_attributes.merge(government_document_supertype: "other")
+
+      content_change = build_content_change(document_type_attributes.merge(tags: content_change_tags))
+      list = create_subscriber_list(unmatched_document_type_attributes.merge(tags: list_tags))
+      query = described_class.new(**content_change)
+      expect(query.lists).not_to include(list)
+    end
+  end
+
+  context "when a subscriber_list has document types and links" do
+    let(:policy_id) { "f05dc04b-ca95-4cca-9875-a7591d055467" }
+    let(:taxon_id) { "f05dc04b-ca95-4cca-9875-a7591d055448" }
+
+    let(:content_change_links) do
+      {
+        policies: [policy_id],
+        taxon_tree: [taxon_id],
+      }
+    end
+
+    let(:subscriber_list_links) do
+      {
+        policies: { any: [policy_id] },
+        taxon_tree: { all: [taxon_id] },
+      }
+    end
+
+    it "includes lists that match on document types and link" do
+      content_change = build_content_change(document_type_attributes.merge(links: content_change_links))
+      list = create_subscriber_list(document_type_attributes.merge(links: subscriber_list_links))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "excludes lists that match on document type but do not match on link" do
+      content_change = build_content_change(document_type_attributes.merge(links: content_change_links))
+      list = create_subscriber_list(document_type_attributes.merge(links: { policies: { any: %w[random-content-id] } }))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+
+    it "exludes lists that match on links but do not match on document types" do
+      content_change = build_content_change(document_type_attributes.merge(links: content_change_links))
+      unmatched_document_type_attributes = document_type_attributes.merge(document_type: "other")
+      list = create_subscriber_list(unmatched_document_type_attributes.merge(links: subscriber_list_links))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+  end
+
+  context "when a content change has a content_purpose_supergroup" do
+    let(:content_purpose_supergroup) { %w[guidance_and_regulation] }
+
+    it "includes lists where the content_purpose_supergroup is set to the desired value" do
+      content_change = build_content_change(document_type_attributes.merge(tags: { content_purpose_supergroup: }))
+      list = create_subscriber_list(document_type_attributes.merge(tags: { content_purpose_supergroup: { any: content_purpose_supergroup } }))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "includes lists even if the content_purpose_supergroup is nil, if the document_type is the same value" do
+      content_change = build_content_change(document_type_attributes.merge(tags: { content_purpose_supergroup: }))
+      list = create_subscriber_list(document_type_attributes)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "excludes lists where the content_purpose_supergroup is set to a different value" do
+      content_change = build_content_change(document_type_attributes.merge(tags: { content_purpose_supergroup: }))
+      list = create_subscriber_list(document_type_attributes.merge(tags: { content_purpose_supergroup: { any: %w[news_and_communications] } }))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+
+    it "excludes lists where the content_purpose_supergroup is set to the same value but the document type is different" do
+      content_change = build_content_change(document_type_attributes.merge(tags: { content_purpose_supergroup: }))
+      unmatched_document_type_attributes = document_type_attributes.merge(government_document_supertype: "other")
+      list = create_subscriber_list(unmatched_document_type_attributes.merge(tags: { content_purpose_supergroup: { any: content_purpose_supergroup } }))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+  end
+
+  context "when a content change has a content_purpose_subgroup" do
+    let(:content_purpose_subgroup) { %w[updates_and_alerts] }
+
+    it "includes lists where the content_purpose_subgroup is set to the desired value" do
+      content_change = build_content_change(document_type_attributes.merge(tags: { content_purpose_subgroup: }))
+      list = create_subscriber_list(document_type_attributes.merge(tags: { content_purpose_subgroup: { any: content_purpose_subgroup } }))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "excludes lists where the content_purpose_subgroup is set to a different value" do
+      content_change = build_content_change(document_type_attributes.merge(tags: { content_purpose_subgroup: }))
+      list = create_subscriber_list(document_type_attributes.merge(tags: { content_purpose_subgroup: { any: %w[speeches] } }))
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
+  end
+
+  context "when a subscriber_list has content id only" do
+    let(:no_match_content_id) { "9376121a-b7bc-4521-b973-b63a72e0f1cf" }
+
+    it "includes lists where the content id matches" do
+      content_change = build_content_change
+      list = create_subscriber_list(content_id:)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).to include(list)
+    end
+
+    it "excludes lists where the content id does not match" do
+      content_change = build_content_change
+      list = create_subscriber_list(content_id: no_match_content_id)
+      query = described_class.new(**content_change)
+
+      expect(query.lists).not_to include(list)
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for reverse linked subscriber lists, ie a subscriber list with both a content id, and a reverse link to itself.

### Why

Soon we need to support single page notifications for document collections. When a user signs up to alerts on a document collection, research has shown an expectation of being notified when changes are made to documents within that collection. This relationship is stored as a reverse link.

Related work:

1. [Add reverse links to the payload for Email Alert API](https://github.com/alphagov/email-alert-service/pull/583)
2. [Document Collection email subscriptions](https://github.com/alphagov/email-alert-frontend/pull/1438)

See https://github.com/alphagov/email-alert-api/pull/1841/commits/4c47061ae10c60edb6e098bf8175799f0f530ea1 for more information.

For ref [this](https://github.com/alphagov/email-alert-api/pull/1640) is the PR that originally implemented single content notifications

Trello https://trello.com/c/tJvdhfdd/1455-support-topic-like-subscriptions-for-document-collections-email-alert-api-m

