### PR TITLE
Change Slack notification channel for failures

### DIFF
--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -20,5 +20,5 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
         with:
           slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
-          channel: govuk-patterns-and-pages-tech
+          channel: govuk-navigation-tech
           message: "Github was unable to complete the CI or Deploy Actions workflow - requires further investigation."


### PR DESCRIPTION
This app is now owned by the navigation team. So routing failure alerts to our slack channel

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
