### PR TITLE
Remove specialist topic code from specs

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -100,7 +100,7 @@ FactoryBot.define do
   factory :subscriber_list do
     sequence(:title) { |n| "title #{n}" }
     sequence(:slug) { |n| "title-#{n}" }
-    tags { { topics: { any: ["motoring/road_rage"] } } }
+    tags { { tribunal_decision_categories: { any: %w[agency-workers] } } }
     created_at { 1.year.ago }
 
     trait :travel_advice do

--- a/spec/features/daily_digest_spec.rb
+++ b/spec/features/daily_digest_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe "Daily digests", type: :request do
-  let(:list_one_topic_id) { "0eb5d0f0-d384-4f27-9da8-3f9e9b22a820" }
+  let(:list_organisation_id) { "0eb5d0f0-d384-4f27-9da8-3f9e9b22a820" }
   let(:list_two_taxon_id) { "6416e4e0-c0c1-457a-8337-4bf8ed9d5f80" }
 
   let(:subscriber_list_one) do
     create_subscriber_list(
       title: "Subscriber list one",
       links: {
-        topics: { any: [list_one_topic_id] },
+        organisations: { any: [list_organisation_id] },
       },
     )
   end
@@ -36,7 +36,7 @@ RSpec.describe "Daily digests", type: :request do
         description: "Description one",
         change_note: "Change note one",
         public_updated_at: "2017-01-01 10:00:00",
-        links: { topics: [list_one_topic_id] },
+        links: { organisations: [list_organisation_id] },
       )
     end
 
@@ -71,7 +71,7 @@ RSpec.describe "Daily digests", type: :request do
     )
 
     travel_to(Time.zone.parse("2017-01-01 09:30")) do
-      create_content_change(links: { topics: [list_one_topic_id] })
+      create_content_change(links: { organisations: [list_organisation_id] })
     end
 
     travel_to(Time.zone.parse("2017-01-01 09:32")) do

--- a/spec/features/weekly_digest_spec.rb
+++ b/spec/features/weekly_digest_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe "Weekly digests", type: :request do
-  let(:list_one_topic_id) { "0eb5d0f0-d384-4f27-9da8-3f9e9b22a820" }
+  let(:list_organisation_id) { "0eb5d0f0-d384-4f27-9da8-3f9e9b22a820" }
   let(:list_two_taxon_id) { "6416e4e0-c0c1-457a-8337-4bf8ed9d5f80" }
 
   let(:subscriber_list_one) do
     create_subscriber_list(
       title: "Subscriber list one",
       links: {
-        topics: { any: [list_one_topic_id] },
+        organisations: { any: [list_organisation_id] },
       },
     )
   end
@@ -39,7 +39,7 @@ RSpec.describe "Weekly digests", type: :request do
         change_note: "Change note one",
         public_updated_at: "2017-01-01 10:00:00",
         links: {
-          topics: [list_one_topic_id],
+          organisations: [list_organisation_id],
         },
       )
     end
@@ -75,7 +75,7 @@ RSpec.describe "Weekly digests", type: :request do
     )
 
     travel_to(Time.zone.parse("2017-01-01 09:30")) do
-      create_content_change(links: { topics: [list_one_topic_id] })
+      create_content_change(links: { organisations: [list_organisation_id] })
     end
 
     travel_to(Time.zone.parse("2017-01-04 09:32")) do

--- a/spec/integration/browsing_subscriber_lists_spec.rb
+++ b/spec/integration/browsing_subscriber_lists_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Browsing subscriber lists", type: :request do
         create(
           :subscriber_list,
           links: {
-            topics: { any: [uuid, "drug-device-alert"] },
+            taxon_tree: { any: [uuid, "96d2db38-2ddd-4a3c-b9b4-11e310c8f256"] },
           },
           tags: {},
           document_type: "",
@@ -23,7 +23,7 @@ RSpec.describe "Browsing subscriber lists", type: :request do
           :subscriber_list,
           links: {},
           tags: {
-            topics: { any: ["oil-and-gas/licensing", "drug-device-alert"] },
+            tribunal_decision_categories: { any: %w[transfer-of-undertakings time-to-train] },
           },
           document_type: "",
         )
@@ -42,7 +42,7 @@ RSpec.describe "Browsing subscriber lists", type: :request do
         create(
           :subscriber_list,
           links: {
-            topics: { any: %w[vat-rates] },
+            taxon_tree: { any: %w[642f0671-8521-4210-91d4-9c9c0e4e2187] },
           },
           tags: {},
           document_type: "tax",
@@ -50,7 +50,7 @@ RSpec.describe "Browsing subscriber lists", type: :request do
       end
 
       it "responds with the matching subscriber list" do
-        get_subscriber_list(links: { topics: { any: [uuid, "drug-device-alert"] } })
+        get_subscriber_list(links: { taxon_tree: { any: [uuid, "96d2db38-2ddd-4a3c-b9b4-11e310c8f256"] } })
         database_subscriber_list = subscriber_list_links_only
 
         expect(response_subscriber_list).to include(
@@ -64,13 +64,13 @@ RSpec.describe "Browsing subscriber lists", type: :request do
       end
 
       it "finds subscriber lists that match all of the links" do
-        get_subscriber_list(links: { topics: { any: [uuid, "drug-device-alert"] } })
+        get_subscriber_list(links: { taxon_tree: { any: [uuid, "96d2db38-2ddd-4a3c-b9b4-11e310c8f256"] } })
         expect(response.status).to eq(200)
         expect(response_subscriber_list[:id]).to eq(subscriber_list_links_only.id)
       end
 
       it "finds subscriber lists that match all of the tags" do
-        get_subscriber_list(tags: { topics: { any: ["drug-device-alert", "oil-and-gas/licensing"] } })
+        get_subscriber_list(tags: { tribunal_decision_categories: { any: %w[time-to-train transfer-of-undertakings] } })
         expect(response.status).to eq(200)
         expect(response_subscriber_list[:id]).to eq(subscriber_list_tags_only.id)
       end
@@ -83,7 +83,7 @@ RSpec.describe "Browsing subscriber lists", type: :request do
 
       it "finds subscriber lists that match links and document type" do
         get_subscriber_list(
-          links: { topics: { any: %w[vat-rates] } },
+          links: { taxon_tree: { any: %w[642f0671-8521-4210-91d4-9c9c0e4e2187] } },
           document_type: "tax",
         )
         expect(response.status).to eq(200)
@@ -96,10 +96,10 @@ RSpec.describe "Browsing subscriber lists", type: :request do
       end
 
       it "copes if the (legacy) links / tags are not in a hash" do
-        get_subscriber_list(links: { topics: [uuid, "drug-device-alert"] })
+        get_subscriber_list(links: { taxon_tree: [uuid, "96d2db38-2ddd-4a3c-b9b4-11e310c8f256"] })
         expect(response_subscriber_list[:id]).to eq(subscriber_list_links_only.id)
 
-        get_subscriber_list(tags: { topics: ["drug-device-alert", "oil-and-gas/licensing"] })
+        get_subscriber_list(tags: { tribunal_decision_categories: %w[time-to-train transfer-of-undertakings] })
         expect(response_subscriber_list[:id]).to eq(subscriber_list_tags_only.id)
       end
     end

--- a/spec/integration/create_subscriber_list_spec.rb
+++ b/spec/integration/create_subscriber_list_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe "Creating a subscriber list", type: :request do
 
       expect(subscriber_list).to include(
         "tags" => {
-          "topics" => {
-            "any" => ["oil-and-gas/licensing"],
+          "tribunal_decision_categories" => {
+            "any" => %w[transfer-of-undertakings],
           },
           "location" => {
             "all" => %w[france germany],
           },
         },
         "links" => {
-          "topics" => {
+          "organisations" => {
             "any" => %w[uuid-888],
           },
           "taxon_tree" => {
@@ -44,7 +44,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
       it "converts them to a nested hash" do
         create_subscriber_list(
           tags: { location: %w[france germany] },
-          links: { topics: %w[uuid-888] },
+          links: { organisations: %w[uuid-888] },
         )
 
         expect(response_subscriber_list).to include(
@@ -54,7 +54,7 @@ RSpec.describe "Creating a subscriber list", type: :request do
             },
           },
           "links" => {
-            "topics" => {
+            "organisations" => {
               "any" => %w[uuid-888],
             },
           },
@@ -115,11 +115,11 @@ RSpec.describe "Creating a subscriber list", type: :request do
       defaults = {
         title: "This is a sample title",
         tags: {
-          topics: { any: ["oil-and-gas/licensing"] },
+          tribunal_decision_categories: { any: %w[transfer-of-undertakings] },
           location: { all: %w[france germany] },
         },
         links: {
-          topics: { any: %w[uuid-888] },
+          organisations: { any: %w[uuid-888] },
           taxon_tree: { all: %w[taxon1 taxon2] },
         },
       }

--- a/spec/integration/send_content_change_spec.rb
+++ b/spec/integration/send_content_change_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Sending a content change", type: :request do
       subject: "This is a subject",
       body: "body stuff",
       tags: {
-        topics: ["oil-and-gas/licensing"],
+        tribunal_decision_categories: %w[transfer-of-undertakings],
       },
       links: {
         organisations: %w[

--- a/spec/lib/email_alert_criteria_spec.rb
+++ b/spec/lib/email_alert_criteria_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe EmailAlertCriteria do
     end
 
     context "when the content item is valid because it contains a supported link type" do
-      let!(:content_item) { valid_content_item_no_parent.merge("links" => { "topics" => [{ "locale" => "en" }] }) }
+      let!(:content_item) { valid_content_item_no_parent.merge("links" => { "taxons" => [{ "locale" => "en" }] }) }
 
       it "should return true" do
         expect(subject.would_trigger_alert?).to be true

--- a/spec/lib/reports/subscriber_lists_report_spec.rb
+++ b/spec/lib/reports/subscriber_lists_report_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Reports::SubscriberListsReport do
   end
 
   it "returns data around active lists for the given date" do
-    expected_criteria_bits = '{"document_type":"","tags":{"topics":{"any":["motoring/road_rage"]}},' \
+    expected_criteria_bits = '{"document_type":"","tags":{"tribunal_decision_categories":{"any":["agency-workers"]}},' \
       '"links":{},"email_document_supertype":"","government_document_supertype":""}'
 
     expected = CSV.generate do |csv|
@@ -68,7 +68,7 @@ RSpec.describe Reports::SubscriberListsReport do
   it "can filter based on list tags (as a string)" do
     create(:subscriber_list, tags: {})
 
-    output = described_class.new(created_at.to_s, tags_pattern: "road").call
+    output = described_class.new(created_at.to_s, tags_pattern: "agency").call
     expect(output.lines.count).to eq 2
 
     output = described_class.new(created_at.to_s, tags_pattern: "nothing").call

--- a/spec/models/subscriber_list_spec.rb
+++ b/spec/models/subscriber_list_spec.rb
@@ -17,24 +17,24 @@ RSpec.describe SubscriberList, type: :model do
     end
 
     it "is valid when tags 'hash' has 'any' values that are arrays" do
-      subject.tags = { topics: { any: %w[bar] } }
+      subject.tags = { tribunal_decision_categories: { any: %w[pension] } }
 
       expect(subject).to be_valid
     end
 
     it "is valid when tags 'hash' has 'all' values that are arrays" do
-      subject.tags = { topics: { all: %w[bar] } }
+      subject.tags = { tribunal_decision_categories: { all: %w[pension] } }
 
       expect(subject).to be_valid
     end
 
     it "is invalid when tags 'hash' has values that are not whitelisted" do
       subject.tags = {
-        foo: { any: %w[bar] },
+        foo: { any: %w[pension] },
         dogs: { all: %w[bark] },
-        organisations: { any: %w[bar] },
-        people: { any: %w[bar] },
-        world_locations: { all: %w[bar] },
+        organisations: { any: %w[pension] },
+        people: { any: %w[pension] },
+        world_locations: { all: %w[pension] },
       }
 
       expect(subject).to be_invalid
@@ -42,33 +42,33 @@ RSpec.describe SubscriberList, type: :model do
     end
 
     it "is invalid when tags 'hash' has values that are not arrays" do
-      subject.tags = { topics: { any: "bar" } }
+      subject.tags = { tribunal_decision_categories: { any: "pension" } }
 
       expect(subject).to be_invalid
       expect(subject.errors[:tags]).to include("All tag values must be sent as Arrays")
     end
 
     it "is valid when links 'hash' has 'any' values that are arrays" do
-      subject.links = { foo: { any: %w[bar] } }
+      subject.links = { foo: { any: %w[pension] } }
 
       expect(subject).to be_valid
     end
 
     it "is valid when links 'hash' has 'all' values that are arrays" do
-      subject.links = { foo: { all: %w[bar] } }
+      subject.links = { foo: { all: %w[pension] } }
 
       expect(subject).to be_valid
     end
 
     it "is invalid when links 'hash' has 'any' values that are not arrays" do
-      subject.links = { foo: { any: "bar" } }
+      subject.links = { foo: { any: "pension" } }
 
       expect(subject).to be_invalid
       expect(subject.errors[:links]).to include("All link values must be sent as Arrays")
     end
 
     it "is invalid when links 'hash' has 'all' values that are not arrays" do
-      subject.links = { foo: { all: "bar" } }
+      subject.links = { foo: { all: "pension" } }
 
       expect(subject).to be_invalid
       expect(subject.errors[:links]).to include("All link values must be sent as Arrays")
@@ -128,10 +128,10 @@ RSpec.describe SubscriberList, type: :model do
 
   describe "#tags" do
     it "deserializes the tag arrays" do
-      list = create(:subscriber_list, tags: { topics: { any: ["environmental-management/boating"], all: ["oil-and-gas/licensing"] } })
+      list = create(:subscriber_list, tags: { tribunal_decision_categories: { any: %w[pension], all: %w[transfer-of-undertakings] } })
       list.reload
 
-      expect(list.tags).to eq(topics: { any: ["environmental-management/boating"], all: ["oil-and-gas/licensing"] })
+      expect(list.tags).to eq(tribunal_decision_categories: { any: %w[pension], all: %w[transfer-of-undertakings] })
     end
   end
 

--- a/spec/queries/find_exact_query_spec.rb
+++ b/spec/queries/find_exact_query_spec.rb
@@ -2,20 +2,20 @@ RSpec.describe FindExactQuery do
   context "when links are in the query" do
     it "not matched when query contains fewer keys than the subscriber_list" do
       create_subscriber_list(links: {
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
         format: { any: %w[guide news_story] },
       })
-      query = build_query(links: { topics: { any: %w[uuid-888] } })
+      query = build_query(links: { people: { any: %w[uuid-888] } })
       expect(query.exact_match).to be_nil
     end
 
     it "not matched when query contains more keys than the subscriber_list" do
       create_subscriber_list(links: {
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
         organisations: { any: %w[org-123 org-555] },
       })
       query = build_query(links: {
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
         organisations: { any: %w[org-123 org-555] },
         foo: %w[bar],
       })
@@ -24,11 +24,11 @@ RSpec.describe FindExactQuery do
 
     it "not matched when matching keys, but different values for a key" do
       create_subscriber_list(links: {
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
         organisations: { any: %w[org-123 org-555] },
       })
       query = build_query(links: {
-        topics: { any: %w[uuid-999] },
+        people: { any: %w[uuid-999] },
         organisations: { any: %w[org-456 org-666] },
       })
       expect(query.exact_match).to be_nil
@@ -36,11 +36,11 @@ RSpec.describe FindExactQuery do
 
     it "matched when matching keys with matching values" do
       subscriber_list = create_subscriber_list(links: {
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
         organisations: { any: %w[org-123 org-555] },
       })
       query = build_query(links: {
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
         organisations: { any: %w[org-123 org-555] },
       })
       expect(query.exact_match).to eq(subscriber_list)
@@ -48,53 +48,53 @@ RSpec.describe FindExactQuery do
 
     it "order of values for keys does not affect matching" do
       subscriber_list = create_subscriber_list(links: {
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
         organisations: { any: %w[org-123 org-555] },
       })
       query = build_query(links: {
         organisations: { any: %w[org-555 org-123] },
-        topics: { any: %w[uuid-888] },
+        people: { any: %w[uuid-888] },
       })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "requires 'and' and 'any' operators to be correctly set" do
       subscriber_list = create_subscriber_list(links: {
-        topics: { all: %w[uuid-888 uuid-999], any: %w[uuid-777] },
+        people: { all: %w[uuid-888 uuid-999], any: %w[uuid-777] },
         taxon_tree: { all: %w[taxon-123 taxon-555] },
       })
       query = build_query(links: {
         taxon_tree: { all: %w[taxon-123 taxon-555] },
-        topics: { all: %w[uuid-888 uuid-999], any: %w[uuid-777] },
+        people: { all: %w[uuid-888 uuid-999], any: %w[uuid-777] },
       })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "does not match unless both operators are present" do
       subscriber_list = create_subscriber_list(links: {
-        topics: { all: %w[uuid-888], any: %w[uuid-777] },
+        people: { all: %w[uuid-888], any: %w[uuid-777] },
       })
-      bad_query = build_query(links: { topics: { all: %w[uuid-888] } })
-      good_query = build_query(links: { topics: { all: %w[uuid-888], any: %w[uuid-777] } })
+      bad_query = build_query(links: { people: { all: %w[uuid-888] } })
+      good_query = build_query(links: { people: { all: %w[uuid-888], any: %w[uuid-777] } })
       expect(bad_query.exact_match).to be_nil
       expect(good_query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber list has the same links" do
-      query = build_query(links: { policies: { any: %w[aa-11] }, taxon_tree: { all: %w[taxon] } })
-      subscriber_list = create_subscriber_list(links: { policies: { any: %w[aa-11] },
+      query = build_query(links: { people: { any: %w[aa-11] }, taxon_tree: { all: %w[taxon] } })
+      subscriber_list = create_subscriber_list(links: { people: { any: %w[aa-11] },
                                                         taxon_tree: { all: %w[taxon] } })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber list has the same links and matching document_type" do
       query = build_query(
-        links: { policies: { any: %w[aa-11] },
+        links: { people: { any: %w[aa-11] },
                  taxon_tree: { all: %w[taxon] } },
         document_type: "travel_advice",
       )
       subscriber_list = create_subscriber_list(
-        links: { policies: { any: %w[aa-11] },
+        links: { people: { any: %w[aa-11] },
                  taxon_tree: { all: %w[taxon] } },
         document_type: "travel_advice",
       )
@@ -102,43 +102,43 @@ RSpec.describe FindExactQuery do
     end
 
     it "matched when subscriber list has the same links and matching email_document_supertype" do
-      query = build_query(links: { policies: { any: %w[aa-11] } }, email_document_supertype: "publications")
-      subscriber_list = create_subscriber_list(links: { policies: { any: %w[aa-11] } }, email_document_supertype: "publications")
+      query = build_query(links: { people: { any: %w[aa-11] } }, email_document_supertype: "publications")
+      subscriber_list = create_subscriber_list(links: { people: { any: %w[aa-11] } }, email_document_supertype: "publications")
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber list has the same tags and matching content_id" do
-      query = build_query(links: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
-      subscriber_list = create_subscriber_list(links: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      query = build_query(links: { people: { any: %w[uuid-937] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      subscriber_list = create_subscriber_list(links: { people: { any: %w[uuid-937] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "not matched when subscriber list has different links" do
-      query = build_query(links: { policies: { any: %w[aa-11] } })
-      _subscriber_list = create_subscriber_list(links: { policies: { any: %w[11-aa] } })
+      query = build_query(links: { people: { any: %w[aa-11] } })
+      _subscriber_list = create_subscriber_list(links: { people: { any: %w[11-aa] } })
       expect(query.exact_match).to be_nil
     end
 
     it "not matched when subscriber list has no links" do
-      query = build_query(links: { policies: { any: %w[aa-11] } })
+      query = build_query(links: { people: { any: %w[aa-11] } })
       _subscriber_list = create_subscriber_list
       expect(query.exact_match).to be_nil
     end
 
     it "not matched on tags if unable to match links - even if it would match" do
-      query = build_query(links: { policies: { any:  %w[aa-11] } }, tags: { policies: { any: %w[apples] } })
-      _subscriber_list = create_subscriber_list(tags: { policies: { any: %w[apples] } })
+      query = build_query(links: { people: { any: %w[aa-11] } }, tags: { tribunal_decision_categories: { any: %w[tax] } })
+      _subscriber_list = create_subscriber_list(links: { people: { any: %w[bb-22] } }, tags: { tribunal_decision_categories: { any: %w[tax] } })
       expect(query.exact_match).to be_nil
     end
 
     it "not matched on document type - even if they match" do
-      query = build_query(links: { policies: { any: %w[aa-11] } }, document_type: "travel_advice")
+      query = build_query(links: { people: { any: %w[aa-11] } }, document_type: "travel_advice")
       _subscriber_list = create_subscriber_list(document_type: "travel_advice")
       expect(query.exact_match).to be_nil
     end
 
     it "not matched on content_id - even if they match" do
-      query = build_query(links: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      query = build_query(links: { people: { any: %w[uuid-937] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       _subscriber_list = create_subscriber_list(content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       expect(query.exact_match).to be_nil
     end
@@ -147,21 +147,21 @@ RSpec.describe FindExactQuery do
   context "when tags are in the query" do
     it "not matched when query contains fewer keys than the subscriber_list" do
       create_subscriber_list(tags: {
-        topics: { any: %w[uuid-888] },
+        tribunal_decision_categories: { any: %w[written-statements] },
         format: { any: %w[guide news_story] },
       })
-      query = build_query(tags: { topics: { any: %w[uuid-888] } })
+      query = build_query(tags: { tribunal_decision_categories: { any: %w[written-statements] } })
       expect(query.exact_match).to be_nil
     end
 
     it "not matched when query contains more keys than the subscriber_list" do
       create_subscriber_list(tags: {
-        topics: { any: %w[uuid-888] },
-        policies: { any: %w[pol-123 pol-555] },
+        tribunal_decision_judges: { any: %w[written-statements] },
+        tribunal_decision_categories: { any: %w[reorganisation time-off] },
       })
       query = build_query(tags: {
-        topics: { any: %w[uuid-888] },
-        policies: { any: %w[pol-123 pol-555] },
+        tribunal_decision_judges: { any: %w[written-statements] },
+        tribunal_decision_categories: { any: %w[reorganisation time-off] },
         foo: %w[bar],
       })
       expect(query.exact_match).to be_nil
@@ -169,116 +169,116 @@ RSpec.describe FindExactQuery do
 
     it "not matched when matching keys, but different values for each key" do
       create_subscriber_list(tags: {
-        topics: { any: %w[uuid-888] },
-        policies: { any: %w[pol-123 pol-555] },
+        tribunal_decision_judges: { any: %w[written-statements] },
+        tribunal_decision_categories: { any: %w[reorganisation time-off] },
       })
       query = build_query(tags: {
-        topics: { any: %w[uuid-999] },
-        policies: { any: %w[pol-456 pol-666] },
+        tribunal_decision_judges: { any: %w[written-pay-statement] },
+        tribunal_decision_categories: { any: %w[right-to-be-accompanied human-rights] },
       })
       expect(query.exact_match).to be_nil
     end
 
     it "matched when matching keys with matching values" do
       subscriber_list = create_subscriber_list(tags: {
-        topics: { any: %w[uuid-888] },
-        policies: { any: %w[pol-123 pol-555] },
+        tribunal_decision_judges: { any: %w[written-statements] },
+        tribunal_decision_categories: { any: %w[reorganisation time-off] },
       })
       query = build_query(tags: {
-        topics: { any: %w[uuid-888] },
-        policies: { any: %w[pol-123 pol-555] },
+        tribunal_decision_judges: { any: %w[written-statements] },
+        tribunal_decision_categories: { any: %w[reorganisation time-off] },
       })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "order of values for keys does not affect matching" do
       subscriber_list = create_subscriber_list(tags: {
-        topics: { any: %w[uuid-888] },
-        policies: { any: %w[pol-123 pol-555] },
+        tribunal_decision_judges: { any: %w[written-statements] },
+        tribunal_decision_categories: { any: %w[reorganisation time-off] },
       })
       query = build_query(tags: {
-        policies: { any: %w[pol-555 pol-123] },
-        topics: { any: %w[uuid-888] },
+        tribunal_decision_categories: { any: %w[time-off reorganisation] },
+        tribunal_decision_judges: { any: %w[written-statements] },
       })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "requires and and any operators to be correctly set" do
       subscriber_list = create_subscriber_list(tags: {
-        topics: { all: %w[uuid-888 uuid-999], any: %w[uuid-777] },
+        tribunal_decision_judges: { all: %w[written-statements written-pay-statement], any: %w[national-minimum-wage] },
         subject: { all: %w[subject-123 subject-555] },
       })
       query = build_query(tags: {
         subject: { all: %w[subject-123 subject-555] },
-        topics: { all: %w[uuid-888 uuid-999], any: %w[uuid-777] },
+        tribunal_decision_judges: { all: %w[written-statements written-pay-statement], any: %w[national-minimum-wage] },
       })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "requires both operators to be present" do
       subscriber_list = create_subscriber_list(tags: {
-        topics: { all: %w[uuid-888], any: %w[uuid-777] },
+        tribunal_decision_judges: { all: %w[written-statements], any: %w[national-minimum-wage] },
       })
-      bad_query = build_query(tags: { topics: { all: %w[uuid-888] } })
-      good_query = build_query(tags: { topics: { all: %w[uuid-888], any: %w[uuid-777] } })
+      bad_query = build_query(tags: { tribunal_decision_judges: { all: %w[written-statements] } })
+      good_query = build_query(tags: { tribunal_decision_judges: { all: %w[written-statements], any: %w[national-minimum-wage] } })
       expect(bad_query.exact_match).to be_nil
       expect(good_query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber tags has the same tags" do
-      query = build_query(tags: { policies: { any: %w[beer] },
-                                  topics: { all: %w[taxon] } })
-      subscriber_list = create_subscriber_list(tags: { policies: { any: %w[beer] },
-                                                       topics: { all: %w[taxon] } })
+      query = build_query(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] },
+                                  tribunal_decision_judges: { all: %w[taxon] } })
+      subscriber_list = create_subscriber_list(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] },
+                                                       tribunal_decision_judges: { all: %w[taxon] } })
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber list has the same tags and matching document_type" do
       query = build_query(
-        tags: { policies: { any: %w[beer] },
-                topics: { all: %w[taxon] } },
+        tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] },
+                tribunal_decision_judges: { all: %w[taxon] } },
         document_type: "document_type",
       )
       subscriber_list = create_subscriber_list(
-        tags: { policies: { any: %w[beer] },
-                topics: { all: %w[taxon] } },
+        tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] },
+                tribunal_decision_judges: { all: %w[taxon] } },
         document_type: "document_type",
       )
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber list has the same tags and matching email_document_supertype" do
-      query = build_query(tags: { policies: { any: %w[beer] } }, email_document_supertype: "publications")
-      subscriber_list = create_subscriber_list(tags: { policies: { any: %w[beer] } }, email_document_supertype: "publications")
+      query = build_query(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } }, email_document_supertype: "publications")
+      subscriber_list = create_subscriber_list(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } }, email_document_supertype: "publications")
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "matched when subscriber list has the same tags and matching content_id" do
-      query = build_query(tags: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
-      subscriber_list = create_subscriber_list(tags: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      query = build_query(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      subscriber_list = create_subscriber_list(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       expect(query.exact_match).to eq(subscriber_list)
     end
 
     it "not matched when subscriber list has different tags" do
-      query = build_query(tags: { policies: { any: %w[beer] } })
-      _subscriber_list = create_subscriber_list(tags: { policies: { any: %w[cider] } })
+      query = build_query(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } })
+      _subscriber_list = create_subscriber_list(tags: { tribunal_decision_categories: { any: %w[notice-appeal] } })
       expect(query.exact_match).to be_nil
     end
 
     it "not matched when subscriber list has no tags" do
-      query = build_query(tags: { policies: %w[beer] })
+      query = build_query(tags: { tribunal_decision_categories: %w[fixed-term-regulations] })
       _subscriber_list = create_subscriber_list
       expect(query.exact_match).to be_nil
     end
 
     it "not matched on document type - even if they match" do
-      query = build_query(tags: { policies: { any: %w[beer] } }, document_type: "travel_advice")
+      query = build_query(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } }, document_type: "travel_advice")
       _subscriber_list = create_subscriber_list(document_type: "travel_advice")
       expect(query.exact_match).to be_nil
     end
 
     it "not matched on content_id - even if they match" do
-      query = build_query(tags: { policies: { any: %w[beer] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
+      query = build_query(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } }, content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       _subscriber_list = create_subscriber_list(content_id: "11a51f5e-3f17-4516-87c7-02afba87ef40")
       expect(query.exact_match).to be_nil
     end
@@ -291,7 +291,7 @@ RSpec.describe FindExactQuery do
   end
 
   it "not matched on different document type" do
-    query = build_query(tags: { policies: { any: %w[beer] } }, document_type: "travel_advice")
+    query = build_query(tags: { tribunal_decision_categories: { any: %w[fixed-term-regulations] } }, document_type: "travel_advice")
     _subscriber_list = create_subscriber_list(document_type: "other")
     expect(query.exact_match).to be_nil
   end

--- a/spec/queries/find_latest_matching_subscription_spec.rb
+++ b/spec/queries/find_latest_matching_subscription_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FindLatestMatchingSubscription do
   let!(:subscriber) { create(:subscriber) }
-  let!(:subscriber_list) { create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } }) }
+  let!(:subscriber_list) { create(:subscriber_list, tags: { tribunal_decision_categories: { any: %w[transfer-of-undertakings] } }) }
   let!(:original_subscription) { create_subscription(:ended, :daily, created_at: 5.days.ago) }
   # `let` (as opposed to `let!`) is lazy, so value will vary according to other subscriptions
   # that have been created, therefore we can safely assert against it

--- a/spec/queries/matched_for_notification_spec.rb
+++ b/spec/queries/matched_for_notification_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MatchedForNotification do
       @subscriber_list_that_should_never_match = create(
         :subscriber_list,
         tags: {
-          topics: { any: %w[Badical-Turbo-Radness] }, format: { any: %w[news_story] }
+          tribunal_decision_categories: { any: %w[jurisdictional-points] }, format: { any: %w[news_story] }
         },
       )
     end
@@ -26,126 +26,140 @@ RSpec.describe MatchedForNotification do
         @lists = {
           tags:
             {
-              any_topic_paye_any_format_guides: create_subscriber_list_with_tags_facets(topics: { any: %w[paye] }, format: { any: %w[policy guide] }),
-              any_topic_vat_licensing: create_subscriber_list_with_tags_facets(topics: { any: %w[vat licensing] }),
+              any_category_tax_any_format_guides: create_subscriber_list_with_tags_facets(tribunal_decision_categories: { any: %w[tax] }, format: { any: %w[policy guide] }),
+              any_category_pension_harassment: create_subscriber_list_with_tags_facets(tribunal_decision_categories: { any: %w[pension harassment] }),
             },
           links:
             {
-              any_topic_paye_any_format_guides: create_subscriber_list_with_links_facets(topics: { any: %w[paye] }, format: { any: %w[policy guide] }),
-              any_topic_vat_licensing: create_subscriber_list_with_links_facets(topics: { any: %w[vat licensing] }),
+              any_category_tax_any_format_guides: create_subscriber_list_with_links_facets(taxon_tree: { any: %w[uuid-001] }, format: { any: %w[policy guide] }),
+              any_category_pension_harassment: create_subscriber_list_with_links_facets(taxon_tree: { any: %w[uuid-002 uuid-003] }),
             },
         }
       end
 
-      %i[links tags].each do |key|
-        it "finds subscriber lists where at least one value of each #{key} in the subscription is present in the query_hash" do
-          lists = execute_query({ topics: %w[paye], format: %w[guide] }, field: key)
-          expect(lists).to eq([@lists[key][:any_topic_paye_any_format_guides]])
+      it "finds subscriber lists where at least one value of each link in the subscription is present in the query_hash" do
+        lists = execute_query({ taxon_tree: %w[uuid-001], format: %w[guide] }, field: :links)
+        expect(lists).to eq([@lists[:links][:any_category_tax_any_format_guides]])
 
-          lists = execute_query({ topics: %w[paye], format: %w[guide] }, field: key)
-          expect(lists).to eq([@lists[key][:any_topic_paye_any_format_guides]])
+        lists = execute_query({ taxon_tree: %w[uuid-001], format: %w[guide] }, field: :links)
+        expect(lists).to eq([@lists[:links][:any_category_tax_any_format_guides]])
 
-          lists = execute_query({ topics: %w[vat] }, field: key)
-          expect(lists).to eq([@lists[key][:any_topic_vat_licensing]])
+        lists = execute_query({ taxon_tree: %w[uuid-002] }, field: :links)
+        expect(lists).to eq([@lists[:links][:any_category_pension_harassment]])
 
-          lists = execute_query({ topics: %w[licensing] }, field: key)
-          expect(lists).to eq([@lists[key][:any_topic_vat_licensing]])
-        end
+        lists = execute_query({ taxon_tree: %w[uuid-003] }, field: :links)
+        expect(lists).to eq([@lists[:links][:any_category_pension_harassment]])
+      end
+
+      it "finds subscriber lists where at least one value of each tag in the subscription is present in the query_hash" do
+        lists = execute_query({ tribunal_decision_categories: %w[tax], format: %w[guide] }, field: :tags)
+        expect(lists).to eq([@lists[:tags][:any_category_tax_any_format_guides]])
+
+        lists = execute_query({ tribunal_decision_categories: %w[tax], format: %w[guide] }, field: :tags)
+        expect(lists).to eq([@lists[:tags][:any_category_tax_any_format_guides]])
+
+        lists = execute_query({ tribunal_decision_categories: %w[pension] }, field: :tags)
+        expect(lists).to eq([@lists[:tags][:any_category_pension_harassment]])
+
+        lists = execute_query({ tribunal_decision_categories: %w[harassment] }, field: :tags)
+        expect(lists).to eq([@lists[:tags][:any_category_pension_harassment]])
       end
     end
 
-    context "matches on all topics" do
+    context "matches on all tribunal decision categories" do
       before do
-        @all_topics_tax_vat = create_subscriber_list_with_tags_facets(topics: { all: %w[vat tax] })
-        @all_topics_tax_vat_licensing = create_subscriber_list_with_tags_facets(topics: { all: %w[vat tax licensing] })
+        @all_categories_tax_pension = create_subscriber_list_with_tags_facets(tribunal_decision_categories: { all: %w[pension tax] })
+        @all_categories_tax_pension_harassment = create_subscriber_list_with_tags_facets(tribunal_decision_categories: { all: %w[pension tax harassment] })
       end
 
-      it "finds subscriber lists matching all topics" do
-        lists = execute_query({ topics: %w[vat tax] })
-        expect(lists).to eq([@all_topics_tax_vat])
+      it "finds subscriber lists matching all tribunal decision categories" do
+        lists = execute_query({ tribunal_decision_categories: %w[pension tax] })
+        expect(lists).to eq([@all_categories_tax_pension])
       end
     end
 
-    context "matches on any and all topics" do
+    context "matches on any and all tribunal decision categories" do
       before do
-        @all_topics_tax_vat_any_topics_licensing_paye = create_subscriber_list_with_tags_facets(topics: { all: %w[vat tax], any: %w[licensing paye] })
-        @all_topics_tax_vat_licensing_any_topics_paye = create_subscriber_list_with_tags_facets(topics: { all: %w[vat tax schools], any: %w[paye] })
+        @all_categories_tax_pension_any_categories_harassment_tax = create_subscriber_list_with_tags_facets(tribunal_decision_categories: { all: %w[pension tax], any: %w[harassment tax] })
+        @all_categories_tax_pension_harassment_any_categories_tax = create_subscriber_list_with_tags_facets(tribunal_decision_categories: { all: %w[pension tax renumeration], any: %w[tax] })
       end
 
-      it "finds subscriber lists matching on both of all and one of any topics" do
-        lists = execute_query({ topics: %w[vat tax licensing] })
-        expect(lists).to eq([@all_topics_tax_vat_any_topics_licensing_paye])
+      it "finds subscriber lists matching on both of all and one of any tribunal decision categories" do
+        lists = execute_query({ tribunal_decision_categories: %w[pension tax harassment] })
+        expect(lists).to eq([@all_categories_tax_pension_any_categories_harassment_tax])
       end
 
-      it "does not find subscriber list for mixture of all and any topics when not all topics present" do
-        lists = execute_query({ field: :links, query_hash: { topics: %w[vat licensing] } })
-        expect(lists).not_to include(@all_topics_tax_vat_any_topics_licensing_paye)
+      it "does not find subscriber list for mixture of all and any tribunal decision categories when not all tribunal decision categories present" do
+        lists = execute_query({ field: :links, query_hash: { tribunal_decision_categories: %w[pension harassment] } })
+        expect(lists).not_to include(@all_categories_tax_pension_any_categories_harassment_tax)
       end
     end
 
-    context "matches on all topics and any policies" do
+    context "matches on all tribunal decision judges and any tribunal decision categories" do
       before do
-        @all_topics_tax_vat_any_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w[vat tax] }, policies: { any: %w[economy industry] })
-        @all_topics_vat_any_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w[paye schools] }, policies: { any: %w[economy industry] })
+        @all_judges_tax_pension_any_categories_redundancy_protective_award =
+          create_subscriber_list_with_tags_facets(tribunal_decision_judges: { all: %w[pension tax] }, tribunal_decision_categories: { any: %w[redundancy protective-award] })
+        @all_judges_pension_any_categories_redundancy_protective_award =
+          create_subscriber_list_with_tags_facets(tribunal_decision_judges: { all: %w[tax renumeration] }, tribunal_decision_categories: { any: %w[redundancy protective-award] })
       end
 
-      it "finds subscriber lists matching a mix of all topics and any policies" do
-        lists = execute_query({ topics: %w[vat tax], policies: %w[economy industry] })
-        expect(lists).to eq([@all_topics_tax_vat_any_policies_economy_industry])
+      it "finds subscriber lists matching a mix of all tribunal decision judges and any tribunal decision categories" do
+        lists = execute_query({ tribunal_decision_judges: %w[pension tax], tribunal_decision_categories: %w[redundancy protective-award] })
+        expect(lists).to eq([@all_judges_tax_pension_any_categories_redundancy_protective_award])
       end
 
-      it "does not find subscriber list for mix of all topics and any policies when not all topics present" do
-        lists = execute_query({ field: :links, query_hash: { topics: %w[vat], policies: %w[economy] } })
-        expect(lists).not_to include(@all_topics_tax_vat_any_policies_economy_industry)
+      it "does not find subscriber list for mix of all tribunal decision judges and any tribunal decision categories when not all tribunal decision judges present" do
+        lists = execute_query({ field: :links, query_hash: { tribunal_decision_judges: %w[pension], tribunal_decision_categories: %w[redundancy] } })
+        expect(lists).not_to include(@all_judges_tax_pension_any_categories_redundancy_protective_award)
       end
     end
 
-    context "matches on all topics and all policies" do
+    context "matches on all tribunal decision judges and all tribunal decision categories" do
       before do
-        @all_topics_tax_vat = create_subscriber_list_with_tags_facets(topics: { all: %w[vat tax] })
-        @all_topics_tax_vat_all_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w[vat tax] }, policies: { all: %w[economy industry] })
-        @all_topics_vat_policies_economy_industry = create_subscriber_list_with_tags_facets(topics: { all: %w[paye schools] }, policies: { all: %w[economy broadband] })
+        @all_judges_tax_pension = create_subscriber_list_with_tags_facets(tribunal_decision_judges: { all: %w[pension tax] })
+        @all_judges_tax_pension_all_categories_redundancy_protective_award = create_subscriber_list_with_tags_facets(tribunal_decision_judges: { all: %w[pension tax] }, tribunal_decision_categories: { all: %w[redundancy protective-award] })
+        @all_judges_pension_tribunal_decision_categories_redundancy_protective_award = create_subscriber_list_with_tags_facets(tribunal_decision_judges: { all: %w[tax renumeration] }, tribunal_decision_categories: { all: %w[redundancy broadband] })
       end
 
-      it "finds subscriber lists matching a mix of all topics and policies" do
-        lists = execute_query({ topics: %w[vat tax licensing], policies: %w[economy industry] })
-        expect(lists).to include(@all_topics_tax_vat_all_policies_economy_industry)
+      it "finds subscriber lists matching a mix of all tribunal decision judges and tribunal decision categories" do
+        lists = execute_query({ tribunal_decision_judges: %w[pension tax harassment], tribunal_decision_categories: %w[redundancy protective-award] })
+        expect(lists).to include(@all_judges_tax_pension_all_categories_redundancy_protective_award)
       end
 
-      it "does not find subscriber list for all topics when not all topics present" do
-        lists = execute_query({ topics: %w[vat schools] })
-        expect(lists).not_to include(@all_topics_tax_vat)
+      it "does not find subscriber list for all tribunal decision judges when not all tribunal decision judges present" do
+        lists = execute_query({ tribunal_decision_judges: %w[pension renumeration] })
+        expect(lists).not_to include(@all_judges_tax_pension)
       end
 
-      it "does not find subscriber list for mix of all topics and policies when not all policies present" do
-        lists = execute_query({ topics: %w[vat tax ufos], policies: %w[economy acceptable_footwear] })
-        expect(lists).to_not include(@all_topics_tax_vat_all_policies_economy_schools)
+      it "does not find subscriber list for mix of all tribunal decision judges and tribunal decision categories when not all tribunal decision categories present" do
+        lists = execute_query({ tribunal_decision_judges: %w[pension tax ufos], tribunal_decision_categories: %w[redundancy acceptable_footwear] })
+        expect(lists).to_not include(@all_judges_tax_pension_all_categories_redundancy_renumeration)
       end
     end
 
     context "there are other, non-matching link types in the query hash" do
       before do
-        @topics_any_licensing = create_subscriber_list_with_tags_facets(topics: { any: %w[licensing] })
+        @tribunal_decision_categories_any_harassment = create_subscriber_list_with_tags_facets(tribunal_decision_categories: { any: %w[harassment] })
       end
 
       it "finds lists where all the link types in the subscription have a value present" do
-        lists = execute_query({ topics: %w[licensing], another_link_thats_not_part_of_the_subscription: %w[elephants] })
-        expect(lists).to eq([@topics_any_licensing])
+        lists = execute_query({ tribunal_decision_categories: %w[harassment], another_link_thats_not_part_of_the_subscription: %w[practice-and-procedure-issues] })
+        expect(lists).to eq([@tribunal_decision_categories_any_harassment])
       end
     end
 
     context "there are non-matching values in the query_hash" do
       before do
-        @topics_any_licensing = create_subscriber_list_with_tags_facets(topics: { any: %w[licensing] })
+        @tribunal_decision_categories_any_harassment = create_subscriber_list_with_tags_facets(tribunal_decision_categories: { any: %w[harassment] })
       end
 
       it "finds lists where all the link types in the subscription have a value present" do
-        lists = execute_query({ topics: %w[licensing elephants] })
-        expect(lists).to eq([@topics_any_licensing])
+        lists = execute_query({ tribunal_decision_categories: %w[harassment practice-and-procedure-issues] })
+        expect(lists).to eq([@tribunal_decision_categories_any_harassment])
       end
 
       it "doesn't return lists which have no tag types present in the document" do
-        lists = execute_query({ another_tag_thats_not_part_of_any_subscription: %w[elephants] })
+        lists = execute_query({ another_tag_thats_not_part_of_any_subscription: %w[practice-and-procedure-issues] })
         expect(lists).to eq([])
       end
     end

--- a/spec/queries/subscriber_list_query_spec.rb
+++ b/spec/queries/subscriber_list_query_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe SubscriberListQuery do
   let(:content_id) { "37ac8e5c-331a-48fc-8ac0-d401579c3d30" }
-  let(:tags) { { policies: %w[eggs] } }
-  let(:links) { { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] } }
+  let(:tags) { { tribunal_decision_categories: %w[public-interest-disclosure] } }
+  let(:links) { { organisations: %w[f05dc04b-ca95-4cca-9875-a7591d055467], taxon_tree: %w[f05dc04b-ca95-4cca-9875-a7591d055448] } }
   let(:document_type) { "travel_advice" }
   let(:email_document_supertype) { "publications" }
   let(:government_document_supertype) { "news_stories" }
@@ -103,8 +103,8 @@ RSpec.describe SubscriberListQuery do
   end
 
   context "when a subscriber_list has document types and tags" do
-    let(:content_change_tags) { { policies: %w[eggs] } }
-    let(:list_tags) { { policies: { any: %w[eggs] } } }
+    let(:content_change_tags) { { tribunal_decision_categories: %w[public-interest-disclosure] } }
+    let(:list_tags) { { tribunal_decision_categories: { any: %w[public-interest-disclosure] } } }
 
     it "includes lists that match on document types and tags" do
       content_change = build_content_change(document_type_attributes.merge(tags: content_change_tags))
@@ -116,7 +116,7 @@ RSpec.describe SubscriberListQuery do
 
     it "excludes lists that match on document type but do not match on tags" do
       content_change = build_content_change(document_type_attributes.merge(tags: content_change_tags))
-      list = create_subscriber_list(document_type_attributes.merge(tags: { policies: { any: %w[cheese] } }))
+      list = create_subscriber_list(document_type_attributes.merge(tags: { tribunal_decision_categories: { any: %w[contract-of-employment] } }))
       query = described_class.new(**content_change)
 
       expect(query.lists).not_to include(list)
@@ -133,19 +133,19 @@ RSpec.describe SubscriberListQuery do
   end
 
   context "when a subscriber_list has document types and links" do
-    let(:policy_id) { "f05dc04b-ca95-4cca-9875-a7591d055467" }
+    let(:document_collection_id) { "f05dc04b-ca95-4cca-9875-a7591d055467" }
     let(:taxon_id) { "f05dc04b-ca95-4cca-9875-a7591d055448" }
 
     let(:content_change_links) do
       {
-        policies: [policy_id],
+        organisations: [document_collection_id],
         taxon_tree: [taxon_id],
       }
     end
 
     let(:subscriber_list_links) do
       {
-        policies: { any: [policy_id] },
+        organisations: { any: [document_collection_id] },
         taxon_tree: { all: [taxon_id] },
       }
     end
@@ -160,7 +160,7 @@ RSpec.describe SubscriberListQuery do
 
     it "excludes lists that match on document type but do not match on link" do
       content_change = build_content_change(document_type_attributes.merge(links: content_change_links))
-      list = create_subscriber_list(document_type_attributes.merge(links: { policies: { any: %w[random-content-id] } }))
+      list = create_subscriber_list(document_type_attributes.merge(links: { organisations: { any: %w[random-content-id] } }))
       query = described_class.new(**content_change)
 
       expect(query.lists).not_to include(list)
@@ -277,7 +277,7 @@ RSpec.describe SubscriberListQuery do
     let(:document_collection_id) { "4d74904a-e45e-47e4-921d-c9dc13c8c9de" }
     let(:content_change_links) { { document_collections: [document_collection_id] } }
     let(:subscriber_list_links) { { document_collections: { any: [document_collection_id] } } }
-    let(:unmatched_content_change_links) { { policies: %w[f05dc04b-ca95-4cca-9875-a7591d055467] } }
+    let(:unmatched_content_change_links) { { people: %w[f05dc04b-ca95-4cca-9875-a7591d055467] } }
     let(:unmatched_content_id) { "f05dc04b-ca95-4cca-9875-a7591d055467" }
 
     it "includes lists that match on content id and match on links" do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -61,7 +61,7 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
-  provider_state "a subscriber list with the tag topic: motoring/road_rage exists" do
+  provider_state "a subscriber list with the tag tribunal decision category: agency-workers exists" do
     set_up do
       create(:subscriber_list)
     end

--- a/spec/services/content_change_handler_service_spec.rb
+++ b/spec/services/content_change_handler_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ContentChangeHandlerService do
     {
       subject: "This is a subject",
       tags: {
-        topics: ["oil-and-gas/licensing"],
+        tribunal_decision_categories: %w[transfer-of-undertakings],
       },
       links: {
         organisations: %w[c380ea42-5d91-41cc-b3cd-0a4cfe439461],
@@ -31,7 +31,7 @@ RSpec.describe ContentChangeHandlerService do
   let(:govuk_request_id) { SecureRandom.uuid }
 
   let!(:subscriber_list) do
-    create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
+    create(:subscriber_list, tags: { tribunal_decision_categories: { any: %w[transfer-of-undertakings] } })
   end
 
   let(:document_type_hash) do
@@ -67,7 +67,7 @@ RSpec.describe ContentChangeHandlerService do
           taxon_tree: %w[6416e4e0-c0c1-457a-8337-4bf8ed9d5f80],
         ),
         tags: hash_including(
-          topics: ["oil-and-gas/licensing"],
+          tribunal_decision_categories: %w[transfer-of-undertakings],
           content_store_document_type: "press_release",
         ),
         email_document_supertype: "email document supertype",

--- a/spec/services/create_subscriber_list_service_spec.rb
+++ b/spec/services/create_subscriber_list_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CreateSubscriberListService do
 
     let(:matching_criteria) do
       {
-        tags: { topics: { any: %w[oil-and-gas/licensing] } },
+        tags: { tribunal_decision_categories: { any: %w[transfer-of-undertakings] } },
         links: { taxon_tree: { any: %w[uuid] } },
         document_type: "travel_advice",
         email_document_supertype: "publications",
@@ -82,7 +82,7 @@ RSpec.describe CreateSubscriberListService do
         expect(list.document_type).to eq("travel_advice")
         expect(list.email_document_supertype).to eq("publications")
         expect(list.government_document_supertype).to eq("news_stories")
-        expect(list.tags).to eq(topics: { any: ["oil-and-gas/licensing"] })
+        expect(list.tags).to eq(tribunal_decision_categories: { any: %w[transfer-of-undertakings] })
         expect(list.links).to match(taxon_tree: { any: %w[uuid] })
       end
 

--- a/spec/services/matched_content_change_generation_service_spec.rb
+++ b/spec/services/matched_content_change_generation_service_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe MatchedContentChangeGenerationService do
   let(:content_change) do
-    create(:content_change, tags: { topics: ["oil-and-gas/licensing"] })
+    create(:content_change, tags: { tribunal_decision_categories: %w[transfer-of-undertakings] })
   end
 
   let!(:subscriber_list) do
-    create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
+    create(:subscriber_list, tags: { tribunal_decision_categories: { any: %w[transfer-of-undertakings] } })
   end
 
   describe ".call" do

--- a/spec/services/matched_message_generation_service_spec.rb
+++ b/spec/services/matched_message_generation_service_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe MatchedMessageGenerationService do
     create(
       :message,
       criteria_rules: [
-        { type: "tag", key: "topics", value: "oil-and-gas/licensing" },
+        { type: "tag", key: "tribunal_decision_categories", value: "transfer-of-undertakings" },
       ],
     )
   end
 
   let!(:subscriber_list) do
-    create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
+    create(:subscriber_list, tags: { tribunal_decision_categories: { any: %w[transfer-of-undertakings] } })
   end
 
   describe ".call" do

--- a/spec/support/content_item_helpers.rb
+++ b/spec/support/content_item_helpers.rb
@@ -16,12 +16,12 @@ module ContentItemHelpers
     }
   end
 
-  def match_by_tags_content_item_for_subscriber_list(subscriber_list:, tags: { "topics" => ["motoring/road_rage"] }, draft: false)
+  def match_by_tags_content_item_for_subscriber_list(subscriber_list:, tags: { "tribunal_decision_categories" => %w[agency-workers] }, draft: false)
     content_item = content_item_for_base_path(subscriber_list_path(subscriber_list)).merge(required_match_attributes(tags:))
     stub_content_store_has_item(subscriber_list_path(subscriber_list), content_item, draft:)
   end
 
-  def match_by_tags_non_triggering_content_item_for_subscriber_list(subscriber_list:, tags: { "topics" => ["motoring/road_rage"] })
+  def match_by_tags_non_triggering_content_item_for_subscriber_list(subscriber_list:, tags: { "tribunal_decision_categories" => %w[agency-workers] })
     merge_items = required_match_attributes(tags:)
     merge_items.delete("locale")
     content_item = content_item_for_base_path(subscriber_list_path(subscriber_list)).merge(merge_items)

--- a/spec/validators/links_validator_spec.rb
+++ b/spec/validators/links_validator_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe LinksValidator do
   it "is invalid when links with other formats are provided" do
     record = record_class.new(links: {
       organisations: { any: %w[dogs cats] },
-      topics: { any: %w[dogs cats] },
+      countries: { any: %w[dogs cats] },
       foo: { any: %w([dogs] !cats) },
       people: { any: %w[\u0000] },
-      policies: { any: "><script>alert(1);</script>" },
+      taxon_tree: { any: "><script>alert(1);</script>" },
     })
 
     expect(record).to be_invalid
     expect(record.errors[:links]).to match([
-      "foo, people, and policies has a value with an invalid format.",
+      "foo, people, and taxon_tree has a value with an invalid format.",
     ])
   end
 end

--- a/spec/validators/tags_validator_spec.rb
+++ b/spec/validators/tags_validator_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe TagsValidator do
   let(:valid_tags) { %w[alpha-numeric-123 Capitals underscores_ slash/separated] }
 
   it "is valid when tags meet the formatting rules" do
-    record = record_class.new(tags: { topics: { any: valid_tags } })
+    record = record_class.new(tags: { tribunal_decision_categories: { any: valid_tags } })
     expect(record).to be_valid
   end
 
   it "is invalid when tag values aren't set as an array" do
-    record = record_class.new(tags: { topics: { any: "a-tag" } })
+    record = record_class.new(tags: { tribunal_decision_categories: { any: "a-tag" } })
     expect(record).to be_invalid
     expect(record.errors[:tags]).to match(["All tag values must be sent as Arrays"])
   end
@@ -31,8 +31,8 @@ RSpec.describe TagsValidator do
   end
 
   it "is invalid when the value for a tag doesn't match the allowed characters" do
-    record = record_class.new(tags: { topics: { any: ["<script>"] } })
+    record = record_class.new(tags: { tribunal_decision_categories: { any: ["<script>"] } })
     expect(record).to be_invalid
-    expect(record.errors[:tags]).to match(["topics has a value with an invalid format."])
+    expect(record.errors[:tags]).to match(["tribunal_decision_categories has a value with an invalid format."])
   end
 end

--- a/spec/workers/process_content_change_worker_spec.rb
+++ b/spec/workers/process_content_change_worker_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe ProcessContentChangeWorker do
   let(:content_change) do
-    create(:content_change, tags: { topics: ["oil-and-gas/licensing"] })
+    create(:content_change, tags: { tribunal_decision_categories: %w[transfer-of-undertakings] })
   end
 
   let(:subscriber_list) do
-    create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
+    create(:subscriber_list, tags: { tribunal_decision_categories: { any: %w[transfer-of-undertakings] } })
   end
 
   describe "#perform" do

--- a/spec/workers/process_message_worker_spec.rb
+++ b/spec/workers/process_message_worker_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe ProcessMessageWorker do
     create(
       :message,
       criteria_rules: [
-        { type: "tag", key: "topics", value: "oil-and-gas/licensing" },
+        { type: "tag", key: "tribunal_decision_categories", value: "transfer-of-undertakings" },
       ],
     )
   end
 
   let(:subscriber_list) do
-    create(:subscriber_list, tags: { topics: { any: ["oil-and-gas/licensing"] } })
+    create(:subscriber_list, tags: { tribunal_decision_categories: { any: %w[transfer-of-undertakings] } })
   end
 
   describe "#perform" do

--- a/spec/workers/subscriber_list_audit_worker_spec.rb
+++ b/spec/workers/subscriber_list_audit_worker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SubscriberListAuditWorker do
       "government_document_supertype" => "email",
       "details" => {
         "tags" => {
-          "topics" => ["motoring/road_rage"],
+          "tribunal_decision_categories" => %w[agency-workers],
         },
         "change_history" => [
           { "public_timestamp" => Time.zone.now.to_s, "note" => "changed" },
@@ -20,8 +20,8 @@ RSpec.describe SubscriberListAuditWorker do
 
   before do
     @sl1 = create(:subscriber_list, :for_single_page_subscription)
-    @sl2 = create(:subscriber_list, :for_single_page_subscription, tags: { topics: { any: ["motoring/calmness"] } })
-    @sl3 = create(:subscriber_list, :for_single_page_subscription, tags: { topics: { any: ["motoring/neutrality"] } })
+    @sl2 = create(:subscriber_list, :for_single_page_subscription, tags: { tribunal_decision_categories: { any: %w[part-time-workers] } })
+    @sl3 = create(:subscriber_list, :for_single_page_subscription, tags: { tribunal_decision_categories: { any: %w[flexible-working] } })
 
     @path_sl1 = URI(@sl1.url).path
     @path_sl2 = URI(@sl2.url).path
@@ -35,7 +35,7 @@ RSpec.describe SubscriberListAuditWorker do
     content_item = content_item_for_base_path(@path_sl2).merge(required_match_attributes).merge(
       "details" => {
         "tags" => {
-          "topics" => ["motoring/calmness"],
+          "tribunal_decision_categories" => %w[part-time-workers],
         },
         "change_history" => [
           { "public_timestamp" => Time.zone.now.to_s, "note" => "changed" },
@@ -49,7 +49,7 @@ RSpec.describe SubscriberListAuditWorker do
     content_item = content_item_for_base_path(@path_sl3).merge(required_match_attributes).merge(
       "details" => {
         "tags" => {
-          "topics" => ["motoring/calmness"],
+          "tribunal_decision_categories" => %w[part-time-workers],
         },
       },
     )


### PR DESCRIPTION
## What

This prepares for https://github.com/alphagov/email-alert-api/pull/2136 and is related to https://github.com/alphagov/gds-api-adapters/pull/1250

## Why

This PR has been extracted from https://github.com/alphagov/email-alert-api/pull/2136 as requested by @hannako 

[Trello ticket](https://trello.com/c/RObMmjXG/2422-remove-specialist-topic-code-from-email-alert-api-l)