### PR TITLE
Add subscriber list metrics endpoint to API

### DIFF
--- a/app/queries/email_criteria_query.rb
+++ b/app/queries/email_criteria_query.rb
@@ -1,0 +1,23 @@
+class EmailCriteriaQuery
+  attr_reader :govuk_path, :draft
+
+  def initialize(govuk_path:, draft: false)
+    @govuk_path = govuk_path
+    @draft = draft
+  end
+
+  def call
+    content_item = content_store_client.content_item(govuk_path).to_hash
+
+    EmailAlertCriteria.new(content_item:).would_trigger_alert?
+  end
+
+private
+
+  def content_store_client
+    return GdsApi.content_store unless @draft
+
+    # We don't appear to need a token for the #content_item method?
+    GdsApi::ContentStore.new(Plek.find("draft-content-store"), bearer_token: "")
+  end
+end

--- a/app/queries/subscriber_lists_by_path_query.rb
+++ b/app/queries/subscriber_lists_by_path_query.rb
@@ -1,0 +1,79 @@
+class SubscriberListsByPathQuery
+  attr_reader :govuk_path, :draft
+
+  def initialize(govuk_path:, draft: false)
+    @govuk_path = govuk_path
+    @draft = draft
+  end
+
+  def call
+    content_item = content_store_client.content_item(govuk_path).to_hash
+
+    SubscriberListQuery.new(
+      content_id: content_item["content_id"],
+      tags: tags_from_content_item(content_item),
+      links: links_from_content_item(content_item),
+      document_type: content_item["document_type"],
+      email_document_supertype: supertypes(content_item)["email_document_supertype"],
+      government_document_supertype: supertypes(content_item)["government_document_supertype"],
+    ).lists
+  end
+
+private
+
+  def content_store_client
+    return GdsApi.content_store unless @draft
+
+    # We don't appear to need a token for the #content_item method?
+    GdsApi::ContentStore.new(Plek.find("draft-content-store"), bearer_token: "")
+  end
+
+  def supertypes(content_item)
+    GovukDocumentTypes.supertypes(document_type: content_item["document_type"])
+  end
+
+  def tags_from_content_item(content_item)
+    content_item["details"].fetch("tags", {}).merge(additional_items(content_item))
+  end
+
+  def links_from_content_item(content_item)
+    compressed_links(content_item).merge(additional_items(content_item).merge("taxon_tree" => taxon_tree(content_item)))
+  end
+
+  def compressed_links(content_item)
+    return {} unless content_item.key?("links")
+
+    keys = (content_item["links"].keys || []) - %w[available_translations taxons]
+    compressed_links = {}
+    keys.each do |k|
+      compressed_links[k] = content_item["links"][k].collect { |i| i["content_id"] }
+    end
+    compressed_links
+  end
+
+  def additional_items(content_item)
+    { "content_store_document_type" => content_item["document_type"] }.merge(supertypes(content_item))
+  end
+
+  def taxon_tree(content_item)
+    return [] unless content_item.key?("links")
+    return [] unless content_item["links"].key?("taxons")
+    return [] unless content_item["links"]["taxons"].any?
+
+    [content_item["links"]["taxons"].first["content_id"]] + get_parent_links(content_item["links"]["taxons"].first)
+  end
+
+  def get_parent_links(taxon_struct)
+    return [] unless taxon_struct.key?("links")
+    return [] unless taxon_struct["links"].key?("parent_taxons")
+    return [] unless taxon_struct["links"]["parent_taxons"].any?
+
+    tree = []
+    taxon_struct["links"]["parent_taxons"].each do |parent_taxon|
+      tree += [parent_taxon["content_id"]]
+      tree += get_parent_links(parent_taxon)
+    end
+
+    tree
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     patch "/subscriber-lists/:slug", to: "subscriber_lists#update"
     post "/subscriber-lists/:slug/bulk-unsubscribe", to: "subscriber_lists#bulk_unsubscribe"
     post "/subscriber-lists/bulk-migrate", to: "subscriber_lists#bulk_migrate"
+    get "/subscriber-lists/metrics/*path", to: "subscriber_lists#metrics"
 
     resources :content_changes, only: %i[create], path: "content-changes"
     resources :spam_reports, path: "spam-reports", only: %i[create]

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,23 @@ It will respond with the JSON response for the `GET` call above.
 
 Returns a `404 Not Found` if there is no such list.
 
+### `GET /subscriber-lists/metrics/*path`
+
+Looks for a subscriber list with a matching path and returns the
+active subscriber list count (or 0 if the list is empty or does
+not exist), and performs a content change query on the path and
+also returns that value (or 0 if the path doesn't generate email
+alerts or there are no subscribers):
+
+```json
+{
+  "subscriber_list_count": 12,
+  "all_notify_count": 26
+}
+```
+
+Always returns 200.
+
 ### `PATCH /subscriber-lists/xxx`
 
 Update data that helps describe the subscriber list, such as the title.
@@ -88,7 +105,7 @@ It requires at least one parameter to update.
 The following fields are accepted:
 - title: The title of this particular list, which will be shown to the user;
   email sent to a user;
-- description: A description of the content this list represents, used by [email-alert-service](https://github.com/alphagov/email-alert-service) to construct emails when a page is unpublished. 
+- description: A description of the content this list represents, used by [email-alert-service](https://github.com/alphagov/email-alert-service) to construct emails when a page is unpublished.
 
 Any additional parameters will be ignored.
 

--- a/lib/email_alert_criteria.rb
+++ b/lib/email_alert_criteria.rb
@@ -1,0 +1,93 @@
+class EmailAlertCriteria
+  attr_reader :content_item
+
+  def initialize(content_item:)
+    @content_item = content_item
+  end
+
+  def would_trigger_alert?
+    return false unless base_path?
+    return false unless title?
+    return false unless public_updated_at?
+    return false unless english?
+    return false unless change_note?
+
+    return false if blocked_publishing_app?
+    return false if blocked_document_type?
+
+    return false unless contains_supported_attribute? ||
+      links_to_service_manual_service_standard? ||
+      has_relevant_document_supertype?
+
+    true
+  end
+
+  def base_path?
+    content_item["base_path"].present?
+  end
+
+  def title?
+    content_item["title"].present?
+  end
+
+  def public_updated_at?
+    content_item["public_updated_at"].present?
+  end
+
+  def english?
+    content_item["locale"].present? && content_item["locale"] == "en"
+  end
+
+  def change_note?
+    history = content_item.dig("details", "change_history")
+    return false if history.blank?
+
+    change_note = history.max_by { |note| note["public_timestamp"] }
+    change_note["note"].present?
+  end
+
+  def blocked_publishing_app?
+    # Note this test is different to the one in email-alert-service,
+    # here we only block collections-publisher, because we know that
+    # travel-advice-publisher and specialist-publisher documents do
+    # trigger emails, and here we don't need to worry about filtering
+    # them out to avoid duplicates. We filter out collections-publisher
+    # because it doesn't manage alertable content
+    content_item["publishing_app"] == "collections-publisher"
+  end
+
+  def blocked_document_type?
+    # These are documents that don't make sense to email someone about as they
+    # are not useful to an end user (coming_soon, special_route), or the emails
+    # are managed outside of email-alert-api (drug_safety_update)
+    %w[coming_soon special_route drug_safety_update].include?(content_item["document_type"])
+  end
+
+  def contains_supported_attribute?
+    supported_attributes = %w[
+      topics
+      policies
+      service_manual_topics
+      taxons
+      world_locations
+      topical_events
+      people
+      policy_areas
+      roles
+    ]
+
+    keys = content_item.fetch("links", {}).keys + content_item.fetch("details", {}).keys
+    (supported_attributes & keys).any?
+  end
+
+  def links_to_service_manual_service_standard?
+    content_item["parent"] == %w[00f693d4-866a-4fe6-a8d6-09cd7db8980b]
+  end
+
+  def has_relevant_document_supertype?
+    return true unless ["other", "", nil].include?(content_item["government_document_supertype"])
+    return true unless ["other", "", nil].include?(content_item["email_document_supertype"])
+
+    false
+  end
+end

--- a/lib/reports/future_content_change_statistics_report.rb
+++ b/lib/reports/future_content_change_statistics_report.rb
@@ -11,16 +11,16 @@ class Reports::FutureContentChangeStatisticsReport
   end
 
   def call
-    content_item = content_store_client.content_item(govuk_path).to_hash
+    unless EmailCriteriaQuery.new(govuk_path:, draft:).call
+      return [
+        "This item would not trigger an email alert itself.",
+        "However, it might have a subscriber list that would be triggered by",
+        "changes to other pages. Try running the",
+        "report:subscriber_list_subscriber_count rake task",
+      ]
+    end
 
-    lists = SubscriberListQuery.new(
-      content_id: content_item["content_id"],
-      tags: tags_from_content_item(content_item),
-      links: links_from_content_item(content_item),
-      document_type: content_item["document_type"],
-      email_document_supertype: supertypes(content_item)["email_document_supertype"],
-      government_document_supertype: supertypes(content_item)["government_document_supertype"],
-    ).lists
+    lists = SubscriberListsByPathQuery.new(govuk_path:, draft:).call
 
     output_string = change_messages.join
 
@@ -34,68 +34,16 @@ class Reports::FutureContentChangeStatisticsReport
   end
 
   def change_messages
-    if draft
+    if @draft
       [
-        "Publishing the drafted changes to #{govuk_path} will trigger alerts on these lists:\n",
+        "Publishing the drafted changes to #{@govuk_path} will trigger alerts on these lists:\n",
         "(NB: publishing as a minor change will not trigger alerts)",
       ]
     else
       [
-        "Publishing major changes to the information on #{govuk_path} will trigger alerts on these lists:\n",
+        "Publishing major changes to the information on #{@govuk_path} will trigger alerts on these lists:\n",
         "(NB: If major changes involve changes to the taxons/links/etc these lists will change)\n",
       ]
     end
-  end
-
-  def content_store_client
-    return GdsApi.content_store unless draft
-
-    # We don't appear to need a token for the #content_item method?
-    GdsApi::ContentStore.new(Plek.find("draft-content-store"), bearer_token: "")
-  end
-
-  def supertypes(content_item)
-    GovukDocumentTypes.supertypes(document_type: content_item["document_type"])
-  end
-
-  def tags_from_content_item(content_item)
-    content_item["details"].fetch("tags", {}).merge(additional_items(content_item))
-  end
-
-  def links_from_content_item(content_item)
-    compressed_links(content_item).merge(additional_items(content_item).merge("taxon_tree" => taxon_tree(content_item)))
-  end
-
-  def compressed_links(content_item)
-    keys = content_item["links"].keys - %w[available_translations taxons]
-    compressed_links = {}
-    keys.each do |k|
-      compressed_links[k] = content_item["links"][k].collect { |i| i["content_id"] }
-    end
-    compressed_links
-  end
-
-  def additional_items(content_item)
-    { "content_store_document_type" => content_item["document_type"] }.merge(supertypes(content_item))
-  end
-
-  def taxon_tree(content_item)
-    return [] unless content_item["links"].key?("taxons")
-    return [] unless content_item["links"]["taxons"].any?
-
-    [content_item["links"]["taxons"].first["content_id"]] + get_parent_links(content_item["links"]["taxons"].first)
-  end
-
-  def get_parent_links(taxon_struct)
-    return [] unless taxon_struct["links"].key?("parent_taxons")
-    return [] unless taxon_struct["links"]["parent_taxons"].any?
-
-    tree = []
-    taxon_struct["links"]["parent_taxons"].each do |parent_taxon|
-      tree += [parent_taxon["content_id"]]
-      tree += get_parent_links(parent_taxon)
-    end
-
-    tree
   end
 end

--- a/spec/integration/show_subscriber_list_metrics_spec.rb
+++ b/spec/integration/show_subscriber_list_metrics_spec.rb
@@ -1,0 +1,103 @@
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe "Show subscriber list metrics", type: :request do
+  include GdsApi::TestHelpers::ContentStore
+
+  describe "GET /subscriber-lists/metrics/*path" do
+    context "with authentication and authorisation" do
+      before do
+        login_with_internal_app
+      end
+
+      context "the subscriber_list exists and is empty" do
+        let!(:subscriber_list) { create(:subscriber_list, url: "/metrictest") }
+
+        it "returns the metrics with zeros" do
+          stub_content_store_has_item(subscriber_list.url)
+          get "/subscriber-lists/metrics/metrictest"
+
+          expect(response.status).to eq(200)
+
+          subscriber_list_metrics_response = JSON.parse(response.body)
+
+          expect(subscriber_list_metrics_response["subscriber_list_count"]).to eq(0)
+          expect(subscriber_list_metrics_response["all_notify_count"]).to eq(0)
+        end
+      end
+
+      context "the subscriber_list exists and has subscribers" do
+        let!(:subscriber_list) { create(:subscriber_list, :for_single_page_subscription) }
+
+        it "returns the metrics with values" do
+          stub_content_store_has_item(subscriber_list.url)
+          get "/subscriber-lists/metrics#{subscriber_list.url}"
+
+          expect(response.status).to eq(200)
+
+          subscriber_list_metrics_response = JSON.parse(response.body)
+
+          expect(subscriber_list_metrics_response["subscriber_list_count"]).to eq(subscriber_list.subscriptions.active.count)
+          expect(subscriber_list_metrics_response["all_notify_count"]).to eq(0)
+        end
+      end
+
+      context "the subscriber_list exists and has subscribers and also matches a link subscriber list" do
+        let!(:subscriber_list) { create(:subscriber_list, :for_single_page_subscription) }
+        let!(:tags_list) { create(:subscriber_list, links: { people: { any: %w[854440e9-c0f1-11e4-8223-005056011aef] } }) }
+        let!(:subscription) { create(:subscription, subscriber_list: tags_list) }
+        let!(:content_item) do
+          content_item_for_base_path(subscriber_list.url).merge(
+            "links" => { "people" => [{ "content_item" => "854440e9-c0f1-11e4-8223-005056011aef" }] },
+            "locale" => "en",
+            "details" => { "change_history" => [{ "note" => "changed!", "public_timestamp" => Time.zone.now }] },
+          )
+        end
+
+        it "returns the metrics with zeros" do
+          stub_content_store_has_item(subscriber_list.url, content_item)
+          get "/subscriber-lists/metrics#{subscriber_list.url}"
+
+          expect(response.status).to eq(200)
+
+          subscriber_list_metrics_response = JSON.parse(response.body)
+
+          expect(subscriber_list_metrics_response["subscriber_list_count"]).to eq(subscriber_list.subscriptions.active.count)
+          expect(subscriber_list_metrics_response["all_notify_count"]).to eq(tags_list.subscriptions.active.count)
+        end
+      end
+
+      context "the subscriber_list doesn't exist" do
+        it "returns the metrics with zeros" do
+          stub_content_store_has_item("/metrictest")
+          get "/subscriber-lists/metrics/metrictest"
+
+          expect(response.status).to eq(200)
+
+          subscriber_list_metrics_response = JSON.parse(response.body)
+
+          expect(subscriber_list_metrics_response["subscriber_list_count"]).to eq(0)
+          expect(subscriber_list_metrics_response["all_notify_count"]).to eq(0)
+        end
+      end
+    end
+
+    context "without authentication" do
+      it "returns a 401" do
+        without_login do
+          get "/subscriber-lists/metrics/metrictest"
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+
+    context "without authorisation" do
+      it "returns a 403" do
+        login_with_signin
+
+        get "/subscriber-lists/metrics/metrictest"
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/lib/email_alert_criteria_spec.rb
+++ b/spec/lib/email_alert_criteria_spec.rb
@@ -1,0 +1,136 @@
+require "gds_api/test_helpers/content_item_helpers"
+
+RSpec.describe EmailAlertCriteria do
+  include GdsApi::TestHelpers::ContentItemHelpers
+  subject { described_class.new(content_item:) }
+
+  describe "#would_trigger_alert?" do
+    context "when the content item has no title" do
+      let!(:content_item) { valid_content_item.except("title") }
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item has no base_path" do
+      let!(:content_item) { valid_content_item.except("base_path") }
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item has no public_updated_at" do
+      let!(:content_item) { valid_content_item.except("public_updated_at") }
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item is not english" do
+      let!(:content_item) { valid_content_item.merge("locale" => "cy") }
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item does not have a change note" do
+      let!(:content_item) do
+        ci = valid_content_item
+        ci["details"].delete("change_history")
+        ci
+      end
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item is from a blocked app" do
+      let!(:content_item) { valid_content_item.merge("publishing_app" => "collections-publisher") }
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item is from a blocked document_type" do
+      let!(:content_item) { valid_content_item.merge("document_type" => "coming_soon") }
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item is otherwise valid but doesn't have a parent/tag/supertype" do
+      let!(:content_item) { valid_content_item_no_parent }
+
+      it "should return true" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item is valid because it is the single instance of service_manual_service_standard" do
+      let!(:content_item) { valid_content_item_no_parent.merge("parent" => %w[00f693d4-866a-4fe6-a8d6-09cd7db8980b]) }
+
+      it "should return true" do
+        expect(subject.would_trigger_alert?).to be true
+      end
+    end
+
+    context "when the content item is valid because it contains a supported link type" do
+      let!(:content_item) { valid_content_item_no_parent.merge("links" => { "topics" => [{ "locale" => "en" }] }) }
+
+      it "should return true" do
+        expect(subject.would_trigger_alert?).to be true
+      end
+    end
+
+    context "when the content item does not have a relevant supertype" do
+      let!(:content_item) { valid_content_item_no_parent.merge("government_document_supertype" => "other") }
+
+      it "should return false" do
+        expect(subject.would_trigger_alert?).to be false
+      end
+    end
+
+    context "when the content item is valid because it has a relevant government_document_supertype" do
+      let!(:content_item) { valid_content_item_no_parent.merge("government_document_supertype" => "news") }
+
+      it "should return true" do
+        expect(subject.would_trigger_alert?).to be true
+      end
+    end
+
+    context "when the content item is valid because it has a relevant email_document_supertype" do
+      let!(:content_item) { valid_content_item_no_parent.merge("email_document_supertype" => "news") }
+
+      it "should return true" do
+        expect(subject.would_trigger_alert?).to be true
+      end
+    end
+  end
+end
+
+def valid_content_item
+  content_item = content_item_for_base_path("/criteria-test")
+  content_item["base_path"] = "/criteria-test"
+  content_item["locale"] = "en"
+  content_item["details"].merge!("change_history" => [{
+    "note" => "updated!",
+    "public_timestamp" => content_item["public_updated_at"],
+  }])
+  content_item["publishing_app"] = "whitehall"
+  content_item["document_type"] = "news"
+  content_item["parent"] = %w[00f693d4-866a-4fe6-a8d6-09cd7db8980b]
+  content_item
+end
+
+def valid_content_item_no_parent
+  content_item = valid_content_item
+  content_item.delete("parent")
+  content_item
+end


### PR DESCRIPTION
Adds /subscriber-lists/metrics/* path. This takes a path to a govuk page and returns subscriber list count (if a list is present) and the number of subscribers who would be notified by a change to the page (this may or may not include the subscriber list count). This can be called by users with the internal_app permission (at the moment this is intended to be called by Content Data, so that alongside the content data for a page you can see some subscriber numbers if relevant)

https://trello.com/c/xng5X4uX/30-add-email-statistics-into-content-data-admin

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
