### PR TITLE
Fix EKS docs link

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -16,7 +16,7 @@ run using the `kubectl` command, as described in the [EKS documentation][eks-doc
 
 [email-manage]: https://www.gov.uk/email/manage
 [drug-updates]: https://www.gov.uk/drug-safety-update
-[eks-docs]: https://docs.publishing.service.gov.uk/manual/kubernetes-infrastructure.html
+[eks-docs]: https://docs.publishing.service.gov.uk/kubernetes/cheatsheet.html
 
 ## Change a subscriber's email address
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR fixes a broken link to the EKS documentation in [docs/support-tasks.md](https://github.com/alphagov/email-alert-api/blob/main/docs/support-tasks.md). The [link in question](https://docs.publishing.service.gov.uk/manual/kubernetes-infrastructure.html) returns a 404 so I've updated it with a link to the [EKS cheatsheet](https://docs.publishing.service.gov.uk/kubernetes/cheatsheet.html) (which is what I think the broken link was trying to redirect to - if you click it, the URL becomes: https://docs.publishing.service.gov.uk/manual/manual/kubernetes/cheatsheet.html).

## Why
Fixes a broken link.

## Visual changes
None.