### PR TITLE
Add RailsCache healthcheck

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
       GovukHealthcheck::SidekiqRedis,
       GovukHealthcheck::ActiveRecord,
+      GovukHealthcheck::RailsCache,
     )
   end
 


### PR DESCRIPTION
We use caching for the polling alert check job,
so should monitor the health of the cache.

Ref: https://github.com/alphagov/email-alert-api/blob/main/app/jobs/polling_alert_check_job.rb#L20-L21

Docs: 
- https://github.com/alphagov/govuk_app_config/blob/main/docs/healthchecks.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
