### PR TITLE
Task to migrate users from a content id based list to a links based list for organisation pages

### DIFF
--- a/lib/bad_list_subscriptions_migrator.rb
+++ b/lib/bad_list_subscriptions_migrator.rb
@@ -1,5 +1,5 @@
 class BadListSubscriptionsMigrator
-  VALID_PREFIXES = %w[topic].freeze
+  VALID_PREFIXES = %w[topic organisations].freeze
 
   attr_reader :prefix
 

--- a/spec/lib/bad_list_subscriptions_migrator_spec.rb
+++ b/spec/lib/bad_list_subscriptions_migrator_spec.rb
@@ -56,11 +56,19 @@ RSpec.describe BadListSubscriptionsMigrator do
       )
     end
 
-    it "can only be called with valid prefix arguments" do
+    it "will raise an error with invalid prefix arguments" do
       prefix = "foo"
       remover = described_class.new(prefix)
       message = "Subscription migration not possible for the provided prefix"
       expect { remover.process_all_lists }.to raise_error(message)
+    end
+
+    it "can can only be called with valid prefix arguments" do
+      valid_prefixes = %w[topic organisations]
+      valid_prefixes.each do |prefix|
+        remover = described_class.new(prefix)
+        expect { remover.process_all_lists }.not_to raise_error
+      end
     end
 
     context "when the destination subscriber list has active subscriptions" do


### PR DESCRIPTION
Extend the migrator added in https://github.com/alphagov/email-alert-api/pull/1943 so it can be run against organisation pages 

Before:
```
total subscriber list count for organisations: 592
bad subscriber list count for organisations: 238
total subscriptions to bad lists: 8445
total active subscriptions to bad lists: 6801
```

Task Output:
```
Bad subscriptions count for prefix 'organisations':6801
Running migration...
Migration complete
There are 0 remaining bad subscriptions for 'organisations' lists.
```

Trello https://trello.com/c/ageAkcub/1856-move-users-subscribed-to-bad-orgs-lists-to-good-orgs-lists-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
