### PR TITLE
Specs for matching content-id subscriber lists to content changes

### DIFF
--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -1,28 +1,30 @@
 RSpec.describe SubscriberListQuery do
-  subject do
-    described_class.new(
+  let(:content_change_attributes) do
+    {
       content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
       tags: { policies: %w[eggs] },
       links: { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] },
       document_type: "travel_advice",
       email_document_supertype: "publications",
       government_document_supertype: "news_stories",
-    )
+    }
   end
 
-  shared_examples "#links matching" do |tags_or_links|
-    it { is_included_in_links tags_or_links, content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
-    it { is_excluded_from_links tags_or_links, content_id: "00000000-0000-0000-0000-000000000000" }
-    it { is_included_in_links tags_or_links, content_id: "" }
-    it { is_included_in_links tags_or_links, document_type: "travel_advice" }
-    it { is_excluded_from_links tags_or_links, document_type: "other" }
-    it { is_included_in_links tags_or_links, email_document_supertype: "publications" }
-    it { is_excluded_from_links tags_or_links, email_document_supertype: "other" }
-    it { is_included_in_links tags_or_links, government_document_supertype: "news_stories" }
-    it { is_excluded_from_links tags_or_links, government_document_supertype: "other" }
+  subject { described_class.new(**content_change_attributes) }
+
+  shared_examples "#list matching" do |tags_or_links|
+    it { includes_subscriber_list(tags_or_links, content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30") }
+    it { excludes_subscriber_list(tags_or_links, content_id: "00000000-0000-0000-0000-000000000000") }
+    it { includes_subscriber_list(tags_or_links, content_id: "") }
+    it { includes_subscriber_list(tags_or_links, document_type: "travel_advice") }
+    it { excludes_subscriber_list(tags_or_links, document_type: "other") }
+    it { includes_subscriber_list(tags_or_links, email_document_supertype: "publications") }
+    it { excludes_subscriber_list(tags_or_links, email_document_supertype: "other") }
+    it { includes_subscriber_list(tags_or_links, government_document_supertype: "news_stories") }
+    it { excludes_subscriber_list(tags_or_links, government_document_supertype: "other") }
 
     it do
-      is_included_in_links(
+      includes_subscriber_list(
         tags_or_links,
         content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
@@ -32,7 +34,7 @@ RSpec.describe SubscriberListQuery do
     end
 
     it do
-      is_excluded_from_links(
+      excludes_subscriber_list(
         tags_or_links,
         content_id: "00000000-0000-0000-0000-000000000000",
         document_type: "travel_advice",
@@ -42,7 +44,7 @@ RSpec.describe SubscriberListQuery do
     end
 
     it do
-      is_included_in_links(
+      includes_subscriber_list(
         tags_or_links,
         content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
@@ -52,7 +54,7 @@ RSpec.describe SubscriberListQuery do
     end
 
     it do
-      is_excluded_from_links(
+      excludes_subscriber_list(
         tags_or_links,
         content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "other",
@@ -62,7 +64,7 @@ RSpec.describe SubscriberListQuery do
     end
 
     it do
-      is_excluded_from_links(
+      excludes_subscriber_list(
         tags_or_links,
         content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
@@ -72,7 +74,7 @@ RSpec.describe SubscriberListQuery do
     end
 
     it do
-      is_excluded_from_links(
+      excludes_subscriber_list(
         tags_or_links,
         content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
@@ -83,7 +85,7 @@ RSpec.describe SubscriberListQuery do
   end
 
   context "when matching has tags fields" do
-    it_behaves_like "#links matching", tags: { policies: { any: %w[eggs] } }, links: {}
+    it_behaves_like "#list matching", tags: { policies: { any: %w[eggs] } }, links: {}
 
     it "excluded when non-matching tags" do
       subscriber_list = create_subscriber_list(tags: { policies: { any: %w[apples] } })
@@ -92,20 +94,21 @@ RSpec.describe SubscriberListQuery do
   end
 
   context "when matching has links fields" do
-    it_behaves_like "#links matching",
+    it_behaves_like "#list matching",
                     links: { policies: { any: %w[f05dc04b-ca95-4cca-9875-a7591d055467] },
                              taxon_tree: { all: %w[f05dc04b-ca95-4cca-9875-a7591d055448] } },
                     tags: {}
 
     it "excluded when non-matching links" do
-      subscriber_list = create_subscriber_list(links: { policies: { any: %w[f05dc04b-ca95-4cca-9875-a7591d055467] },
-                                                        taxon_tree: { all: %w[f05dc04b-ca95-4cca-9875-a7591d055448 f05dc04b-ca95-4cca-9875-a7591d055446] } })
+      list_params = { links: { policies: { any: %w[f05dc04b-ca95-4cca-9875-a7591d055467] },
+                               taxon_tree: { all: %w[f05dc04b-ca95-4cca-9875-a7591d055448 f05dc04b-ca95-4cca-9875-a7591d055446] } } }
+      subscriber_list = create_subscriber_list(list_params)
       expect(subject.lists).not_to include(subscriber_list)
     end
   end
 
   context "when matching neither links or tags fields" do
-    it_behaves_like "#links matching", links: {}, tags: {}
+    it_behaves_like "#list matching", links: {}, tags: {}
   end
 
   context "when a content_purpose_supergroup is provided" do
@@ -116,56 +119,59 @@ RSpec.describe SubscriberListQuery do
       }
     end
 
+    let(:query) { described_class.new(**default_list_attributes.merge(query_params)) }
+
     it "includes subscriber lists where the content_purpose_supergroup is set to the desired value" do
       list_params = { document_type: "travel_advice", tags: { content_purpose_supergroup: { any: %w[guidance_and_regulation] } } }
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(**defaults.merge(query_params))
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
+
       expect(query.lists).to include(subscriber_list)
     end
 
     it "includes subscriber lists even if the content_purpose_supergroup is nil, if the document_type is the same value" do
       list_params = { document_type: "travel_advice" }
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(**defaults.merge(query_params))
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
+
       expect(query.lists).to include(subscriber_list)
     end
 
     it "includes subscriber lists where the content_purpose_supergroup is set to the same value" do
       list_params = { tags: { content_purpose_supergroup: { any: %w[guidance_and_regulation] } } }
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(**defaults.merge(query_params))
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
+
       expect(query.lists).to include(subscriber_list)
     end
 
     it "excludes subscriber lists where the content_purpose_supergroup is set to a different value" do
       list_params = { document_type: "travel_advice", tags: { content_purpose_supergroup: { any: %w[news_and_communications] } } }
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(**defaults.merge(query_params))
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
+
       expect(query.lists).not_to include(subscriber_list)
     end
 
     it "excludes subscriber lists where the content_purpose_supergroup is set to the same value but the document type is different" do
       list_params = { tags: { content_purpose_supergroup: { any: %w[guidance_and_regulation] } }, document_type: "edition" }
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(**defaults.merge(query_params))
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
+
       expect(query.lists).not_to include(subscriber_list)
     end
   end
 
   context "when a content_purpose_subgroup is provided" do
-    query_params = { tags: { content_purpose_subgroup: %w[updates_and_alerts] } }
-    list_params = { tags: { content_purpose_subgroup: { any: %w[updates_and_alerts] } } }
+    let(:query_params) { { tags: { content_purpose_subgroup: %w[updates_and_alerts] } } }
+    let(:query) { described_class.new(**default_list_attributes.merge(query_params)) }
 
     it "includes subscriber lists where the content_purpose_subgroup is set to the desired value" do
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(**defaults.merge(query_params))
+      list_params = { tags: { content_purpose_subgroup: { any: %w[updates_and_alerts] } } }
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
+
       expect(query.lists).to include(subscriber_list)
     end
 
     it "excludes subscriber lists where the content_purpose_subgroup is set to a different value" do
       list_params = { tags: { content_purpose_subgroup: { any: %w[speeches_and_statements] } } }
-      subscriber_list = create(:subscriber_list, defaults.merge(list_params))
-      query = described_class.new(**defaults.merge(query_params))
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(list_params))
+
       expect(query.lists).not_to include(subscriber_list)
     end
   end
@@ -174,7 +180,7 @@ RSpec.describe SubscriberListQuery do
     create(:subscriber_list, options)
   end
 
-  def defaults
+  let(:default_list_attributes) do
     {
       content_id: nil,
       links: {},
@@ -185,13 +191,13 @@ RSpec.describe SubscriberListQuery do
     }
   end
 
-  def is_included_in_links(links_or_tags, criteria)
-    subscriber_list = create(:subscriber_list, defaults.merge(links_or_tags).merge(criteria))
+  def includes_subscriber_list(tags_or_links, additional_list_attributes)
+    subscriber_list = create_subscriber_list(default_list_attributes.merge(tags_or_links).merge(additional_list_attributes))
     expect(subject.lists).to include(subscriber_list)
   end
 
-  def is_excluded_from_links(links_or_tags, criteria)
-    subscriber_list = create(:subscriber_list, defaults.merge(links_or_tags).merge(criteria))
+  def excludes_subscriber_list(tags_or_links, additional_list_attributes)
+    subscriber_list = create_subscriber_list(default_list_attributes.merge(tags_or_links).merge(additional_list_attributes))
     expect(subject.lists).not_to include(subscriber_list)
   end
 end

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -13,9 +13,6 @@ RSpec.describe SubscriberListQuery do
   subject { described_class.new(**content_change_attributes) }
 
   shared_examples "#list matching" do |tags_or_links|
-    it { includes_subscriber_list(tags_or_links, content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30") }
-    it { excludes_subscriber_list(tags_or_links, content_id: "00000000-0000-0000-0000-000000000000") }
-    it { includes_subscriber_list(tags_or_links, content_id: "") }
     it { includes_subscriber_list(tags_or_links, document_type: "travel_advice") }
     it { excludes_subscriber_list(tags_or_links, document_type: "other") }
     it { includes_subscriber_list(tags_or_links, email_document_supertype: "publications") }
@@ -26,7 +23,6 @@ RSpec.describe SubscriberListQuery do
     it do
       includes_subscriber_list(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
         email_document_supertype: "publications",
         government_document_supertype: "news_stories",
@@ -36,17 +32,6 @@ RSpec.describe SubscriberListQuery do
     it do
       excludes_subscriber_list(
         tags_or_links,
-        content_id: "00000000-0000-0000-0000-000000000000",
-        document_type: "travel_advice",
-        email_document_supertype: "publications",
-        government_document_supertype: "news_stories",
-      )
-    end
-
-    it do
-      excludes_subscriber_list(
-        tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "other",
         email_document_supertype: "publications",
         government_document_supertype: "news_stories",
@@ -56,7 +41,6 @@ RSpec.describe SubscriberListQuery do
     it do
       excludes_subscriber_list(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
         email_document_supertype: "other",
         government_document_supertype: "news_stories",
@@ -66,7 +50,6 @@ RSpec.describe SubscriberListQuery do
     it do
       excludes_subscriber_list(
         tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
         document_type: "travel_advice",
         email_document_supertype: "publications",
         government_document_supertype: "other",

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -149,6 +149,21 @@ RSpec.describe SubscriberListQuery do
     end
   end
 
+  context "when list has content id only" do
+    let(:matching_content_id) { "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
+    let(:no_match_content_id) { "9376121a-b7bc-4521-b973-b63a72e0f1cf" }
+
+    it "includes lists where the content id matches" do
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(content_id: matching_content_id))
+      expect(subject.lists).to include(subscriber_list)
+    end
+
+    it "excludes lists where the content id does not match" do
+      subscriber_list = create_subscriber_list(default_list_attributes.merge(content_id: no_match_content_id))
+      expect(subject.lists).not_to include(subscriber_list)
+    end
+  end
+
   def create_subscriber_list(options)
     create(:subscriber_list, options)
   end

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -44,16 +44,6 @@ RSpec.describe SubscriberListQuery do
     end
 
     it do
-      includes_subscriber_list(
-        tags_or_links,
-        content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",
-        document_type: "travel_advice",
-        email_document_supertype: "publications",
-        government_document_supertype: "news_stories",
-      )
-    end
-
-    it do
       excludes_subscriber_list(
         tags_or_links,
         content_id: "37ac8e5c-331a-48fc-8ac0-d401579c3d30",


### PR DESCRIPTION
This PR tidies up some of the tests for matching content-id based subscriber lists against content changes. See commit messages for more information.

This is in preparation for an incoming change, where we will start storing lists that match on `content-id` AND `links`. If we make it clear that we don't yet do that, the new behaviour will be easier to review.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
