### PR TITLE
Stop sending duplicate confirmation emails

### DIFF
--- a/app/services/create_subscription_service.rb
+++ b/app/services/create_subscription_service.rb
@@ -20,18 +20,22 @@ class CreateSubscriptionService
       )
 
       if subscription
-        return subscription if subscription.frequency == frequency
+        if subscription.frequency == frequency
+          return { record: subscription, new_record: false }
+        end
 
         subscription.end(reason: :frequency_changed)
       end
 
-      Subscription.create!(
+      new_subscription = Subscription.create!(
         subscriber:,
         subscriber_list:,
         frequency:,
         signon_user_uid: current_user.uid,
         source: subscription ? :frequency_changed : :user_signed_up,
       )
+
+      { record: new_subscription, new_record: true }
     rescue ArgumentError
       # This happens if a frequency is provided that isn't included
       # in the enum which is in the Subscription model

--- a/app/services/merge_subscribers_service.rb
+++ b/app/services/merge_subscribers_service.rb
@@ -49,7 +49,8 @@ private
       subscriber_to_keep,
       other.frequency,
       current_user,
-    )
+    )[:record]
+
     new_subscription.update!(source: :subscriber_merged)
     new_subscription
   end

--- a/spec/integration/create_subscription_spec.rb
+++ b/spec/integration/create_subscription_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe "Creating a subscription", type: :request do
         expect(subscription.reload.ended?).to be false
       end
 
-      it "sends a confirmation email" do
+      it "doesn't send a confirmation email" do
         stub_notify
         create_subscription
-        expect(a_request(:post, /notifications/)).to have_been_made.at_least_once
+        expect(a_request(:post, /notifications/)).to_not have_been_made
       end
     end
 


### PR DESCRIPTION
We've received a report of duplicate email confirmations being sent out when a user has subscribed to a number of subscriptions. This change prevents a confirmation email being sent if the user is already subscribed and the frequency is the same.

The confirmation page in Email Alert Frontend remains unchanged.

As the CreateSubscriptionServive uses a lock on the subscriber record, this should prevent duplicate emails being sent out for issues like double clicks as the lock will only be released when the record has been created.

Trello:
https://trello.com/c/hJ5up59M/2249-stop-sending-duplicate-signup-emails-if-user-clicks-confirmation-more-than-once

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
