### PR TITLE
Fix alert document type for travel advice

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -46,4 +46,4 @@
     check_travel_advice_alerts:
       every: '15m'
       class: AlertCheckWorker
-      args:  ["travel_advice_alert"]
+      args:  ["travel_advice"]


### PR DESCRIPTION
Document type for travel advice was erroneously added as travel_advice_alert instead of travel_advice.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
