### PR TITLE
[NAV-19058] Add rake task to get subscriber list count by slug

### DIFF
--- a/lib/reports/subscriber_list_by_slug_subscriber_count_report.rb
+++ b/lib/reports/subscriber_list_by_slug_subscriber_count_report.rb
@@ -1,0 +1,24 @@
+class Reports::SubscriberListBySlugSubscriberCountReport
+  class BadDateError < StandardError; end
+
+  attr_reader :slug
+
+  def initialize(slug)
+    @slug = slug
+  end
+
+  def call
+    list = SubscriberList.find_by_slug(slug)
+    date = Time.zone.now.end_of_day
+
+    if list
+      count = list.subscriptions
+          .active_on(date)
+          .count
+
+      "Subscriber list for #{slug} had #{count} subscribers on #{date}."
+    else
+      raise "Subscriber list cannot be found with slug: #{slug}"
+    end
+  end
+end

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -35,6 +35,13 @@ namespace :report do
     ).call
   end
 
+  desc "Output a simple count of active subscribers by subscriber_list slug"
+  task :subscriber_list_by_slug_subscriber_count, %i[slug] => :environment do |_t, args|
+    puts Reports::SubscriberListBySlugSubscriberCountReport.new(
+      args.fetch(:slug),
+    ).call
+  end
+
   desc "Output a subscribers count list for past dates by the subscrber_list URL "
   task :subscriber_count_list, %i[url start_date end_date] => :environment do |_t, args|
     puts Reports::SubscriberCountListReport.new(

--- a/spec/lib/reports/subscriber_list_by_slug_subscriber_count_report_spec.rb
+++ b/spec/lib/reports/subscriber_list_by_slug_subscriber_count_report_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Reports::SubscriberListBySlugSubscriberCountReport do
+  let(:slug) { "ministry-of-magic" }
+  let(:created_at) { 10.days.ago.midday }
+  let(:list) { create(:subscriber_list, created_at:, title: "Ministry of Magic", slug: "ministry-of-magic", url: "/government/organisations/ministry-of-magic") }
+
+  before { create_range_of_subscribers(list, created_at) }
+
+  context "when passed a slug that matches a subscriber list" do
+    let(:active_on_date) { Time.zone.now.end_of_day }
+
+    it "returns a count up to Time.zone.now, excluding ended subscriptions" do
+      expect(described_class.new(slug).call).to include("Subscriber list for #{slug} had 4 subscribers on #{active_on_date}.")
+    end
+  end
+
+  context "when passed a slug that does not match a subscriber list" do
+    it "it returns a useful message" do
+      expect { described_class.new("non-existent-slug").call }
+      .to raise_error(RuntimeError, "Subscriber list cannot be found with slug: non-existent-slug")
+    end
+  end
+
+  def create_range_of_subscribers(list, created_at)
+    create(:subscription, :immediately, subscriber_list: list, created_at:)
+    create(:subscription, :daily, subscriber_list: list, created_at:)
+    create(:subscription, :weekly, subscriber_list: list, created_at:)
+    create(:subscription, :ended, ended_at: created_at, subscriber_list: list)
+    create(:subscription, :ended, ended_at: created_at, ended_reason: :frequency_changed, subscriber_list: list)
+    create(:subscription, :immediately, subscriber_list: list, created_at: Time.zone.now)
+  end
+end

--- a/spec/lib/tasks/report_spec.rb
+++ b/spec/lib/tasks/report_spec.rb
@@ -34,6 +34,26 @@ RSpec.describe "report" do
     end
   end
 
+  describe "subscriber_list_by_slug_subscriber_count" do
+    after(:each) do
+      Rake::Task["report:subscriber_list_by_slug_subscriber_count"].reenable
+    end
+
+    context "with a valid subscriber list" do
+      let(:subscriber_list) { create(:subscriber_list) }
+
+      it "outputs a count of subscribers for a matched subscriber list" do
+        expect { Rake::Task["report:subscriber_list_by_slug_subscriber_count"].invoke(subscriber_list.slug) }
+          .to output.to_stdout
+      end
+    end
+
+    it "outputs a helpful message if the subscriber list is not found" do
+      expect { Rake::Task["report:subscriber_list_by_slug_subscriber_count"].invoke("non-existent-slug") }
+      .to raise_error(RuntimeError, "Subscriber list cannot be found with slug: non-existent-slug")
+    end
+  end
+
   describe "single_page_notifications_top_subscriber_lists" do
     it "outputs a report of single page notification subscriber lists" do
       expect { Rake::Task["report:single_page_notifications_top_subscriber_lists"].invoke }


### PR DESCRIPTION
It's not always easy to find out the URL of a subscriber list, and in most cases other report rake tasks return the slug of a subscriber list.

This has been tested on Integration, see example output:

```
> kubectl -n apps exec -it deploy/email-alert-api -- bundle exec rake 'report:subscriber_list_by_slug_subscriber_count[department-for-culture-media-and-sport-9a1e4ff9b9]'

Subscriber list for department-for-culture-media-and-sport-9a1e4ff9b9 had 1151 subscribers on 2026-09-11 23:59:59 +0100.
```

Jira card - https://gov-uk.atlassian.net/browse/NAV-19058

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
