### PR TITLE
Improve coverage

### DIFF
--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -43,10 +43,6 @@ class Subscriber < ApplicationRecord
     !govuk_account_id.nil?
   end
 
-  def nullified?
-    address.nil?
-  end
-
   def as_json(options = {})
     options[:except] ||= %i[signon_user_uid]
     super(options)

--- a/app/models/subscriber_list.rb
+++ b/app/models/subscriber_list.rb
@@ -22,23 +22,6 @@ class SubscriberList < ApplicationRecord
     self.links_digest = HashDigest.new(links).generate
   end
 
-  scope :find_by_links_value,
-        lambda { |content_id|
-          # For this query to return the content id has to be wrapped in a
-          # double quote blame psql 9.
-          sql = <<~SQLSTRING
-            :id IN (
-                 SELECT json_array_elements(
-                  CASE
-                    WHEN ((link_table.link#>'{any}') IS NOT NULL) THEN link_table.link->'any'
-                    WHEN ((link_table.link#>'{all}') IS NOT NULL) THEN link_table.link->'all'
-                    ELSE link_table.link
-                  END)::text AS content_id FROM (SELECT ((json_each(links)).value)::json AS link) AS link_table
-            )
-          SQLSTRING
-          where(sql, id: "\"#{content_id}\"")
-        }
-
   scope :matching_criteria_rules,
         lambda { |criteria_rules|
           SubscriberListsByCriteriaQuery.call(self, criteria_rules)

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -1,4 +1,9 @@
+require "gds_api/test_helpers/content_store"
+
 RSpec.describe "report" do
+  include ContentItemHelpers
+  include GdsApi::TestHelpers::ContentStore
+
   describe "matched_content_changes" do
     it "outputs a CSV of matched content changes" do
       expect { Rake::Task["report:matched_content_changes"].invoke }
@@ -30,6 +35,53 @@ RSpec.describe "report" do
   describe "single_page_notifications_top_subscriber_lists" do
     it "outputs a report of single page notification subscriber lists" do
       expect { Rake::Task["report:single_page_notifications_top_subscriber_lists"].invoke }
+        .to output.to_stdout
+    end
+  end
+
+  describe "historical_content_change_statistics" do
+    it "outputs a report of people notified for recent content change" do
+      expect { Rake::Task["report:historical_content_change_statistics"].invoke("/url") }
+        .to output.to_stdout
+    end
+  end
+
+  describe "future_content_change_statistics" do
+    context "with a valid content item" do
+      before do
+        subscriber_list = create(:subscriber_list, :for_single_page_subscription)
+        # match_by_tags_content_item_for_subscriber_list(subscriber_list:)
+        @path = subscriber_list_path(subscriber_list)
+      end
+
+      it "outputs a report of people who would be notified of a major change" do
+        expect { Rake::Task["report:future_content_change_statistics"].invoke(@path) }
+          .to output(/title 1 \([0-9]+ active subscribers\)/).to_stdout
+      end
+    end
+
+    context "with a content item that wouldn't trigger an alert" do
+      before do
+        subscriber_list = create(:subscriber_list, :for_single_page_subscription)
+        match_by_tags_non_triggering_content_item_for_subscriber_list(subscriber_list:)
+        @path_2 = subscriber_list_path(subscriber_list)
+      end
+
+      it "outputs a report of people who would be notified of a major change" do
+        expect { Rake::Task["report:future_content_change_statistics"].invoke(@path_2) }
+          .to output(/would not trigger an email alert/).to_stdout
+      end
+    end
+  end
+
+  describe "finder_statistics" do
+    before do
+      content_item = content_item_for_base_path("/url")
+      stub_content_store_has_item("/url", content_item)
+    end
+
+    it "outputs a report of people who are subscribed to lists created from a finder" do
+      expect { Rake::Task["report:finder_statistics"].invoke("/url") }
         .to output.to_stdout
     end
   end

--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -1,4 +1,33 @@
 RSpec.describe "support" do
+  after(:each) do
+    Rake::Task["support:emails:stats_for_content_id"].reenable
+  end
+
+  describe "stats_for_content_id" do
+    context "with invalid dates" do
+      it "outputs all subscriptions for a subscriber" do
+        expect { Rake::Task["support:emails:stats_for_content_id"].invoke(SecureRandom.uuid, "bad_date", "bad_date") }
+          .to raise_error(SystemExit, /Cannot parse dates/)
+      end
+    end
+
+    context "with matching emails" do
+      let(:valid_email) { create(:email, content_id: SecureRandom.uuid) }
+
+      it "outputs all subscriptions for a subscriber" do
+        expect { Rake::Task["support:emails:stats_for_content_id"].invoke(valid_email.content_id) }
+          .to output(/1 emails sent/).to_stdout
+      end
+    end
+
+    context "without matching emails" do
+      it "outputs all subscriptions for a subscriber" do
+        expect { Rake::Task["support:emails:stats_for_content_id"].invoke(SecureRandom.uuid) }
+          .to output(/No emails sent/).to_stdout
+      end
+    end
+  end
+
   describe "get_notifications_from_notify_by_email_id" do
     before { stub_request(:get, /notifications\.service\.gov\.uk/).to_return(status: 404) }
 

--- a/spec/support/content_item_helpers.rb
+++ b/spec/support/content_item_helpers.rb
@@ -1,0 +1,34 @@
+require "gds_api/test_helpers/content_store"
+
+module ContentItemHelpers
+  include GdsApi::TestHelpers::ContentStore
+
+  def required_match_attributes(tags:)
+    {
+      "locale" => "en",
+      "government_document_supertype" => "email",
+      "details" => {
+        "tags" => tags,
+        "change_history" => [
+          { "public_timestamp" => Time.zone.now.to_s, "note" => "changed" },
+        ],
+      },
+    }
+  end
+
+  def match_by_tags_content_item_for_subscriber_list(subscriber_list:, tags: { "topics" => ["motoring/road_rage"] }, draft: false)
+    content_item = content_item_for_base_path(subscriber_list_path(subscriber_list)).merge(required_match_attributes(tags:))
+    stub_content_store_has_item(subscriber_list_path(subscriber_list), content_item, draft:)
+  end
+
+  def match_by_tags_non_triggering_content_item_for_subscriber_list(subscriber_list:, tags: { "topics" => ["motoring/road_rage"] })
+    merge_items = required_match_attributes(tags:)
+    merge_items.delete("locale")
+    content_item = content_item_for_base_path(subscriber_list_path(subscriber_list)).merge(merge_items)
+    stub_content_store_has_item(subscriber_list_path(subscriber_list), content_item)
+  end
+
+  def subscriber_list_path(subscriber_list)
+    URI(subscriber_list.url).path
+  end
+end


### PR DESCRIPTION
App has slipped below 95% line coverage. This removes some unused code and improves rake task test coverage to bring us back up to 95%, minimum required for dependabot auto-merging.

https://trello.com/c/Rpv3ukRG/61-update-dependabot-merger-config-to-v2-for-email-alert-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
