### PR TITLE
Temporary bulk migrate endpoint

### DIFF
--- a/app/builders/bulk_migrate_confirmation_email_builder.rb
+++ b/app/builders/bulk_migrate_confirmation_email_builder.rb
@@ -1,0 +1,46 @@
+class BulkMigrateConfirmationEmailBuilder
+  include Callable
+
+  def initialize(source_id:, destination_id:, count:)
+    @source_id = source_id
+    @destination_id = destination_id
+    @count = count
+  end
+
+  def call
+    Email.create!(
+      subject:,
+      body:,
+      address: ENV["BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT"],
+    )
+  end
+
+private
+
+  attr_reader :source_id, :destination_id, :count
+
+  def subject
+    "Bulk migration of #{source_subscriber_list_title} is complete"
+  end
+
+  def source_subscriber_list_title
+    SubscriberList.find(source_id).title
+  end
+
+  def destination_subscriber_list_title
+    SubscriberList.find(destination_id).title
+  end
+
+  def body
+    <<~BODY
+      #{count} subscriptions have been migrated:
+      From "#{source_subscriber_list_title}"
+      To "#{destination_subscriber_list_title}"
+
+      No email notification has been sent to users.
+
+      Thanks
+      GOV.UK emails
+    BODY
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -25,6 +25,7 @@ class Subscription < ApplicationRecord
     bulk_immediate_to_digest: 6, # Potentially unused (for a one-off migration)
     subscriber_merged: 7,
     bulk_unsubscribed: 8,
+    bulk_migrated: 9,
   }, _prefix: :ended
 
   scope :active, -> { where(ended_at: nil) }

--- a/app/workers/bulk_migrate_list_worker.rb
+++ b/app/workers/bulk_migrate_list_worker.rb
@@ -1,0 +1,59 @@
+class BulkMigrateListWorker < ApplicationWorker
+  def perform(source_list_id, destination_list_id)
+    @source_list_id = source_list_id
+    @destination_list_id = destination_list_id
+
+    run_with_advisory_lock(SubscriberList, source_list_id) do
+      if subscribers_to_move_count.zero?
+        logger.warn("no active subscriptions for #{source_list.title}")
+        return
+      end
+
+      migrate_subscribers
+    end
+  end
+
+private
+
+  def source_list
+    @source_list ||= SubscriberList.find(@source_list_id)
+  end
+
+  def destination_list
+    @destination_list ||= SubscriberList.find(@destination_list_id)
+  end
+
+  def subscribers_to_move_count
+    @subscribers_to_move_count ||= source_list.active_subscriptions_count
+  end
+
+  def migrate_subscribers
+    subscribers = source_list.subscribers
+    subscribers.each do |subscriber|
+      Subscription.transaction do
+        existing_subscription = Subscription.active.find_by(
+          subscriber:,
+          subscriber_list: source_list,
+        )
+
+        next unless existing_subscription
+
+        existing_subscription.end(reason: :bulk_migrated)
+
+        destination_subscriber_list_subscription = Subscription.find_by(
+          subscriber:,
+          subscriber_list: destination_list,
+        )
+
+        if destination_subscriber_list_subscription.blank?
+          Subscription.create!(
+            subscriber:,
+            subscriber_list: destination_list,
+            frequency: existing_subscription.frequency,
+            source: :subscriber_list_changed,
+          )
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     get "/subscriber-lists/:slug", to: "subscriber_lists#show"
     patch "/subscriber-lists/:slug", to: "subscriber_lists#update"
     post "/subscriber-lists/:slug/bulk-unsubscribe", to: "subscriber_lists#bulk_unsubscribe"
+    post "/subscriber-lists/bulk-migrate", to: "subscriber_lists#bulk_migrate"
 
     resources :content_changes, only: %i[create], path: "content-changes"
     resources :spam_reports, path: "spam-reports", only: %i[create]

--- a/spec/builders/bulk_migrate_confirmation_email_builder.rb
+++ b/spec/builders/bulk_migrate_confirmation_email_builder.rb
@@ -1,0 +1,40 @@
+RSpec.describe BulkMigrateConfirmationEmailBuilder do
+  describe ".call" do
+    let(:source_subscriber_list) { create(:subscriber_list) }
+    let(:destination_subscriber_list) { create(:subscriber_list) }
+    let(:count) { 10 }
+
+    around(:each) do |example|
+      ClimateControl.modify(BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT: "test@test.uk") do
+        example.run
+      end
+    end
+
+    it "creates an email addressed to bulk migrate confirmation account" do
+      described_class.call(
+        source_id: source_subscriber_list.id,
+        destination_id: destination_subscriber_list.id,
+        count:,
+      )
+
+      presented_body = <<~BODY
+        #{count} subscriptions have been migrated:
+        From "#{source_subscriber_list.title}"
+        To "#{destination_subscriber_list.title}"
+
+        No email notification has been sent to users.
+
+        Thanks
+        GOV.UK emails
+      BODY
+
+      expected_email_attributes = {
+        "subject" => "Bulk migration of #{source_subscriber_list.title} is complete",
+        "body" => presented_body,
+        "address" => "test@test.uk",
+      }
+
+      expect(Email.last.attributes).to include expected_email_attributes
+    end
+  end
+end

--- a/spec/integration/bulk_migrate_spec.rb
+++ b/spec/integration/bulk_migrate_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe "Migrating users from one subscriber list to another", type: :request do
+  it "requires a source slug paramater and a destination slug paramater" do
+    post "/subscriber-lists/bulk-migrate"
+
+    expect(response.status).to eq(422)
+    expect(JSON.parse(response.body)["error"]).to eq "Must provide slugs for source and destination subscriber lists"
+  end
+
+  it "requires a valid source subscriber list" do
+    subscriber_list = create(:subscriber_list)
+    params = {
+      "to_slug" => subscriber_list.slug,
+      "from_slug" => "nothing-here",
+    }
+    post("/subscriber-lists/bulk-migrate", params:)
+
+    expect(response.status).to eq(404)
+    expect(JSON.parse(response.body)["error"]).to eq "Could not find source subscriber list"
+  end
+
+  it "requires a valid successor subscriber list" do
+    subscriber_list = create(:subscriber_list)
+    params = {
+      "to_slug" => "nothing-here",
+      "from_slug" => subscriber_list.slug,
+    }
+    post("/subscriber-lists/bulk-migrate", params:)
+
+    expect(response.status).to eq(404)
+    expect(JSON.parse(response.body)["error"]).to eq "Could not find destination subscriber list"
+  end
+
+  context "when both source and destination subscriber lists exist" do
+    let!(:existing_subscription) { create(:subscription) }
+    let(:subscriber) { existing_subscription.subscriber }
+    let(:source_list) { existing_subscription.subscriber_list }
+    let(:destination_list) { create(:subscriber_list) }
+    let(:params) do
+      {
+        "to_slug" => destination_list.slug,
+        "from_slug" => source_list.slug,
+      }
+    end
+    it "migrates subscribers" do
+      post("/subscriber-lists/bulk-migrate", params:)
+
+      expect(existing_subscription.reload.ended_reason).to eq("bulk_migrated")
+      expect(destination_list.subscribers.count).to eq 1
+      expect(source_list.active_subscriptions_count).to eq 0
+      expect(destination_list.subscribers).to include(subscriber)
+      expect(source_list.subscriptions.active).not_to include(subscriber)
+    end
+  end
+end

--- a/spec/workers/bulk_migrate_list_worker_spec.rb
+++ b/spec/workers/bulk_migrate_list_worker_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe BulkMigrateListWorker do
+  let!(:source_list) { create(:subscriber_list) }
+  let!(:destination_list) { create(:subscriber_list) }
+
+  let!(:source_list_subscribers) do
+    create(:subscriber).tap do |subscriber|
+      create(:subscription, subscriber:, subscriber_list: source_list)
+    end
+  end
+
+  let!(:other_list_subscribers) do
+    create(:subscriber).tap do |subscriber|
+      other_list = create(:subscriber_list)
+      create(:subscription, subscriber:, subscriber_list: other_list)
+    end
+  end
+
+  describe "#perform" do
+    it "migrates subscribers from the source list to the successor list" do
+      source_list_subscriber_id = source_list.subscribers.first.id
+
+      described_class.new.perform(source_list.id, destination_list.id)
+
+      expect(source_list.active_subscriptions_count).to be 0
+      expect(source_list.subscriptions.last.ended_reason).to eq("bulk_migrated")
+
+      expect(destination_list.subscriptions.count).to be 1
+      expect(destination_list.subscribers.first.id).to eq source_list_subscriber_id
+    end
+
+    it "will not move subscribers from other lists" do
+      expect { described_class.new.perform(source_list.id, destination_list.id) }.not_to(change { other_list_subscribers.ended_subscriptions.count })
+    end
+  end
+end


### PR DESCRIPTION
## What

This PR adds a bulk migrate end point to email alert API, follow up work will be needed:
- To extend GDS API adaptors.
- Create new google group and add the address to govuk-helm-charts so it's available as an environment variable

## How

Sample request:
```
Services.email_alert_api.bulk_migrate(to_slug:"living-in-bangladesh-8ef41adaf2", from_slug:"child-benefit-f71e6de312")
```
### Why

This quarter we will begin retiring specialist topics and redirecting them to either existing content on GOV.UK, or to specialist topics converted into document collections.

In the case of a specialist topic being retired and redirected to a converted document collection, the content of those two pages is similar enough that we are permitted (within the rules of GDPR) to migrate users from the specialist topic email subscription over to the document collection email subscription. We will not notify users of this migration.

There is currently a [rake task](https://github.com/alphagov/email-alert-api/blob/main/lib/tasks/data_migration.rake#L4) to perform the bulk migration of one list to another. Why don't we just use that?
- The quantity of specialist topics that we will be redirecting to converted document collections is greater than 100 so it would take a lot of developer time to run the task manually. 
- It would be a challenging workflow: if there's a gap between the specialist topic being redirected, and the subscribers being migrated, some users might miss out of notifications that the dept assumes they have been sent.

This endpoint will be called by the [`tag archiver` service](https://github.com/alphagov/collections-publisher/blob/main/app/services/tag_archiver.rb) in collections publisher, when the conditions for a migration are met.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
https://trello.com/c/wWCEhzzq/1713-add-bulk-migrate-endpoint-to-email-alert-api-l