### PR TITLE
Revert "Add temporary rake task to send bulk email following incident"

### DIFF
--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -26,47 +26,4 @@ namespace :bulk_email do
     end
     puts "Sending #{email_ids.count} emails to subscribers on the following lists: #{subscriber_lists.pluck(:slug).join(', ')}"
   end
-
-  desc "Send an apology email following an incident"
-  task :temp_incident_new_subscribers, [] => :environment do
-    affected_subscribers = []
-    Subscription.where(created_at: Time.zone.local(2023, 2, 8, 14, 38)..Time.zone.local(2023, 4, 4, 14, 24)).find_in_batches do |subscriptions|
-      affected_subscribers << subscriptions.select { |subscription| subscription.subscriber_list.content_id.present? }.map(&:subscriber).map(&:address)
-    end
-
-    unique_email_addresses = affected_subscribers.flatten.uniq
-
-    explanation = <<~BODY
-      Hello,
-
-      You recently signed up to email notifications on GOV.UK. Due to an update to our system you may not have been subscribed to all updates you expected since 8th February 2023.
-
-      If the subscription appears in ‘Manage your GOV.UK email subscriptions’ (https://www.gov.uk/email/manage) but you have not received them, we recommend that you unsubscribe and sign up again for notifications through the GOV.UK website. You will then be sent a new confirmation link.
-
-      Travel alerts and subscriptions to the ‘alerts, recalls and safety information: drugs and medical devices’ (https://www.gov.uk/drug-device-alerts) have not been affected.
-
-      Apologies for any inconvenience,
-      GOV.UK Team
-    BODY
-
-    follow_up_emails = []
-
-    ApplicationRecord.transaction do
-      follow_up_emails = unique_email_addresses.map do |email|
-        next if email.blank? # this is only an issue in integration, where the data sync appears to have wiped some addresses
-
-        Email.create!(
-          subject: "Action needed on email notifications",
-          body: explanation,
-          address: email,
-        )
-      end
-    end
-
-    follow_up_emails.each do |email|
-      next if email.nil?
-
-      SendEmailWorker.perform_async_in_queue(email.id, queue: :send_email_immediate)
-    end
-  end
 end

--- a/spec/lib/tasks/bulk_email_spec.rb
+++ b/spec/lib/tasks/bulk_email_spec.rb
@@ -52,38 +52,4 @@ RSpec.describe "bulk_email" do
         ).to_stdout
     end
   end
-
-  describe "temp_incident_new_subscribers" do
-    before do
-      Rake::Task["bulk_email:temp_incident_new_subscribers"].reenable
-    end
-
-    it "sends a single apology email to affected subscribers" do
-      # affected subscriptions
-      create(:subscription, created_at: Time.zone.local(2023, 2, 10, 14, 30), subscriber_list: create(:subscriber_list, :for_single_page_subscription)) # we can't differentiate between these and the incorrect subscriptions, so they are affected
-      create(:subscription, created_at: Time.zone.local(2023, 3, 7, 14, 30), subscriber_list: create(:subscriber_list, content_id: SecureRandom.uuid)) # this is how we incorrectly subscribed users to affected alerts
-
-      # same user has made multiple subscriptions, but will only get one email (not one per subscription)
-      subscriber = create(:subscriber, address: "subscribed-twice@gov.uk")
-      create(:subscription, created_at: Time.zone.local(2023, 3, 7, 14, 30), subscriber_list: create(:subscriber_list, content_id: SecureRandom.uuid), subscriber:)
-      create(:subscription, created_at: Time.zone.local(2023, 3, 7, 14, 30), subscriber_list: create(:subscriber_list, content_id: SecureRandom.uuid), subscriber:)
-
-      # unaffected subscriptions
-      create(:subscription, created_at: Time.zone.local(2023, 1, 7, 14, 30), subscriber_list: create(:subscriber_list, :for_single_page_subscription)) # before the incident
-      create(:subscription, created_at: Time.zone.local(2023, 4, 5, 14, 30), subscriber_list: create(:subscriber_list, :for_single_page_subscription)) # after the incident
-      create(:subscription, created_at: Time.zone.local(2023, 3, 7, 14, 30), subscriber_list: create(:subscriber_list, :travel_advice)) # during incident but unaffected signup journey
-      create(:subscription, created_at: Time.zone.local(2023, 3, 7, 14, 30), subscriber_list: create(:subscriber_list, :medical_safety_alert)) # during incident but unaffected signup journey
-
-      expect(SendEmailWorker)
-        .to receive(:perform_async_in_queue)
-        .with(instance_of(String), queue: :send_email_immediate)
-        .exactly(3).times
-
-      expect { Rake::Task["bulk_email:temp_incident_new_subscribers"].invoke }
-        .to change { Email.count }.by(3)
-
-      apology_emails = Email.where(subject: "Action needed on email notifications")
-      expect(apology_emails.first.body).to include("You recently signed up to")
-    end
-  end
 end


### PR DESCRIPTION
The task has been run in production, so the code can now be removed.

This reverts commit 76ecef53d287fa1f58b9889582a37e959cf9132a.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
