### PR TITLE
Set logger level to debug for callbacks

### DIFF
--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -5,7 +5,7 @@ class StatusUpdatesController < ApplicationController
     status = params.require(:status)
     reference = params.require(:reference)
 
-    logger.info("Email #{reference} callback received with status: #{status}")
+    logger.debug("Email #{reference} callback received with status: #{status}")
     GovukStatsd.increment("status_update.status.#{status}")
 
     # We are deliberatly omitting "technical-failure" as Notify say this is


### PR DESCRIPTION
- We don't need to log all callbacks in normal operation, so it shouldn't be logging at info level.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
