### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "govuk_personalisation"
 gem "govuk_sidekiq"
 gem "json-schema"
 gem "jwt"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "nokogiri"
 gem "notifications-ruby-client"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ DEPENDENCIES
   json-schema
   jwt
   listen
+  mail (~> 2.7.1)
   nokogiri
   notifications-ruby-client
   pact


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
