### PR TITLE
Remove brexit checklist criteria

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -17,7 +17,7 @@ report:csv_subscriber_lists["2020-11-05"]
 SLUGS=living-in-spain,living-in-italy report:csv_subscriber_lists["2020-11-05"]
 
 # or with tags containing a string
-TAGS_PATTERN=brexit_checklist_criteria report:csv_subscriber_lists["2020-11-05"]
+TAGS_PATTERN=country report:csv_subscriber_lists["2020-11-05"]
 
 # or with links containing a string
 LINKS_PATTERN=countries report:csv_subscriber_lists["2020-11-05"]

--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -133,12 +133,4 @@ namespace :support do
       end
     end
   end
-
-  desc "Destroy all Brexit checker subscriptions"
-  task destroy_all_brexit_checker_subscriptions: :environment do
-    brexit_subscriber_lists = SubscriberList.where("tags ->> 'brexit_checklist_criteria' IS NOT NULL")
-
-    puts "Destroying #{brexit_subscriber_lists.count} subscriber #{'list'.pluralize(brexit_subscriber_lists.count)}"
-    brexit_subscriber_lists.destroy_all
-  end
 end

--- a/lib/valid_tags.rb
+++ b/lib/valid_tags.rb
@@ -5,7 +5,6 @@ class ValidTags
     alert_type
     appear_in_find_eu_exit_guidance_business_finder
     assessment_date
-    brexit_checklist_criteria
     business_activity
     business_sizes
     business_stages

--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -80,32 +80,4 @@ RSpec.describe "support" do
       end
     end
   end
-
-  describe "destroy_all_brexit_checker_subscriptions" do
-    before do
-      Rake::Task["support:destroy_all_brexit_checker_subscriptions"].reenable
-    end
-
-    it "destroys all Brexit checker subscriptions" do
-      subscription = create :subscription, :brexit_checker
-      subscriber_list = subscription.subscriber_list
-
-      expect {
-        Rake::Task["support:destroy_all_brexit_checker_subscriptions"].invoke
-      }.to change { SubscriberList.exists?(subscriber_list.id) }.to(false)
-
-      expect(Subscription.exists?(subscription.id)).to be false
-    end
-
-    it "only destroys Brexit checker subscriptions" do
-      create :subscription, :brexit_checker
-      subscription = create :subscription
-
-      expect {
-        Rake::Task["support:destroy_all_brexit_checker_subscriptions"].invoke
-      }.to output("Destroying 1 subscriber list\n").to_stdout
-
-      expect(Subscription.exists?(subscription.id)).to be true
-    end
-  end
 end


### PR DESCRIPTION
Final removal of code existing only for the BrexitChecker.

https://trello.com/c/8x01txnU/2184-brexit-checker-uses-email-alert-api-as-a-substitute-database

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
