### PR TITLE
Add additional information to Email model

### DIFF
--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -28,6 +28,7 @@ private
           subscriber_id: subscriber.id,
           created_at: now,
           updated_at: now,
+          content_id: content.try(:content_id),
         }
       end
     end

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -23,6 +23,13 @@ class StatusUpdatesController < ApplicationController
       UnsubscribeAllService.call(subscriber, :non_existent_email) if subscriber
     end
 
+    begin
+      Email.find(reference).update!(notify_status: status)
+    rescue StandardError
+      # At the moment we don't want to do anything if
+      # the reference can't be found.
+    end
+
     head :no_content
   end
 

--- a/db/migrate/20231102140714_add_content_id_to_email.rb
+++ b/db/migrate/20231102140714_add_content_id_to_email.rb
@@ -1,0 +1,6 @@
+class AddContentIdToEmail < ActiveRecord::Migration[7.1]
+  def change
+    add_column :emails, :content_id, :uuid
+    add_index :emails, :content_id
+  end
+end

--- a/db/migrate/20231102150419_update_emails_add_notify_status_and_id_index.rb
+++ b/db/migrate/20231102150419_update_emails_add_notify_status_and_id_index.rb
@@ -1,0 +1,7 @@
+class UpdateEmailsAddNotifyStatusAndIdIndex < ActiveRecord::Migration[7.1]
+  def change
+    add_column :emails, :notify_status, :string
+    add_index :emails, :notify_status
+    add_index :emails, :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
-
+ActiveRecord::Schema[7.1].define(version: 2023_11_02_140714) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -24,15 +23,15 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
     t.text "description", null: false
     t.json "links", default: {}, null: false
     t.json "tags", default: {}, null: false
-    t.datetime "public_updated_at", null: false
+    t.datetime "public_updated_at", precision: nil, null: false
     t.string "email_document_supertype", null: false
     t.string "government_document_supertype", null: false
     t.string "govuk_request_id", null: false
     t.string "document_type", null: false
     t.string "publishing_app", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "processed_at"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "processed_at", precision: nil
     t.integer "priority", default: 0
     t.string "signon_user_uid"
     t.text "footnote", default: "", null: false
@@ -43,9 +42,9 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
   create_table "digest_run_subscribers", force: :cascade do |t|
     t.integer "digest_run_id", null: false
     t.integer "subscriber_id", null: false
-    t.datetime "processed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "processed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["digest_run_id", "subscriber_id"], name: "index_digest_run_subscribers_on_digest_run_id_and_subscriber_id", unique: true
     t.index ["digest_run_id"], name: "index_digest_run_subscribers_on_digest_run_id"
     t.index ["subscriber_id"], name: "index_digest_run_subscribers_on_subscriber_id"
@@ -53,13 +52,13 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
 
   create_table "digest_runs", force: :cascade do |t|
     t.date "date", null: false
-    t.datetime "starts_at", null: false
-    t.datetime "ends_at", null: false
+    t.datetime "starts_at", precision: nil, null: false
+    t.datetime "ends_at", precision: nil, null: false
     t.integer "range", null: false
-    t.datetime "completed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "processed_at"
+    t.datetime "completed_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "processed_at", precision: nil
     t.index ["completed_at"], name: "index_digest_runs_on_completed_at"
     t.index ["created_at"], name: "index_digest_runs_on_created_at"
     t.index ["date", "range"], name: "index_digest_runs_on_date_and_range", unique: true
@@ -68,21 +67,23 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
   create_table "emails", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.text "subject", null: false
     t.text "body", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "address", null: false
     t.bigint "subscriber_id"
     t.integer "status", default: 0, null: false
-    t.datetime "sent_at"
+    t.datetime "sent_at", precision: nil
+    t.uuid "content_id"
     t.index ["address"], name: "index_emails_on_address"
+    t.index ["content_id"], name: "index_emails_on_content_id"
     t.index ["created_at"], name: "index_emails_on_created_at"
     t.index ["subscriber_id"], name: "index_emails_on_subscriber_id"
   end
 
   create_table "matched_content_changes", force: :cascade do |t|
     t.bigint "subscriber_list_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "content_change_id", null: false
     t.index ["content_change_id", "subscriber_list_id"], name: "index_matched_content_changes_content_change_subscriber_list", unique: true
     t.index ["content_change_id"], name: "index_matched_content_changes_on_content_change_id"
@@ -92,8 +93,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
   create_table "matched_messages", force: :cascade do |t|
     t.uuid "message_id", null: false
     t.bigint "subscriber_list_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["message_id", "subscriber_list_id"], name: "index_matched_messages_on_message_id_and_subscriber_list_id", unique: true
     t.index ["message_id"], name: "index_matched_messages_on_message_id"
     t.index ["subscriber_list_id"], name: "index_matched_messages_on_subscriber_list_id"
@@ -103,12 +104,12 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
     t.text "sender_message_id"
     t.text "title", null: false
     t.text "body", null: false
-    t.datetime "processed_at"
+    t.datetime "processed_at", precision: nil
     t.string "signon_user_uid"
     t.string "govuk_request_id", null: false
     t.integer "priority", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.json "criteria_rules"
     t.boolean "omit_footer_unsubscribe_link", default: false, null: false
     t.boolean "override_subscription_frequency_to_immediate", default: false, null: false
@@ -117,8 +118,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
     t.text "title", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "document_type", default: "", null: false
     t.json "tags", default: {}, null: false
     t.json "links", default: {}, null: false
@@ -142,8 +143,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
 
   create_table "subscribers", force: :cascade do |t|
     t.string "address"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "signon_user_uid"
     t.string "govuk_account_id"
     t.index "lower((address)::text)", name: "index_subscribers_on_lower_address", unique: true
@@ -151,8 +152,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
   end
 
   create_table "subscription_contents", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "digest_run_subscriber_id"
     t.uuid "email_id"
     t.uuid "subscription_id", null: false
@@ -170,12 +171,12 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_21_161623) do
   create_table "subscriptions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.bigint "subscriber_id", null: false
     t.bigint "subscriber_list_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "frequency", default: 0, null: false
     t.string "signon_user_uid"
     t.integer "source", default: 0, null: false
-    t.datetime "ended_at"
+    t.datetime "ended_at", precision: nil
     t.integer "ended_reason"
     t.uuid "ended_email_id"
     t.index ["created_at"], name: "index_subscriptions_on_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_02_140714) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_02_150419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -74,9 +74,12 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_140714) do
     t.integer "status", default: 0, null: false
     t.datetime "sent_at", precision: nil
     t.uuid "content_id"
+    t.string "notify_status"
     t.index ["address"], name: "index_emails_on_address"
     t.index ["content_id"], name: "index_emails_on_content_id"
     t.index ["created_at"], name: "index_emails_on_created_at"
+    t.index ["id"], name: "index_emails_on_id"
+    t.index ["notify_status"], name: "index_emails_on_notify_status"
     t.index ["subscriber_id"], name: "index_emails_on_subscriber_id"
   end
 

--- a/spec/builders/immediate_email_builder_spec.rb
+++ b/spec/builders/immediate_email_builder_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ImmediateEmailBuilder do
       it "creates an email" do
         expect(email.subject).to eq("Update from GOV.UK for: Title")
         expect(email.subscriber_id).to eq(subscriber.id)
+        expect(email.content_id).to eq(content_change.content_id)
 
         expect(email.body).to eq(
           <<~BODY,
@@ -68,6 +69,7 @@ RSpec.describe ImmediateEmailBuilder do
       it "creates an email" do
         expect(email.subject).to eq("Update from GOV.UK for: Title")
         expect(email.subscriber_id).to eq(subscriber.id)
+        expect(email.content_id).to be nil
 
         expect(email.body).to eq(
           <<~BODY,

--- a/spec/integration/status_updates_spec.rb
+++ b/spec/integration/status_updates_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe "Receiving a status update", type: :request do
       expect(response.body).to eq("")
     end
 
+    context "with a relevant email" do
+      before do
+        @email = create(:email, id: params[:reference])
+      end
+
+      it "updates the referenced email" do
+        post("/status-updates", params:)
+
+        expect(@email.reload.notify_status).to eq(status)
+      end
+    end
+
     context "when a user does not have 'status_updates' permission" do
       let(:permissions) { %w[signin] }
 


### PR DESCRIPTION
Adds content_id and notify_status columns to the Email model, and the support code to populate them - the content_id from the immediate email builder and the notify_status from the callback endpoint. Also adds an index on the existing email id field so that we have a fast lookup during the callback endpoint rather than a field scan.

https://trello.com/c/xdMu72UJ/2245-add-new-information-to-email-alert-api-email-model

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
