### PR TITLE
Remove topics as a supported attribute

### DIFF
--- a/lib/email_alert_criteria.rb
+++ b/lib/email_alert_criteria.rb
@@ -65,7 +65,6 @@ class EmailAlertCriteria
 
   def contains_supported_attribute?
     supported_attributes = %w[
-      topics
       policies
       service_manual_topics
       taxons

--- a/spec/lib/email_alert_criteria_spec.rb
+++ b/spec/lib/email_alert_criteria_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe EmailAlertCriteria do
     end
 
     context "when the content item is valid because it contains a supported link type" do
-      let!(:content_item) { valid_content_item_no_parent.merge("links" => { "topics" => [{ "locale" => "en" }] }) }
+      let!(:content_item) { valid_content_item_no_parent.merge("links" => { "taxons" => [{ "locale" => "en" }] }) }
 
       it "should return true" do
         expect(subject.would_trigger_alert?).to be true


### PR DESCRIPTION
- topic was [removed as a supported attribute](https://github.com/alphagov/email-alert-service/pull/732) in the MajorChangeMessageProcessor of email-alert-service, which this class tries to imitate.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
