### PR TITLE
Add task to get sent/delivered stats for a specific content_id

### DIFF
--- a/docs/alert_check_scheduled_jobs.md
+++ b/docs/alert_check_scheduled_jobs.md
@@ -47,3 +47,12 @@ kubectl -n apps deploy/email-alert-api -- rails c
 ```
 
 This will clear the delivered status for the email, and run the alert check worker. Prometheus should collect the metrics after a minute, and set off the alert.
+
+## Support Tasks
+
+To check the emails sent out for a specific Content ID (if an alert goes off), you can use this task:
+
+```
+kubectl config use-context govuk-<ENVIRONMENT>
+kubectl -n apps deploy/email-alert-api -- rake 'support:emails:stats_for_content_id[<CONTENT ID>,<START_DATE (optional)>,<END_DATE (optional)>]'
+```

--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -152,3 +152,9 @@ that can be overridden to increase or decrease the output number.
 ```bash
 kubectl -n apps exec -it deploy/email-alert-api -- bundle exec rake 'report:single_page_notifications_top_subscriber_lists[5]'
 ```
+
+## Find out sent/delivered stats for a specific Content ID:
+
+```bash
+kubectl -n apps exec it deploy/email-alert-api -- bundle exec rake 'support:emails:stats_for_content_id[<CONTENT ID>,<START_DATE (optional)>,<END_DATE (optional)>]'
+```


### PR DESCRIPTION
This task is to support the new runbook for handling alerts 

https://trello.com/c/7k2DR4Sb/2293-update-alert-documentation-runbook

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
