### PR TITLE
Define provider states for gds-api-adapter pact tests

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -142,4 +142,23 @@ Pact.provider_states_for "GDS API Adapters" do
       stub_account_api_unauthorized_user_info
     end
   end
+
+  provider_state "subscriber lists exist with 'source_list_slug' and 'destination_list_slug'" do
+    set_up do
+      create(:subscriber_list, slug: "source_list_slug")
+      create(:subscriber_list, slug: "destination_list_slug")
+    end
+  end
+
+  provider_state "a subscriber list exists for 'source_slug'" do
+    set_up do
+      create(:subscriber_list, slug: "source_list_slug")
+    end
+  end
+
+  provider_state "a subscriber list exists for 'destination_slug'" do
+    set_up do
+      create(:subscriber_list, slug: "destination_slug")
+    end
+  end
 end


### PR DESCRIPTION
consumer tests: https://github.com/alphagov/gds-api-adapters/pull/1197/commits/537c3a8041f504c03cba4e8e2029ff9f5a2a7fdc

https://trello.com/c/REpV5NW7/1714-add-bulk-migrate-endpoint-to-gds-api-adaptors-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
