### PR TITLE
Limit bulky job concurrency to 2

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,12 +8,19 @@
   # Use powers of 2: higher priority groups are checked twice as often.
   - [send_email_transactional, 8] # To send one-off emails, such as subscription confirmation.
   - [send_email_immediate_high, 8] # To send high priority emails to users with immediate subscriptions e.g. travel advice.
-  - [process_and_generate_emails, 4] # To generate emails to users with immediate subscriptions for content changes and messages.
   - [email_generation_digest, 4] # To generate emails to users with daily or weekly subscriptions for content changes and messages.
   - [send_email_immediate, 2] # To send emails to users with immediate subscriptions.
   - [send_email_digest, 2] # To send digest emails to users with either daily or weekly subscriptions.
   - [subscriber_list_audit, 1] # To crawl the GOV.UK site for audit purposes.
   - [default, 1] # Miscellaneous operations e.g. initiating digest runs, monitoring, DB cleanup and recovering lost Sidekiq jobs.
+:capsules:
+  # Bulk capsule is for heavy jobs like ContentChanges which we can't control the rate of, but which should only be handled
+  # a few at a time to prevent running the worker process/pod out of memory/ Compare this with Digest generators, which are heavy
+  # weight but we control the rate of, so they're safe to be in the default capsule.
+  :bulk:
+    :concurrency: 2
+    :queues:
+      - [process_and_generate_emails, 4] # To generate emails to users with immediate subscriptions for content changes and messages.
 :scheduler:
   :schedule:
     daily_digest_initiator:


### PR DESCRIPTION
- Following on from an incident in which multiple travel alerts were scheduled
  to be published at the same time, which caused the queue to run out of memory,
  we want to limit the number of heavy jobs running at the same time.
- This capsule config moves the processing of the process_and_generate_emails
  queue to 2 processes per worker (in practise, we have 2 workers, so this
  is a real-life concurrency of 4). In theory, if travel advice alerts for all
  companies were published simultaneously, it would take 48-50 minutes to
  process them all, which might lead to false positives in the alert, since
  the last jobs would be putting their emails onto a gigantic queue. However,
  this is unlikely, and at least the emails would actually get sent.
- The number of threads available for other queues remains unchanged, so speed
  of processing email sending jobs should remain the same.

https://trello.com/c/dOfJPrFN/676-limit-concurrency-for-large-jobs-in-email-alert-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
