### PR TITLE
Add GitHub Action workflow for verifying pact tests

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -1,0 +1,49 @@
+# Pact verify workflow
+#
+# This workflow asserts that Pact contract tests are valid against this
+# codebase. It is trigged when changes are made to this project and it
+# is explicitly called by GDS API Adapters when changes are made there.
+on:
+  pull_request:
+  push:
+  workflow_call:
+    inputs:
+      # what branch or Git SHA to clone this app with, only applies when
+      # called as a workflow, so current commit applies to push/pull requests
+      commitish:
+        required: false
+        type: string
+        default: main
+      pact_consumer_version:
+        required: true
+        type: string
+
+jobs:
+  pact_verify:
+    name: Verify pact tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        ports: ["5432:5432"]
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis
+        ports: ["6379:6379"]
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version || 'branch-main' }}
+      TEST_DATABASE_URL: postgresql://postgres@localhost/test-db
+      RAILS_ENV: test
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: alphagov/email-alert-api
+          ref: ${{ inputs.commitish || github.sha }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rails db:setup
+      - run: bundle exec rake pact:verify

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,7 @@ library("govuk")
 
 node {
   govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/email-alert-api-test")
-  govuk.buildProject()
+  govuk.buildProject(
+    overrideTestTask: { sh("bundle exec rake lint spec") }
+  )
 }


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This moves the pact verification to a GitHub Action and will no longer be performed by a Jenkins build. This workflow will also be called by GDS API Adapters as part of its CI build to assert that newly generated pacts are valid against this app. To avoid running this same task twice `pact:verify` is no longer part of the Jenkins test actions and instead the other rake default steps are included.

For more details see https://github.com/alphagov/gds-api-adapters/pull/1175

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
