### PR TITLE
Extend the bad_list_subscriptions_migrator

### DIFF
--- a/lib/bad_list_subscriptions_migrator.rb
+++ b/lib/bad_list_subscriptions_migrator.rb
@@ -1,5 +1,13 @@
 class BadListSubscriptionsMigrator
-  VALID_PREFIXES = %w[topic organisations].freeze
+  VALID_PREFIXES = %w[
+    topic
+    organisations
+    government/people
+    government/ministers
+    government/topical-events
+    service-manual
+    service-manual/service-standard
+  ].freeze
 
   attr_reader :prefix
 

--- a/spec/lib/bad_list_subscriptions_migrator_spec.rb
+++ b/spec/lib/bad_list_subscriptions_migrator_spec.rb
@@ -64,7 +64,15 @@ RSpec.describe BadListSubscriptionsMigrator do
     end
 
     it "can can only be called with valid prefix arguments" do
-      valid_prefixes = %w[topic organisations]
+      valid_prefixes = %w[
+        topic
+        organisations
+        government/people
+        government/ministers
+        government/topical-events
+        service-manual
+        service-manual/service-standard
+      ]
       valid_prefixes.each do |prefix|
         remover = described_class.new(prefix)
         expect { remover.process_all_lists }.not_to raise_error


### PR DESCRIPTION
So it can be run against subscriber lists created for the following content types

person
ministerial_role
topical_event
servive_manual_topic
service_manual_standard

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
