### PR TITLE
Dockerfile cleanup + fix bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,15 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+features
+log
+node_modules
+script
+spec
+test
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
-WORKDIR /app
-COPY Gemfile* .ruby-version /app/
+
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-COPY . /app
+COPY . .
+RUN bootsnap precompile --gemfile .
+
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=email-alert-api
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]


### PR DESCRIPTION
- Build the bootsnap cache into the image to reduce the resource usage spike on startup.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Add .dockerignore.

Tested: app boots successfully with `docker run`.
