### PR TITLE
Refactor subscriber list mover

### DIFF
--- a/lib/subscriber_list_mover.rb
+++ b/lib/subscriber_list_mover.rb
@@ -8,24 +8,23 @@ class SubscriberListMover
   end
 
   def call
-    source_subscriber_list = SubscriberList.find_by(slug: from_slug)
     raise "Source subscriber list #{from_slug} does not exist" if source_subscriber_list.nil?
-
-    source_subscriptions = Subscription.active.find_by(subscriber_list_id: source_subscriber_list.id)
-    raise "No active subscriptions to move from #{from_slug}" if source_subscriptions.nil?
-
-    destination_subscriber_list = SubscriberList.find_by(slug: to_slug)
     raise "Destination subscriber list #{to_slug} does not exist" if destination_subscriber_list.nil?
 
-    subscribers = source_subscriber_list.subscribers
-    sub_count = source_subscriber_list.subscriptions.active.count
-    puts "#{sub_count} active subscribers moving from #{from_slug} to #{to_slug}"
+    an_active_subscription = Subscription.active.find_by(subscriber_list_id: source_subscriber_list.id)
+    raise "No active subscriptions to move from #{from_slug}" if an_active_subscription.blank?
+
+    active_subscription_count = source_subscriber_list.subscriptions.active.count
 
     if send_email
-      emails_for_subscribed = build_emails(source_subscriber_list)
+      emails = BulkSubscriberListEmailBuilder.call(
+        subject: email_subject,
+        body: email_body,
+        subscriber_lists: source_subscriber_list,
+      )
     end
 
-    subscribers.each do |subscriber|
+    source_subscriber_list.subscribers.each do |subscriber|
       Subscription.transaction do
         existing_subscription = Subscription.active.find_by(
           subscriber:,
@@ -52,28 +51,39 @@ class SubscriberListMover
       end
     end
 
-    puts "#{sub_count} active subscribers moved from #{from_slug} to #{to_slug}."
+    puts "#{active_subscription_count} active subscribers moved from #{from_slug} to #{to_slug}."
 
     if send_email
       puts "Sending emails to subscribers about change"
-      email_change_to_subscribers(emails_for_subscribed)
+      emails.each { |id| SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate) }
     end
   end
 
-  def build_emails(source_subscriber_list)
-    email_subject = "Changes to GOV.UK emails"
-    list_title = source_subscriber_list.title
+private
 
+  def source_subscriber_list
+    @source_subscriber_list ||= SubscriberList.find_by(slug: from_slug)
+  end
+
+  def destination_subscriber_list
+    @destination_subscriber_list ||= SubscriberList.find_by(slug: to_slug)
+  end
+
+  def email_subject
+    "Changes to GOV.UK emails"
+  end
+
+  def email_body
     email_redirect = PublicUrls.url_for(
       base_path: "/email/manage",
       utm_campaign: "govuk-subscription-ended",
       utm_source: from_slug,
     )
 
-    bulk_move_template = <<~BODY.freeze
+    <<~BODY.freeze
       Hello,
 
-      You’ve subscribed to get emails about #{list_title}.
+      You’ve subscribed to get emails about #{source_subscriber_list.title}.
 
       GOV.UK is changing the way we send emails, so you may notice a difference in the number and type of updates you get.
 
@@ -82,17 +92,5 @@ class SubscriberListMover
       Thanks,
       GOV.UK
     BODY
-
-    BulkSubscriberListEmailBuilder.call(
-      subject: email_subject,
-      body: bulk_move_template,
-      subscriber_lists: source_subscriber_list,
-    )
-  end
-
-  def email_change_to_subscribers(emails_for_subscribed)
-    emails_for_subscribed.each do |id|
-      SendEmailWorker.perform_async_in_queue(id, queue: :send_email_immediate)
-    end
   end
 end

--- a/spec/lib/subscriber_list_mover_spec.rb
+++ b/spec/lib/subscriber_list_mover_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe SubscriberListMover do
   let(:list_1) { create :subscriber_list }
   let(:list_2) { create :subscriber_list }
+  let(:email) { create :email }
 
   before do
     list_1.subscriptions << create_list(:subscription, 2)
@@ -8,6 +9,12 @@ RSpec.describe SubscriberListMover do
 
     allow($stdout).to receive(:puts)
     allow(SendEmailWorker).to receive(:perform_async_in_queue)
+  end
+
+  around(:each) do |example|
+    ClimateControl.modify(BULK_MIGRATE_CONFIRMATION_EMAIL_ACCOUNT: "test@test.uk") do
+      example.run
+    end
   end
 
   describe "#with_send_email_false" do
@@ -36,14 +43,32 @@ RSpec.describe SubscriberListMover do
       expect(list_2.subscriptions.count).to eq 3
     end
 
-    it "ends from_slug subscriptions with reason: subscriber_list_changed" do
+    it "ends from_slug subscriptions with reason: bulk_migrated" do
       expect(list_1.subscriptions.count).to eq 2
       expect(list_1.subscriptions[1].ended_reason).to eq nil
 
       described_class.new(from_slug: list_1.slug, to_slug: list_2.slug).call
 
       expect(list_1.subscriptions.count).to eq 2
-      expect(list_1.subscriptions[1].reload.ended_reason).to eq "subscriber_list_changed"
+      expect(list_1.subscriptions[1].reload.ended_reason).to eq "bulk_migrated"
+    end
+
+    it "sends a confirmation email to an internal mailbox" do
+      allow(BulkMigrateConfirmationEmailBuilder).to receive(:call).and_return(email)
+      source_subscriber_list = SubscriberList.find_by(slug: list_1.slug)
+      destination_subscriber_list = SubscriberList.find_by(slug: list_2.slug)
+
+      expect(BulkMigrateConfirmationEmailBuilder)
+      .to receive(:call)
+      .with(source_id: source_subscriber_list.id,
+            destination_id: destination_subscriber_list.id,
+            count: 2)
+
+      expect(SendEmailWorker)
+        .to receive(:perform_async_in_queue)
+        .with(email.id, queue: :send_email_transactional)
+
+      described_class.new(from_slug: list_1.slug, to_slug: list_2.slug).call
     end
   end
 


### PR DESCRIPTION
When the bulk-migrate endpoint was added to this application (https://github.com/alphagov/email-alert-api/pull/1919/commits/1af9c9885a39207f506de646bce2bfc099326ac6), a new asynchronous worker was created to run the bulk migration of subscriptions. The endpoint has now been retired, but that worker can be used by the subscriber list mover rake task. 

- This makes the code easier to read
- Leverages the internal confirmation email feature
- Correctly sets the subscription's ended reason as :bulk_migrated instead of :subscriber_list_changed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
