### PR TITLE
Subscriber list stats for finders

### DIFF
--- a/app/queries/subscriber_lists_for_finder_query.rb
+++ b/app/queries/subscriber_lists_for_finder_query.rb
@@ -1,0 +1,31 @@
+class SubscriberListsForFinderQuery
+  attr_reader :govuk_path
+
+  class NotAFinderError < StandardError; end
+
+  def initialize(govuk_path:)
+    @govuk_path = govuk_path
+  end
+
+  SELECT_FOR_TAGS_TEMPLATE = <<-SQL.freeze
+    SELECT EXISTS (
+      SELECT formats FROM (
+        SELECT json_array_elements_text(tags -> ? -> 'any') AS formats
+      ) AS allowed_formats WHERE formats = ?
+    )
+  SQL
+
+  def call
+    content_item = GdsApi.content_store.content_item(govuk_path).to_hash
+    raise NotAFinderError unless content_item["document_type"] == "finder"
+
+    lists = []
+    content_item["details"]["filter"].each_key do |filter_name|
+      Array(content_item["details"]["filter"][filter_name]).each do |filter_value|
+        lists += SubscriberList.where(SELECT_FOR_TAGS_TEMPLATE, filter_name, filter_value)
+      end
+    end
+
+    lists.uniq
+  end
+end

--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -113,10 +113,26 @@ This will report on the number of active subscriptions for a given path.
 > **Warning**
 >
 > This is called simple because it only gets subscriber lists for a direct path. There may still be subscriptions by topic or link, so finding an empty or missing subcription list does not mean that no-one will receive email updates about that page! See below for a more detailed description of how to get the subscriber list.
+> It also won't work that well if the path is a finder. See below for better tasks for finders or detailed subscriber lists.
 
 The path should be the full path on gov.uk (for instance /government/statistics/examples if the page you're interested in is https://www.gov.uk/government/statistics/examples)
 
 You can also pass it a :active_on_datetime which will count how many active subscriptions there were at the end of the day on a particular date. The active_on_date defaults to today if not specified, and should be in ISO8601 format, for example 2022-03-03T12:12:16+00:00. The time will always be rounded to the end of the day, even if that is in the future.
+
+## Get stats for subscribers to a finder by its URL
+
+To see a report on the number of subscribers to a finder, :
+
+```bash
+kubectl -n apps exec -it deploy/email-alert-api -- bundle exec rake 'report:finder_statistics[<path>]'
+```
+This will report on the number of subscriber lists to the finder on a given path.
+
+The path should be the full path on gov.uk (for instance /cma-cases if the page you're interested in is https://www.gov.uk/cma-cases)
+
+Because finder subscriptions can include the filters active on the finder at the point the subscription was created, there may be more than one subscriber list. Finders require an email_alert_signup item in the links section of their content item to allow alerts, so if there are no subscriptions to a finder
+it may be because it cannot be signed up to.
+
 
 ## Finding out how many messages were sent when a page changed
 

--- a/lib/reports/finder_statistics_report.rb
+++ b/lib/reports/finder_statistics_report.rb
@@ -1,0 +1,27 @@
+require "reports/concerns/notification_stats"
+
+class Reports::FinderStatisticsReport
+  include Reports::Concerns::NotificationStats
+
+  attr_reader :govuk_path
+
+  def initialize(govuk_path)
+    @govuk_path = govuk_path
+  end
+
+  def call
+    lists = SubscriberListsForFinderQuery.new(govuk_path:).call
+
+    output_string = "\nLists created from this finder\n"
+
+    list_names_array(lists).each { |ln| output_string += " - #{ln}\n" }
+
+    output_string += "\nResulting in:\n"
+
+    list_stats_array(lists).each { |ls| output_string += " - #{ls}\n" }
+
+    output_string
+  rescue SubscriberListsForFinderQuery::NotAFinderError
+    ["This item is not a finder, so isn't suitable for this report."]
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -43,4 +43,11 @@ namespace :report do
       args.fetch(:draft, "false").downcase == "true",
     ).call
   end
+
+  desc "Output how many people are subscribed to lists created from a finder at the given path"
+  task :finder_statistics, %i[govuk_path] => :environment do |_t, args|
+    puts Reports::FinderStatisticsReport.new(
+      args.fetch(:govuk_path),
+    ).call
+  end
 end

--- a/spec/lib/reports/finder_statistics_report_spec.rb
+++ b/spec/lib/reports/finder_statistics_report_spec.rb
@@ -1,0 +1,35 @@
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe Reports::FinderStatisticsReport do
+  include GdsApi::TestHelpers::ContentStore
+
+  let(:govuk_path) { "/cma-cases" }
+
+  let(:expected) do
+    <<~OUTPUT
+
+      Lists created from this finder
+       - Example List (0 active subscribers)
+
+      Resulting in:
+       - notified immediately: 0
+       - notified next day:    0
+       - notified at weekend:  0
+       - notified total:       0
+    OUTPUT
+  end
+
+  before do
+    content_item = content_item_for_base_path(govuk_path).merge(
+      "document_type" => "finder",
+      "links" => { "email_alert_signup" => { "withdrawn" => false } },
+      "details" => { "filter" => { "format" => "cma_case" } },
+    )
+    stub_content_store_has_item(govuk_path, content_item)
+    create(:subscriber_list, title: "Example List", tags: { format: { any: %w[cma_case] } })
+  end
+
+  it "returns data around active lists for the given date" do
+    expect(described_class.new(govuk_path).call).to eq expected
+  end
+end

--- a/spec/queries/subscriber_lists_for_finder_query_spec.rb
+++ b/spec/queries/subscriber_lists_for_finder_query_spec.rb
@@ -1,0 +1,43 @@
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe SubscriberListsForFinderQuery do
+  include GdsApi::TestHelpers::ContentStore
+
+  describe ".call" do
+    let(:govuk_path) { "/cma-cases" }
+    let!(:content_item) do
+      content_item_for_base_path(govuk_path).merge(
+        "document_type" => "finder",
+        "links" => { "email_alert_signup" => { "withdrawn" => false } },
+        "details" => { "filter" => { "format" => "cma_case" } },
+      )
+    end
+
+    before do
+      stub_content_store_has_item(govuk_path, content_item)
+    end
+
+    it "can match a list" do
+      list = create(:subscriber_list, tags: { format: { any: %w[cma_case] } })
+
+      result = described_class.new(govuk_path:).call
+      expect(result).to contain_exactly(list)
+    end
+
+    context "with non-finder" do
+      let!(:non_finder_content_item) do
+        content_item_for_base_path(govuk_path).merge("document_type" => "external_content")
+      end
+
+      before do
+        stub_content_store_has_item(govuk_path, non_finder_content_item)
+      end
+
+      it "raises a NotAFinderError" do
+        create(:subscriber_list, tags: { format: { any: %w[cma_case] } })
+
+        expect { described_class.new(govuk_path:).call }.to raise_error(SubscriberListsForFinderQuery::NotAFinderError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a rake task that will get subscriber lists for a finder (since these don't work well with existing rake tasks)

https://trello.com/c/ZM53KHEM/2406-consider-how-email-alert-api-reports-mailing-list-sizes-for-finders

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
