### PR TITLE
fix: improve logged message for fallback to polling Notify

### DIFF
--- a/app/jobs/polling_alert_check_job.rb
+++ b/app/jobs/polling_alert_check_job.rb
@@ -24,7 +24,7 @@ class PollingAlertCheckJob < ApplicationJob
   def any_emails_delivered_for?(content_id, valid_from, document_type)
     return true if Email.where("notify_status = 'delivered' AND content_id = ? AND created_at > ?", content_id, valid_from).exists?
 
-    Rails.logger.info("First pass couldn't find any delivered emails for #{document_type.titleize} records with content id #{content_id}, reverting to polling")
+    Rails.logger.warn("No records in database of delivered emails for #{document_type.titleize} records with content id #{content_id}, polling Notify directly about first 100 emails")
 
     service = CheckNotifyEmailService.new("delivered")
     Email.sent.where("content_id = ? AND created_at > ? AND notify_status IS NULL", content_id, valid_from).order(:created_at).first(100).any? do |email|


### PR DESCRIPTION
- Two recent incidents (one real, one false positive) in review complained about log messages being at the wrong level. Bump this to a warning as well as the main message on line 11. We will also update the docs to reinforce that the info level message on line 15 is for both good and bad outcomes.

https://docs.publishing.service.gov.uk/manual/alerts/email-alerts-travel-medical.html#find-out-which-mailshot-was-affected

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
