### PR TITLE
Add rake task to bulk unsubscribe active subscribers from a subscription list

### DIFF
--- a/docs/support-tasks.md
+++ b/docs/support-tasks.md
@@ -54,6 +54,13 @@ You can find out the slug of the subscriber list by running the `view_subscripti
 $ kubectl -n apps exec -it deploy/email-alert-api -- bundle exec rake support:unsubscribe_single_subscription[<email_address>,<subscriber_list_slug>]
 ```
 
+## Unsubscribe all subscribers from a specific subscription
+
+This task unsubscribes all active subscribers from a subscription, given a subscriber list slug.
+
+```bash
+$ kubectl -n apps exec -it deploy/email-alert-api -- bundle exec rake support:unsubscribe_all_subscribers_from_subscription[<subscriber_list_slug>]
+
 ## Unsubscribe a subscriber from all emails
 
 This task unsubscribes one subscriber from everything they have subscribed to.

--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -79,6 +79,27 @@ namespace :support do
     end
   end
 
+  desc "Unsubscribe all active subscribers from a single subscription list"
+  task :unsubscribe_all_subscribers_from_subscription, [:subscriber_list_slug] => :environment do |_t, args|
+    subscriber_list_slug = args[:subscriber_list_slug]
+    subscriber_list = SubscriberList.find_by(slug: subscriber_list_slug)
+
+    abort("Cannot find subscriber list #{subscriber_list_slug}") if subscriber_list.nil?
+
+    subscribers = subscriber_list.subscribers
+
+    subscribers.each do |subscriber|
+      active_subscription = Subscription.active.find_by(subscriber_list:, subscriber:)
+
+      if active_subscription
+        active_subscription.end(reason: :unsubscribed)
+        puts "Unsubscribing #{subscriber.address} from #{subscriber_list_slug}"
+      else
+        puts "Subscriber #{subscriber.address} already unsubscribed from #{subscriber_list_slug}"
+      end
+    end
+  end
+
   desc "Unsubscribe a subscriber from all subscriptions"
   task :unsubscribe_all_subscriptions, [:email_address] => :environment do |_t, args|
     email_address = args[:email_address]

--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -72,7 +72,7 @@ namespace :support do
       active_subscription = Subscription.active.find_by(subscriber_list:, subscriber:)
       if active_subscription
         active_subscription.end(reason: :unsubscribed)
-        puts "Unsubscribing from #{email_address} from #{subscriber_list_slug}"
+        puts "Unsubscribing #{email_address} from #{subscriber_list_slug}"
       else
         puts "Subscriber #{email_address} already unsubscribed from #{subscriber_list_slug}"
       end

--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe "support" do
-  after(:each) do
-    Rake::Task["support:emails:stats_for_content_id"].reenable
-  end
-
   describe "stats_for_content_id" do
+    after(:each) do
+      Rake::Task["support:emails:stats_for_content_id"].reenable
+    end
+
     context "with invalid dates" do
       it "outputs all subscriptions for a subscriber" do
         expect { Rake::Task["support:emails:stats_for_content_id"].invoke(SecureRandom.uuid, "bad_date", "bad_date") }
@@ -47,8 +47,17 @@ RSpec.describe "support" do
   end
 
   describe "view_emails" do
+    after(:each) do
+      Rake::Task["support:view_emails"].reenable
+    end
+
+    it "displays error message if email is not provided" do
+      expect { Rake::Task["support:view_emails"].invoke }
+        .to raise_error(ArgumentError, /Provide an email!/)
+    end
+
     it "outputs the latest emails sent to an email address" do
-      expect { Rake::Task["support:view_emails"].invoke("foo@example.org") }
+      expect { Rake::Task["support:view_emails"].invoke("foo@example.org", 1) }
         .to output.to_stdout
     end
   end
@@ -139,6 +148,137 @@ RSpec.describe "support" do
 
       expect { Rake::Task["support:unsubscribe_all_subscribers_from_subscription"].invoke("another-list") }
       .to output(/Subscriber unsubscribed@test.com already unsubscribed from another-list/).to_stdout
+    end
+  end
+
+  describe "unsubscribe_single_subscription" do
+    before do
+      @subscriber_list = create(:subscriber_list, slug: "my-list", title: "My List")
+    end
+
+    after(:each) do
+      Rake::Task["support:unsubscribe_single_subscription"].reenable
+    end
+
+    it "displays error message if subscriber is not found" do
+      expect { Rake::Task["support:unsubscribe_single_subscription"].invoke("test@example.com", "my-list") }
+      .to output(/Subscriber test@example.com not found/).to_stdout
+    end
+
+    it "displays error message if subscriber list is not found but subscriber exists" do
+      create(:subscriber, address: "test-1@example.com")
+
+      expect { Rake::Task["support:unsubscribe_single_subscription"].invoke("test-1@example.com", "invalid-subscription-list") }
+      .to output(/Subscriber list invalid-subscription-list not found/).to_stdout
+    end
+
+    it "displays error message if subscriber is not subscribed to subscriber list" do
+      create(:subscriber, address: "notsubscribed@example.com")
+
+      expect { Rake::Task["support:unsubscribe_single_subscription"].invoke("notsubscribed@example.com", "my-list") }
+      .to output(/Subscriber notsubscribed@example.com does not appear to be signed up for my-list/).to_stdout
+    end
+
+    it "successfully unsubscribes an active subscriber" do
+      subscriber = create(:subscriber, address: "subscribed@example.com")
+      active_subscription = create(:subscription, subscriber_list: @subscriber_list, subscriber:)
+
+      expect { Rake::Task["support:unsubscribe_single_subscription"].invoke("subscribed@example.com", "my-list") }
+      .to output(/Unsubscribing subscribed@example.com from my-list/).to_stdout
+      .and change { active_subscription.reload.ended_reason }
+      .from(nil)
+      .to("unsubscribed")
+    end
+
+    it "displays message if subscriber has already been unsubscribed" do
+      subscriber = create(:subscriber, address: "unsubscribed@example.com")
+      create(:subscription, :ended, subscriber_list: @subscriber_list, subscriber:)
+
+      expect { Rake::Task["support:unsubscribe_single_subscription"].invoke("unsubscribed@example.com", "my-list") }
+      .to output(/Subscriber unsubscribed@example.com already unsubscribed from my-list/).to_stdout
+    end
+  end
+
+  describe "unsubscribe_all_subscriptions" do
+    after(:each) do
+      Rake::Task["support:unsubscribe_all_subscriptions"].reenable
+    end
+
+    it "displays error essage if the subscriber is not found" do
+      expect { Rake::Task["support:unsubscribe_all_subscriptions"].invoke("test@example.com") }
+      .to output(/Subscriber test@example.com not found/).to_stdout
+    end
+
+    it "displays message if user has been unsubscribed" do
+      subscriber_list1 = create(:subscriber_list, slug: "my-list", title: "My List")
+      subscriber_list2 = create(:subscriber_list, slug: "another-list", title: "another List")
+      subscriber = create(:subscriber, address: "subscribed@example.com")
+      active_subscription1 = create(:subscription, subscriber_list: subscriber_list1, subscriber:)
+      active_subscription2 = create(:subscription, subscriber_list: subscriber_list2, subscriber:)
+
+      expect { Rake::Task["support:unsubscribe_all_subscriptions"].invoke("subscribed@example.com") }
+      .to output(/Unsubscribing subscribed@example.com/).to_stdout
+      .and change { active_subscription1.reload.ended_reason }
+      .from(nil)
+      .to("unsubscribed")
+      .and change { active_subscription2.reload.ended_reason }
+      .from(nil)
+      .to("unsubscribed")
+    end
+  end
+
+  describe "change_email_address" do
+    after(:each) do
+      Rake::Task["support:change_email_address"].reenable
+    end
+
+    it "displays error message and aborts if email address is not found" do
+      expect { Rake::Task["support:change_email_address"].invoke("old@example.com", "new@example.com") }
+      .to raise_error(SystemExit, /Cannot find any subscriber with email address old@example.com/)
+    end
+
+    it "displays message when email address for subsciber has been changed" do
+      subscriber = create(:subscriber, address: "old@example.com")
+
+      expect { Rake::Task["support:change_email_address"].invoke("old@example.com", "new@example.com") }
+      .to output(/Changed email address for old@example.com to new@example.com/).to_stdout
+      .and change { subscriber.reload.address }
+      .from("old@example.com")
+      .to("new@example.com")
+    end
+  end
+
+  describe "view_subscriptions" do
+    after(:each) do
+      Rake::Task["support:view_subscriptions"].reenable
+    end
+
+    it "displays error message and aborts if email address is not found" do
+      expect { Rake::Task["support:view_subscriptions"].invoke("test@example.com") }
+      .to raise_error(SystemExit, /Cannot find any subscriber with email address test@example.com/)
+    end
+
+    it "displays all subscriptions for a subscriber" do
+      subscriber = create(:subscriber, address: "test@example.com")
+      subscriber_list1 = create(:subscriber_list, slug: "my-list", title: "My List")
+      subscriber_list2 = create(:subscriber_list, slug: "another-list", title: "Another List")
+      subscription1 = create(:subscription, subscriber_list: subscriber_list1, subscriber:)
+      subscription2 = create(:subscription, :ended, subscriber_list: subscriber_list2, subscriber:)
+
+      report = <<~TEXT
+        [{:status=>"Active",
+          :subscriber_list=>"#{subscriber_list1.title} (slug: #{subscriber_list1.slug})",
+          :frequency=>"#{subscription1.frequency}",
+          :timeline=>"Subscribed #{subscription1.created_at}"},
+         {:status=>"Inactive (#{subscription2.ended_reason})",
+          :subscriber_list=>"#{subscriber_list2.title} (slug: #{subscriber_list2.slug})",
+          :frequency=>"#{subscription2.frequency}",
+          :timeline=>
+           "Subscribed #{subscription2.created_at}, Ended #{subscription2.ended_at}"}]
+      TEXT
+
+      expect { Rake::Task["support:view_subscriptions"].invoke("test@example.com") }
+      .to output(report).to_stdout
     end
   end
 end


### PR DESCRIPTION
When organisations close/merge, we want to be able to unsubscribe all active subscribers from the organisation's subscription list. This rake task makes it easier to do this in bulk rather than individually using the `support:unsubscribe_single_subscription]` rake task.

This has been tested on Integration.

Sample output:
```
Unsubscribing anon-2562571@example.com from central-digital-and-data-office
Unsubscribing anon-2527485@example.com from central-digital-and-data-office
Subscriber anon-461468@example.com already unsubscribed from central-digital-and-data-office
```

Trello card: https://trello.com/c/jU0FVxFn/443-bulk-emailing-email-subscribers-of-closing-organisations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
