### PR TITLE
fix: update wrapping code to ensure backslashes are escaped

### DIFF
--- a/app/queries/subscriber_lists_by_criteria_query.rb
+++ b/app/queries/subscriber_lists_by_criteria_query.rb
@@ -41,6 +41,10 @@ private
     end
   end
 
+  def wrap_in_double_quotes(input)
+    %("#{input.gsub('\\', '\&\&').gsub('"', '\"')}")
+  end
+
   def type_rule(scope, type:, key:, value:)
     hash_rule_to_scope = lambda do |field|
       # we only apply this rule to SubscriberList tagged to "any", it didn't seem
@@ -48,9 +52,7 @@ private
       scope.where(
         ":value IN (SELECT json_array_elements(#{field}->:key->'any')::text)",
         key:,
-        # Postgres returns a string in double quotes where other double quote
-        # characters are escaped
-        value: %("#{value.gsub('"', '\\"')}"),
+        value: wrap_in_double_quotes(value),
       )
     end
 


### PR DESCRIPTION
- Existing code didn't escape backslashes, which might not have been a problem but did set off https://github.com/alphagov/email-alert-api/security/code-scanning/1.
- Code here copied from ActiveRecord Quoting, but altered to wrap in double quotes (active record only wraps in single quotes, which won't work here)

Original for reference:
  # File activerecord/lib/active_record/connection_adapters/abstract/quoting.rb, line 131 def quote_string(s)
  s.gsub("\\", '\&\&').gsub("'", "''") # ' (for ruby-mode) end

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
