### PR TITLE
Adjust alert check flag lifetime

### DIFF
--- a/app/workers/polling_alert_check_worker.rb
+++ b/app/workers/polling_alert_check_worker.rb
@@ -14,8 +14,11 @@ class PollingAlertCheckWorker < ApplicationWorker
 
     Rails.logger.info("Checking #{document_type.titleize} records: #{delivered} out of #{content_items.count} alerts have been delivered to at least one recipient")
 
-    Rails.cache.write("current_#{document_type}s", content_items.count, expires_in: 15.minutes)
-    Rails.cache.write("delivered_#{document_type}s", delivered, expires_in: 15.minutes)
+    # Job runs every 15 minutes, expiry is 2 x job so that we don't have blank spots
+    # if the job is slightly delayed.
+    expiry_time = Time.zone.now + 30.minutes
+    Rails.cache.write("current_#{document_type}s", content_items.count, expires_at: expiry_time)
+    Rails.cache.write("delivered_#{document_type}s", delivered, expires_at: expiry_time)
   end
 
   def any_emails_delivered_for?(content_id, valid_from, document_type)


### PR DESCRIPTION
- The flag expiry time of 15 minutes sometimes caused little blip alerts where at times of high load the elements expired before being renewed. Although this is usually safe (the collector defaults to 0 for all metrics, which is a no alarm state), occasionally the read has happened between the metrics expiring, causing false positive alarms which resolve themselves a few minutes later. We double the expiry time to make sure that the flags don't rely on the job being perfectly on time.
- Note that this doesn't affect the happy path - under normal circumstances, the flags are still getting regenerated every 15 minutes, so we can still detect a problem within 15 minutes.
- We also move to generating the expiry time once and using expire_at: so the two caches have the exact same expiry time.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
