### PR TITLE
Fix openstruct error

### DIFF
--- a/app/controllers/subscribers_auth_token_controller.rb
+++ b/app/controllers/subscribers_auth_token_controller.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 class SubscribersAuthTokenController < ApplicationController
   before_action :validate_params
 

--- a/app/controllers/subscriptions_auth_token_controller.rb
+++ b/app/controllers/subscriptions_auth_token_controller.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 class SubscriptionsAuthTokenController < ApplicationController
   before_action :validate_params
 

--- a/app/models/content_change.rb
+++ b/app/models/content_change.rb
@@ -16,7 +16,7 @@ class ContentChange < ApplicationRecord
   has_many :matched_content_changes
   has_many :subscription_contents
 
-  enum priority: { normal: 0, high: 1 }
+  enum :priority, { normal: 0, high: 1 }
 
   def queue
     priority == "high" ? :send_email_immediate_high : :send_email_immediate

--- a/app/models/digest_run.rb
+++ b/app/models/digest_run.rb
@@ -9,7 +9,7 @@ class DigestRun < ApplicationRecord
   has_many :digest_run_subscribers, dependent: :destroy
   has_many :subscribers, through: :digest_run_subscribers
 
-  enum range: { daily: 0, weekly: 1 }
+  enum :range, { daily: 0, weekly: 1 }
 
   def mark_as_completed
     completed_time = digest_run_subscribers.maximum(:processed_at) || Time.zone.now

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,7 +1,7 @@
 # Any validations added this to this model won't be applied on record
 # creation as this table is populated by the #insert_all bulk method
 class Email < ApplicationRecord
-  enum status: { pending: 0, sent: 1, failed: 2 }
+  enum :status, { pending: 0, sent: 1, failed: 2 }
 
   def self.timed_bulk_insert(records, batch_size)
     return insert_all!(records) unless records.size == batch_size

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,7 +8,7 @@ class Message < ApplicationRecord
   validates :criteria_rules, criteria_schema: true, allow_blank: true
   validates :sender_message_id, uuid: true, uniqueness: true, allow_nil: true
 
-  enum priority: { normal: 0, high: 1 }
+  enum :priority, { normal: 0, high: 1 }
 
   def queue
     :send_email_immediate

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,9 +4,9 @@ class Subscription < ApplicationRecord
 
   has_many :subscription_contents, dependent: :destroy
 
-  enum frequency: { immediately: 0, daily: 1, weekly: 2 }
+  enum :frequency, { immediately: 0, daily: 1, weekly: 2 }
 
-  enum source: {
+  enum :source, {
     user_signed_up: 0,
     frequency_changed: 1,
     imported: 2, # Historical (from govDelivery migration)
@@ -14,9 +14,9 @@ class Subscription < ApplicationRecord
     bulk_immediate_to_digest: 4, # Historical (for a one-off migration)
     subscriber_merged: 5,
     support_task: 6,
-  }, _prefix: true
+  }, prefix: true
 
-  enum ended_reason: {
+  enum :ended_reason, {
     unsubscribed: 0,
     non_existent_email: 1,
     frequency_changed: 2,
@@ -27,7 +27,7 @@ class Subscription < ApplicationRecord
     subscriber_merged: 7,
     bulk_unsubscribed: 8,
     bulk_migrated: 9,
-  }, _prefix: :ended
+  }, prefix: :ended
 
   scope :active, -> { where(ended_at: nil) }
   scope :ended, -> { where.not(ended_at: nil) }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 FactoryBot.define do
   trait :skip_validation do
     to_create { |instance| instance.save!(validate: false) }


### PR DESCRIPTION
- OpenStruct now no longer explicitly included by Rails, so require it when necessary. (Fixes errors like this in Integration: https://govuk.sentry.io/issues/5873217739/?project=202220&referrer=project-issue-stream)
- Also update enums to clear deprecations and prepare for Rails 8.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
