### PR TITLE
Temp rake task to bulk unsubscribe some orphaned subscriptions

### DIFF
--- a/lib/tasks/bulk_email.rake
+++ b/lib/tasks/bulk_email.rake
@@ -26,4 +26,59 @@ namespace :bulk_email do
     end
     puts "Sending #{email_ids.count} emails to subscribers on the following lists: #{subscriber_lists.pluck(:slug).join(', ')}"
   end
+
+  desc "Bulk unsubscribe archived specialist topic subscribers"
+  task archived_specialist_topic_subscribers: :environment do
+    data = [
+      {
+        "list_slug" => "immigration-rules-4f0e641750",
+        "redirect_title" => "Visas and immigration operational guidance",
+        "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+      },
+      {
+        "list_slug" => "asylum-policy",
+        "redirect_title" => "Visas and immigration operational guidance",
+        "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+      },
+      {
+        "list_slug" => "fees-and-forms",
+        "redirect_title" => "Visas and immigration operational guidance",
+        "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+      },
+      {
+        "list_slug" => "nationality-guidance",
+        "redirect_title" => "Visas and immigration operational guidance",
+        "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+      },
+      {
+        "list_slug" => "entry-clearance-guidance",
+        "redirect_title" => "Visas and immigration operational guidance",
+        "redirect_url" => "government/collections/visas-and-immigration-operational-guidance",
+      },
+      {
+        "list_slug" => "immigration-staff-guidance",
+        "redirect_title" => "Immigration staff guidance",
+        "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+      },
+      {
+        "list_slug" => "business-auditing-accounting-and-reporting-38e0c4ed05",
+        "redirect_title" => "Accounting for UK companies",
+        "redirect_url" => "/guidance/accounting-for-uk-companies",
+      },
+      {
+        "list_slug" => "enforcement",
+        "redirect_title" => "Visas and immigration operational guidance",
+        "redirect_url" => "government/collections/visas-and-immigration-operational-guidance",
+      },
+      {
+        "list_slug" => "windrush-caseworker-guidance",
+        "redirect_title" => "Visas and immigration operational guidance",
+        "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+      },
+    ]
+
+    data.each do |hash|
+      TopicListBulkUnsubscriber.call(hash)
+    end
+  end
 end

--- a/lib/topic_list_bulk_unsubscriber.rb
+++ b/lib/topic_list_bulk_unsubscriber.rb
@@ -1,0 +1,61 @@
+class TopicListBulkUnsubscriber
+  include Callable
+
+  def initialize(opts = {})
+    opts.each { |k, v| instance_variable_set("@#{k}", v) }
+  end
+
+  def call
+    bulk_email
+    bulk_unsubscribe
+  end
+
+private
+
+  attr_reader :list_slug, :redirect_title, :redirect_url
+
+  def bulk_email
+    puts "#{subscriber_list.active_subscriptions_count} subscribers of #{subscriber_list.title} will be emailed"
+
+    email_ids = BulkSubscriberListEmailBuilder.call(
+      subject: email_subject,
+      body: email_body,
+      subscriber_lists: [subscriber_list],
+    )
+
+    puts "#{email_ids.count} emails queued for delivery"
+
+    email_ids.each do |id|
+      SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate)
+    end
+  end
+
+  def email_subject
+    "Update from GOV.UK for: #{subscriber_list.title}"
+  end
+
+  def subscriber_list
+    @subscriber_list ||= SubscriberList.find_by_slug(list_slug)
+  end
+
+  def email_body
+    <<~BODY
+      Update from GOV.UK for:
+      #{subscriber_list.title}
+      _________________________________________________________________
+      You asked GOV.UK to email you when we add or update a page about:
+      #{subscriber_list.title}
+      This topic has been archived. You will not get any more emails about it.
+      You can find more information about this topic at [#{redirect_title}](#{redirect_url}).
+    BODY
+  end
+
+  def bulk_unsubscribe
+    subscriptions = subscriber_list.subscriptions.active
+    subscriptions.each do |subscription|
+      subscription.end(reason: 8)
+    end
+
+    puts "#{subscriber_list.active_subscriptions_count} subscribers left for #{subscriber_list.title}"
+  end
+end

--- a/spec/lib/tasks/bulk_email_spec.rb
+++ b/spec/lib/tasks/bulk_email_spec.rb
@@ -52,4 +52,66 @@ RSpec.describe "bulk_email" do
         ).to_stdout
     end
   end
+
+  describe "archived_specialist_topic_subscribers" do
+    before do
+      Rake::Task["bulk_email:archived_specialist_topic_subscribers"].reenable
+    end
+
+    it "is hardcoded to call the TopicListBulkUnsubscriber with 9 malformed archived specialist topic lists" do
+      data = [
+        {
+          "list_slug" => "immigration-rules-4f0e641750",
+          "redirect_title" => "Visas and immigration operational guidance",
+          "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+        },
+        {
+          "list_slug" => "asylum-policy",
+          "redirect_title" => "Visas and immigration operational guidance",
+          "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+        },
+        {
+          "list_slug" => "fees-and-forms",
+          "redirect_title" => "Visas and immigration operational guidance",
+          "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+        },
+        {
+          "list_slug" => "nationality-guidance",
+          "redirect_title" => "Visas and immigration operational guidance",
+          "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+        },
+        {
+          "list_slug" => "entry-clearance-guidance",
+          "redirect_title" => "Visas and immigration operational guidance",
+          "redirect_url" => "government/collections/visas-and-immigration-operational-guidance",
+        },
+        {
+          "list_slug" => "immigration-staff-guidance",
+          "redirect_title" => "Immigration staff guidance",
+          "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+        },
+        {
+          "list_slug" => "business-auditing-accounting-and-reporting-38e0c4ed05",
+          "redirect_title" => "Accounting for UK companies",
+          "redirect_url" => "/guidance/accounting-for-uk-companies",
+        },
+        {
+          "list_slug" => "enforcement",
+          "redirect_title" => "Visas and immigration operational guidance",
+          "redirect_url" => "government/collections/visas-and-immigration-operational-guidance",
+        },
+        {
+          "list_slug" => "windrush-caseworker-guidance",
+          "redirect_title" => "Visas and immigration operational guidance",
+          "redirect_url" => "/government/collections/visas-and-immigration-operational-guidance",
+        },
+      ]
+
+      data.each do |specialist_topic_data|
+        expect(TopicListBulkUnsubscriber).to receive(:call).with(specialist_topic_data)
+      end
+
+      Rake::Task["bulk_email:archived_specialist_topic_subscribers"].invoke
+    end
+  end
 end

--- a/spec/lib/topic_list_bulk_unsubscriber_spec.rb
+++ b/spec/lib/topic_list_bulk_unsubscriber_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe TopicListBulkUnsubscriber do
+  describe ".call" do
+    let(:subscriber_list_slug) { "archived_topic" }
+    let(:redirect_title) { "Visas and immigration operational guidance" }
+    let(:redirect_url) { "/government/collections/visas-and-immigration-operational-guidance" }
+    let!(:subscriber_list) { create(:subscriber_list, slug: subscriber_list_slug, title: "Archived Topic") }
+    let!(:subscription) { create(:subscription, subscriber_list:) }
+
+    it "calls the BulkSubscriberListEmailBuilder and unsubscribes users" do
+      expected_subject = "Update from GOV.UK for: #{subscriber_list.title}"
+      expected_body = <<~BODY
+        Update from GOV.UK for:
+        #{subscriber_list.title}
+        _________________________________________________________________
+        You asked GOV.UK to email you when we add or update a page about:
+        #{subscriber_list.title}
+        This topic has been archived. You will not get any more emails about it.
+        You can find more information about this topic at [#{redirect_title}](#{redirect_url}).
+      BODY
+
+      expect(BulkSubscriberListEmailBuilder)
+        .to receive(:call)
+        .with(subject: expected_subject,
+              body: expected_body,
+              subscriber_lists: [subscriber_list])
+        .and_call_original
+
+      information = {
+        "list_slug" => subscriber_list_slug,
+        "redirect_title" => redirect_title,
+        "redirect_url" => redirect_url,
+      }
+
+      TopicListBulkUnsubscriber.call(information)
+      expect(subscriber_list.subscriptions.last.ended_reason).to eq "bulk_unsubscribed"
+    end
+  end
+end


### PR DESCRIPTION
Bulk unsubscribe users still linked to archived specialist topic subscriber lists.
Set the subscription ended reason as `bulk_unsubscribe`. 
The subscriber list itself doesn't need deleting, as this will be removed by the [historical data deletion worker](https://github.com/alphagov/email-alert-api/blob/main/app/workers/historical_data_deletion_worker.rb#L40).

Trello https://trello.com/c/3wIQ3UHA/1858-reinstate-and-run-the-rake-task-to-bulk-unsubscribe-users-who-remain-subscribed-to-archived-specialist-topics-m