### PR TITLE
Allow HistoricDataDeletionWorker to delete Subscribers/SubscriberLists that have older inactive subscriptions.

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -30,6 +30,7 @@ class Subscription < ApplicationRecord
 
   scope :active, -> { where(ended_at: nil) }
   scope :ended, -> { where.not(ended_at: nil) }
+  scope :not_historical, -> { where("ended_at IS NULL OR ended_at >= ?", 1.week.ago) }
 
   scope :active_on,
         lambda { |date|

--- a/spec/workers/historical_data_deletion_worker_spec.rb
+++ b/spec/workers/historical_data_deletion_worker_spec.rb
@@ -71,10 +71,16 @@ RSpec.describe HistoricalDataDeletionWorker do
         expect { perform }.to_not change(SubscriberList, :count)
       end
 
-      it "shouldn't remove subscriber lists which have recent active subscriptions" do
+      it "shouldn't remove subscriber lists which have recently ended subscriptions" do
         subscriber_list = create(:subscriber_list, created_at: historic_date)
-        create(:subscription, ended_at: 1.week.ago, subscriber_list:)
+        create(:subscription, ended_at: 6.days.ago, subscriber_list:)
         expect { perform }.to_not change(SubscriberList, :count)
+      end
+
+      it "should remove subscriber lists which have older ended subscriptions" do
+        subscriber_list = create(:subscriber_list, created_at: historic_date)
+        create(:subscription, ended_at: 2.weeks.ago, subscriber_list:)
+        expect { perform }.to change(SubscriberList, :count).by(-1)
       end
     end
 
@@ -99,6 +105,12 @@ RSpec.describe HistoricalDataDeletionWorker do
         subscriber = create(:subscriber, created_at: historic_date)
         create(:subscription, subscriber:)
         expect { perform }.to_not change(Subscriber, :count)
+      end
+
+      it "shouldn't remove old subscribers with recently ended subscriptions" do
+        subscriber = create(:subscriber, created_at: historic_date)
+        create(:subscription, ended_at: 6.days.ago, subscriber:)
+        expect { perform }.to_not change(SubscriberList, :count)
       end
     end
   end


### PR DESCRIPTION
- add new scope for subscriptions that are either active or ended less than a week ago
- add this scope to the selections in the worker so it can delete Subscribers or SubscriberLists if they only contain older ended subscriptions, so they more closely match what the original specs actually asked for.
- replace .delete calls with .destroy calls in worker to allow rails to maintain db relation consistency (slower but correct, and worker does not need to be super performant)

https://trello.com/c/HFy9tpyE/2215-investigate-whether-historic-email-subscription-data-can-be-more-aggressively-deleted

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
