### PR TITLE
Add last_alerted_at to the subscriber_lists table

### DIFF
--- a/app/services/update_last_alerted_at_subscriber_list_service.rb
+++ b/app/services/update_last_alerted_at_subscriber_list_service.rb
@@ -1,0 +1,16 @@
+class UpdateLastAlertedAtSubscriberListService
+  include Callable
+
+  def initialize(content_change)
+    @content_change = content_change
+  end
+
+  def call
+    subscriber_list_ids = MatchedContentChange.where(content_change_id: content_change.id).pluck(:subscriber_list_id)
+    SubscriberList.where(id: subscriber_list_ids).update_all(last_alerted_at: Time.zone.now)
+  end
+
+private
+
+  attr_reader :content_change
+end

--- a/app/workers/process_content_change_worker.rb
+++ b/app/workers/process_content_change_worker.rb
@@ -7,6 +7,7 @@ class ProcessContentChangeWorker < ApplicationWorker
       return if content_change.processed_at
 
       MatchedContentChangeGenerationService.call(content_change)
+      UpdateLastAlertedAtSubscriberListService.call(content_change)
       ImmediateEmailGenerationService.call(content_change)
 
       content_change.update!(processed_at: Time.zone.now)

--- a/db/migrate/20240513131857_add_last_alerted_at.rb
+++ b/db/migrate/20240513131857_add_last_alerted_at.rb
@@ -1,0 +1,5 @@
+class AddLastAlertedAt < ActiveRecord::Migration[7.1]
+  def change
+    add_column :subscriber_lists, :last_alerted_at, :datetime, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_11_100041) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_13_131857) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -144,6 +144,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_100041) do
     t.uuid "content_id"
     t.text "description"
     t.datetime "last_audited_at"
+    t.datetime "last_alerted_at"
     t.index ["content_id"], name: "index_subscriber_lists_on_content_id"
     t.index ["document_type"], name: "index_subscriber_lists_on_document_type"
     t.index ["email_document_supertype"], name: "index_subscriber_lists_on_email_document_supertype"

--- a/spec/services/update_last_alerted_at_subscriber_list_service_spec.rb
+++ b/spec/services/update_last_alerted_at_subscriber_list_service_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe UpdateLastAlertedAtSubscriberListService do
+  describe ".call" do
+    let(:associated_subscription) { create(:subscription) }
+    let(:associated_content_change) { create(:content_change) }
+
+    it "updates the last_alerted_at date for the associated_subscription subscriber_list" do
+      create(
+        :matched_content_change,
+        subscriber_list: associated_subscription.subscriber_list,
+        content_change: associated_content_change,
+      )
+
+      expect {
+        described_class.call(associated_content_change)
+      }.to change { associated_subscription.subscriber_list.reload.last_alerted_at }.from(nil).to(be_present)
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

https://trello.com/c/J83hIxvI/105-add-last-alerted-at-field-to-subscriberlists, [Jira issue PNP-7989](https://gov-uk.atlassian.net/browse/PNP-7989)
