### PR TITLE
Subscribers count rake task

### DIFF
--- a/lib/reports/subscriber_count_list_report.rb
+++ b/lib/reports/subscriber_count_list_report.rb
@@ -1,0 +1,43 @@
+require "csv"
+
+class Reports::SubscriberCountListReport
+  class BadDateError < StandardError; end
+
+  attr_reader :url, :start_date, :end_date
+
+  def initialize(url, start_date = nil, end_date = nil)
+    @url = url
+    @start_date = start_date || Time.zone.now.beginning_of_month
+    @end_date = end_date || Time.zone.now.end_of_day
+  end
+
+  def call
+    list = SubscriberList.find_by_url(url)
+    return "Subscriber list cannot be found with URL: #{url}" unless list
+
+    results = {}
+    current_date = formatted_date(start_date).beginning_of_month
+    end_date_formatted = formatted_date(end_date).end_of_month
+
+    while current_date <= end_date_formatted
+      count = list.subscriptions.active_on(current_date.end_of_day).count
+      results[current_date.strftime("%d-%m-%Y")] = count
+      current_date = current_date.next_month
+    end
+
+    CSV.generate do |csv|
+      csv << %w[Date Count]
+      results.each { |date, count| csv << [date, count] }
+    end
+  rescue ArgumentError
+    "Cannot parse dates, are these valid ISO8601 dates?: start_date=#{start_date}, end_date=#{end_date}"
+  end
+
+private
+
+  def formatted_date(date)
+    return date if date.instance_of?(ActiveSupport::TimeWithZone)
+
+    Time.zone.strptime(date, "%F")
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -24,6 +24,15 @@ namespace :report do
     ).call
   end
 
+  desc "Output a subscribers count list for past dates by the subscrber_list URL "
+  task :subscriber_count_list, %i[url start_date end_date] => :environment do |_t, args|
+    puts Reports::SubscriberCountListReport.new(
+      args.fetch(:url),
+      args[:start_date],
+      args[:end_date],
+    ).call
+  end
+
   desc "Output a report of top single page notification subscriber lists"
   task :single_page_notifications_top_subscriber_lists, %i[limit] => :environment do |_t, args|
     puts Reports::SinglePageNotificationsReport.new(args[:limit] || 25).call.join("\n")

--- a/spec/lib/reports/subscribe_count_list_report_spec.rb
+++ b/spec/lib/reports/subscribe_count_list_report_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe Reports::SubscriberCountListReport do
+  let(:url) { "/url" }
+  let(:created_at) { 1.month.ago.beginning_of_month }
+  let(:list) { create(:subscriber_list, created_at:, title: "list 1", slug: "list-1", url:) }
+
+  before { create_range_of_subscribers(list, created_at) }
+
+  context "when passed a URL matching subscriber list along with start and end dates" do
+    let(:start_date) { 1.month.ago.beginning_of_month }
+    let(:end_date) { Time.zone.now.end_of_month }
+
+    it "returns a list of subscribers count, excluding ended subscriptions" do
+      result = described_class.new(url, start_date, end_date).call
+      expect(result).to include("Date,Count")
+      expect(result).to include("#{1.month.ago.beginning_of_month.strftime('%d-%m-%Y')},1")
+      expect(result).to include("#{Time.zone.now.beginning_of_month.strftime('%d-%m-%Y')},4")
+    end
+  end
+
+  context "when passed an invalid URL" do
+    before do
+      allow(SubscriberList).to receive(:find_by_url).with(url).and_return(nil)
+    end
+
+    it "gives a error message" do
+      result = described_class.new(url).call
+      expect(result).to include("Subscriber list cannot be found with URL")
+    end
+  end
+
+  context "when passed invalid dates" do
+    let(:start_date) { "invalid-start-date" }
+    let(:end_date) { "invalid-end-date" }
+
+    it "returns an error message" do
+      result = described_class.new(url, start_date, end_date).call
+      expect(result).to include("Cannot parse dates, are these valid ISO8601 dates?: start_date=#{start_date}, end_date=#{end_date}")
+    end
+  end
+
+  context "when dates are not given" do
+    it "handles TimeWithZone objects without parsing" do
+      result = described_class.new(url).call
+      expect(result).to include("Date,Count")
+    end
+  end
+
+  context "when passed valid date strings" do
+    let(:start_date) { "2025-07-01" }
+    let(:end_date) { "2025-08-10" }
+
+    it "parses string dates correctly" do
+      result = described_class.new(url, start_date, end_date).call
+      expect(result).to include("Date,Count")
+    end
+  end
+
+  def create_range_of_subscribers(list, created_at)
+    create(:subscription, subscriber_list: list, created_at:)
+    create(:subscription, subscriber_list: list, created_at: Time.zone.now.beginning_of_month)
+    create(:subscription, subscriber_list: list, created_at: Time.zone.now.beginning_of_month)
+    create(:subscription, subscriber_list: list, created_at: Time.zone.now.beginning_of_month)
+  end
+end


### PR DESCRIPTION
## What

Rake task to generate a csv with a list of `subscribers count` for the 1st of every month when the start date and end dates are specified for the given `URL`.

[Trello](https://trello.com/c/8GaBOqyo)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
