### PR TITLE
Update metric collector to new values

### DIFF
--- a/app/workers/alert_check_worker.rb
+++ b/app/workers/alert_check_worker.rb
@@ -8,11 +8,11 @@ class AlertCheckWorker < ApplicationWorker
       if any_emails_delivered_for?(ci[:content_id], ci[:valid_from])
         delivered += 1
       else
-        Rails.logger.warn("Couldn't find any delivered emails for #{document_type.titleize}s with content id #{ci[:content_id]} (at #{ci[:url]})")
+        Rails.logger.warn("Couldn't find any delivered emails for #{document_type.titleize} records with content id #{ci[:content_id]} (at #{ci[:url]})")
       end
     end
 
-    Rails.logger.info("Checking #{document_type.titleize}s: #{delivered} out of #{content_items.count} alerts have been delivered to at least one recipient")
+    Rails.logger.info("Checking #{document_type.titleize} records: #{delivered} out of #{content_items.count} alerts have been delivered to at least one recipient")
 
     Rails.cache.write("current_#{document_type}s", content_items.count, expires_in: 15.minutes)
     Rails.cache.write("delivered_#{document_type}s", delivered, expires_in: 15.minutes)

--- a/lib/collectors/global_prometheus_collector.rb
+++ b/lib/collectors/global_prometheus_collector.rb
@@ -13,9 +13,9 @@ module Collectors
       delivered_medical_safety_alerts = PrometheusExporter::Metric::Gauge.new("email_alert_api_delivered_medical_safety_alerts", "Number of current medical safety alerts marked as delivered")
       delivered_medical_safety_alerts.observe(Rails.cache.fetch("delivered_medical_safety_alerts") { 0 })
       current_travel_advice_alerts = PrometheusExporter::Metric::Gauge.new("email_alert_api_current_travel_advice_alerts", "Number of travel advice alerts email-alert-api is checking")
-      current_travel_advice_alerts.observe(Rails.cache.fetch("current_travel_advice_alerts") { 0 })
+      current_travel_advice_alerts.observe(Rails.cache.fetch("current_travel_advices") { 0 })
       delivered_travel_advice_alerts = PrometheusExporter::Metric::Gauge.new("email_alert_api_delivered_travel_advice_alerts", "Number of current travel advice alerts marked as delivered")
-      delivered_travel_advice_alerts.observe(Rails.cache.fetch("delivered_travel_advice_alerts") { 0 })
+      delivered_travel_advice_alerts.observe(Rails.cache.fetch("delivered_travel_advices") { 0 })
 
       [current_medical_safety_alerts, delivered_medical_safety_alerts, current_travel_advice_alerts, delivered_travel_advice_alerts]
     end


### PR DESCRIPTION
The metrics created relied on the document type - update this so the collector is looking for the right cached value to put into the metric (and update log strings slightly to make more sense)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

