### PR TITLE
Add one-click-unsubscribe params when calling Notify

### DIFF
--- a/app/builders/immediate_email_builder.rb
+++ b/app/builders/immediate_email_builder.rb
@@ -26,6 +26,7 @@ private
           subject:,
           body: body(subscription, subscriber),
           subscriber_id: subscriber.id,
+          subscription_id: subscription.id,
           created_at: now,
           updated_at: now,
           content_id: content.try(:content_id),

--- a/app/services/send_email_service/send_notify_email.rb
+++ b/app/services/send_email_service/send_notify_email.rb
@@ -13,6 +13,7 @@ class SendEmailService::SendNotifyEmail
       email_address: email.address,
       template_id: Rails.application.config.notify_template_id,
       reference: email.id,
+      one_click_unsubscribe_url: one_click_unsubscribe_url(email.subscription_id),
       personalisation: {
         subject: email.subject,
         body: email.body,
@@ -38,6 +39,17 @@ class SendEmailService::SendNotifyEmail
 private
 
   attr_reader :email, :client
+
+  def one_click_unsubscribe_url(subscription_id)
+    return nil unless subscription_id
+
+    subscription = Subscription.find(subscription_id)
+    PublicUrls.unsubscribe_one_click(
+      subscription,
+      utm_source: subscription.subscriber_list.slug,
+      utm_content: subscription.frequency,
+    )
+  end
 
   def undeliverable_failure?(error)
     return false unless error.is_a?(Notifications::Client::BadRequestError)

--- a/db/migrate/20240522152228_add_subscription_id_to_email.rb
+++ b/db/migrate/20240522152228_add_subscription_id_to_email.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionIdToEmail < ActiveRecord::Migration[7.1]
+  def change
+    add_column :emails, :subscription_id, :uuid, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_13_131857) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_152228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_131857) do
     t.datetime "sent_at", precision: nil
     t.uuid "content_id"
     t.string "notify_status"
+    t.uuid "subscription_id"
     t.index ["address"], name: "index_emails_on_address"
     t.index ["content_id"], name: "index_emails_on_content_id"
     t.index ["created_at"], name: "index_emails_on_created_at"
@@ -117,14 +118,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_131857) do
     t.boolean "omit_footer_unsubscribe_link", default: false, null: false
     t.boolean "override_subscription_frequency_to_immediate", default: false, null: false
     t.index ["sender_message_id"], name: "index_messages_on_sender_message_id", unique: true
-  end
-
-  create_table "subscriber_list_audits", force: :cascade do |t|
-    t.bigint "subscriber_list_id", null: false
-    t.integer "reference_count", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["subscriber_list_id"], name: "index_subscriber_list_audits_on_subscriber_list_id"
   end
 
   create_table "subscriber_lists", id: :serial, force: :cascade do |t|
@@ -217,7 +210,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_131857) do
   add_foreign_key "matched_content_changes", "subscriber_lists", on_delete: :cascade
   add_foreign_key "matched_messages", "messages", on_delete: :cascade
   add_foreign_key "matched_messages", "subscriber_lists", on_delete: :cascade
-  add_foreign_key "subscriber_list_audits", "subscriber_lists"
   add_foreign_key "subscription_contents", "content_changes", on_delete: :restrict
   add_foreign_key "subscription_contents", "digest_run_subscribers", on_delete: :cascade
   add_foreign_key "subscription_contents", "emails", on_delete: :cascade

--- a/lib/public_urls.rb
+++ b/lib/public_urls.rb
@@ -24,6 +24,14 @@ module PublicUrls
       url_for(base_path: "/email/unsubscribe/#{subscription.id}", **params)
     end
 
+    def unsubscribe_one_click(subscription, **utm_params)
+      subscriber_id = subscription.subscriber_id
+      token = AuthTokenGeneratorService.call(subscriber_id:, one_click: true)
+
+      params = utm_params.merge(token:)
+      url_for(base_path: "/email/unsubscribe/one-click/#{subscription.id}", **params)
+    end
+
   private
 
     def website_root

--- a/spec/services/send_email_service/send_notify_email_spec.rb
+++ b/spec/services/send_email_service/send_notify_email_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SendEmailService::SendNotifyEmail do
       expect(notify_client).to have_received(:send_email).with(
         email_address: email.address,
         template_id: Rails.application.config.notify_template_id,
+        one_click_unsubscribe_url: nil,
         reference: email.id,
         personalisation: {
           subject: email.subject,
@@ -28,6 +29,26 @@ RSpec.describe SendEmailService::SendNotifyEmail do
         expect { described_class.call(email) }
           .to change { email.reload.status }.to("sent")
           .and change { email.reload.sent_at }.to(Time.zone.now)
+      end
+    end
+
+    context "with a subscription id passed in" do
+      let!(:subscription) { create(:subscription) }
+      let(:email) { create(:email, subscription_id: subscription.id) }
+
+      it "includes a one-click unsubscribe parameter" do
+        described_class.call(email)
+
+        expect(notify_client).to have_received(:send_email).with(
+          email_address: email.address,
+          template_id: Rails.application.config.notify_template_id,
+          one_click_unsubscribe_url: /\/email\/unsubscribe\/one-click\/#{subscription.id}.*token=/,
+          reference: email.id,
+          personalisation: {
+            subject: email.subject,
+            body: email.body,
+          },
+        )
       end
     end
 


### PR DESCRIPTION
- Save subscription in Email
- Calculate unsubscribe token with new path and add that to header when sending emails via Notify.

This allows Notify to create one-click unsubscribe headers in our outgoing emails, to improve the unsubscribe journey in supporting email agents and reduce the chances of our emails being marked as spam instead of being unsubscribed from. Note that our default is to cancel a specific subscription, not to unsubscribe the user from all subscriptions. We may revisit that if it proves to be a problem.

https://trello.com/c/ONisAn0b/52-add-one-click-unsubscribe-support-to-email-alert-api-frontend

Related: https://github.com/alphagov/email-alert-frontend/pull/1773

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
