### PR TITLE
Add rake task to show content change statistics for a given page.

### DIFF
--- a/lib/reports/content_change_statistics_report.rb
+++ b/lib/reports/content_change_statistics_report.rb
@@ -1,0 +1,35 @@
+class Reports::ContentChangeStatisticsReport
+  attr_reader :url
+
+  def initialize(url)
+    @url = url
+  end
+
+  def call
+    content_changes = ContentChange.where(base_path: url).order(:public_updated_at)
+
+    if content_changes.any?
+      output_string = "#{content_changes.count} content changes registered for #{url}.\n\n"
+
+      content_changes.each do |cc|
+        output_string += "Content change on #{cc.public_updated_at}:\n"
+
+        lists = SubscriberListQuery.new(content_id: cc.content_id, tags: cc.tags, links: cc.links, document_type: cc.document_type, email_document_supertype: cc.email_document_supertype, government_document_supertype: cc.government_document_supertype).lists
+
+        total_subs = lists.sum { |l| l.subscriptions.active.count }
+        immediately_subs = lists.sum { |l| l.subscriptions.active.immediately.count }
+        daily_subs = lists.sum { |l| l.subscriptions.active.daily.count }
+        weekly_subs = lists.sum { |l| l.subscriptions.active.weekly.count }
+
+        output_string += " - notified immediately: #{immediately_subs}\n"
+        output_string += " - notified next day:    #{daily_subs}\n"
+        output_string += " - notified at weekend:  #{weekly_subs}\n"
+        output_string += " - notified total:       #{total_subs}\n\n"
+      end
+
+      output_string
+    else
+      "No content changes registered for that URL: #{url}"
+    end
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -28,4 +28,11 @@ namespace :report do
   task :single_page_notifications_top_subscriber_lists, %i[limit] => :environment do |_t, args|
     puts Reports::SinglePageNotificationsReport.new(args[:limit] || 25).call.join("\n")
   end
+
+  desc "Output content-change information for a page URL"
+  task :content_change_statistics, %i[url] => :environment do |_t, args|
+    puts Reports::ContentChangeStatisticsReport.new(
+      args.fetch(:url),
+    ).call
+  end
 end


### PR DESCRIPTION
- previously this was a series of steps in the documentation, this just cleans it up nicely and slaps a rake task around it.
- we also explain a little better in the docs what it actually does.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

