### PR TITLE
Add valid tags for Algorithmic Transparency Record email sign up page

### DIFF
--- a/lib/valid_tags.rb
+++ b/lib/valid_tags.rb
@@ -3,6 +3,7 @@ class ValidTags
     aircraft_category
     aircraft_type
     alert_type
+    algorithmic_transparency_record_function
     appear_in_find_eu_exit_guidance_business_finder
     assessment_date
     business_activity


### PR DESCRIPTION
Add tags for Algorithmic Transparency Record. This document type has been requested by the Department of Science, Innovation and Technology. The records explain how and why public sector organisations use AI and algorithmic tools for decision making.

[Trello card](https://trello.com/c/RUJDt3Ga)
