### PR TITLE
Remove unused welcome route and controller

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,7 +1,0 @@
-class WelcomeController < ApplicationController
-  def index
-    message = "Welcome to Email Alert API. For source code and documentation"\
-      " please visit: https://github.com/alphagov/email-alert-api"
-    render json: { message: }
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   scope format: false, defaults: { format: :json } do
-    root "welcome#index"
     resources :subscriber_lists, path: "subscriber-lists", only: %i[create]
     get "/subscriber-lists", to: "subscriber_lists#index"
     get "/subscriber-lists/:slug", to: "subscriber_lists#show"


### PR DESCRIPTION
We don't need the welcome controller and it isn't tested, so remove it and its route.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
