### PR TITLE
Add GitHub Action workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "Jenkinsfile"
+      - ".git**"
+  pull_request:
+
+jobs:
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+
+  lint-ruby:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
+
+  test-ruby:
+    name: Test Ruby
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Postgres
+        id: setup-postgres
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-postgres@main
+
+      - name: Setup Redis
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Initialize database
+        env:
+          RAILS_ENV: test
+          TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
+        run: bundle exec rails db:setup
+
+      - name: Run RSpec
+        env:
+          RAILS_ENV: test
+          TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
+        run: bundle exec rake spec
+

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "sidekiq-scheduler"
 gem "with_advisory_lock"
 
 group :test do
+  gem "brakeman"
   gem "climate_control"
   gem "equivalent-xml"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     awesome_print (1.9.2)
     bootsnap (1.15.0)
       msgpack (~> 1.2)
+    brakeman (5.4.0)
     builder (3.2.4)
     byebug (11.1.3)
     climate_control (1.2.0)
@@ -455,6 +456,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  brakeman
   climate_control
   database_cleaner
   equivalent-xml


### PR DESCRIPTION
This is an initial workflow to enable CI using GitHub Actions. It makes use of
reusable workflows and composite actions defined in govuk-infrastructure. The
CI workflow is initially only used to support deployments to the new EKS
infrastructure and not to immediately replace the CI workflow in Jenkins.

The CI workflow makes use of individual jobs to run each testing and linting
tool. This allows the processes to run concurrently and improves the visibility
of status in the GitHub UI.

Most jobs make use of reusable workflows as they are consistent across the
majority of our repositories - this allows us to easily maintain them in a
single place. However, the test-ruby job (and/or integration-tests) is defined
per repo as backing services and other dependencies vary greatly between repos.
Backing services (such as databases) are created using a composite action
instead of a job service. This is because they contain a lot of shared config
and makes it easier for us to maintain.
