### PR TITLE
Add audit task for Subscriber Lists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "ratelimit"
 gem "redcarpet"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
+gem "sitemap-parser"
 gem "with_advisory_lock"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
     expgen (0.1.1)
       parslet
     factory_bot (6.4.5)
@@ -661,6 +663,9 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sitemap-parser (0.5.6)
+      nokogiri (~> 1.6)
+      typhoeus (>= 0.6, < 2.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -675,6 +680,8 @@ GEM
     timeout (0.4.1)
     tins (1.32.1)
       sync
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -735,6 +742,7 @@ DEPENDENCIES
   sentry-sidekiq
   sidekiq-scheduler
   simplecov
+  sitemap-parser
   webmock
   with_advisory_lock
 

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -27,6 +27,11 @@ class SubscriberList < ApplicationRecord
           SubscriberListsByCriteriaQuery.call(self, criteria_rules)
         }
 
+  scope :unaudited_since,
+        lambda { |since_date|
+          where("last_audited_at IS NULL OR last_audited_at < ?", since_date)
+        }
+
   def active_subscriptions_count
     subscriptions.active.count
   end

--- a/app/queries/subscriber_lists_by_content_item_query.rb
+++ b/app/queries/subscriber_lists_by_content_item_query.rb
@@ -1,0 +1,69 @@
+class SubscriberListsByContentItemQuery
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def call
+    SubscriberListQuery.new(
+      content_id: content_item["content_id"],
+      tags: tags_from_content_item(content_item),
+      links: links_from_content_item(content_item),
+      document_type: content_item["document_type"],
+      email_document_supertype: supertypes(content_item)["email_document_supertype"],
+      government_document_supertype: supertypes(content_item)["government_document_supertype"],
+    ).lists
+  end
+
+private
+
+  def supertypes(content_item)
+    GovukDocumentTypes.supertypes(document_type: content_item["document_type"])
+  end
+
+  def tags_from_content_item(content_item)
+    content_item["details"].fetch("tags", {}).merge(additional_items(content_item))
+  end
+
+  def links_from_content_item(content_item)
+    compressed_links(content_item).merge(additional_items(content_item).merge("taxon_tree" => taxon_tree(content_item)))
+  end
+
+  def compressed_links(content_item)
+    return {} unless content_item.key?("links")
+
+    keys = (content_item["links"].keys || []) - %w[available_translations taxons]
+    compressed_links = {}
+    keys.each do |k|
+      compressed_links[k] = content_item["links"][k].collect { |i| i["content_id"] }
+    end
+    compressed_links
+  end
+
+  def additional_items(content_item)
+    { "content_store_document_type" => content_item["document_type"] }.merge(supertypes(content_item))
+  end
+
+  def taxon_tree(content_item)
+    return [] unless content_item.key?("links")
+    return [] unless content_item["links"].key?("taxons")
+    return [] unless content_item["links"]["taxons"].any?
+
+    [content_item["links"]["taxons"].first["content_id"]] + get_parent_links(content_item["links"]["taxons"].first)
+  end
+
+  def get_parent_links(taxon_struct)
+    return [] unless taxon_struct.key?("links")
+    return [] unless taxon_struct["links"].key?("parent_taxons")
+    return [] unless taxon_struct["links"]["parent_taxons"].any?
+
+    tree = []
+    taxon_struct["links"]["parent_taxons"].each do |parent_taxon|
+      tree += [parent_taxon["content_id"]]
+      tree += get_parent_links(parent_taxon)
+    end
+
+    tree
+  end
+end

--- a/app/queries/subscriber_lists_by_path_query.rb
+++ b/app/queries/subscriber_lists_by_path_query.rb
@@ -9,14 +9,7 @@ class SubscriberListsByPathQuery
   def call
     content_item = content_store_client.content_item(govuk_path).to_hash
 
-    SubscriberListQuery.new(
-      content_id: content_item["content_id"],
-      tags: tags_from_content_item(content_item),
-      links: links_from_content_item(content_item),
-      document_type: content_item["document_type"],
-      email_document_supertype: supertypes(content_item)["email_document_supertype"],
-      government_document_supertype: supertypes(content_item)["government_document_supertype"],
-    ).lists
+    SubscriberListsByContentItemQuery.new(content_item).call
   end
 
 private
@@ -26,54 +19,5 @@ private
 
     # We don't appear to need a token for the #content_item method?
     GdsApi::ContentStore.new(Plek.find("draft-content-store"), bearer_token: "")
-  end
-
-  def supertypes(content_item)
-    GovukDocumentTypes.supertypes(document_type: content_item["document_type"])
-  end
-
-  def tags_from_content_item(content_item)
-    content_item["details"].fetch("tags", {}).merge(additional_items(content_item))
-  end
-
-  def links_from_content_item(content_item)
-    compressed_links(content_item).merge(additional_items(content_item).merge("taxon_tree" => taxon_tree(content_item)))
-  end
-
-  def compressed_links(content_item)
-    return {} unless content_item.key?("links")
-
-    keys = (content_item["links"].keys || []) - %w[available_translations taxons]
-    compressed_links = {}
-    keys.each do |k|
-      compressed_links[k] = content_item["links"][k].collect { |i| i["content_id"] }
-    end
-    compressed_links
-  end
-
-  def additional_items(content_item)
-    { "content_store_document_type" => content_item["document_type"] }.merge(supertypes(content_item))
-  end
-
-  def taxon_tree(content_item)
-    return [] unless content_item.key?("links")
-    return [] unless content_item["links"].key?("taxons")
-    return [] unless content_item["links"]["taxons"].any?
-
-    [content_item["links"]["taxons"].first["content_id"]] + get_parent_links(content_item["links"]["taxons"].first)
-  end
-
-  def get_parent_links(taxon_struct)
-    return [] unless taxon_struct.key?("links")
-    return [] unless taxon_struct["links"].key?("parent_taxons")
-    return [] unless taxon_struct["links"]["parent_taxons"].any?
-
-    tree = []
-    taxon_struct["links"]["parent_taxons"].each do |parent_taxon|
-      tree += [parent_taxon["content_id"]]
-      tree += get_parent_links(parent_taxon)
-    end
-
-    tree
   end
 end

--- a/app/workers/subscriber_list_audit_worker.rb
+++ b/app/workers/subscriber_list_audit_worker.rb
@@ -1,0 +1,24 @@
+class SubscriberListAuditWorker < ApplicationWorker
+  sidekiq_options queue: :subscriber_list_audit
+
+  def perform(url_batch, audit_start_time_string)
+    audit_start_time = Time.zone.parse(audit_start_time_string)
+    content_store_client = GdsApi.content_store
+    return unless SubscriberList.unaudited_since(audit_start_time).any?
+
+    url_batch.each do |url|
+      parsed_url = URI.parse(url)
+      govuk_path = parsed_url.path
+      begin
+        content_item = content_store_client.content_item(govuk_path).to_hash
+
+        if EmailAlertCriteria.new(content_item:).would_trigger_alert?
+          lists = SubscriberListsByContentItemQuery.new(content_item).call
+          lists.each { |list| list.update_column(:last_audited_at, audit_start_time) }
+        end
+      rescue StandardError
+        # We don't really need to do much here, just not crash the worker
+      end
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,6 +12,7 @@
   - [email_generation_digest, 4] # To generate emails to users with daily or weekly subscriptions for content changes and messages.
   - [send_email_immediate, 2] # To send emails to users with immediate subscriptions.
   - [send_email_digest, 2] # To send digest emails to users with either daily or weekly subscriptions.
+  - [subscriber_list_audit, 1] # To crawl the GOV.UK site for audit purposes.
   - [default, 1] # Miscellaneous operations e.g. initiating digest runs, monitoring, DB cleanup and recovering lost Sidekiq jobs.
 :scheduler:
   :schedule:

--- a/db/migrate/20240411100041_add_last_audited_at_to_subscriber_lists.rb
+++ b/db/migrate/20240411100041_add_last_audited_at_to_subscriber_lists.rb
@@ -1,0 +1,5 @@
+class AddLastAuditedAtToSubscriberLists < ActiveRecord::Migration[7.1]
+  def change
+    add_column :subscriber_lists, :last_audited_at, :datetime, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_02_150419) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_11_100041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -119,6 +119,14 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_150419) do
     t.index ["sender_message_id"], name: "index_messages_on_sender_message_id", unique: true
   end
 
+  create_table "subscriber_list_audits", force: :cascade do |t|
+    t.bigint "subscriber_list_id", null: false
+    t.integer "reference_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subscriber_list_id"], name: "index_subscriber_list_audits_on_subscriber_list_id"
+  end
+
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
     t.text "title", null: false
     t.datetime "created_at", precision: nil
@@ -135,6 +143,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_150419) do
     t.string "links_digest"
     t.uuid "content_id"
     t.text "description"
+    t.datetime "last_audited_at"
     t.index ["content_id"], name: "index_subscriber_lists_on_content_id"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"
@@ -207,6 +216,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_150419) do
   add_foreign_key "matched_content_changes", "subscriber_lists", on_delete: :cascade
   add_foreign_key "matched_messages", "messages", on_delete: :cascade
   add_foreign_key "matched_messages", "subscriber_lists", on_delete: :cascade
+  add_foreign_key "subscriber_list_audits", "subscriber_lists"
   add_foreign_key "subscription_contents", "content_changes", on_delete: :restrict
   add_foreign_key "subscription_contents", "digest_run_subscribers", on_delete: :cascade
   add_foreign_key "subscription_contents", "emails", on_delete: :cascade

--- a/docs/subscriber-list-audit.md
+++ b/docs/subscriber-list-audit.md
@@ -1,0 +1,49 @@
+# Subscriber List Audit
+
+## Background
+
+At the moment it's possible to get into a state where subscriber lists exist
+but cannot be triggered:
+- if the keys or fields used to trigger the list are out-of-date with real
+  content,
+- if a format is fully retired without the correct manual intervention to
+  clean up the lists,
+- if content is unpublished and the automatic list cleanup code fails.
+
+To determine whether untriggerable lists exist, we can run an audit over the
+gov.uk website using the sitemap. We iterate over the sitemap, getting the
+content item for each path and then comparing it against the EmailAlertCriteria
+(to check if the path would _ever_ trigger a subscriber list), then if it passes
+that test against the ContentItemListQuery, which returns a list of SubscriberLists
+that would be triggered by major changes to that path. For each of those
+SubscriberLists, we update a last_audited_at field with the time the audit started.
+At the end of the process, any list that has an empty last_audited_at field or
+where the field is older than the time the audit started must not have been marked,
+so we know that it can't be triggered.
+
+## Running the audit
+
+This is a long-running job which needs to be run asynchronously. To kick it off, use:
+
+```bash
+kubectl -n apps exec -it deploy/email-alert-api -- rake 'subscriber_list_audit:start'
+```
+
+NB: It will probably only reliably run in production, as the time taken to iterate
+over the sight may be more than a day, which in integration will be interrupted
+by the environment sync.
+
+To check the number of workers remaining on the job:
+
+```bash
+kubectl -n apps exec -it deploy/email-alert-api -- rake 'subscriber_list_audit:queue_size'
+```
+
+When there are no workers remaining, you can run:
+
+```bash
+kubectl -n apps exec -it deploy/email-alert-api -- rake 'subscriber_list_audit:report[2024-04-16]'
+```
+
+to get a list of all subscriber lists that have either not been marked in an audit, or have not
+been marked in an audit since the specified date.

--- a/lib/tasks/subscriber_list_audit.rake
+++ b/lib/tasks/subscriber_list_audit.rake
@@ -1,0 +1,43 @@
+require "sidekiq/api"
+require "sitemap-parser"
+
+namespace :subscriber_list_audit do
+  desc "Create audit workers"
+  task :start, %i[batch_size] => :environment do |_t, args|
+    batch_size = args.fetch(:batch_size, "100").to_i
+
+    puts("Creating audit workers with batch size #{batch_size}")
+
+    base_sitemap = SitemapParser.new("#{Plek.website_root}/sitemap.xml")
+    sitemap_parts = base_sitemap.sitemap.at("sitemapindex").element_children.map { |element| element.at("loc").content }
+
+    audit_start_time = Time.zone.now
+
+    sitemap_parts.each do |sitemap_url|
+      sitemap = SitemapParser.new(sitemap_url)
+      urls = sitemap.to_a
+
+      puts("Read #{urls.count} URLs from sitemap section #{sitemap_url}")
+
+      urls.each_slice(batch_size) do |batch|
+        SubscriberListAuditWorker.perform_async(batch, audit_start_time.to_s)
+      end
+    end
+
+    puts("Batch workers created. Use rails subscriber_list_audit:queue_size to monitor queue size")
+  end
+
+  desc "Check audit worker queue size"
+  task queue_size: :environment do
+    audit_queue = Sidekiq::Queue.new(:subscriber_list_audit)
+    puts("#{audit_queue.size} jobs remaining to be processed")
+  end
+
+  desc "Show Subscriber Lists unaudited since a given date (defaults to now)"
+  task :report, %i[since_date] => :environment do |_t, args|
+    since_date = Date.parse(args.fetch(:since_date, Time.zone.now.to_s))
+    SubscriberList.unaudited_since(since_date).each do |subscriber_list|
+      puts("#{subscriber_list.id}: #{subscriber_list.title}")
+    end
+  end
+end

--- a/spec/lib/tasks/subscriber_list_audit_spec.rb
+++ b/spec/lib/tasks/subscriber_list_audit_spec.rb
@@ -1,0 +1,61 @@
+SITEMAP_INDEX = <<-SITEMAP_INDEX_XML.freeze
+  <?xml version='1.0' encoding='UTF-8'?>
+  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+      <loc>http://www.dev.gov.uk/sitemaps/sitemap_1.xml</loc>
+      <lastmod>2024-04-22T02:50:02+00:00</lastmod>
+    </sitemap>
+  </sitemapindex>
+SITEMAP_INDEX_XML
+
+SITEMAP = <<-SITEMAP_XML.freeze
+  <?xml version='1.0' encoding='UTF-8'?>
+  <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url>
+          <loc>http://www.dev.gov.uk/example-page-1</loc>
+          <lastmod>2006-11-18</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.8</priority>
+      </url>
+  </urlset>
+SITEMAP_XML
+
+RSpec.describe "subscriber_list_audit" do
+  describe "start" do
+    before do
+      stub_request(:get, "http://www.dev.gov.uk/sitemap.xml").to_return(status: 200, body: SITEMAP_INDEX, headers: {})
+      stub_request(:get, "http://www.dev.gov.uk/sitemaps/sitemap_1.xml").to_return(status: 200, body: SITEMAP, headers: {})
+    end
+
+    it "outputs a CSV of matched content changes" do
+      expected_string = <<~END_EXPECTED_STRING
+        Creating audit workers with batch size 100
+        Read 1 URLs from sitemap section http://www.dev.gov.uk/sitemaps/sitemap_1.xml
+        Batch workers created. Use rails subscriber_list_audit:queue_size to monitor queue size
+      END_EXPECTED_STRING
+
+      expect { Rake::Task["subscriber_list_audit:start"].invoke }
+        .to output(expected_string).to_stdout
+    end
+  end
+
+  describe "queue_size" do
+    it "outputs a CSV of matched content changes" do
+      expect { Rake::Task["subscriber_list_audit:queue_size"].invoke }
+        .to output("0 jobs remaining to be processed\n").to_stdout
+    end
+  end
+
+  describe "report" do
+    before do
+      @sl = create(:subscriber_list)
+    end
+
+    it "outputs a CSV of matched content changes" do
+      expect { Rake::Task["subscriber_list_audit:report"].invoke }
+        .to output("#{@sl.id}: #{@sl.title}\n").to_stdout
+    end
+  end
+end

--- a/spec/workers/subscriber_list_audit_worker_spec.rb
+++ b/spec/workers/subscriber_list_audit_worker_spec.rb
@@ -1,0 +1,102 @@
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe SubscriberListAuditWorker do
+  include GdsApi::TestHelpers::ContentStore
+
+  let(:required_match_attributes) do
+    {
+      "locale" => "en",
+      "government_document_supertype" => "email",
+      "details" => {
+        "tags" => {
+          "topics" => ["motoring/road_rage"],
+        },
+        "change_history" => [
+          { "public_timestamp" => Time.zone.now.to_s, "note" => "changed" },
+        ],
+      },
+    }
+  end
+
+  before do
+    @sl1 = create(:subscriber_list, :for_single_page_subscription)
+    @sl2 = create(:subscriber_list, :for_single_page_subscription, tags: { topics: { any: ["motoring/calmness"] } })
+    @sl3 = create(:subscriber_list, :for_single_page_subscription, tags: { topics: { any: ["motoring/neutrality"] } })
+
+    @path_sl1 = URI(@sl1.url).path
+    @path_sl2 = URI(@sl2.url).path
+    @path_sl3 = URI(@sl3.url).path
+
+    # First content item matchs first subscriber list
+    content_item = content_item_for_base_path(@path_sl1).merge(required_match_attributes)
+    stub_content_store_has_item(@path_sl1, content_item)
+
+    # Second content item matchs second subscriber list
+    content_item = content_item_for_base_path(@path_sl2).merge(required_match_attributes).merge(
+      "details" => {
+        "tags" => {
+          "topics" => ["motoring/calmness"],
+        },
+        "change_history" => [
+          { "public_timestamp" => Time.zone.now.to_s, "note" => "changed" },
+        ],
+      },
+    )
+    stub_content_store_has_item(@path_sl2, content_item)
+
+    # Third content item matchs third subscriber list but doesn't have a change history, so
+    # can't trigger email alerts.
+    content_item = content_item_for_base_path(@path_sl3).merge(required_match_attributes).merge(
+      "details" => {
+        "tags" => {
+          "topics" => ["motoring/calmness"],
+        },
+      },
+    )
+    stub_content_store_has_item(@path_sl3, content_item)
+  end
+
+  describe "#perform" do
+    let(:url_batch) { [@sl1.url, @sl2.url, @sl3.url] }
+    let(:audit_start_time) { Time.zone.now - 5.minutes }
+
+    it "Updates subscriber lists that can be triggered" do
+      described_class.new.perform(url_batch, audit_start_time.to_s)
+
+      expect(SubscriberList.where(last_audited_at: Time.zone.parse(audit_start_time.to_s)).count).to eq(2)
+    end
+
+    it "Doesn't update subscriber lists that can't be triggered" do
+      described_class.new.perform(url_batch, audit_start_time.to_s)
+
+      @sl3.reload
+      expect(@sl3.last_audited_at).to be_nil
+    end
+
+    context "when a content item in the sitemap doesn't exist in the content store" do
+      before do
+        stub_content_store_does_not_have_item(@path_sl1)
+      end
+
+      it "ignores that item and continues" do
+        described_class.new.perform(url_batch, audit_start_time.to_s)
+
+        expect(SubscriberList.where(last_audited_at: nil).count).to eq(2)
+      end
+    end
+
+    context "when everything has been audited recently" do
+      before do
+        @sl1.update_column(:last_audited_at, Time.zone.now)
+        @sl2.update_column(:last_audited_at, Time.zone.now)
+        @sl3.update_column(:last_audited_at, Time.zone.now)
+      end
+
+      it "shortcuts to completion" do
+        expect(EmailAlertCriteria).not_to receive(:new)
+
+        described_class.new.perform(url_batch, audit_start_time.to_s)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a set of rake tasks, a new field and worker to support an audit of SubscriberLists. It's believed that many of these may have become orphaned, so the audit task will crawl the GOV.UK sitemap, and record the subscriber lists touched by a change on any given page. At the end of the audit, any subscriber lists not marked as auditied will be known to be orphaned, and we can look into deleting them (and possibly related subscribers/subscriptions) to tidy up the data a bit.

https://trello.com/c/PjRE1A0G/14-email-alert-api-has-dead-lists-that-will-never-send-any-email

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
