### PR TITLE
Improve rake task

### DIFF
--- a/lib/reports/concerns/notification_stats.rb
+++ b/lib/reports/concerns/notification_stats.rb
@@ -1,6 +1,6 @@
 module Reports::Concerns::NotificationStats
   def list_names_array(lists)
-    lists.collect(&:title)
+    lists.map { |l| "#{l.title} (#{l.subscriptions.active.count} active subscribers)" }
   end
 
   def list_stats_array(lists)

--- a/lib/reports/future_content_change_statistics_report.rb
+++ b/lib/reports/future_content_change_statistics_report.rb
@@ -59,7 +59,7 @@ class Reports::FutureContentChangeStatisticsReport
   end
 
   def tags_from_content_item(content_item)
-    content_item["details"]["tags"].merge(additional_items(content_item))
+    content_item["details"].fetch("tags", {}).merge(additional_items(content_item))
   end
 
   def links_from_content_item(content_item)
@@ -80,6 +80,9 @@ class Reports::FutureContentChangeStatisticsReport
   end
 
   def taxon_tree(content_item)
+    return [] unless content_item["links"].key?("taxons")
+    return [] unless content_item["links"]["taxons"].any?
+
     [content_item["links"]["taxons"].first["content_id"]] + get_parent_links(content_item["links"]["taxons"].first)
   end
 

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -40,7 +40,7 @@ namespace :report do
   task :future_content_change_statistics, %i[govuk_path draft] => :environment do |_t, args|
     puts Reports::FutureContentChangeStatisticsReport.new(
       args.fetch(:govuk_path),
-      args.fetch(:draft).downcase == "true",
+      args.fetch(:draft, "false").downcase == "true",
     ).call
   end
 end


### PR DESCRIPTION
The rake task report:future_content_change_statistics currently implies that the draft parameter is optional, but treats it as mandatory, and is also brittle when a content item doesn't have exactly the elements it's expecting. This PR adds a 
default for the draft parameter, and also handles missing taxon and tag items.

We also add individual active subscriber counts to each list, so that it's possible to see how each list contributes to the total number of subscribers (useful because there are several "all of GOV.UK" lists that effect the totals a lot)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
