### PR TITLE
Sort emails by date in `support:view_emails` Rake task

### DIFF
--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -25,7 +25,7 @@ namespace :support do
     limit = args[:limit] ? args[:limit].to_i : 10
     raise ArgumentError, "Provide an email!" if email_address.blank?
 
-    query = Email.where(address: email_address)
+    query = Email.where(address: email_address).order(created_at: :desc)
     puts "#{query.count} emails sent to #{email_address}:"
     results = query.limit(limit).map do |email|
       {


### PR DESCRIPTION
Because this task returns only 10 emails by default, and because it doesn't sort them by date, in practice it returns 10 random ones instead of the 10 most recent ones. This has bitten me recently when working on 2nd line.

This PR fixes that issue by sorting the emails by date, newest first.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️