### PR TITLE
Remove specialist topic code from email alert API

### DIFF
--- a/lib/email_alert_criteria.rb
+++ b/lib/email_alert_criteria.rb
@@ -65,7 +65,6 @@ class EmailAlertCriteria
 
   def contains_supported_attribute?
     supported_attributes = %w[
-      topics
       policies
       service_manual_topics
       taxons

--- a/lib/valid_tags.rb
+++ b/lib/valid_tags.rb
@@ -65,7 +65,6 @@ class ValidTags
     subject
     therapeutic_area
     tiers_or_standalone_items
-    topics
     tribunal_decision_categories
     tribunal_decision_category
     tribunal_decision_country


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

When all specialist topic pages have been archived and redirected, we need to remove the specialist topic related code from Email alert API

## Why

Remove tech debt.

[Trello ticket](https://trello.com/c/RObMmjXG/2422-remove-specialist-topic-code-from-email-alert-api-l)

## Dependencies

The [following PR](https://github.com/alphagov/email-alert-api/pull/2147) has been extracted from the current one and needs to be merged first.
The [following PR](https://github.com/alphagov/gds-api-adapters/pull/1250) fixes Pact tests.